### PR TITLE
Add helpers to Relationship and PathFinder

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/path-to-member.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/path-to-member.smithy
@@ -1,0 +1,11 @@
+namespace smithy.example
+
+operation Operation(Input) -> Output
+
+structure Input {
+  foo: String,
+}
+
+structure Output {
+  foo: String,
+}


### PR DESCRIPTION
This commit adds a method to easily create paths to top-level input or output
members of an operation. It also add helper functionality to
Relationship to add more constructor forms and a method to get the
neighbor or throw if the shape isn't present.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
