### PR TITLE
Improve CLI

### DIFF
--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -25,8 +25,6 @@ dependencies {
     implementation(project(":smithy-build"))
     implementation(project(":smithy-linters"))
     implementation(project(":smithy-diff"))
-    implementation(project(":smithy-codegen-core"))
-    implementation(project(":smithy-codegen-freemarker"))
 }
 
 application {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -26,28 +26,43 @@ import software.amazon.smithy.cli.commands.ValidateCommand;
  * Entry point of the Smithy CLI.
  */
 public final class SmithyCli {
+
+    private Consumer<Integer> exitFunction = System::exit;
+    private ClassLoader classLoader = getClass().getClassLoader();
+
     private SmithyCli() {}
 
-    public static void main(String... args) {
-        run(System::exit, args);
+    public static SmithyCli create() {
+        return new SmithyCli();
     }
 
-    public static int run(Consumer<Integer> exitFunction, String... args) {
+    public SmithyCli exitFunction(Consumer<Integer> exitFunction) {
+        this.exitFunction = exitFunction;
+        return this;
+    }
+
+    public SmithyCli classLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        return this;
+    }
+
+    public static void main(String... args) {
+        SmithyCli.create().run(args);
+    }
+
+    public int run(String... args) {
         Cli cli = new Cli("smithy");
-        cli.addCommand(new ValidateCommand());
-        cli.addCommand(new BuildCommand());
-        cli.addCommand(new DiffCommand());
-        cli.addCommand(new GenerateCommand());
+        cli.addCommand(new ValidateCommand(classLoader));
+        cli.addCommand(new BuildCommand(classLoader));
+        cli.addCommand(new DiffCommand(classLoader));
+        cli.addCommand(new GenerateCommand(classLoader));
         cli.addCommand(new OptimizeCommand());
+
         int code = cli.run(args);
         if (code != 0) {
             exitFunction.accept(code);
         }
 
         return 0;
-    }
-
-    public static ClassLoader getConfiguredClassLoader() {
-        return SmithyCli.class.getClassLoader();
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -21,12 +21,17 @@ import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.Colors;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.Parser;
-import software.amazon.smithy.cli.SmithyCli;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.validation.ValidatedResult;
 
 public final class ValidateCommand implements Command {
+    private ClassLoader classLoader;
+
+    public ValidateCommand(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
     @Override
     public String getName() {
         return "validate";
@@ -55,19 +60,13 @@ public final class ValidateCommand implements Command {
         }
 
         List<String> models = arguments.positionalArguments();
-
-        if (models.isEmpty()) {
-            throw new CliError("No models were provided as positional arguments");
-        }
-
         System.err.println(String.format("Validating Smithy models: %s", String.join(" ", models)));
 
-        ClassLoader loader = SmithyCli.getConfiguredClassLoader();
-        ModelAssembler assembler = Model.assembler(loader);
+        ModelAssembler assembler = Model.assembler(classLoader);
 
         if (arguments.has("--discover")) {
             System.err.println("Enabling model discovery");
-            assembler.discoverModels(loader);
+            assembler.discoverModels(classLoader);
         }
 
         if (arguments.has("--ignore-unknown-traits")) {

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
@@ -44,8 +44,8 @@ public class CliTest {
     @Test
     public void printsMainHelp() throws Exception {
         Cli cli = new Cli("mytest");
-        cli.addCommand(new BuildCommand());
-        cli.addCommand(new ValidateCommand());
+        cli.addCommand(new BuildCommand(getClass().getClassLoader()));
+        cli.addCommand(new ValidateCommand(getClass().getClassLoader()));
         PrintStream out = System.out;
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(outputStream);
@@ -63,8 +63,8 @@ public class CliTest {
     @Test
     public void printsSubcommandHelp() throws Exception {
         Cli cli = new Cli("mytest");
-        cli.addCommand(new BuildCommand());
-        cli.addCommand(new ValidateCommand());
+        cli.addCommand(new BuildCommand(getClass().getClassLoader()));
+        cli.addCommand(new ValidateCommand(getClass().getClassLoader()));
         PrintStream out = System.out;
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(outputStream);

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
@@ -31,7 +31,7 @@ public class BuildCommandTest {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(outputStream);
         System.setOut(printStream);
-        assertThat(SmithyCli.run(code -> {}, "build", "--help"), is(0));
+        assertThat(SmithyCli.create().exitFunction(code -> {}).run("build", "--help"), is(0));
         System.setOut(out);
         String help = outputStream.toString("UTF-8");
 

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/ValidateCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/ValidateCommandTest.java
@@ -31,7 +31,7 @@ public class ValidateCommandTest {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(outputStream);
         System.setOut(printStream);
-        assertThat(SmithyCli.run(code -> {}, "validate", "--help"), is(0));
+        assertThat(SmithyCli.create().exitFunction(code -> {}).run("validate", "--help"), is(0));
         System.setOut(out);
         String help = outputStream.toString("UTF-8");
 


### PR DESCRIPTION
This commit updates the CLI to remove the dependencies on codegen and
Freemarker codegen. This is done to make the CLI as lightweight as
possible, and consumers can bring whatever dependencies they need at
build time. This commit also allows commands to be invoked without
passing in explicit models to validate, allowing models to be found just
from the classpath and model discovery.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
