### PR TITLE
Fix license filenames for jars

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,8 +66,8 @@ subprojects {
 
         // Reusable license copySpec
         val licenseSpec = copySpec {
-            from("${project.rootDir}/LICENSE.txt")
-            from("${project.rootDir}/NOTICE.txt")
+            from("${project.rootDir}/LICENSE")
+            from("${project.rootDir}/NOTICE")
         }
 
         // Set up tasks that build source and javadoc jars.


### PR DESCRIPTION
Fixes an issue with the licenseSpec being directed to the wrong files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
