### PR TITLE
Add support for CORS in Smithy -> API Gateway

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.smithy.aws.traits.apigateway.IntegrationResponse;
+import software.amazon.smithy.aws.traits.apigateway.MockIntegrationTrait;
+import software.amazon.smithy.jsonschema.Schema;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.traits.CorsTrait;
+import software.amazon.smithy.openapi.OpenApiException;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
+import software.amazon.smithy.openapi.model.OperationObject;
+import software.amazon.smithy.openapi.model.ParameterObject;
+import software.amazon.smithy.openapi.model.PathItem;
+import software.amazon.smithy.openapi.model.Ref;
+import software.amazon.smithy.openapi.model.ResponseObject;
+import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Adds CORS-preflight OPTIONS requests using mock API Gateway integrations.
+ *
+ * <p>This allows clients to first make an OPTIONS request to a URI to
+ * determine what possible actions can be made on the URI. Rather than require
+ * models to explicitly define and implement these protocol-specific
+ * integrations, we can generate a static response using API Gateway mock
+ * integrations.
+ *
+ * <p>TODO: Only add security scheme headers on a per/operation basis.
+ * We currently add security headers to the CORS headers that contains all
+ * security schemes defined in the model. An improvement here would be to only
+ * include headers that are added by security schemes on a per/operation basis.
+ *
+ * <p>This extension only takes effect if the service being converted to
+ * OpenAPI has the CORS trait.
+ *
+ * @see <a href="https://fetch.spec.whatwg.org/#cors-preflight-fetch-0">CORS-preflight fetch</a>
+ */
+final class AddCorsPreflightIntegration implements OpenApiMapper {
+    private static final Logger LOGGER = Logger.getLogger(AddCorsPreflightIntegration.class.getName());
+    private static final String API_GATEWAY_DEFAULT_ACCEPT_VALUE = "application/json";
+    private static final String INTEGRATION_EXTENSION = "x-amazon-apigateway-integration";
+    private static final String PREFLIGHT_SUCCESS = "{\"statusCode\":200}";
+
+    @Override
+    public PathItem updatePathItem(Context context, String path, PathItem pathItem) {
+        return context.getService().getTrait(CorsTrait.class)
+                .map(corsTrait -> addPreflightIntegration(context, path, pathItem, corsTrait))
+                .orElse(pathItem);
+    }
+
+    private static PathItem addPreflightIntegration(
+            Context context, String path, PathItem pathItem, CorsTrait corsTrait) {
+        // Filter out any path for which an OPTIONS handler has already been defined
+        if (pathItem.getOptions().isPresent()) {
+            LOGGER.fine(() -> path + " already defines an OPTIONS request, so no need to generate CORS-preflight");
+            return pathItem;
+        }
+
+        LOGGER.fine(() -> "Adding CORS-preflight OPTIONS request and API Gateway integration for " + path);
+        Map<CorsHeader, String> headers = deduceCorsHeaders(context, path, pathItem, corsTrait);
+        return pathItem.toBuilder()
+                .options(createPreflightOperation(path, pathItem, headers))
+                .build();
+    }
+
+    private static Map<CorsHeader, String> deduceCorsHeaders(
+            Context context, String path, PathItem pathItem, CorsTrait corsTrait) {
+        Map<CorsHeader, String> corsHeaders = new HashMap<>();
+        corsHeaders.put(CorsHeader.MAX_AGE, String.valueOf(corsTrait.getMaxAge()));
+        corsHeaders.put(CorsHeader.ALLOW_ORIGIN, corsTrait.getOrigin());
+        corsHeaders.put(CorsHeader.ALLOW_METHODS, getAllowMethods(pathItem));
+
+        if (context.usesHttpCredentials()) {
+            corsHeaders.put(CorsHeader.ALLOW_CREDENTIALS, "true");
+        }
+
+        // Find each header defined in this PathItem. The collected headers are added to the
+        // Access-Control-Allow-Headers header list. Note that any further modifications that
+        // add headers during the Smithy to OpenAPI conversion process will need to update this
+        // list of headers accordingly.
+        Set<String> headerNames = new TreeSet<>(corsTrait.getAdditionalAllowedHeaders());
+        headerNames.addAll(findAllHeaders(path, pathItem));
+
+        // Add all headers generated by security schemes.
+        for (SecuritySchemeConverter converter : context.getSecuritySchemeConverters()) {
+            headerNames.addAll(converter.getAuthRequestHeaders());
+        }
+
+        LOGGER.fine(() -> String.format(
+                "Adding the following %s headers to `%s`: %s", CorsHeader.ALLOW_HEADERS, path, headerNames));
+        corsHeaders.put(CorsHeader.ALLOW_HEADERS, String.join(",", headerNames));
+
+        return corsHeaders;
+    }
+
+    private static Collection<String> findAllHeaders(String path, PathItem pathItem) {
+        // Get all "in" = "header" parameters and gather up their "name" properties.
+        return pathItem.getOperations().values().stream()
+                .flatMap(operationObject -> operationObject.getParameters().stream())
+                .filter(parameter -> parameter.getIn().filter(in -> in.equals("header")).isPresent())
+                .map(parameter -> parameter.getName().orElseThrow(() -> new OpenApiException(
+                        "OpenAPI header parameter is missing a name in " + path)))
+                .collect(Collectors.toList());
+    }
+
+    private static String getAllowMethods(PathItem item) {
+        return String.join(",", item.getOperations().keySet());
+    }
+
+    private static OperationObject createPreflightOperation(
+            String path, PathItem pathItem, Map<CorsHeader, String> headers) {
+        return OperationObject.builder()
+                .tags(ListUtils.of("CORS"))
+                .description("Handles CORS-preflight requests")
+                .operationId(createOperationId(path))
+                .putResponse("200", createPreflightResponse(headers))
+                .parameters(findPathParameters(pathItem))
+                .putExtension(INTEGRATION_EXTENSION, createPreflightIntegration(headers, pathItem))
+                .build();
+    }
+
+    private static List<ParameterObject> findPathParameters(PathItem pathItem) {
+        // The first found operation in the path is used for path parameters since they should all be the same.
+        List<ParameterObject> parameterObjects = new ArrayList<>();
+        Iterator<OperationObject> iter = pathItem.getOperations().values().iterator();
+        if (iter.hasNext()) {
+            for (ParameterObject parameter : iter.next().getParameters()) {
+                if (parameter.getIn().filter(in -> in.equals("path")).isPresent()) {
+                    parameterObjects.add(parameter);
+                }
+            }
+        }
+
+        return parameterObjects;
+    }
+
+    private static String createOperationId(String path) {
+        // Make the operationId all alphanumeric camel case characters.
+        return CaseUtils.toCamelCase("Cors" + path, true, '{', '}', '/', '?', '&', '=')
+                .replaceAll("[^A-Z0-9a-z_]", "_");
+    }
+
+    private static ResponseObject createPreflightResponse(Map<CorsHeader, String> headers) {
+        // The preflight response just returns all of the computed CORS headers.
+        ResponseObject.Builder builder = ResponseObject.builder()
+                .description("Canned response for CORS-preflight requests");
+        ParameterObject headerParameter = ParameterObject.builder()
+                .schema(Schema.builder().type("string").build())
+                .build();
+        headers.forEach((name, value) -> builder.putHeader(name.toString(), Ref.local(headerParameter)));
+        return builder.build();
+    }
+
+    private static ObjectNode createPreflightIntegration(Map<CorsHeader, String> headers, PathItem pathItem) {
+        IntegrationResponse.Builder responseBuilder = IntegrationResponse.builder().statusCode("200");
+
+        // Add each CORS header to the mock integration response.
+        for (Map.Entry<CorsHeader, String> e : headers.entrySet()) {
+            responseBuilder.putResponseParameter("method.response.header." + e.getKey(), "'" + e.getValue() + "'");
+        }
+
+        MockIntegrationTrait.Builder integration = MockIntegrationTrait.builder()
+                .passThroughBehavior("when_no_match")
+                .putResponse("default", responseBuilder.build())
+                .putRequestTemplate(API_GATEWAY_DEFAULT_ACCEPT_VALUE, PREFLIGHT_SUCCESS);
+
+        // Add a request template for every mime-type of every response.
+        for (OperationObject operation : pathItem.getOperations().values()) {
+            for (String mimeType : operation.getResponses().keySet()) {
+                integration.putRequestTemplate(mimeType, PREFLIGHT_SUCCESS);
+            }
+        }
+
+        // Ensure that the mock integration include the "type" = "mock" property.
+        return integration.build().toNode().expectObjectNode().withMember("type", "mock");
+    }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsResponseHeaders.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsResponseHeaders.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.jsonschema.Schema;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.traits.CorsTrait;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.model.ParameterObject;
+import software.amazon.smithy.openapi.model.Ref;
+import software.amazon.smithy.openapi.model.ResponseObject;
+
+/**
+ * Adds CORS-specific headers to every response in the API.
+ *
+ * <p>Values will be provided for the headers added to each operation by updating
+ * the API Gateway integration of each operation to provide a static value for
+ * each CORS header. This mapping is performed in {@link AddIntegrations}.
+ *
+ * <p>This extension only takes effect if the service being converted to
+ * OpenAPI has the CORS trait.
+ */
+final class AddCorsResponseHeaders implements OpenApiMapper {
+    private static final Logger LOGGER = Logger.getLogger(AddCorsResponseHeaders.class.getName());
+
+    @Override
+    public ResponseObject updateResponse(
+            Context context, String status, OperationShape shape, ResponseObject response) {
+        return context.getService().getTrait(CorsTrait.class)
+                .map(corsTrait -> addCorsHeadersToResponse(context, shape, response, corsTrait))
+                .orElse(response);
+    }
+
+    private ResponseObject addCorsHeadersToResponse(
+            Context context, OperationShape operation, ResponseObject response, CorsTrait corsTrait) {
+        // Determine which headers have been added to the response.
+        List<String> headers = new ArrayList<>();
+        headers.add(CorsHeader.ALLOW_ORIGIN.toString());
+        if (!CorsHeader.deduceOperationHeaders(context, operation, corsTrait).isEmpty()) {
+            headers.add(CorsHeader.EXPOSE_HEADERS.toString());
+        }
+
+        // Only add the "Access-Control-Allow-Credentials" header if one of the authentications schemes
+        // of the service uses HTTP credentials such as cookies or browser-managed usernames as specified
+        // in https://fetch.spec.whatwg.org/#credentials.
+        if (context.usesHttpCredentials()) {
+            headers.add(CorsHeader.ALLOW_CREDENTIALS.toString());
+        }
+
+        LOGGER.finer(() -> String.format("Adding CORS headers to `%s` response: %s", operation.getId(), headers));
+
+        ResponseObject.Builder builder = response.toBuilder();
+        Schema headerSchema = Schema.builder().type("string").build();
+
+        // Inject the header parameters into the response IFF the header does not already exist.
+        for (String headerName : headers) {
+            if (!response.getHeader(headerName).isPresent()) {
+                ParameterObject headerParam = ParameterObject.builder()
+                        .schema(headerSchema)
+                        .build();
+                builder.putHeader(headerName, Ref.local(headerParam));
+            }
+        }
+
+        return builder.build();
+    }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -15,37 +15,141 @@
 
 package software.amazon.smithy.aws.apigateway.openapi;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Logger;
+import software.amazon.smithy.aws.traits.apigateway.IntegrationTrait;
 import software.amazon.smithy.aws.traits.apigateway.IntegrationTraitIndex;
 import software.amazon.smithy.aws.traits.apigateway.MockIntegrationTrait;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.traits.CorsTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.openapi.OpenApiException;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OperationObject;
+import software.amazon.smithy.utils.Pair;
 
 /**
  * Adds API Gateway integrations to operations.
+ *
+ * <p>If the service has the {@link CorsTrait}, then integration responses
+ * will include a statically computed Access-Control-Expose-Headers
+ * CORS headers that contains every header exposed by the integration,
+ * and Access-Control-Allow-Credentials header if the operation uses
+ * a security scheme that needs it, and and Access-Control-Allow-Origin
+ * header that is the result of {@link CorsTrait#getOrigin()}.
  */
-public final class AddIntegrations implements OpenApiMapper {
-    private static final String EXTENSION_NAME = "x-amazon-apigateway-integration";
+final class AddIntegrations implements OpenApiMapper {
     private static final Logger LOGGER = Logger.getLogger(AddIntegrations.class.getName());
+    private static final String EXTENSION_NAME = "x-amazon-apigateway-integration";
+    private static final String RESPONSES_KEY = "responses";
+    private static final String HEADER_PREFIX = "method.response.header.";
+    private static final String DEFAULT_KEY = "default";
+    private static final String STATUS_CODE_KEY = "statusCode";
+    private static final String RESPONSE_PARAMETERS_KEY = "responseParameters";
 
     @Override
     public OperationObject updateOperation(Context context, OperationShape shape, OperationObject operation) {
         IntegrationTraitIndex index = context.getModel().getKnowledge(IntegrationTraitIndex.class);
         return index.getIntegrationTrait(context.getService(), shape)
-                .map(trait -> {
-                    ObjectNode node = trait.toNode().expectObjectNode();
-                    if (trait instanceof MockIntegrationTrait) {
-                        node = node.withMember("type", Node.from("mock"));
-                    }
-                    return operation.toBuilder().putExtension(EXTENSION_NAME, node).build();
-                })
+                .map(trait -> operation.toBuilder()
+                        .putExtension(EXTENSION_NAME, createIntegration(context, shape, trait))
+                        .build())
                 .orElseGet(() -> {
                     LOGGER.warning("No API Gateway integration trait found for " + shape.getId());
                     return operation;
                 });
+    }
+
+    private ObjectNode createIntegration(Context context, OperationShape shape, Trait integration) {
+        ObjectNode integrationObject = getIntegrationAsObject(context, shape, integration);
+        return context.getService().getTrait(CorsTrait.class)
+                .map(cors -> {
+                    LOGGER.fine(() -> String.format("Adding CORS to `%s` operation responses", shape.getId()));
+                    return updateIntegrationWithCors(context, shape, integrationObject, cors);
+                })
+                .orElse(integrationObject);
+    }
+
+    private static ObjectNode getIntegrationAsObject(Context context, OperationShape shape, Trait integration) {
+        if (integration instanceof MockIntegrationTrait) {
+            return integration.toNode().expectObjectNode().withMember("type", Node.from("mock"));
+        } else if (integration instanceof IntegrationTrait) {
+            return ((IntegrationTrait) integration).toExpandedNode(context.getService(), shape);
+        } else {
+            throw new OpenApiException("Unexpected integration trait: " + integration);
+        }
+    }
+
+    private ObjectNode updateIntegrationWithCors(
+            Context context, OperationShape shape, ObjectNode integrationNode, CorsTrait cors) {
+        ObjectNode responses = integrationNode.getObjectMember(RESPONSES_KEY).orElse(Node.objectNode());
+
+        // Always include a "default" response that has the same HTTP response code.
+        if (!responses.getMember(DEFAULT_KEY).isPresent()) {
+            responses = responses.withMember(DEFAULT_KEY, Node.objectNode().withMember(STATUS_CODE_KEY, "200"));
+        }
+
+        Map<CorsHeader, String> corsHeaders = new HashMap<>();
+        corsHeaders.put(CorsHeader.ALLOW_ORIGIN, cors.getOrigin());
+        if (context.usesHttpCredentials()) {
+            corsHeaders.put(CorsHeader.ALLOW_CREDENTIALS, "true");
+        }
+
+        LOGGER.finer(() -> String.format("Adding the following CORS headers to the API Gateway integration of %s: %s",
+                                         shape.getId(), corsHeaders));
+        Set<String> deducedHeaders = CorsHeader.deduceOperationHeaders(context, shape, cors);
+        LOGGER.fine(() -> String.format("Detected the following headers for operation %s: %s",
+                                        shape.getId(), deducedHeaders));
+
+        // Update each response by adding CORS headers.
+        responses = responses.getMembers().entrySet().stream()
+                .peek(entry -> LOGGER.fine(() -> String.format(
+                        "Updating integration response %s for `%s` with CORS", entry.getKey(), shape.getId())))
+                .map(entry -> Pair.of(entry.getKey(), updateIntegrationResponse(
+                        shape, corsHeaders, deducedHeaders, entry.getValue().expectObjectNode())))
+                .collect(ObjectNode.collect(Pair::getLeft, Pair::getRight));
+
+        return integrationNode.withMember(RESPONSES_KEY, responses);
+    }
+
+    private ObjectNode updateIntegrationResponse(
+            OperationShape shape, Map<CorsHeader, String> corsHeaders, Set<String> deduced, ObjectNode response) {
+        Map<CorsHeader, String> responseHeaders = new HashMap<>(corsHeaders);
+        ObjectNode responseParams = response.getObjectMember(RESPONSE_PARAMETERS_KEY).orElseGet(Node::objectNode);
+
+        // Created a sorted set of all headers exposed in the integration.
+        Set<String> headersToExpose = new TreeSet<>(deduced);
+        responseParams.getStringMap().keySet().stream()
+                .filter(parameterName -> parameterName.startsWith(HEADER_PREFIX))
+                .map(parameterName -> parameterName.substring(HEADER_PREFIX.length()))
+                .forEach(headersToExpose::add);
+        String headersToExposeString = String.join(",", headersToExpose);
+
+        // If there are exposed headers, then add a new header to the integration
+        // that lists all of them. See https://fetch.spec.whatwg.org/#http-access-control-expose-headers.
+        if (!headersToExposeString.isEmpty()) {
+            responseHeaders.put(CorsHeader.EXPOSE_HEADERS, headersToExposeString);
+            LOGGER.fine(() -> String.format("Adding `%s` header to `%s` with value of `%s`",
+                                            CorsHeader.EXPOSE_HEADERS, shape.getId(), headersToExposeString));
+        }
+
+        if (responseHeaders.isEmpty()) {
+            LOGGER.fine(() -> "No headers are exposed by " + shape.getId());
+            return response;
+        }
+
+        // Create an updated response that injects Access-Control-Expose-Headers.
+        ObjectNode.Builder builder = responseParams.toBuilder();
+        for (Map.Entry<CorsHeader, String> entry : responseHeaders.entrySet()) {
+            builder.withMember(HEADER_PREFIX + entry.getKey(), "'" + entry.getValue() + "'");
+        }
+
+        return response.withMember(RESPONSE_PARAMETERS_KEY, builder.build());
     }
 }

--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayExtension.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayExtension.java
@@ -30,7 +30,10 @@ public final class ApiGatewayExtension implements Smithy2OpenApiExtension {
                 new AddBinaryTypes(),
                 new AddIntegrations(),
                 new AddRequestValidators(),
-                new CloudFormationSubstitution()
+                new CloudFormationSubstitution(),
+                new AddCorsResponseHeaders(),
+                new AddCorsPreflightIntegration(),
+                new AddCorsToGatewayResponses()
         );
     }
 

--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CorsHeader.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CorsHeader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.traits.CorsTrait;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
+
+enum CorsHeader {
+
+    ALLOW_CREDENTIALS("Access-Control-Allow-Credentials"),
+    ALLOW_HEADERS("Access-Control-Allow-Headers"),
+    ALLOW_METHODS("Access-Control-Allow-Methods"),
+    ALLOW_ORIGIN("Access-Control-Allow-Origin"),
+    EXPOSE_HEADERS("Access-Control-Expose-Headers"),
+    MAX_AGE("Access-Control-Max-Age");
+
+    private final String headerName;
+
+    CorsHeader(String headerName) {
+        this.headerName = headerName;
+    }
+
+    @Override
+    public String toString() {
+        return headerName;
+    }
+
+    static Set<String> deduceOperationHeaders(Context context, OperationShape shape, CorsTrait cors) {
+        // The deduced response headers of an operation consist of any headers
+        // returned by security schemes, any headers returned by the protocol,
+        // and any headers explicitly modeled on the operation.
+        Set<String> result = new TreeSet<>(cors.getAdditionalExposedHeaders());
+        result.addAll(context.getOpenApiProtocol().getProtocolResponseHeaders(context, shape));
+        for (SecuritySchemeConverter converter : context.getSecuritySchemeConverters()) {
+            result.addAll(converter.getAuthResponseHeaders());
+        }
+
+        return result;
+    }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CorsTest.java
+++ b/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CorsTest.java
@@ -1,0 +1,86 @@
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.IoUtils;
+
+public class CorsTest {
+    @Test
+    public void corsIntegrationTest() {
+        Model model = Model.assembler(getClass().getClassLoader())
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("cors-model.json"))
+                .assemble()
+                .unwrap();
+        ObjectNode result = OpenApiConverter.create().convertToNode(model, ShapeId.from("example.smithy#MyService"));
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("cors-model.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+
+    @Test
+    public void skipsExplicitlyDefinedOptionsOperations() {
+        Model model = Model.assembler(getClass().getClassLoader())
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("cors-explicit-options.json"))
+                .assemble()
+                .unwrap();
+        ObjectNode result = OpenApiConverter.create().convertToNode(model, ShapeId.from("example.smithy#MyService"));
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("cors-explicit-options.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+
+    /**
+     * This test asserts two things: First, it ensures that any existing CORS headers
+     * set on an explicitly added API Gateway integration are not overwritten
+     * (i.e., the "Access-Control-Allow-Origin" is "domain.com" intsead of https://foo.com).
+     * Next, it asserts that any other headers in the gateway response show up in the
+     * injected Access-Control-Expose-Headers header.
+     */
+    @Test
+    public void findsExistingGatewayHeaders() {
+        Model model = Model.assembler(getClass().getClassLoader())
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("cors-explicit-options.json"))
+                .assemble()
+                .unwrap();
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("cors-with-custom-gateway-response-headers.openapi.json")));
+
+        // Create an OpenAPI model.
+        ObjectNode result = OpenApiConverter.create()
+                .addOpenApiMapper(new OpenApiMapper() {
+                    @Override
+                    public byte getOrder() {
+                        return -127;
+                    }
+
+                    @Override
+                    public OpenApi after(Context context, OpenApi openapi) {
+                        // Inject a gateway response into the model.
+                        return openapi.toBuilder()
+                                .putExtension("x-amazon-apigateway-gateway-responses", Node.objectNodeBuilder()
+                                        .withMember("ACCESS_DENIED", Node.objectNode()
+                                                .withMember("statusCode", 403)
+                                                .withMember("responseParameters", Node.objectNode()
+                                                        .withMember("gatewayresponse.header.Access-Control-Allow-Origin", "'domain.com'")
+                                                        .withMember("gatewayresponse.header.Foo", "'baz'")))
+                                        .build())
+                                .build();
+                    }
+                })
+                .convertToNode(model, ShapeId.from("example.smithy#MyService"));
+
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.json
@@ -1,0 +1,57 @@
+{
+  "smithy": "1.0",
+  "example.smithy": {
+    "shapes": {
+      "MyService": {
+        "type": "service",
+        "version": "2006-03-01",
+        "protocols": [{"name": "aws.rest-json-1.1", "auth": ["http-basic"]}],
+        "operations": [
+          "Foo",
+          "FooOptions"
+        ],
+        "cors": {
+          "origin": "https://foo.com"
+        }
+      },
+      "Foo": {
+        "type": "operation",
+        "http": {
+          "uri": "/foo",
+          "method": "PUT",
+          "code": 201
+        },
+        "aws.apigateway#integration": {
+          "type": "aws_proxy",
+          "credentials": "arn:aws:iam::123456789012:role/Foo",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:bar/invocations",
+          "httpMethod": "POST"
+        }
+      },
+      "FooOptions": {
+        "type": "operation",
+        "output": "FooOptionsOutput",
+        "http": {
+          "uri": "/foo",
+          "method": "OPTIONS",
+          "code": 200
+        },
+        "aws.apigateway#integration": {
+          "type": "aws",
+          "credentials": "arn:aws:iam::123456789012:role/FooOptions",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:baz/invocations",
+          "httpMethod": "POST"
+        }
+      },
+      "FooOptionsOutput": {
+        "type": "structure",
+        "members": {
+          "hd": {
+            "target": "String",
+            "httpHeader": "X-Hd"
+          }
+        }
+      }
+    }
+  }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
@@ -1,0 +1,106 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "MyService",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/foo": {
+      "put": {
+        "operationId": "Foo",
+        "responses": {
+          "201": {
+            "description": "Foo response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws_proxy",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:bar/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/Foo",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'"
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "FooOptions",
+        "responses": {
+          "200": {
+            "description": "FooOptions 200 response",
+            "headers": {
+              "X-Hd": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:baz/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/FooOptions",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "http-basic": {
+        "type": "http",
+        "description": "HTTP Basic authentication",
+        "scheme": "Basic"
+      }
+    }
+  },
+  "security": [
+    {
+      "http-basic": [ ]
+    }
+  ],
+  "x-amazon-apigateway-gateway-responses": {
+    "DEFAULT_4XX": {
+      "responseTemplates": {
+        "application/json": "{\"message\":$context.error.messageString}"
+      },
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'https://foo.com'"
+      }
+    },
+    "DEFAULT_5XX": {
+      "responseTemplates": {
+        "application/json": "{\"message\":$context.error.messageString}"
+      },
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'https://foo.com'"
+      }
+    }
+  }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
@@ -1,0 +1,177 @@
+{
+  "smithy": "1.0",
+  "example.smithy": {
+    "shapes": {
+      "MyService": {
+        "type": "service",
+        "version": "2006-03-01",
+        "protocols": [{"name": "aws.rest-json-1.1", "auth": ["aws.v4", "http-basic"]}],
+        "cors": {
+          "origin": "https://www.example.com",
+          "maxAge": 86400,
+          "additionalAllowedHeaders": [
+            "X-Service-Input-Metadata"
+          ],
+          "additionalExposedHeaders": [
+            "X-Service-Output-Metadata"
+          ]
+        },
+        "resources": [
+          "Payload"
+        ],
+        "aws.apigateway#integration": {
+          "type": "aws_proxy",
+          "credentials": "arn:aws:iam::123456789012:role/{serviceName}{operationName}LambdaRole",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:{serviceName}{operationName}/invocations",
+          "httpMethod": "POST"
+        }
+      },
+      "Payload": {
+        "type": "resource",
+        "identifiers": {
+          "id": "smithy.api#String"
+        },
+        "create": "PutPayload",
+        "read": "GetPayload",
+        "delete": "DeletePayload",
+        "list": "ListPayloads"
+      },
+      "PutPayload": {
+        "type": "operation",
+        "idempotent": true,
+        "input": "PutPayloadInput",
+        "http": {
+          "uri": "/payload/{id}",
+          "method": "PUT",
+          "code": 201
+        }
+      },
+      "GetPayload": {
+        "type": "operation",
+        "readonly": true,
+        "input": "GetPayloadInput",
+        "output": "GetPayloadOutput",
+        "http": {
+          "uri": "/payload/{id}",
+          "method": "GET"
+        }
+      },
+      "DeletePayload": {
+        "type": "operation",
+        "idempotent": true,
+        "input": "DeletePayloadInput",
+        "http": {
+          "uri": "/payload/{id}",
+          "method": "DELETE",
+          "code": 204
+        }
+      },
+      "ListPayloads": {
+        "type": "operation",
+        "readonly": true,
+        "output": "ListPayloadsOutput",
+        "http": {
+          "uri": "/payload",
+          "method": "GET"
+        }
+      },
+      "PutPayloadInput": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "required": true,
+            "httpLabel": true
+          },
+          "header": {
+            "target": "smithy.api#String",
+            "httpHeader": "X-Foo-Header"
+          },
+          "query": {
+            "target": "smithy.api#Integer",
+            "httpQuery": "query"
+          },
+          "enum": {
+            "target": "EnumString",
+            "httpHeader": "X-EnumString"
+          },
+          "body": {
+            "target": "smithy.api#Blob",
+            "httpPayload": true
+          }
+        }
+      },
+      "GetPayloadInput": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "httpLabel": true,
+            "required": true
+          }
+        }
+      },
+      "GetPayloadOutput": {
+        "type": "structure",
+        "members": {
+          "header": {
+            "target": "smithy.api#String",
+            "httpHeader": "X-Foo-Header"
+          },
+          "body": {
+            "target": "smithy.api#Blob",
+            "httpPayload": true
+          }
+        }
+      },
+      "DeletePayloadInput": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "httpLabel": true,
+            "required": true
+          }
+        }
+      },
+      "ListPayloadsOutput": {
+        "type": "structure",
+        "members": {
+          "items": {
+            "target": "PayloadDescriptions"
+          }
+        }
+      },
+      "EnumString": {
+        "type": "string",
+        "enum": {
+          "a": {
+            "name": "A"
+          },
+          "c": {
+            "name": "C"
+          }
+        }
+      },
+      "PayloadDescriptions": {
+        "type": "list",
+        "member": {
+          "target": "PayloadDescription"
+        }
+      },
+      "PayloadDescription": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "required": true
+          },
+          "createdAt": {
+            "target": "smithy.api#Timestamp",
+            "required": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -1,0 +1,429 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "MyService",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/payload/{id}": {
+      "get": {
+        "operationId": "GetPayload",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetPayload 200 response",
+            "headers": {
+              "X-Foo-Header": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Expose-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws_proxy",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceGetPayload/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/MyServiceGetPayloadLambdaRole",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Service-Output-Metadata'"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PutPayload",
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "string",
+                "format": "byte"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          {
+            "name": "X-Foo-Header",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-EnumString",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "a",
+                "c"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "PutPayload response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Expose-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws_proxy",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServicePutPayload/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/MyServicePutPayloadLambdaRole",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Service-Output-Metadata'"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeletePayload",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "DeletePayload response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Expose-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws_proxy",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceDeletePayload/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/MyServiceDeletePayloadLambdaRole",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Service-Output-Metadata'"
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "description": "Handles CORS-preflight requests",
+        "operationId": "CorsPayloadId",
+        "tags": [
+          "CORS"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Canned response for CORS-preflight requests",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Max-Age": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "passThroughBehavior": "when_no_match",
+          "requestTemplates": {
+            "200": "{\"statusCode\":200}",
+            "201": "{\"statusCode\":200}",
+            "application/json": "{\"statusCode\":200}",
+            "204": "{\"statusCode\":200}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Max-Age": "'86400'",
+                "method.response.header.Access-Control-Allow-Headers": "'Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,X-EnumString,X-Foo-Header,X-Service-Input-Metadata'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'",
+                "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,PUT'"
+              }
+            }
+          },
+          "type": "mock"
+        }
+      }
+    },
+    "/payload": {
+      "get": {
+        "operationId": "ListPayloads",
+        "responses": {
+          "200": {
+            "description": "ListPayloads 200 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Expose-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "$ref": "#/components/schemas/ExampleSmithyListPayloadsOutputItemsMember"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws_proxy",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceListPayloads/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/MyServiceListPayloadsLambdaRole",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Service-Output-Metadata'"
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "description": "Handles CORS-preflight requests",
+        "operationId": "CorsPayload",
+        "tags": [
+          "CORS"
+        ],
+        "responses": {
+          "200": {
+            "description": "Canned response for CORS-preflight requests",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Max-Age": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "passThroughBehavior": "when_no_match",
+          "requestTemplates": {
+            "application/json": "{\"statusCode\":200}",
+            "200": "{\"statusCode\":200}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Max-Age": "'86400'",
+                "method.response.header.Access-Control-Allow-Headers": "'Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,X-Service-Input-Metadata'",
+                "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'",
+                "method.response.header.Access-Control-Allow-Methods": "'GET'"
+              }
+            }
+          },
+          "type": "mock"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ExampleSmithyPayloadDescriptionsMember": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createdAt",
+          "id"
+        ]
+      },
+      "ExampleSmithyListPayloadsOutputItemsMember": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ExampleSmithyPayloadDescriptionsMember"
+        }
+      }
+    },
+    "securitySchemes": {
+      "sigv4": {
+        "type": "apiKey",
+        "description": "AWS Signature Version 4 authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "awsSigv4"
+      },
+      "http-basic": {
+        "type": "http",
+        "description": "HTTP Basic authentication",
+        "scheme": "Basic"
+      }
+    }
+  },
+  "security": [
+    {
+      "sigv4": [ ]
+    },
+    {
+      "http-basic": [ ]
+    }
+  ],
+  "x-amazon-apigateway-gateway-responses": {
+    "DEFAULT_4XX": {
+      "responseTemplates": {
+        "application/json": "{\"message\":$context.error.messageString}"
+      },
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'https://www.example.com'"
+      }
+    },
+    "DEFAULT_5XX": {
+      "responseTemplates": {
+        "application/json": "{\"message\":$context.error.messageString}"
+      },
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'https://www.example.com'"
+      }
+    }
+  }
+}

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "MyService",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/foo": {
+      "put": {
+        "operationId": "Foo",
+        "responses": {
+          "201": {
+            "description": "Foo response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws_proxy",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:bar/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/Foo",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'"
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "FooOptions",
+        "responses": {
+          "200": {
+            "description": "FooOptions 200 response",
+            "headers": {
+              "X-Hd": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws",
+          "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:baz/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::123456789012:role/FooOptions",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "http-basic": {
+        "type": "http",
+        "description": "HTTP Basic authentication",
+        "scheme": "Basic"
+      }
+    }
+  },
+  "security": [
+    {
+      "http-basic": [ ]
+    }
+  ],
+  "x-amazon-apigateway-gateway-responses": {
+    "ACCESS_DENIED": {
+      "statusCode": 403,
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'domain.com'",
+        "gatewayresponse.header.Foo": "'baz'",
+        "gatewayresponse.header.Access-Control-Expose-Headers": "'Access-Control-Allow-Origin,Foo'"
+      }
+    }
+  }
+}

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/IntegrationTraitIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/IntegrationTraitIndex.java
@@ -89,7 +89,7 @@ public class IntegrationTraitIndex implements KnowledgeIndex {
                     .ifPresent(resourceShape -> walk(index, service, resourceShape, updatedTrait));
         }
 
-        for (ShapeId operation : current.getOperations()) {
+        for (ShapeId operation : current.getAllOperations()) {
             index.getShape(operation).ifPresent(op -> serviceMapping.put(operation, extractTrait(op, updatedTrait)));
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
@@ -42,10 +42,25 @@ public abstract class EntityShape extends Shape {
     }
 
     /**
+     * Gets operations bound only through the "operations" property.
+     *
+     * <p>This will not include operations bound to resources using
+     * a lifecycle operation binding.
+     *
      * @return Get the "operations" directly bound to this shape.
+     * @see #getAllOperations()
      */
-    public Set<ShapeId> getOperations() {
+    public final Set<ShapeId> getOperations() {
         return operations;
+    }
+
+    /**
+     * Get all operations directly bound to this shape.
+     *
+     * @return Returns all operations bound to the shape.
+     */
+    public Set<ShapeId> getAllOperations() {
+        return getOperations();
     }
 
     @Override
@@ -55,7 +70,7 @@ public abstract class EntityShape extends Shape {
         }
 
         EntityShape o = (EntityShape) other;
-        return resources.equals(o.resources) && operations.equals(o.operations);
+        return getResources().equals(o.getResources()) && getAllOperations().equals(o.getAllOperations());
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -73,11 +73,7 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
         return Optional.of(this);
     }
 
-    /**
-     * Gets all operations, including lifecycle operations and non-lifecycle.
-     *
-     * @return Returns all bound operations.
-     */
+    @Override
     public Set<ShapeId> getAllOperations() {
         Set<ShapeId> result = new HashSet<>(getOperations());
         getCreate().ifPresent(result::add);

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Context.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Context.java
@@ -163,4 +163,18 @@ public final class Context {
     public List<SecuritySchemeConverter> getSecuritySchemeConverters() {
         return securitySchemeConverters;
     }
+
+    /**
+     * Reports if any authentication mechanisms in the entire model use HTTP
+     * credentials, such as cookies, browser-managed usernames and passwords,
+     * or TLS client certificates.
+     *
+     * <p>This is useful when integrating with things like CORS.</p>
+     *
+     * @return Whether any authentication mechanism relies on browser-managed credentials.
+     * @see <a href="https://fetch.spec.whatwg.org/#credentials" target="_blank">Browser-managed credentials</a>
+     */
+    public boolean usesHttpCredentials() {
+        return getSecuritySchemeConverters().stream().anyMatch(SecuritySchemeConverter::usesHttpCredentials);
+    }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OperationObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OperationObject.java
@@ -229,7 +229,7 @@ public final class OperationObject extends Component implements ToSmithyBuilder<
             return this;
         }
 
-        public Builder parameters(List<ParameterObject> parameters) {
+        public Builder parameters(Collection<ParameterObject> parameters) {
             this.parameters.clear();
             this.parameters.addAll(parameters);
             return this;
@@ -272,7 +272,7 @@ public final class OperationObject extends Component implements ToSmithyBuilder<
             return this;
         }
 
-        public Builder security(List<Map<String, List<String>>> security) {
+        public Builder security(Collection<Map<String, List<String>>> security) {
             this.security.clear();
             this.security.addAll(security);
             return this;
@@ -283,7 +283,7 @@ public final class OperationObject extends Component implements ToSmithyBuilder<
             return this;
         }
 
-        public Builder servers(List<ServerObject> servers) {
+        public Builder servers(Collection<ServerObject> servers) {
             this.servers.clear();
             this.servers.addAll(servers);
             return this;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ResponseObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ResponseObject.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.openapi.model;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -43,6 +44,22 @@ public final class ResponseObject extends Component implements ToSmithyBuilder<R
 
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Gets a header by case-insensitive header name.
+     *
+     * @param header Header to retrieve.
+     * @return Returns the optionally found header.
+     */
+    public Optional<Ref<ParameterObject>> getHeader(String header) {
+        for (Map.Entry<String, Ref<ParameterObject>> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(header)) {
+                return Optional.of(entry.getValue());
+            }
+        }
+
+        return Optional.empty();
     }
 
     public Map<String, Ref<ParameterObject>> getHeaders() {


### PR DESCRIPTION
This commit adds support for injecting CORS-preflight OPTIONS requests
if they don't already exist under a path, injects CORS headers into
modeled responses (e.g., Access-Control-Expose-Headers), injects CORS
headers into gateway responses, and injects CORS headers into API
Gateway integrations.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
