### PR TITLE
Add CloudFormation Fn::Sub expansion for API Gateway

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/main/java/module-info.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/module-info.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.aws.apigateway.openapi.AddApiKeySource;
 import software.amazon.smithy.aws.apigateway.openapi.AddAuthorizers;
 import software.amazon.smithy.aws.apigateway.openapi.AddBinaryTypes;
 import software.amazon.smithy.aws.apigateway.openapi.AddRequestValidators;
+import software.amazon.smithy.aws.apigateway.openapi.CloudFormationSubstitution;
 import software.amazon.smithy.openapi.fromsmithy.SmithyOpenApiPlugin;
 
 module software.amazon.smithy.aws.apigateway.openapi {
@@ -29,5 +30,6 @@ module software.amazon.smithy.aws.apigateway.openapi {
             AddAuthorizers,
             AddRequestValidators,
             AddBinaryTypes,
-            AddApiKeySource;
+            AddApiKeySource,
+            CloudFormationSubstitution;
 }

--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayConstants.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+/**
+ * API Gateway OpenAPI constants.
+ */
+public final class ApiGatewayConstants {
+    /**
+     * If set to true, disables CloudFormation substitutions of specific paths
+     * when they contain ${} placeholders. When found, these are expanded into
+     * CloudFormation Fn::Sub intrinsic functions.
+     */
+    public static final String DISABLE_CLOUDFORMATION_SUBSTITUTION = "apigateway.disableCloudFormationSubstitution";
+
+    private ApiGatewayConstants() {}
+}

--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.openapi.OpenApiConstants;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.SmithyOpenApiPlugin;
+import software.amazon.smithy.openapi.model.OpenApi;
+
+/**
+ * Finds and replaces CloudFormation variables into Fn::Sub intrinsic functions.
+ */
+public final class CloudFormationSubstitution implements SmithyOpenApiPlugin {
+    private static final Logger LOGGER = Logger.getLogger(CloudFormationSubstitution.class.getName());
+    private static final String SUBSTITUTION_KEY = "Fn::Sub";
+    private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{.+}");
+
+    /**
+     * This is a hardcoded list of paths that are known to contain ARNs or identifiers
+     * commonly extracted out of CloudFormation. This list may need to be updated over
+     * time as new features are added. Note that this list only expands to simple
+     * Fn::Sub. Anything more complex needs to be handled through JSON substitutions
+     * via {@link OpenApiConstants#SUBSTITUTIONS} as can anything that does not appear
+     * in this list.
+     */
+    private static final List<String> PATHS = Arrays.asList(
+            "components/securitySchemes/*/x-amazon-apigateway-authorizer/providerARNs/*",
+            "components/securitySchemes/*/x-amazon-apigateway-authorizer/authorizerCredentials",
+            "components/securitySchemes/*/x-amazon-apigateway-authorizer/authorizerUri",
+            "paths/*/*/x-amazon-apigateway-integration/connectionId",
+            "paths/*/*/x-amazon-apigateway-integration/credentials",
+            "paths/*/*/x-amazon-apigateway-integration/uri");
+
+    @Override
+    public byte getOrder() {
+        return 127;
+    }
+
+    @Override
+    public ObjectNode updateNode(Context context, OpenApi openapi, ObjectNode node) {
+        if (!context.getConfig().getBooleanMemberOrDefault(ApiGatewayConstants.DISABLE_CLOUDFORMATION_SUBSTITUTION)) {
+            return node.accept(new CloudFormationFnSubInjector(PATHS)).expectObjectNode();
+        }
+
+        return node;
+    }
+
+    private static class CloudFormationFnSubInjector extends NodeVisitor.Default<Node> {
+        private final Deque<String> stack = new ArrayDeque<>();
+        private final List<String[]> paths;
+
+        CloudFormationFnSubInjector(List<String> paths) {
+            this.paths = paths.stream().map(path -> path.split(Pattern.quote("/"))).collect(Collectors.toList());
+        }
+
+        @Override
+        protected Node getDefault(Node node) {
+            return node;
+        }
+
+        @Override
+        public Node arrayNode(ArrayNode node) {
+            List<Node> result = new ArrayList<>();
+            for (int i = 0; i < node.size(); i++) {
+                Node member = node.get(i).get();
+                stack.addLast(String.valueOf(i));
+                result.add(member.accept(this));
+                stack.removeLast();
+            }
+
+            return new ArrayNode(result, SourceLocation.NONE);
+        }
+
+        @Override
+        public Node objectNode(ObjectNode node) {
+            Map<StringNode, Node> result = new LinkedHashMap<>();
+            for (Map.Entry<StringNode, Node> entry : node.getMembers().entrySet()) {
+                stack.addLast(entry.getKey().getValue());
+                result.put(entry.getKey(), entry.getValue().accept(this));
+                stack.removeLast();
+            }
+
+            return new ObjectNode(result, SourceLocation.NONE);
+        }
+
+        @Override
+        public Node stringNode(StringNode node) {
+            if (SUBSTITUTION_PATTERN.matcher(node.getValue()).find() && isInPath()) {
+                LOGGER.fine(() -> String.format(
+                        "Detected CloudFormation variable syntax in %s; replacing with a `Fn::Sub` "
+                        + "CloudFormation intrinsic function block", node.getValue()));
+                return Node.objectNode().withMember(SUBSTITUTION_KEY, node);
+            }
+
+            return node;
+        }
+
+        private boolean isInPath() {
+            return paths.stream().anyMatch(this::matchesPath);
+        }
+
+        private boolean matchesPath(String[] path) {
+            Iterator<String> iterator = stack.iterator();
+            for (String segment : path) {
+                if (!iterator.hasNext()) {
+                    return false;
+                }
+                String current = iterator.next();
+                if (!segment.equals(current) && !segment.equals("*")) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
+++ b/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.LoaderUtils;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+
+public class CloudFormationSubstitutionTest {
+    @Test
+    public void performsSubstitutionsByDefault() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("cloudformation-substitutions.json"))
+                .assemble()
+                .unwrap();
+
+        ObjectNode expected = Node.parse(
+                LoaderUtils.readUtf8File(getClass().getResource("substitution-performed.json").getPath()))
+                .expectObjectNode();
+
+        var actual = OpenApiConverter.create()
+                .classLoader(getClass().getClassLoader())
+                .convertToNode(model, ShapeId.from("example.smithy#MyService"));
+
+        Node.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void pluginCanBeDisabled() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("cloudformation-substitutions.json"))
+                .assemble()
+                .unwrap();
+
+        ObjectNode expected = Node.parse(
+                LoaderUtils.readUtf8File(getClass().getResource("substitution-not-performed.json").getPath()))
+                .expectObjectNode();
+
+        var actual = OpenApiConverter.create()
+                .classLoader(getClass().getClassLoader())
+                .putSetting(ApiGatewayConstants.DISABLE_CLOUDFORMATION_SUBSTITUTION, true)
+                .convertToNode(model, ShapeId.from("example.smithy#MyService"));
+
+        Node.assertEquals(expected, actual);
+    }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cloudformation-substitutions.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cloudformation-substitutions.json
@@ -1,0 +1,32 @@
+{
+  "smithy": "1.0",
+  "example.smithy": {
+    "shapes": {
+      "MyService": {
+        "type": "service",
+        "version": "2006-03-01",
+        "protocols": {
+          "aws.rest-json": {
+          }
+        },
+        "authentication": {
+          "apigateway.cognito-user-pools": {
+            "settings": {
+              "providerARNs": "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/user_pool_id,arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/other_user_pool_id"
+            }
+          }
+        },
+        "operations": [
+          "MyOperation"
+        ]
+      },
+      "MyOperation": {
+        "type": "operation",
+        "http": {
+          "uri": "/foo",
+          "method": "GET"
+        }
+      }
+    }
+  }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "MyService",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "operationId": "MyOperation",
+        "responses": {
+          "200": {
+            "description": "MyOperation response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apigateway.cognito-user-pools": {
+        "type": "apiKey",
+        "description": "Amazon Cognito User Pools authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "cognito_user_pools",
+        "x-amazon-apigateway-authorizer": {
+          "type": "cognito_user_pools",
+          "providerARNs": [
+            "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/user_pool_id",
+            "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/other_user_pool_id"
+          ]
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "apigateway.cognito-user-pools": [ ]
+    }
+  ]
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "MyService",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "operationId": "MyOperation",
+        "responses": {
+          "200": {
+            "description": "MyOperation response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apigateway.cognito-user-pools": {
+        "type": "apiKey",
+        "description": "Amazon Cognito User Pools authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "cognito_user_pools",
+        "x-amazon-apigateway-authorizer": {
+          "type": "cognito_user_pools",
+          "providerARNs": [
+            {"Fn::Sub": "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/user_pool_id"},
+            {"Fn::Sub": "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/other_user_pool_id"}
+          ]
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "apigateway.cognito-user-pools": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds the automatic expansion of ${} placeholders in specific
places of a generated API Gateway model to become a CloudFormation
Fn::Sub. This can be disabled if necessary. Additional paths could
potentially be supported later using additional configuration options.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
