### PR TITLE
Make matching protocol names more explicit

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -360,17 +360,17 @@ public final class OpenApiConverter {
 
         throw new OpenApiException(String.format(
                 "Unable to resolve a supported protocol for service: `%s`. Protocol service providers were "
-                + "found for the following protocol patterns: [%s]. This service supports the following "
+                + "found for the following protocols: [%s]. But this service supports the following "
                 + "protocols: [%s]",
                 service.getId(),
-                ValidationUtils.tickedList(protocols.stream().map(OpenApiProtocol::getProtocolNamePattern)),
+                ValidationUtils.tickedList(protocols.stream().flatMap(p -> p.getProtocolNames().stream())),
                 ValidationUtils.tickedList(protoTrait.getProtocolNames())));
     }
 
     // Finds an OpenAPI protocol matching the given protocol name.
     private Optional<OpenApiProtocol> findProtocol(String protocolName, List<OpenApiProtocol> protocols) {
         return protocols.stream()
-                .filter(protocol -> protocol.getProtocolNamePattern().matcher(protocolName).find())
+                .filter(protocol -> protocol.getProtocolNames().contains(protocolName))
                 .findFirst();
     }
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.openapi.fromsmithy;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.pattern.UriPattern;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -34,15 +33,15 @@ import software.amazon.smithy.utils.SetUtils;
  *
  * <p>Instances of {@code OpenApiProtocol} are discovered using SPI and
  * matched with configuration settings based on the result of matching
- * a protocol against {@link #getProtocolNamePattern()}.
+ * a protocol against {@link #getProtocolNames()}.
  */
 public interface OpenApiProtocol {
     /**
-     * Gets a pattern used to match protocol names.
+     * Gets the names of the protocol that this implementation supports.
      *
-     * @return Returns the protocol name pattern.
+     * @return Returns the supported protocol names.
      */
-    Pattern getProtocolNamePattern();
+    Set<String> getProtocolNames();
 
     /**
      * Creates an operation entry, including the method, URI, and operation

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocol.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.openapi.fromsmithy.protocols;
 
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.Set;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.shapes.Shape;
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Provides the conversion from Smithy aws.rest-json-1.0 and
@@ -32,8 +33,8 @@ import software.amazon.smithy.openapi.fromsmithy.Context;
  */
 public final class AwsRestJsonProtocol extends AbstractRestProtocol {
     @Override
-    public Pattern getProtocolNamePattern() {
-        return Pattern.compile("^aws\\.rest-json(?:-1\\.[0|1])?$");
+    public Set<String> getProtocolNames() {
+        return SetUtils.of("aws.rest-json", "aws.rest-json-1.0", "aws.rest-json-1.1");
     }
 
     @Override

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocolTest.java
@@ -25,6 +25,7 @@ public class AwsRestJsonProtocolTest {
             "adds-header-mediatype-format.json",
             "supports-payloads.json"
     })
+
     public void testProtocolResult(String smithy) {
         Model model = Model.assembler()
                 .addImport(getClass().getResource(smithy))

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-header-mediatype-format.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-header-mediatype-format.json
@@ -5,7 +5,7 @@
       "Service": {
         "type": "service",
         "version": "2006-03-01",
-        "protocols": [{"name": "aws.rest-json"}],
+        "protocols": [{"name": "aws.rest-json-1.0"}],
         "operations": [
           "Operation"
         ]

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-header-timestamp-format.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-header-timestamp-format.json
@@ -5,7 +5,7 @@
       "Service": {
         "type": "service",
         "version": "2006-03-01",
-        "protocols": [{"name": "aws.rest-json"}],
+        "protocols": [{"name": "aws.rest-json-1.1"}],
         "operations": [
           "Operation"
         ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The previous behavior of matching based on regular expressions was a bit confusing when a match couldn't be found since we spit out a bunch of regular expressions. This update makes protocol implementations much more explicit and harder to get matching against them wrong.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
