### PR TITLE
Update computed operation condition keys

### DIFF
--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/iam/ConditionKeysIndexTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/iam/ConditionKeysIndexTest.java
@@ -18,7 +18,10 @@ package software.amazon.smithy.aws.traits.iam;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
@@ -51,19 +54,16 @@ public class ConditionKeysIndexTest {
         assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#Resource2")),
                    containsInAnyOrder("aws:accountId", "foo:baz",
                                       "myservice:Resource1Id1", "myservice:Resource2Id2"));
-        // Note that this operation does bind all identifiers, so it includes both ID1 and 2.
-        assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#GetResource2")),
-                   containsInAnyOrder("aws:accountId", "foo:baz",
-                                      "myservice:Resource1Id1", "myservice:Resource2Id2"));
-        // Note that this operation does not bind all identifiers, so it does not include ID2.
-        assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#ListResource2")),
-                   containsInAnyOrder("aws:accountId", "foo:baz", "myservice:Resource1Id1"));
+        // Note that while this operation binds identifiers, it contains no unique ConditionKeys to bind.
+        assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#GetResource2")), is(empty()));
 
         // Defined context keys are assembled from the names and mapped with the definitions.
         assertThat(index.getDefinedConditionKeys(service).get("myservice:Resource1Id1").getDocumentation(),
                    not(Optional.empty()));
+        assertEquals(index.getDefinedConditionKeys(service).get("myservice:Resource2Id2").getDocumentation().get(),
+                "This is Foo");
         assertThat(index.getDefinedConditionKeys(service, ShapeId.from("smithy.example#GetResource2")).keySet(),
-                   containsInAnyOrder("foo:baz", "myservice:Resource1Id1", "myservice:Resource2Id2"));
+                   is(empty()));
     }
 
     @Test

--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/iam/successful-condition-keys.smithy
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/iam/successful-condition-keys.smithy
@@ -25,7 +25,7 @@ resource Resource1 {
 resource Resource2 {
   identifiers: {
     id1: ArnString,
-    id2: String,
+    id2: FooString,
   },
   read: GetResource2,
   list: ListResource2,
@@ -40,8 +40,11 @@ structure GetResource2Input {
   id1: ArnString,
 
   @required
-  id2: String
+  id2: FooString
 }
+
+@documentation("This is Foo")
+string FooString
 
 @readonly
 @collectionOperation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.3.0"
+    version = "0.3.1"
 }
 
 subprojects {


### PR DESCRIPTION
This commit changes the way resource operation conditition keys
are derived to not use those defined on the enclosing resource.
It also adds the ability to derive inferred condition key
documentation from the model, if present, instead of computing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
