### PR TITLE
Sort OpenAPI maps using TreeMap

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/CallbackObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/CallbackObject.java
@@ -16,8 +16,8 @@
 package software.amazon.smithy.openapi.model;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -27,7 +27,7 @@ public final class CallbackObject extends Component implements ToSmithyBuilder<C
 
     private CallbackObject(Builder builder) {
         super(builder);
-        paths = Collections.unmodifiableMap(new LinkedHashMap<>(builder.paths));
+        paths = Collections.unmodifiableMap(new TreeMap<>(builder.paths));
     }
 
     public static Builder builder() {
@@ -53,7 +53,7 @@ public final class CallbackObject extends Component implements ToSmithyBuilder<C
     }
 
     public static final class Builder extends Component.Builder<Builder, CallbackObject> {
-        private Map<String, PathItem> paths = new LinkedHashMap<>();
+        private Map<String, PathItem> paths = new TreeMap<>();
 
         private Builder() {}
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/Component.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/Component.java
@@ -15,9 +15,9 @@
 
 package software.amazon.smithy.openapi.model;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.ToNode;
@@ -35,7 +35,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
  */
 public abstract class Component implements ToNode {
     private Node node;
-    private final Map<String, Node> extensions = new LinkedHashMap<>();
+    private final Map<String, Node> extensions = new TreeMap<>();
 
     protected Component(Builder<?, ?> builder) {
         extensions.putAll(builder.getExtensions());
@@ -86,7 +86,7 @@ public abstract class Component implements ToNode {
     }
 
     public abstract static class Builder<B extends Builder, C extends Component> implements SmithyBuilder<C> {
-        private final Map<String, Node> extensions = new LinkedHashMap<>();
+        private final Map<String, Node> extensions = new TreeMap<>();
 
         public Map<String, Node> getExtensions() {
             return extensions;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ComponentsObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ComponentsObject.java
@@ -15,22 +15,22 @@
 
 package software.amazon.smithy.openapi.model;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 public final class ComponentsObject extends Component implements ToSmithyBuilder<ComponentsObject> {
-    private final Map<String, Schema> schemas = new LinkedHashMap<>();
-    private final Map<String, ResponseObject> responses = new LinkedHashMap<>();
-    private final Map<String, ParameterObject> parameters = new LinkedHashMap<>();
-    private final Map<String, RequestBodyObject> requestBodies = new LinkedHashMap<>();
-    private final Map<String, ParameterObject> headers = new LinkedHashMap<>();
-    private final Map<String, SecurityScheme> securitySchemes = new LinkedHashMap<>();
-    private final Map<String, LinkObject> links = new LinkedHashMap<>();
-    private final Map<String, CallbackObject> callbacks = new LinkedHashMap<>();
+    private final Map<String, Schema> schemas = new TreeMap<>();
+    private final Map<String, ResponseObject> responses = new TreeMap<>();
+    private final Map<String, ParameterObject> parameters = new TreeMap<>();
+    private final Map<String, RequestBodyObject> requestBodies = new TreeMap<>();
+    private final Map<String, ParameterObject> headers = new TreeMap<>();
+    private final Map<String, SecurityScheme> securitySchemes = new TreeMap<>();
+    private final Map<String, LinkObject> links = new TreeMap<>();
+    private final Map<String, CallbackObject> callbacks = new TreeMap<>();
 
     private ComponentsObject(Builder builder) {
         super(builder);
@@ -142,14 +142,14 @@ public final class ComponentsObject extends Component implements ToSmithyBuilder
     }
 
     public static final class Builder extends Component.Builder<Builder, ComponentsObject> {
-        private final Map<String, Schema> schemas = new LinkedHashMap<>();
-        private final Map<String, ResponseObject> responses = new LinkedHashMap<>();
-        private final Map<String, ParameterObject> parameters = new LinkedHashMap<>();
-        private final Map<String, RequestBodyObject> requestBodies = new LinkedHashMap<>();
-        private final Map<String, ParameterObject> headers = new LinkedHashMap<>();
-        private final Map<String, SecurityScheme> securitySchemes = new LinkedHashMap<>();
-        private final Map<String, LinkObject> links = new LinkedHashMap<>();
-        private final Map<String, CallbackObject> callbacks = new LinkedHashMap<>();
+        private final Map<String, Schema> schemas = new TreeMap<>();
+        private final Map<String, ResponseObject> responses = new TreeMap<>();
+        private final Map<String, ParameterObject> parameters = new TreeMap<>();
+        private final Map<String, RequestBodyObject> requestBodies = new TreeMap<>();
+        private final Map<String, ParameterObject> headers = new TreeMap<>();
+        private final Map<String, SecurityScheme> securitySchemes = new TreeMap<>();
+        private final Map<String, LinkObject> links = new TreeMap<>();
+        private final Map<String, CallbackObject> callbacks = new TreeMap<>();
 
         private Builder() {}
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/EncodingObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/EncodingObject.java
@@ -15,15 +15,15 @@
 
 package software.amazon.smithy.openapi.model;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 public final class EncodingObject extends Component implements ToSmithyBuilder<EncodingObject> {
-    private final Map<String, ParameterObject> headers = new LinkedHashMap<>();
+    private final Map<String, ParameterObject> headers = new TreeMap<>();
     private final String contentType;
     private final String style;
     private final boolean explode;
@@ -96,7 +96,7 @@ public final class EncodingObject extends Component implements ToSmithyBuilder<E
     }
 
     public static final class Builder extends Component.Builder<Builder, EncodingObject> {
-        private final Map<String, ParameterObject> headers = new LinkedHashMap<>();
+        private final Map<String, ParameterObject> headers = new TreeMap<>();
         private String contentType;
         private String style;
         private boolean explode;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/LinkObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/LinkObject.java
@@ -15,15 +15,15 @@
 
 package software.amazon.smithy.openapi.model;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 public final class LinkObject extends Component implements ToSmithyBuilder<LinkObject> {
-    private final Map<String, Node> parameters = new LinkedHashMap<>();
+    private final Map<String, Node> parameters = new TreeMap<>();
     private final String operationRef;
     private final String operationId;
     private final Node requestBody;
@@ -98,7 +98,7 @@ public final class LinkObject extends Component implements ToSmithyBuilder<LinkO
     }
 
     public static final class Builder extends Component.Builder<Builder, LinkObject> {
-        private final Map<String, Node> parameters = new LinkedHashMap<>();
+        private final Map<String, Node> parameters = new TreeMap<>();
         private String operationRef;
         private String operationId;
         private Node requestBody;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/MediaTypeObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/MediaTypeObject.java
@@ -15,9 +15,9 @@
 
 package software.amazon.smithy.openapi.model;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -26,8 +26,8 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final class MediaTypeObject extends Component implements ToSmithyBuilder<MediaTypeObject> {
     private final Schema schema;
     private final Node example;
-    private final Map<String, Node> examples = new LinkedHashMap<>();
-    private final Map<String, EncodingObject> encoding = new LinkedHashMap<>();
+    private final Map<String, Node> examples = new TreeMap<>();
+    private final Map<String, EncodingObject> encoding = new TreeMap<>();
 
     private MediaTypeObject(Builder builder) {
         super(builder);
@@ -89,8 +89,8 @@ public final class MediaTypeObject extends Component implements ToSmithyBuilder<
     public static final class Builder extends Component.Builder<Builder, MediaTypeObject> {
         private Schema schema;
         private Node example;
-        private final Map<String, Node> examples = new LinkedHashMap<>();
-        private final Map<String, EncodingObject> encoding = new LinkedHashMap<>();
+        private final Map<String, Node> examples = new TreeMap<>();
+        private final Map<String, EncodingObject> encoding = new TreeMap<>();
 
         private Builder() {}
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
@@ -16,10 +16,11 @@
 package software.amazon.smithy.openapi.model;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -31,7 +32,7 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
     private final String openapi;
     private final InfoObject info;
     private final List<ServerObject> servers;
-    private final Map<String, PathItem> paths = new LinkedHashMap<>();
+    private final Map<String, PathItem> paths = new TreeMap<>();
     private final ComponentsObject components;
     private final List<Map<String, List<String>>> security;
     private final List<TagObject> tags;
@@ -120,6 +121,7 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
         if (!security.isEmpty()) {
             builder.withMember("security", security.stream()
                     .map(mapping -> mapping.entrySet().stream()
+                            .sorted(Comparator.comparing(Map.Entry::getKey))
                             .collect(ObjectNode.collectStringKeys(
                                     Map.Entry::getKey,
                                     entry -> entry.getValue().stream().map(Node::from).collect(ArrayNode.collect()))))
@@ -127,7 +129,7 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
         }
 
         if (!tags.isEmpty()) {
-            builder.withMember("tags", tags.stream().collect(ArrayNode.collect()));
+            builder.withMember("tags", tags.stream().sorted().collect(ArrayNode.collect()));
         }
 
         return builder;
@@ -137,7 +139,7 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
         private String openapi;
         private InfoObject info;
         private final List<ServerObject> servers = new ArrayList<>();
-        private Map<String, PathItem> paths = new LinkedHashMap<>();
+        private Map<String, PathItem> paths = new TreeMap<>();
         private ComponentsObject components;
         private final List<Map<String, List<String>>> security = new ArrayList<>();
         private final List<TagObject> tags = new ArrayList<>();

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ParameterObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ParameterObject.java
@@ -16,9 +16,9 @@
 package software.amazon.smithy.openapi.model;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -52,8 +52,8 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
         allowReserved = builder.allowReserved;
         schema = builder.schema;
         example = builder.example;
-        examples = Collections.unmodifiableMap(new LinkedHashMap<>(builder.examples));
-        content = Collections.unmodifiableMap(new LinkedHashMap<>(builder.content));
+        examples = Collections.unmodifiableMap(new TreeMap<>(builder.examples));
+        content = Collections.unmodifiableMap(new TreeMap<>(builder.content));
     }
 
     public static Builder builder() {
@@ -186,8 +186,8 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
         private boolean allowReserved;
         private Schema schema;
         private Node example;
-        private final Map<String, Node> examples = new LinkedHashMap<>();
-        private final Map<String, MediaTypeObject> content = new LinkedHashMap<>();
+        private final Map<String, Node> examples = new TreeMap<>();
+        private final Map<String, MediaTypeObject> content = new TreeMap<>();
 
         private Builder() {}
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/PathItem.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/PathItem.java
@@ -131,17 +131,17 @@ public final class PathItem extends Component implements ToSmithyBuilder<PathIte
         ObjectNode.Builder builder = Node.objectNodeBuilder()
                 .withOptionalMember("description", getDescription().map(Node::from))
                 .withOptionalMember("summary", getSummary().map(Node::from))
-                .withOptionalMember("get", getGet())
-                .withOptionalMember("put", getPut())
-                .withOptionalMember("post", getPost())
                 .withOptionalMember("delete", getDelete())
-                .withOptionalMember("options", getOptions())
+                .withOptionalMember("get", getGet())
                 .withOptionalMember("head", getHead())
+                .withOptionalMember("options", getOptions())
                 .withOptionalMember("patch", getPatch())
+                .withOptionalMember("post", getPost())
+                .withOptionalMember("put", getPut())
                 .withOptionalMember("trace", getTrace());
 
         if (!parameters.isEmpty()) {
-            builder.withMember("tags", getParameters().stream().map(Ref::toNode).collect(ArrayNode.collect()));
+            builder.withMember("parameters", getParameters().stream().map(Ref::toNode).collect(ArrayNode.collect()));
         }
 
         if (!servers.isEmpty()) {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/RequestBodyObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/RequestBodyObject.java
@@ -15,16 +15,16 @@
 
 package software.amazon.smithy.openapi.model;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 public final class RequestBodyObject extends Component implements ToSmithyBuilder<RequestBodyObject> {
     private final String description;
-    private final Map<String, MediaTypeObject> content = new LinkedHashMap<>();
+    private final Map<String, MediaTypeObject> content = new TreeMap<>();
     private final boolean required;
 
     private RequestBodyObject(Builder builder) {
@@ -74,7 +74,7 @@ public final class RequestBodyObject extends Component implements ToSmithyBuilde
     }
 
     public static final class Builder extends Component.Builder<Builder, RequestBodyObject> {
-        private final Map<String, MediaTypeObject> content = new LinkedHashMap<>();
+        private final Map<String, MediaTypeObject> content = new TreeMap<>();
         private String description;
         private boolean required;
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ResponseObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ResponseObject.java
@@ -16,9 +16,9 @@
 package software.amazon.smithy.openapi.model;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -33,9 +33,9 @@ public final class ResponseObject extends Component implements ToSmithyBuilder<R
     private ResponseObject(Builder builder) {
         super(builder);
         description = SmithyBuilder.requiredState("description", builder.description);
-        headers = Collections.unmodifiableMap(new LinkedHashMap<>(builder.headers));
-        content = Collections.unmodifiableMap(new LinkedHashMap<>(builder.content));
-        links = Collections.unmodifiableMap(new LinkedHashMap<>(builder.links));
+        headers = Collections.unmodifiableMap(new TreeMap<>(builder.headers));
+        content = Collections.unmodifiableMap(new TreeMap<>(builder.content));
+        links = Collections.unmodifiableMap(new TreeMap<>(builder.links));
     }
 
     public static Builder builder() {
@@ -109,9 +109,9 @@ public final class ResponseObject extends Component implements ToSmithyBuilder<R
 
     public static final class Builder extends Component.Builder<Builder, ResponseObject> {
         private String description;
-        private final Map<String, Ref<ParameterObject>> headers = new LinkedHashMap<>();
-        private final Map<String, MediaTypeObject> content = new LinkedHashMap<>();
-        private final Map<String, Ref<LinkObject>> links = new LinkedHashMap<>();
+        private final Map<String, Ref<ParameterObject>> headers = new TreeMap<>();
+        private final Map<String, MediaTypeObject> content = new TreeMap<>();
+        private final Map<String, Ref<LinkObject>> links = new TreeMap<>();
 
         private Builder() {}
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -69,7 +69,7 @@ public class OpenApiConverterTest {
                 .unwrap();
         OpenApi result = OpenApiConverter.create()
                 .putSetting(OpenApiConstants.OPEN_API_TAGS, true)
-                .putSetting(OpenApiConstants.OPEN_API_SUPPORTED_TAGS, Node.fromStrings("foo", "baz"))
+                .putSetting(OpenApiConstants.OPEN_API_SUPPORTED_TAGS, Node.fromStrings("baz", "foo"))
                 .convert(model, ShapeId.from("smithy.example#Service"));
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("tagged-service.openapi.json")));

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service.json
@@ -11,7 +11,7 @@
       },
       "Operation1": {
         "type": "operation",
-        "tags": ["foo", "bar", "baz", "qux"],
+        "tags": ["bar", "baz", "foo", "qux"],
         "http": {"uri": "/operation1", "method": "GET"}
       },
       "Operation2": {

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service.openapi.json
@@ -8,7 +8,7 @@
     "/operation1": {
       "get": {
         "operationId": "Operation1",
-        "tags": ["foo", "baz"],
+        "tags": ["baz", "foo"],
         "responses": {
           "200": {
             "description": "Operation1 response"


### PR DESCRIPTION
The key-value pairs given to maps used in the OpenAPI model will mostly
likely be unordered. Using a LinkedHashMap internally doesn't add a lot
of value and just serves to maintain the originally provided unordered
values. This change updates maps to be backed by TreeMap to ensure the
result is sorted. This cuts down on diff noise significantly when
serializing and provides a predictable iteration order.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
