### PR TITLE
Generalize computing the HTTP OpenAPI HTTP status

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -36,7 +36,6 @@ import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.jsonschema.SchemaDocument;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.AuthIndex;
-import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -591,8 +590,8 @@ public final class OpenApiConverter {
         // responses vs new/mutated responses.
         Map<String, ResponseObject> originalResponses = operation.getResponses();
         if (operation.getResponses().isEmpty()) {
-            int code = context.getModel().getKnowledge(HttpBindingIndex.class).getResponseCode(shape);
-            originalResponses = MapUtils.of(String.valueOf(code), ResponseObject.builder()
+            String code = context.getOpenApiProtocol().getOperationResponseStatusCode(context, shape);
+            originalResponses = MapUtils.of(code, ResponseObject.builder()
                     .description(shape.getId().getName() + " response").build());
         }
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
@@ -18,8 +18,10 @@ package software.amazon.smithy.openapi.fromsmithy;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.pattern.UriPattern;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.openapi.OpenApiException;
 import software.amazon.smithy.openapi.model.OpenApi;
@@ -94,6 +96,22 @@ public interface OpenApiProtocol {
                 .orElseThrow(() -> new OpenApiException(
                         "The `" + operation.getId() + "` operation has no `http` binding trait, which is "
                         + "required to compute a method (using the default protocol implementation)"));
+    }
+
+    /**
+     * Gets the response status code of an operation or error shape.
+     *
+     * <p>The default implementation will attempt to use HTTP binding traits
+     * to determine the HTTP status code of an operation or error structure.
+     *
+     * @param context The build context.
+     * @param operationOrError Operation or error shape ID.
+     * @return Returns the status code as a string.
+     */
+    default String getOperationResponseStatusCode(Context context, ToShapeId operationOrError) {
+        return String.valueOf(context.getModel()
+                .getKnowledge(HttpBindingIndex.class)
+                .getResponseCode(operationOrError));
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -241,7 +241,7 @@ abstract class AbstractRestProtocol implements OpenApiProtocol {
                 operationIndex.getErrors(operation).stream()
         ).map(shape -> {
             Shape operationOrError = shape.hasTrait(ErrorTrait.class) ? shape : operation;
-            String statusCode = String.valueOf(bindingIndex.getResponseCode(operationOrError));
+            String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, operationOrError);
             ResponseObject response = createResponse(context, bindingIndex, statusCode, operation, operationOrError);
             return Pair.of(statusCode, response);
         }).collect(Collectors.toMap(Pair::getLeft, Pair::getRight, (a, b) -> b, LinkedHashMap::new));


### PR DESCRIPTION
This commit decouples OpenAPI implementation code from HTTP bindings by
moving the responsibility of computing an HTTP status code to an OpenAPI
protocol implementation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
