### PR TITLE
Add Cognito User Pools support and more authn info

### DIFF
--- a/smithy-openapi/src/main/java/module-info.java
+++ b/smithy-openapi/src/main/java/module-info.java
@@ -10,6 +10,7 @@ import software.amazon.smithy.openapi.fromsmithy.plugins.CheckForPrefixHeaders;
 import software.amazon.smithy.openapi.fromsmithy.plugins.RemoveUnusedComponentsPlugin;
 import software.amazon.smithy.openapi.fromsmithy.plugins.UnsupportedTraitsPlugin;
 import software.amazon.smithy.openapi.fromsmithy.protocols.AwsRestJsonProtocol;
+import software.amazon.smithy.openapi.fromsmithy.security.AmazonCognitoUserPools;
 import software.amazon.smithy.openapi.fromsmithy.security.AwsV4;
 import software.amazon.smithy.openapi.fromsmithy.security.HttpBasic;
 import software.amazon.smithy.openapi.fromsmithy.security.HttpBearer;
@@ -32,17 +33,22 @@ module software.amazon.smithy.openapi {
     uses SecuritySchemeConverter;
 
     provides OpenApiProtocol with AwsRestJsonProtocol;
+
     provides SchemaBuilderMapper with OpenApiJsonSchemaMapper;
+
     provides SmithyOpenApiPlugin with
             CheckForGreedyLabels,
             CheckForPrefixHeaders,
             RemoveUnusedComponentsPlugin,
             UnsupportedTraitsPlugin;
+
     provides SecuritySchemeConverter with
+            AmazonCognitoUserPools,
             AwsV4,
             HttpBasic,
             HttpDigest,
             HttpBearer,
             XApiKey;
+
     provides SmithyBuildPlugin with Smithy2OpenApi;
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.openapi.fromsmithy;
 import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.AuthenticationTrait;
 import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.model.SecurityScheme;
 
@@ -25,11 +26,16 @@ public interface SecuritySchemeConverter {
      * Creates an OpenAPI security scheme.
      *
      * @param context Conversion context
+     * @param authTrait Authentication trait of the service.
+     * @param authScheme The matching authentication scheme being converted.
      * @return The generated security scheme
      *
      * @see <a href="https://swagger.io/specification/#securitySchemeObject">Security Scheme Object</a>
      */
-    SecurityScheme createSecurityScheme(Context context);
+    SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme);
 
     /**
      * Get the name that should be used for this security scheme throughout

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/AmazonCognitoUserPools.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/AmazonCognitoUserPools.java
@@ -1,0 +1,65 @@
+package software.amazon.smithy.openapi.fromsmithy.security;
+
+import java.util.Set;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.traits.AuthenticationTrait;
+import software.amazon.smithy.openapi.OpenApiException;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
+import software.amazon.smithy.openapi.model.SecurityScheme;
+
+/**
+ * An authentication scheme converter that adds Cognito User Pool based
+ * authentication ({@code cognito_user_pools} to an OpenAPI model when the
+ * {@code apigateway.cognito-user-pools} authentication scheme is found on
+ * a service shape.
+ *
+ * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html">Integrate a REST API with a User Pool </a>
+ */
+public class AmazonCognitoUserPools implements SecuritySchemeConverter {
+    private static final String SCHEME = "apigateway.cognito-user-pools";
+    private static final String AUTH_HEADER = "Authorization";
+    private static final Set<String> REQUEST_HEADERS = Set.of(AUTH_HEADER);
+    private static final String AUTH_TYPE = "cognito_user_pools";
+    private static final String PROVIDER_ARNS_PROPERTY = "providerARNs";
+
+    @Override
+    public String getAuthenticationSchemeName() {
+        return SCHEME;
+    }
+
+    @Override
+    public SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme
+    ) {
+        // Providers are provided in the providerARNs property as a CSV list of ARNs.
+        var providers = authScheme.getSetting(PROVIDER_ARNS_PROPERTY)
+                .orElseThrow(() -> new OpenApiException(String.format(
+                        "Missing required `%s` property in `%s` authentication scheme of `%s`.",
+                        PROVIDER_ARNS_PROPERTY, SCHEME, context.getService().getId())))
+                .split(",");
+
+        // Trim any whitespace from the string.
+        for (var i = 0; i < providers.length; i++) {
+            providers[i] = providers[i].trim();
+        }
+
+        return SecurityScheme.builder()
+                .type("apiKey")
+                .description("Amazon Cognito User Pools authentication")
+                .name(AUTH_HEADER)
+                .in("header")
+                .putExtension("x-amazon-apigateway-authtype", Node.from(AUTH_TYPE))
+                .putExtension("x-amazon-apigateway-authorizer", Node.objectNode()
+                        .withMember("type", Node.from(AUTH_TYPE))
+                        .withMember(PROVIDER_ARNS_PROPERTY, Node.fromStrings(providers)))
+                .build();
+    }
+
+    @Override
+    public Set<String> getAuthRequestHeaders() {
+        return REQUEST_HEADERS;
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4.java
@@ -2,6 +2,7 @@ package software.amazon.smithy.openapi.fromsmithy.security;
 
 import java.util.Set;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.traits.AuthenticationTrait;
 import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
@@ -27,7 +28,11 @@ public final class AwsV4 implements SecuritySchemeConverter {
     }
 
     @Override
-    public SecurityScheme createSecurityScheme(Context context) {
+    public SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme
+    ) {
         return SecurityScheme.builder()
                 .type("apiKey")
                 .description("AWS Signature Version 4 authentication")

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasic.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasic.java
@@ -1,5 +1,6 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
+import software.amazon.smithy.model.traits.AuthenticationTrait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
@@ -14,7 +15,11 @@ public final class HttpBasic implements SecuritySchemeConverter {
     }
 
     @Override
-    public SecurityScheme createSecurityScheme(Context context) {
+    public SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme
+    ) {
         return SecurityScheme.builder()
                 .type("http")
                 .scheme("Basic")

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearer.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearer.java
@@ -1,5 +1,6 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
+import software.amazon.smithy.model.traits.AuthenticationTrait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
@@ -14,7 +15,11 @@ public final class HttpBearer implements SecuritySchemeConverter {
     }
 
     @Override
-    public SecurityScheme createSecurityScheme(Context context) {
+    public SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme
+    ) {
         return SecurityScheme.builder()
                 .type("http")
                 .scheme("Bearer")

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigest.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigest.java
@@ -1,5 +1,6 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
+import software.amazon.smithy.model.traits.AuthenticationTrait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
@@ -14,7 +15,11 @@ public final class HttpDigest implements SecuritySchemeConverter {
     }
 
     @Override
-    public SecurityScheme createSecurityScheme(Context context) {
+    public SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme
+    ) {
         return SecurityScheme.builder()
                 .type("http")
                 .scheme("Digest")

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
@@ -1,5 +1,6 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
+import software.amazon.smithy.model.traits.AuthenticationTrait;
 import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
@@ -25,7 +26,11 @@ public final class XApiKey implements SecuritySchemeConverter {
     }
 
     @Override
-    public SecurityScheme createSecurityScheme(Context context) {
+    public SecurityScheme createSecurityScheme(
+            Context context,
+            AuthenticationTrait authTrait,
+            AuthenticationTrait.AuthScheme authScheme
+    ) {
         return SecurityScheme.builder()
                 .type("apiKey")
                 .in("header")

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AmazonCognitoUserPoolsTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AmazonCognitoUserPoolsTest.java
@@ -1,0 +1,41 @@
+package software.amazon.smithy.openapi.fromsmithy.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.LoaderUtils;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiException;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+
+public class AmazonCognitoUserPoolsTest {
+    @Test
+    public void addsAwsV4() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("cognito-user-pools-security.json"))
+                .assemble()
+                .unwrap();
+        var result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        var expectedNode = Node.parse(LoaderUtils.readInputStream(
+                getClass().getResourceAsStream("cognito-user-pools-security.openapi.json"), "UTF-8"));
+
+        assertThat(result.toNode(), equalTo(expectedNode));
+    }
+
+    @Test
+    public void requiresProviderArns() {
+        var thrown = Assertions.assertThrows(OpenApiException.class, () -> {
+            Model model = Model.assembler()
+                    .addImport(getClass().getResource("invalid-cognito-user-pools-security.json"))
+                    .assemble()
+                    .unwrap();
+            OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        });
+
+        Assertions.assertTrue(thrown.getMessage().contains("providerARNs"));
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/cognito-user-pools-security.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/cognito-user-pools-security.json
@@ -1,0 +1,18 @@
+{
+  "smithy": "1.0",
+  "smithy.example": {
+    "shapes": {
+      "Service": {
+        "type": "service",
+        "version": "2006-03-01",
+        "protocols": {"aws.rest-json": {}},
+        "authentication": {"apigateway.cognito-user-pools": {"settings": {"providerARNs": "arn:foo:baz"}}},
+        "operations": ["Operation1"]
+      },
+      "Operation1": {
+        "type": "operation",
+        "http": {"uri": "/", "method": "GET"}
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/cognito-user-pools-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/cognito-user-pools-security.openapi.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "Operation1",
+        "responses": {
+          "200": {
+            "description": "Operation1 response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apigateway.cognito-user-pools": {
+        "type": "apiKey",
+        "description": "Amazon Cognito User Pools authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "cognito_user_pools",
+        "x-amazon-apigateway-authorizer": {
+          "type": "cognito_user_pools",
+          "providerARNs": [
+            "arn:foo:baz"
+          ]
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "apigateway.cognito-user-pools": [ ]
+    }
+  ]
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/invalid-cognito-user-pools-security.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/invalid-cognito-user-pools-security.json
@@ -1,0 +1,18 @@
+{
+  "smithy": "1.0",
+  "smithy.example": {
+    "shapes": {
+      "Service": {
+        "type": "service",
+        "version": "2006-03-01",
+        "protocols": {"aws.rest-json": {}},
+        "authentication": {"apigateway.cognito-user-pools": {}},
+        "operations": ["Operation1"]
+      },
+      "Operation1": {
+        "type": "operation",
+        "http": {"uri": "/", "method": "GET"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds Cognito User Pool support to the OpenAPI converter and
provides more informaiton to authentication scheme converters to make
them easier to implement.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
