### PR TITLE
Update ValidationEvent fromSourceException

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/SourceException.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/SourceException.java
@@ -44,4 +44,14 @@ public class SourceException extends RuntimeException implements FromSourceLocat
             return message.contains(asString) ? message : message + " (" + asString + ")";
         }
     }
+
+    /**
+     * Retrieves the message for this exception without the appended source
+     * location.
+     *
+     * @return The trimmed message.
+     */
+    public String getMessageWithoutLocation() {
+        return getMessage().replace(" (" + sourceLocation + ")", "");
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
@@ -720,13 +720,10 @@ final class LoaderVisitor {
                     .orElseGet(() -> new DynamicTrait(traitName, traitValue));
             shapeBuilder.addTrait(createdTrait);
         } catch (SourceException e) {
-            events.add(ValidationEvent.builder()
-                    .eventId(Validator.MODEL_ERROR)
-                    .severity(Severity.ERROR)
+            events.add(ValidationEvent.fromSourceException(e, format("Error creating trait `%s`: ",
+                            Trait.getIdiomaticTraitName(traitName)))
+                    .toBuilder()
                     .shapeId(shapeBuilder.getId())
-                    .sourceLocation(traitValue.getSourceLocation())
-                    .message(format("Error creating trait `%s`: %s",
-                                    Trait.getIdiomaticTraitName(traitName), e.getMessage()))
                     .build());
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
@@ -85,10 +85,11 @@ public final class ValidationEvent implements ToNode, ToSmithyBuilder<Validation
      * @return Returns a created validation event with an ID of Model.
      */
     public static ValidationEvent fromSourceException(SourceException exception, String prefix) {
+        // Get the message without source location since it's in the event.
         return ValidationEvent.builder()
                 .eventId(MODEL_ERROR)
                 .severity(ERROR)
-                .message(prefix + exception.getMessage())
+                .message(prefix + exception.getMessageWithoutLocation())
                 .sourceLocation(exception.getSourceLocation())
                 .build();
     }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/external-documentation.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/external-documentation.errors
@@ -1,1 +1,1 @@
-[ERROR] ns.foo#Invalid: Error creating trait `externalDocumentation`: externalDocumentation must be a valid URL. Found invalid! (/Users/stickevi/Documents/Repositories/SmithyPublic/smithy/smithy-model/build/resources/test/software/amazon/smithy/model/errorfiles/validators/external-documentation.json [15, 42]) | Model
+[ERROR] ns.foo#Invalid: Error creating trait `externalDocumentation`: externalDocumentation must be a valid URL. Found invalid! | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.errors
@@ -22,7 +22,7 @@
 [ERROR] ns.foo#KInput: `httpHeader` field name binding conflicts found for the `x-foo` header in the following structure members: `a`, `b` | HttpHeaderTrait
 [ERROR] ns.foo#KInput: `httpQuery` parameter name binding conflicts found for the `foo` parameter in the following structure members: `c`, `d` | HttpQueryTrait
 [ERROR] ns.foo#L: Operation URI, `/k`, conflicts with other operation URIs in the same service: [`ns.foo#K` (/k)] | HttpUriConflict
-[ERROR] ns.foo#MInput$a: Error creating trait `httpHeader`: httpHeader cannot be set to `Authorization` (/Users/stickevi/Documents/Repositories/SmithyPublic/smithy/smithy-model/build/resources/test/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.json [356, 39]) | Model
+[ERROR] ns.foo#MInput$a: Error creating trait `httpHeader`: httpHeader cannot be set to `Authorization` | Model
 [ERROR] ns.foo#NInput$a: This `a` structure member is marked with the `httpLabel` trait, but no corresponding `http` URI label could be found when used as the input of the `ns.foo#N` operation. | HttpLabelTrait
 [ERROR] ns.foo#OInput$a: Members with the `httpLabel` trait must be required. | HttpLabelTrait
 [ERROR] ns.foo#PInput$a: The `a` structure member corresponds to a greedy label when used as the input of the `ns.foo#P` operation. This member targets (integer: `ns.foo#Integer`), but greedy labels must target string shapes. | HttpLabelTrait


### PR DESCRIPTION
This commit removes the source location from the message of a
ValidationEvent generated from a SourceException. It also cleans up
a couple of bad test case files and changes the way trait creation
ValidationEvents are built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
