### PR TITLE
Add OpenAPI node mappers and Node diff

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -294,6 +294,40 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Testing helper used to compare two Nodes for equivalence.
+     *
+     * <p>Compares two Node values and throws if they aren't equal. The
+     * thrown exception contains a message that shows the differences
+     * between the two Nodes as returned by {@link #diff(ToNode, ToNode)}.
+     *
+     * @param actual Node to use as the starting node.
+     * @param expected Node to compare against.
+     * @throws ExpectationNotMetException if the nodes are not equivalent.
+     */
+    public static void assertEquals(ToNode actual, ToNode expected) {
+        var actualNode = actual.toNode();
+        var expectedNode = expected.toNode();
+        if (!actualNode.equals(expectedNode)) {
+            throw new ExpectationNotMetException(String.format(
+                    "Actual node did not match expected Node.%nActual:%n%s%nExpected:%n%s%nDiff: %s",
+                    Node.prettyPrintJson(actualNode),
+                    Node.prettyPrintJson(expectedNode),
+                    String.join(System.lineSeparator(), diff(actualNode, expectedNode))), actualNode);
+        }
+    }
+
+    /**
+     * Computes the differences between two Nodes as a String.
+     *
+     * @param actual Node to use as the starting node.
+     * @param expected Node to compare against.
+     * @return Returns the differences as a String.
+     */
+    public static List<String> diff(ToNode actual, ToNode expected) {
+        return NodeDiff.diff(actual, expected);
+    }
+
+    /**
      * Gets the type of the node.
      *
      * @return Returns the node type.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeDiff.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeDiff.java
@@ -1,0 +1,110 @@
+package software.amazon.smithy.model.node;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Creates a line-by-line diff of two Node values.
+ */
+final class NodeDiff {
+
+    NodeDiff() {}
+
+    static List<String> diff(ToNode actual, ToNode expected) {
+        return new NodeDiff().findDifferences(actual.toNode(), expected.toNode(), "")
+                .collect(Collectors.toList());
+    }
+
+    Stream<String> findDifferences(Node actual, Node expected, String prefix) {
+        if (actual.equals(expected)) {
+            return Stream.empty();
+        }
+
+        if (!actual.getType().equals(expected.getType())) {
+            return Stream.of(String.format(
+                    "[%s]: Expected node of type `%s` but found node of type `%s`.%n%nExpected: %s%n%n Found: %s",
+                    prefix,
+                    expected.getType(),
+                    actual.getType(),
+                    nodeToJson(expected, true),
+                    nodeToJson(actual, true)));
+        }
+
+        switch (actual.getType()) {
+            case OBJECT:
+                return findDifferences(actual.expectObjectNode(), expected.expectObjectNode(), prefix);
+            case ARRAY:
+                return findDifferences(actual.expectArrayNode(), expected.expectArrayNode(), prefix);
+            default:
+                return Stream.of(String.format(
+                        "[%s]: Expected `%s` but found `%s`",
+                        prefix, nodeToJson(expected, false), nodeToJson(actual, false)));
+        }
+    }
+
+    private Stream<String> findDifferences(ObjectNode actual, ObjectNode expected, String prefix) {
+        List<String> differences = new ArrayList<>();
+        Set<String> actualKeys = actual.getMembers().keySet().stream().map(StringNode::getValue)
+                .collect(Collectors.toSet());
+        Set<String> expectedKeys = expected.getMembers().keySet().stream().map(StringNode::getValue)
+                .collect(Collectors.toSet());
+
+        Set<String> extraKeys = new HashSet<>(actualKeys);
+        extraKeys.removeAll(expectedKeys);
+        for (String extraKey : extraKeys) {
+            differences.add(String.format(
+                    "[%s]: Extra key `%s` encountered with content: %s", prefix, extraKey,
+                    nodeToJson(actual.expectMember(extraKey), true)));
+        }
+
+        Set<String> missingKeys = new HashSet<>(expectedKeys);
+        missingKeys.removeAll(actualKeys);
+        for (String missingKey : missingKeys) {
+            differences.add(String.format("[%s]: Expected key `%s` not present.", prefix, missingKey));
+        }
+
+        Set<String> sharedKeys = new HashSet<>(actualKeys);
+        sharedKeys.retainAll(expectedKeys);
+
+        return Stream.concat(differences.stream(), sharedKeys.stream()
+                .flatMap(key -> findDifferences(
+                        actual.expectMember(key),
+                        expected.expectMember(key),
+                        String.format("%s/%s", prefix, key.replace("^", "^^").replace("/", "^/")))));
+    }
+
+    private Stream<String> findDifferences(ArrayNode actual, ArrayNode expected, String prefix) {
+        List<String> differences = new ArrayList<>();
+        List<Node> actualElements = actual.getElements();
+        List<Node> expectedElements = expected.getElements();
+
+        for (int i = expectedElements.size(); i < actualElements.size(); i++) {
+            differences.add(String.format(
+                    "[%s]: Extra element encountered in list at position %d: %s", prefix, i,
+                    nodeToJson(actualElements.get(i), true)));
+        }
+
+        for (int i = actualElements.size(); i < expectedElements.size(); i++) {
+            differences.add(String.format(
+                    "[%s]: Expected element (position %d) not encountered in list: %s", prefix, i,
+                    nodeToJson(expectedElements.get(i), true)));
+        }
+
+        return Stream.concat(
+                differences.stream(),
+                IntStream.range(0, Math.min(actualElements.size(), expectedElements.size())).boxed()
+                        .flatMap(i -> findDifferences(
+                                actualElements.get(i),
+                                expectedElements.get(i),
+                                String.format("%s[%d]", prefix, i))));
+    }
+
+    private static String nodeToJson(Node node, boolean prettyPrint) {
+        return prettyPrint ? Node.prettyPrintJson(node) : Node.printJson(node);
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeDiffTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeDiffTest.java
@@ -1,0 +1,140 @@
+package software.amazon.smithy.model.node;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+import org.junit.jupiter.api.Test;
+
+public class NodeDiffTest {
+    @Test
+    public void detectsNodeTypeDifference() {
+        assertThat(NodeDiff.diff(Node.nullNode(), Node.from(true)), contains(
+                "[]: Expected node of type `boolean` but found node of type `null`.\n\nExpected: true\n\n Found: null"));
+    }
+
+    @Test
+    public void comparesBooleans() {
+        assertThat(NodeDiff.diff(Node.from(true), Node.from(true)), empty());
+        assertThat(NodeDiff.diff(Node.from(true), Node.from(false)),
+                   contains("[]: Expected `false` but found `true`"));
+    }
+
+    @Test
+    public void comparesNumbers() {
+        assertThat(NodeDiff.diff(Node.from(10), Node.from(10)), empty());
+        assertThat(NodeDiff.diff(Node.from(2), Node.from(1)),
+                   contains("[]: Expected `1` but found `2`"));
+    }
+
+    @Test
+    public void comparesStrings() {
+        assertThat(NodeDiff.diff(Node.from("pop"), Node.from("pop")), empty());
+        assertThat(NodeDiff.diff(Node.from("foo"), Node.from("bar")),
+                   contains("[]: Expected `\"bar\"` but found `\"foo\"`"));
+    }
+
+    @Test
+    public void comparesNulls() {
+        assertThat(NodeDiff.diff(Node.nullNode(), Node.nullNode()), empty());
+    }
+
+    @Test
+    public void detectsExtraListElements() {
+        Node actual = Node.fromStrings("snap", "crackle", "pop");
+        Node expected = Node.fromStrings("snap", "crackle");
+
+        assertThat(NodeDiff.diff(actual, expected),
+                   contains("[]: Extra element encountered in list at position 2: \"pop\""));
+    }
+
+    @Test
+    public void detectsMissingListElements() {
+        Node actual = Node.fromStrings("snap", "crackle");
+        Node expected = Node.fromStrings("snap", "crackle", "pop");
+
+        assertThat(NodeDiff.diff(actual, expected),
+                   contains("[]: Expected element (position 2) not encountered in list: \"pop\""));
+    }
+
+    @Test
+    public void detectsDifferentListElements() {
+        Node actual = Node.fromStrings("fizz", "buzz", "pop");
+        Node expected = Node.fromStrings("snap", "crackle", "pop");
+
+        assertThat(NodeDiff.diff(actual, expected), contains(
+                "[[0]]: Expected `\"snap\"` but found `\"fizz\"`",
+                "[[1]]: Expected `\"crackle\"` but found `\"buzz\"`"));
+    }
+
+    @Test
+    public void reportsMultipleDifferenceTypesOnLists() {
+        Node actual = Node.fromStrings("fizz", "buzz");
+        Node expected = Node.fromStrings("snap", "crackle", "pop");
+
+        assertThat(NodeDiff.diff(actual, expected), contains(
+                "[]: Expected element (position 2) not encountered in list: \"pop\"",
+                "[[0]]: Expected `\"snap\"` but found `\"fizz\"`",
+                "[[1]]: Expected `\"crackle\"` but found `\"buzz\"`"));
+    }
+
+    @Test
+    public void detectsExtraObjectKeys() {
+        Node actual = Node.objectNode().withMember("foo", Node.from("bar")).withMember("fizz", Node.from("buzz"));
+        Node expected = Node.objectNode().withMember("foo", Node.from("bar"));
+
+        assertThat(NodeDiff.diff(actual, expected),
+                   contains("[]: Extra key `fizz` encountered with content: \"buzz\""));
+    }
+
+    @Test
+    public void detectsMissingObjectKeys() {
+        Node actual = Node.objectNode().withMember("foo", Node.from("bar"));
+        Node expected = Node.objectNode().withMember("foo", Node.from("bar")).withMember("fizz", Node.from("buzz"));
+
+        assertThat(NodeDiff.diff(actual, expected),
+                   contains("[]: Expected key `fizz` not present."));
+    }
+
+    @Test
+    public void detectsDifferentObjectKeys() {
+        Node actual = Node.objectNode().withMember("foo", Node.from("bar"));
+        Node expected = Node.objectNode().withMember("foo", Node.from("baz"));
+
+        assertThat(NodeDiff.diff(actual, expected),
+                   contains("[/foo]: Expected `\"baz\"` but found `\"bar\"`"));
+    }
+
+    @Test
+    public void reportsMultipleDifferenceTypesOnObjects() {
+        Node actual = Node.objectNode().withMember("foo", Node.from("bar")).withMember("snap", Node.from("crackle"));
+        Node expected = Node.objectNode().withMember("foo", Node.from("baz")).withMember("fizz", Node.from("buzz"));
+
+        assertThat(NodeDiff.diff(actual, expected), containsInAnyOrder(
+                "[/foo]: Expected `\"baz\"` but found `\"bar\"`",
+                "[]: Expected key `fizz` not present.",
+                "[]: Extra key `snap` encountered with content: \"crackle\""));
+    }
+
+    @Test
+    public void detectsDeeplyNestedDifferences() {
+        Node expected = Node.objectNode()
+                .withMember("foo", Node.arrayNode().withValue(Node.from("bar")).withValue(
+                        Node.objectNode()
+                                .withMember("baz", Node.arrayNode()
+                                        .withValue(Node.from("snap"))
+                                        .withValue(Node.objectNode()
+                                                           .withMember("crackle", Node.from("pop"))))));
+        Node actual = Node.objectNode()
+                .withMember("foo", Node.arrayNode()
+                        .withValue(Node.from("bar"))
+                        .withValue(Node.objectNode()
+                                           .withMember("baz", Node.arrayNode().withValue(Node.from("snap"))
+                                                   .withValue(Node.objectNode()
+                                                                      .withMember("crackle", Node.from("quux"))))));
+
+        assertThat(NodeDiff.diff(actual, expected), contains(
+                "[/foo[1]/baz[1]/crackle]: Expected `\"pop\"` but found `\"quux\"`"));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeTest.java
@@ -186,4 +186,19 @@ public class NodeTest {
 
         assertThat(result.getType(), is(NodeType.OBJECT));
     }
+
+    @Test
+    public void ensuresNodesAreEqual() {
+        var node = Node.from(true);
+
+        Node.assertEquals(node, node);
+    }
+
+    @Test
+    public void throwsWhenNodesArentEqual() {
+        var a = Node.objectNodeBuilder().withMember("foo", "bar").withMember("baz", true).build();
+        var b = Node.objectNodeBuilder().withMember("foo", "bar").withMember("baz", false).build();
+
+        Assertions.assertThrows(ExpectationNotMetException.class, () -> Node.assertEquals(a, b));
+    }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Context.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Context.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.ProtocolsTrait;
 import software.amazon.smithy.openapi.OpenApiException;
-import software.amazon.smithy.openapi.model.OpenApi;
 
 /**
  * Smithy to OpenAPI conversion context object.
@@ -34,14 +33,12 @@ public final class Context {
     private final Model model;
     private final ServiceShape service;
     private final JsonSchemaConverter jsonSchemaConverter;
-    private final OpenApi.Builder openApiBuilder;
     private final String protocolName;
     private final ProtocolsTrait.Protocol protocol;
     private final SchemaDocument schemas;
     private final List<SecuritySchemeConverter> securitySchemeConverters;
 
     public Context(
-            OpenApi.Builder openApiBuilder,
             Model model,
             ServiceShape service,
             JsonSchemaConverter jsonSchemaConverter,
@@ -50,7 +47,6 @@ public final class Context {
             SchemaDocument schemas,
             List<SecuritySchemeConverter> securitySchemeConverters
     ) {
-        this.openApiBuilder = openApiBuilder;
         this.model = model;
         this.service = service;
         this.jsonSchemaConverter = jsonSchemaConverter;
@@ -58,15 +54,6 @@ public final class Context {
         this.protocol = protocol;
         this.schemas = schemas;
         this.securitySchemeConverters = securitySchemeConverters;
-    }
-
-    /**
-     * Gets the OpenAPI builder being created.
-     *
-     * @return Returns the OpenAPI builder.
-     */
-    public OpenApi.Builder getOpenApiBuilder() {
-        return openApiBuilder;
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApi.java
@@ -22,7 +22,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.openapi.OpenApiConstants;
 
 /**
- * Converts Smithy to an OpenAPI model.
+ * Converts Smithy to an OpenAPI model and saves it as a JSON file.
  *
  * <p>This plugin requires a setting named "service" that is the
  * Shape ID of the Smithy service shape to convert to OpenAPI.
@@ -49,7 +49,7 @@ public final class Smithy2OpenApi implements SmithyBuildPlugin {
                 .expectStringNode("`" + OpenApiConstants.SERVICE + "` must be a string value")
                 .getValue());
 
-        var openApi = converter.convert(context.getModel(), shapeId);
-        context.getFileManifest().writeJson(shapeId.getName() + ".openapi.json", openApi.toNode());
+        var openApiNode = converter.convertToNode(context.getModel(), shapeId);
+        context.getFileManifest().writeJson(shapeId.getName() + ".openapi.json", openApiNode);
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/CheckForGreedyLabels.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/CheckForGreedyLabels.java
@@ -17,6 +17,11 @@ public class CheckForGreedyLabels implements SmithyOpenApiPlugin {
     private static final Logger LOGGER = Logger.getLogger(CheckForGreedyLabels.class.getName());
 
     @Override
+    public byte getOrder() {
+        return -128;
+    }
+
+    @Override
     public OpenApi after(Context context, OpenApi openApi) {
         var forbid = context.getConfig().getBooleanMemberOrDefault(OpenApiConstants.FORBID_GREEDY_LABELS);
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/CheckForPrefixHeaders.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/CheckForPrefixHeaders.java
@@ -25,6 +25,11 @@ public class CheckForPrefixHeaders implements SmithyOpenApiPlugin {
     private static final Logger LOGGER = Logger.getLogger(CheckForGreedyLabels.class.getName());
 
     @Override
+    public byte getOrder() {
+        return -128;
+    }
+
+    @Override
     public void before(Context context, OpenApi.Builder builder) {
         var httpBindings = context.getModel().getKnowledge(HttpBindingIndex.class);
         context.getModel().getShapeIndex().shapes(OperationShape.class).forEach(operation -> {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/RemoveUnusedComponentsPlugin.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/RemoveUnusedComponentsPlugin.java
@@ -27,6 +27,11 @@ public class RemoveUnusedComponentsPlugin implements SmithyOpenApiPlugin {
     private static final Logger LOGGER = Logger.getLogger(RemoveUnusedComponentsPlugin.class.getName());
 
     @Override
+    public byte getOrder() {
+        return 64;
+    }
+
+    @Override
     public OpenApi after(Context context, OpenApi openapi) {
         if (context.getConfig().getBooleanMemberOrDefault(OpenApiConstants.OPENAPI_KEEP_UNUSED_COMPONENTS)) {
             return openapi;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/UnsupportedTraitsPlugin.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/plugins/UnsupportedTraitsPlugin.java
@@ -22,6 +22,11 @@ public final class UnsupportedTraitsPlugin implements SmithyOpenApiPlugin {
             "inputEventStream", "outputEventStream", "eventPayload", "eventHeader", "streaming");
 
     @Override
+    public byte getOrder() {
+        return -128;
+    }
+
+    @Override
     public void before(Context context, OpenApi.Builder builder) {
         List<Pair<ShapeId, List<String>>> violations = context.getModel().getShapeIndex().shapes()
                 .map(shape -> new Pair<>(shape.getId(), TRAITS.stream()

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.openapi.fromsmithy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import java.util.Optional;
@@ -44,7 +43,7 @@ public class OpenApiConverterTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("test-service.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -60,7 +59,7 @@ public class OpenApiConverterTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("tagged-service.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -116,7 +115,7 @@ public class OpenApiConverterTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("unsupported-http-method.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -174,6 +173,6 @@ public class OpenApiConverterTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("mixed-security-service.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
@@ -83,7 +83,7 @@ public class OpenApiJsonSchemaMapperTest {
                 .config(Node.objectNodeBuilder().withMember(OpenApiConstants.OPEN_API_MODE, true).build())
                 .convert(ShapeIndex.builder().addShape(string).build(), string);
 
-        assertThat(document.getRootSchema().getExtension("externalDocs").get(), equalTo(Node.from(link)));
+        Node.assertEquals(document.getRootSchema().getExtension("externalDocs").get(), Node.from(link));
     }
 
     @Test

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocolTest.java
@@ -1,8 +1,5 @@
 package software.amazon.smithy.openapi.fromsmithy.protocols;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -24,7 +21,7 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("adds-json-document-bodies.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -50,7 +47,7 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("adds-path-timestamp-format.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -63,7 +60,7 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("adds-query-timestamp-format.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -76,7 +73,7 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("adds-query-blob-format.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -89,7 +86,7 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("adds-header-timestamp-format.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -102,7 +99,7 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("adds-header-mediatype-format.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test
@@ -115,6 +112,6 @@ public class AwsRestJsonProtocolTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("supports-payloads.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AmazonCognitoUserPoolsTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AmazonCognitoUserPoolsTest.java
@@ -1,8 +1,5 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -23,7 +20,7 @@ public class AmazonCognitoUserPoolsTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("cognito-user-pools-security.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 
     @Test

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4Test.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4Test.java
@@ -1,8 +1,5 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.LoaderUtils;
@@ -21,6 +18,6 @@ public class AwsV4Test {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("awsv4-security.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasicTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasicTest.java
@@ -1,8 +1,5 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.LoaderUtils;
@@ -21,6 +18,6 @@ public class HttpBasicTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("http-basic-security.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigestTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigestTest.java
@@ -1,8 +1,5 @@
 package software.amazon.smithy.openapi.fromsmithy.security;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.LoaderUtils;
@@ -21,6 +18,6 @@ public class HttpDigestTest {
         var expectedNode = Node.parse(LoaderUtils.readInputStream(
                 getClass().getResourceAsStream("http-digest-security.openapi.json"), "UTF-8"));
 
-        assertThat(result.toNode(), equalTo(expectedNode));
+        Node.assertEquals(result, expectedNode);
     }
 }


### PR DESCRIPTION
This commit adds the ability to map over the Node representation of an
OpenAPI model. This will allow plugins for things like expanding
CloudFormation expressions or substitutions. In order to make this more
deterministic, a sort order has been added to plugins using a byte
value.

To improve tests with more helpful error messages when working with
Nodes, the Node#assertEquals and Node#diff methods were added to the
Node class based on the previous NodeDiffer code.

Followup commits will add substitution support to the OpenAPI converter.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
