### PR TITLE
Fix unreferenced private prelude shape

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.2.0"
+    version = "0.2.1"
 }
 
 subprojects {

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/smithy-prelude-traits.json
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/smithy-prelude-traits.json
@@ -292,16 +292,6 @@
         },
         "private": true
       },
-      "StringMap": {
-        "type": "map",
-        "key": {
-          "target": "String"
-        },
-        "value": {
-          "target": "String"
-        },
-        "private": true
-      },
       "NonEmptyStringMap": {
         "type": "map",
         "key": {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
@@ -45,7 +45,7 @@ public class ScrubTraitDefinitionsTest {
         assertThat(index.getShape(ShapeId.from("ns.foo#IpsumList")), Matchers.not(Optional.empty()));
         assertThat(index.getShape(ShapeId.from("ns.foo#KeepStructure")), Matchers.not(Optional.empty()));
 
-        // Make sure public prelude shapes were'nt removed.
+        // Make sure public prelude shapes weren't removed.
         assertThat(index.getShape(ShapeId.from("smithy.api#String")), Matchers.not(Optional.empty()));
         assertThat(index.getShape(ShapeId.from("smithy.api#Blob")), Matchers.not(Optional.empty()));
         assertThat(index.getShape(ShapeId.from("smithy.api#Boolean")), Matchers.not(Optional.empty()));


### PR DESCRIPTION
This commit removes the unused, private smithy.api#StringMap from the
prelude traits file. It also adds a test to enforce that private shapes
cannot be in the prelude if they are unreferenced by a trait definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
