### PR TITLE
Add effective ARN resolution to ArnIndex

### DIFF
--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
@@ -99,4 +99,20 @@ public class ArnIndexTest {
         assertThat(arnIndex.getServiceArnNamespace(ShapeId.from("ns.foo#EmptyAwsService")),
                    equalTo("emptyawsservice"));
     }
+
+    @Test
+    public void findsEffectiveArns() {
+        Model m = Model.assembler()
+                .discoverModels(ArnIndexTest.class.getClassLoader())
+                .addImport(ArnIndexTest.class.getResource("effective-arns.json"))
+                .assemble()
+                .unwrap();
+        ArnIndex index = m.getKnowledge(ArnIndex.class);
+        ShapeId service = ShapeId.from("ns.foo#SomeService");
+
+        assertThat(index.getEffectiveOperationArn(service, ShapeId.from("ns.foo#InstanceOperation")).map(ArnTrait::getTemplate),
+                   equalTo(Optional.of("foo/{id}")));
+        assertThat(index.getEffectiveOperationArn(service, ShapeId.from("ns.foo#CollectionOperation")).map(ArnTrait::getTemplate),
+                   equalTo(Optional.of("foo")));
+    }
 }

--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/effective-arns.json
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/effective-arns.json
@@ -1,0 +1,44 @@
+{
+  "smithy": "1.0",
+  "ns.foo": {
+    "shapes": {
+      "SomeService": {
+        "type": "service",
+        "version": "2018-03-17",
+        "aws.api#service": {"sdkServiceId": "Some Value"},
+        "resources": ["Resource1"]
+      },
+      "Resource1": {
+        "type": "resource",
+        "aws.api#arn": {"template": "foo"},
+        "resources": ["Resource2"]
+      },
+      "Resource2": {
+        "type": "resource",
+        "identifiers": {"id": "String"},
+        "aws.api#arn": {"template": "foo/{id}"},
+        "operations": ["InstanceOperation", "CollectionOperation"]
+      },
+      "InstanceOperation": {
+        "type": "operation",
+        "input": "InstanceOperationInput"
+      },
+      "InstanceOperationInput": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "required": true,
+            "target": "String"
+          }
+        }
+      },
+      "CollectionOperation": {
+        "type": "operation",
+        "input": "CollectionOperationInput"
+      },
+      "CollectionOperationInput": {
+        "type": "structure"
+      }
+    }
+  }
+}


### PR DESCRIPTION
We have a use case that needs to know the ARN that is in effect for an
operation bound within a service. Operations bound to a resource using
an instance binding have an effective ARN equal to the ARN of the
resource. Operations bound using a collection binding have an effective
ARN equal to the parent of the resource it's bound to.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
