### PR TITLE
Clean up relationships and selectors

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -143,22 +143,24 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
     @Override
     public List<Relationship> structureShape(StructureShape shape) {
         return shape.getAllMembers().values().stream()
-                .map(member -> new Relationship(shape, RelationshipType.STRUCTURE_MEMBER, member.getId(), member))
+                .map(member -> Relationship.create(shape, RelationshipType.STRUCTURE_MEMBER, member))
                 .collect(Collectors.toList());
     }
 
     @Override
     public List<Relationship> unionShape(UnionShape shape) {
         return shape.getAllMembers().values().stream()
-                .map(member -> new Relationship(shape, RelationshipType.UNION_MEMBER, member.getId(), member))
+                .map(member -> Relationship.create(shape, RelationshipType.UNION_MEMBER, member))
                 .collect(Collectors.toList());
     }
 
     private Relationship relationship(Shape shape, RelationshipType type, MemberShape memberShape) {
-        return new Relationship(shape, type, memberShape.getId(), memberShape);
+        return Relationship.create(shape, type, memberShape);
     }
 
     private Relationship relationship(Shape shape, RelationshipType type, ShapeId neighborShapeId) {
-        return new Relationship(shape, type, neighborShapeId, shapeIndex.getShape(neighborShapeId).orElse(null));
+        return shapeIndex.getShape(neighborShapeId)
+                .map(target -> Relationship.create(shape, type, target))
+                .orElseGet(() -> Relationship.createInvalid(shape, type, neighborShapeId));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipDirection.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipDirection.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.neighbor;
+
+/**
+ * Defines the directionality of a relationship.
+ */
+public enum RelationshipDirection {
+    /**
+     * A directed relationship that goes from a shape to a shape that it
+     * references. For example, a {@link RelationshipType#MEMBER_TARGET}
+     * is a directed relationship.
+     */
+    DIRECTED,
+
+    /**
+     * The relationship goes from a shape to the shape that defines a
+     * directed relationship to the shape. For example, a
+     * {@link RelationshipType#BOUND} relation is an inverted relationship.
+     */
+    INVERTED,
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipType.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.neighbor;
 
+import java.util.Optional;
+import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -32,7 +34,7 @@ public enum RelationshipType {
      * A resource relationship exists between a service or resource and the
      * resources bound through the "resources" property.
      */
-    RESOURCE,
+    RESOURCE("resource", RelationshipDirection.DIRECTED),
 
     /**
      * An operation relationship exists between a service and the operations
@@ -40,7 +42,7 @@ public enum RelationshipType {
      * resource and the operations bound to the resource in only the
      * "operations" property.
      */
-    OPERATION,
+    OPERATION("operation", RelationshipDirection.DIRECTED),
 
     /**
      * A BINDING relationship exists between the following shapes:
@@ -55,115 +57,152 @@ public enum RelationshipType {
      * The subject of the relationship is that shape that was bound, and the
      * target is the shape that declared the binding.
      */
-    BOUND,
+    BOUND("bound", RelationshipDirection.INVERTED),
 
     /**
      * Relationships that exist between a resource and the create lifecycle
      * operation.
      */
-    CREATE,
+    CREATE("create", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist between a resource and the get lifecycle
      * operation.
      */
-    READ,
+    READ("read", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist between a resource and the update lifecycle
      * operation.
      */
-    UPDATE,
+    UPDATE("update", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist between a resource and the delete lifecycle
      * operation.
      */
-    DELETE,
+    DELETE("delete", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist between a resource and the list lifecycle
      * operation.
      */
-    LIST,
+    LIST("list", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist between a {@link ResourceShape member} and
      * the shapes that are referenced by its identifiers property.
      */
-    IDENTIFIER,
+    IDENTIFIER("identifier", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships exist on {@link MemberShape member} shapes. The subject
      * of the relationship is the member shape, and the neighbor is the
      * aggregate shape that contains the member.
      */
-    MEMBER_CONTAINER,
+    MEMBER_CONTAINER(null, RelationshipDirection.INVERTED),
 
     /**
      * Relationships exist on {@link MemberShape member} shapes. The subject
      * of the relationship is the member shape, and the neighbor is the shape
      * that the member targets.
      */
-    MEMBER_TARGET,
+    MEMBER_TARGET(null, RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link OperationShape operation} shapes.
      * They reference {@link StructureShape structure} shapes that are used
      * as input.
      */
-    INPUT,
+    INPUT("input", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link OperationShape operation} shapes.
      * They reference {@link StructureShape structure} shapes that are used
      * as output.
      */
-    OUTPUT,
+    OUTPUT("output", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link OperationShape operation} shapes.
      * They reference {@link StructureShape structure} shapes that can be
      * returned from the operation.
      */
-    ERROR,
+    ERROR("error", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link ListShape list} shapes to their
      * {@link MemberShape member shapes}.
      */
-    LIST_MEMBER,
+    LIST_MEMBER("member", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link SetShape set} shapes to their
      * {@link MemberShape member shapes}.
      */
-    SET_MEMBER,
+    SET_MEMBER("member", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link MapShape map} shapes. They reference
      * {@link MemberShape member} shapes that define the key type for the map.
      */
-    MAP_KEY,
+    MAP_KEY("member", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link MapShape map} shapes. They
      * reference {@link MemberShape member} shapes that define the value type
      * for the map.
      */
-    MAP_VALUE,
+    MAP_VALUE("member", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link StructureShape structure} shapes.
      * They reference {@link MemberShape member} shapes that define the
      * attributes of a structure.
      */
-    STRUCTURE_MEMBER,
+    STRUCTURE_MEMBER("member", RelationshipDirection.DIRECTED),
 
     /**
      * Relationships that exist on {@link UnionShape union}
      * shapes. They reference the {@link MemberShape member} shapes that define
      * the members of the union.
      */
-    UNION_MEMBER;
+    UNION_MEMBER("member", RelationshipDirection.DIRECTED);
+
+    private String selectorLabel;
+    private RelationshipDirection direction;
+
+    RelationshipType(String selectorLabel, RelationshipDirection direction) {
+        this.selectorLabel = selectorLabel;
+        this.direction = direction;
+    }
+
+    /**
+     * Gets the token that is used in {@link Selector} expressions when
+     * referring to the relationship or an empty {@code Optional} if this
+     * relationship is not used directly in a selector.
+     *
+     * @return Returns the optionally present selector token for this relationship.
+     */
+    public Optional<String> getSelectorLabel() {
+        return Optional.ofNullable(selectorLabel);
+    }
+
+    /**
+     * Gets the direction of the relationship.
+     *
+     * <p>A {@link RelationshipDirection#DIRECTED} direction is formed from a shape
+     * that defines a reference to another shape (for example, when a resource
+     * defines operations or resources it contains).
+     *
+     * <p>A {@link RelationshipDirection#INVERTED} relationship is a relationship
+     * from a shape to a shape that defines a relationship to it. The target
+     * of such a relationship doesn't define the relationship, but is the
+     * target of the relationship.
+     *
+     * @return Returns the direction of the relationship.
+     */
+    public RelationshipDirection getDirection() {
+        return direction;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/NeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/NeighborSelector.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,29 +51,14 @@ final class NeighborSelector implements Selector {
 
     private Optional<Shape> createNeighbor(Relationship rel, Shape target) {
         if (rel.getRelationshipType() != RelationshipType.MEMBER_CONTAINER
-                && (relTypes.isEmpty() || relTypes.contains(getRelType(rel.getRelationshipType())))) {
+                && (relTypes.isEmpty() || relTypes.contains(getRelType(rel)))) {
             return Optional.of(target);
         }
 
         return Optional.empty();
     }
 
-    /**
-     * Gets the name that appears in a selector for a relationship type.
-     *
-     * @param rel Relationship type to convert to a selector relationship.
-     * @return Returns the converted name.
-     */
-    static String getRelType(RelationshipType rel) {
-        switch (rel) {
-            case STRUCTURE_MEMBER:
-            case UNION_MEMBER:
-            case LIST_MEMBER:
-            case MAP_KEY:
-            case MAP_VALUE:
-                return "member";
-            default:
-                return rel.toString().toLowerCase(Locale.ENGLISH);
-        }
+    private static String getRelType(Relationship rel) {
+        return rel.getSelectorLabel().orElse("");
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Parser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Parser.java
@@ -16,10 +16,13 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import software.amazon.smithy.model.neighbor.RelationshipType;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -33,9 +36,7 @@ import software.amazon.smithy.utils.SetUtils;
  */
 final class Parser {
     private static final Set<Character> BREAK_TOKENS = SetUtils.of(',', ']', ')');
-    private static final List<String> REL_TYPES = ListUtils.of(
-            "identifier", "create", "read", "update", "delete", "list", "member", "input", "output", "error",
-            "operation", "resource", "bound");
+    private static final Set<String> REL_TYPES = new HashSet<>();
     private static final List<String> FUNCTIONS = ListUtils.of("test", "each", "of", "not");
     private static final List<String> ATTRIBUTES = ListUtils.of(
             "trait|", "id|namespace", "id|name", "id|member", "id", "service|version");
@@ -44,11 +45,20 @@ final class Parser {
     private static final List<String> START_FUNCTION = ListUtils.of("(");
     private static final List<String> FUNCTION_ARG_NEXT_TOKEN = ListUtils.of(")", ",");
     private static final List<String> MULTI_EDGE_NEXT_ARG_TOKEN = ListUtils.of(",", "]->");
-    private static final List<String> EXPRESSION_TOKENS = ListUtils.of(
-            ":", "[", ">", "-[",
-            "*", "blob", "boolean", "string", "byte", "short", "integer", "long", "float", "document", "double",
-            "bigInteger", "bigDecimal", "timestamp", "list", "map", "set", "structure", "union", "service",
-            "operation", "resource", "member", "number", "simpleType", "collection");
+    private static final List<String> EXPRESSION_TOKENS = new ArrayList<>(Arrays.asList(
+            ":", "[", ">", "-[", "*", "number", "simpleType", "collection"));
+
+    static {
+        // Adds selector relationship labels.
+        for (RelationshipType rel : RelationshipType.values()) {
+            rel.getSelectorLabel().ifPresent(REL_TYPES::add);
+        }
+
+        // Adds all shape types as possible tokens.
+        for (ShapeType type : ShapeType.values()) {
+            EXPRESSION_TOKENS.add(type.toString());
+        }
+    }
 
     private final String expression;
     private int position = 0;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
@@ -63,7 +63,7 @@ public enum ShapeType {
     public static Optional<ShapeType> fromString(String text) {
         for (ShapeType e : values()) {
             if (e.stringValue.equals(text)) {
-                return Optional.ofNullable(e);
+                return Optional.of(e);
             }
         }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
@@ -64,10 +64,10 @@ public class BottomUpNeighborVisitorTest {
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 
         assertThat(neighborVisitor.getNeighbors(shape), containsInAnyOrder(
-                new Relationship(listMemberShape, RelationshipType.MEMBER_TARGET, shape.getId(), shape),
-                new Relationship(mapKeyShape, RelationshipType.MEMBER_TARGET, shape.getId(), shape),
-                new Relationship(mapValueShape, RelationshipType.MEMBER_TARGET, shape.getId(), shape),
-                new Relationship(structureMemberShape, RelationshipType.MEMBER_TARGET, shape.getId(), shape)));
+                Relationship.create(listMemberShape, RelationshipType.MEMBER_TARGET, shape),
+                Relationship.create(mapKeyShape, RelationshipType.MEMBER_TARGET, shape),
+                Relationship.create(mapValueShape, RelationshipType.MEMBER_TARGET, shape),
+                Relationship.create(structureMemberShape, RelationshipType.MEMBER_TARGET, shape)));
     }
 
     @Test
@@ -111,17 +111,15 @@ public class BottomUpNeighborVisitorTest {
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 
         assertThat(neighborVisitor.getNeighbors(listMemberShape), containsInAnyOrder(
-                new Relationship(listShape, RelationshipType.LIST_MEMBER, listMemberShape.getId(), listMemberShape)));
+                Relationship.create(listShape, RelationshipType.LIST_MEMBER, listMemberShape)));
         assertThat(neighborVisitor.getNeighbors(mapKeyShape), containsInAnyOrder(
-                new Relationship(mapShape, RelationshipType.MAP_KEY, mapKeyShape.getId(), mapKeyShape)));
+                Relationship.create(mapShape, RelationshipType.MAP_KEY, mapKeyShape)));
         assertThat(neighborVisitor.getNeighbors(mapValueShape), containsInAnyOrder(
-                new Relationship(mapShape, RelationshipType.MAP_VALUE, mapValueShape.getId(), mapValueShape)));
+                Relationship.create(mapShape, RelationshipType.MAP_VALUE, mapValueShape)));
         assertThat(neighborVisitor.getNeighbors(structureMemberShape), containsInAnyOrder(
-                new Relationship(structureShape, RelationshipType.STRUCTURE_MEMBER, structureMemberShape.getId(),
-                        structureMemberShape)));
+                Relationship.create(structureShape, RelationshipType.STRUCTURE_MEMBER, structureMemberShape)));
         assertThat(neighborVisitor.getNeighbors(tuMemberShape), containsInAnyOrder(
-                new Relationship(unionShape, RelationshipType.UNION_MEMBER, tuMemberShape.getId(),
-                        tuMemberShape)));
+                Relationship.create(unionShape, RelationshipType.UNION_MEMBER, tuMemberShape)));
     }
 
     @Test
@@ -145,14 +143,14 @@ public class BottomUpNeighborVisitorTest {
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 
         assertThat(neighborVisitor.getNeighbors(input), containsInAnyOrder(
-                new Relationship(fooOperation, RelationshipType.INPUT, input.getId(), input),
-                new Relationship(barOperation, RelationshipType.OUTPUT, input.getId(), input)));
+                Relationship.create(fooOperation, RelationshipType.INPUT, input),
+                Relationship.create(barOperation, RelationshipType.OUTPUT, input)));
         assertThat(neighborVisitor.getNeighbors(output), containsInAnyOrder(
-                new Relationship(fooOperation, RelationshipType.OUTPUT, output.getId(), output),
-                new Relationship(barOperation, RelationshipType.INPUT, output.getId(), output)));
+                Relationship.create(fooOperation, RelationshipType.OUTPUT, output),
+                Relationship.create(barOperation, RelationshipType.INPUT, output)));
         assertThat(neighborVisitor.getNeighbors(error), containsInAnyOrder(
-                new Relationship(fooOperation, RelationshipType.ERROR, error.getId(), error),
-                new Relationship(barOperation, RelationshipType.ERROR, error.getId(), error)));
+                Relationship.create(fooOperation, RelationshipType.ERROR, error),
+                Relationship.create(barOperation, RelationshipType.ERROR, error)));
     }
 
     @Test
@@ -171,8 +169,8 @@ public class BottomUpNeighborVisitorTest {
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 
         assertThat(neighborVisitor.getNeighbors(service), containsInAnyOrder(
-                new Relationship(resourceShape, RelationshipType.BOUND, service.getId(), service),
-                new Relationship(operationShape, RelationshipType.BOUND, service.getId(), service)
+                Relationship.create(resourceShape, RelationshipType.BOUND, service),
+                Relationship.create(operationShape, RelationshipType.BOUND, service)
         ));
     }
 
@@ -202,16 +200,16 @@ public class BottomUpNeighborVisitorTest {
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 
         assertThat(neighborVisitor.getNeighbors(child2), containsInAnyOrder(
-                new Relationship(child1, RelationshipType.RESOURCE, child2.getId(), child2)));
+                Relationship.create(child1, RelationshipType.RESOURCE, child2)));
         assertThat(neighborVisitor.getNeighbors(child1), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.RESOURCE, child1.getId(), child1),
-                new Relationship(otherService, RelationshipType.RESOURCE, child1.getId(), child1),
-                new Relationship(child2, RelationshipType.BOUND, child1.getId(), child1)));
+                Relationship.create(resource, RelationshipType.RESOURCE, child1),
+                Relationship.create(otherService, RelationshipType.RESOURCE, child1),
+                Relationship.create(child2, RelationshipType.BOUND, child1)));
         assertThat(neighborVisitor.getNeighbors(resource), containsInAnyOrder(
-                new Relationship(parent, RelationshipType.RESOURCE, resource.getId(), resource),
-                new Relationship(child1, RelationshipType.BOUND, resource.getId(), resource)));
+                Relationship.create(parent, RelationshipType.RESOURCE, resource),
+                Relationship.create(child1, RelationshipType.BOUND, resource)));
         assertThat(neighborVisitor.getNeighbors(child2), containsInAnyOrder(
-                new Relationship(child1, RelationshipType.RESOURCE, child2.getId(), child2)));
+                Relationship.create(child1, RelationshipType.RESOURCE, child2)));
     }
 
     @Test
@@ -261,23 +259,23 @@ public class BottomUpNeighborVisitorTest {
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 
         assertThat(neighborVisitor.getNeighbors(namedOperation), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.OPERATION, namedOperation.getId(), namedOperation),
-                new Relationship(otherService, RelationshipType.OPERATION, namedOperation.getId(), namedOperation)));
+                Relationship.create(resource, RelationshipType.OPERATION, namedOperation),
+                Relationship.create(otherService, RelationshipType.OPERATION, namedOperation)));
         assertThat(neighborVisitor.getNeighbors(createOperation), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.CREATE, createOperation.getId(), createOperation),
-                new Relationship(resource, RelationshipType.OPERATION, createOperation.getId(), createOperation)));
+                Relationship.create(resource, RelationshipType.CREATE, createOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, createOperation)));
         assertThat(neighborVisitor.getNeighbors(getOperation), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.READ, getOperation.getId(), getOperation),
-                new Relationship(resource, RelationshipType.OPERATION, getOperation.getId(), getOperation)));
+                Relationship.create(resource, RelationshipType.READ, getOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, getOperation)));
         assertThat(neighborVisitor.getNeighbors(updateOperation), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.UPDATE, updateOperation.getId(), updateOperation),
-                new Relationship(resource, RelationshipType.OPERATION, updateOperation.getId(), updateOperation)));
+                Relationship.create(resource, RelationshipType.UPDATE, updateOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, updateOperation)));
         assertThat(neighborVisitor.getNeighbors(deleteOperation), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.DELETE, deleteOperation.getId(), deleteOperation),
-                new Relationship(resource, RelationshipType.OPERATION, deleteOperation.getId(), deleteOperation)));
+                Relationship.create(resource, RelationshipType.DELETE, deleteOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, deleteOperation)));
         assertThat(neighborVisitor.getNeighbors(listOperation), containsInAnyOrder(
-                new Relationship(resource, RelationshipType.LIST, listOperation.getId(), listOperation),
-                new Relationship(resource, RelationshipType.OPERATION, listOperation.getId(), listOperation)));
+                Relationship.create(resource, RelationshipType.LIST, listOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, listOperation)));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
@@ -98,8 +98,7 @@ public class NeighborVisitorTest {
         MemberShape memberTarget = list.getMember();
         List<Relationship> relationships = list.accept(neighborVisitor);
 
-        assertThat(relationships, contains(
-                new Relationship(list, RelationshipType.LIST_MEMBER, memberTarget.getId(), memberTarget)));
+        assertThat(relationships, contains(Relationship.create(list, RelationshipType.LIST_MEMBER, memberTarget)));
     }
 
     @Test
@@ -124,8 +123,8 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = map.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(map, RelationshipType.MAP_KEY, keyTarget.getId(), keyTarget),
-                new Relationship(map, RelationshipType.MAP_VALUE, valueTarget.getId(), valueTarget)));
+                Relationship.create(map, RelationshipType.MAP_KEY, keyTarget),
+                Relationship.create(map, RelationshipType.MAP_VALUE, valueTarget)));
     }
 
     @Test
@@ -156,8 +155,8 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = struct.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(struct, RelationshipType.STRUCTURE_MEMBER, member1Target.getId(), member1Target),
-                new Relationship(struct, RelationshipType.STRUCTURE_MEMBER, member2Target.getId(), member2Target)));
+                Relationship.create(struct, RelationshipType.STRUCTURE_MEMBER, member1Target),
+                Relationship.create(struct, RelationshipType.STRUCTURE_MEMBER, member2Target)));
     }
 
     @Test
@@ -188,8 +187,8 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = union.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(union, RelationshipType.UNION_MEMBER, v1Target.getId(), v1Target),
-                new Relationship(union, RelationshipType.UNION_MEMBER, v2Target.getId(), v2Target)));
+                Relationship.create(union, RelationshipType.UNION_MEMBER, v1Target),
+                Relationship.create(union, RelationshipType.UNION_MEMBER, v2Target)));
     }
 
     @Test
@@ -209,10 +208,10 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = service.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(service, RelationshipType.RESOURCE, resourceShape.getId(), resourceShape),
-                new Relationship(service, RelationshipType.OPERATION, operationShape.getId(), operationShape),
-                new Relationship(resourceShape, RelationshipType.BOUND, service.getId(), service),
-                new Relationship(operationShape, RelationshipType.BOUND, service.getId(), service)));
+                Relationship.create(service, RelationshipType.RESOURCE, resourceShape),
+                Relationship.create(service, RelationshipType.OPERATION, operationShape),
+                Relationship.create(resourceShape, RelationshipType.BOUND, service),
+                Relationship.create(operationShape, RelationshipType.BOUND, service)));
     }
 
     @Test
@@ -262,31 +261,31 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = resource.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(parent, RelationshipType.RESOURCE, resource.getId(), resource),
+                Relationship.create(parent, RelationshipType.RESOURCE, resource),
 
-                new Relationship(resource, RelationshipType.BOUND, parent.getId(), parent),
-                new Relationship(resource, RelationshipType.IDENTIFIER, identifier.getId(), identifier),
-                new Relationship(resource, RelationshipType.CREATE, createOperation.getId(), createOperation),
-                new Relationship(resource, RelationshipType.READ, getOperation.getId(), getOperation),
-                new Relationship(resource, RelationshipType.UPDATE, updateOperation.getId(), updateOperation),
-                new Relationship(resource, RelationshipType.DELETE, deleteOperation.getId(), deleteOperation),
-                new Relationship(resource, RelationshipType.LIST, listOperation.getId(), listOperation),
-                new Relationship(resource, RelationshipType.OPERATION, createOperation.getId(), createOperation),
-                new Relationship(resource, RelationshipType.OPERATION, getOperation.getId(), getOperation),
-                new Relationship(resource, RelationshipType.OPERATION, updateOperation.getId(), updateOperation),
-                new Relationship(resource, RelationshipType.OPERATION, deleteOperation.getId(), deleteOperation),
-                new Relationship(resource, RelationshipType.OPERATION, listOperation.getId(), listOperation),
-                new Relationship(resource, RelationshipType.OPERATION, namedOperation.getId(), namedOperation),
-                new Relationship(resource, RelationshipType.RESOURCE, child1.getId(), child1),
+                Relationship.create(resource, RelationshipType.BOUND, parent),
+                Relationship.create(resource, RelationshipType.IDENTIFIER, identifier),
+                Relationship.create(resource, RelationshipType.CREATE, createOperation),
+                Relationship.create(resource, RelationshipType.READ, getOperation),
+                Relationship.create(resource, RelationshipType.UPDATE, updateOperation),
+                Relationship.create(resource, RelationshipType.DELETE, deleteOperation),
+                Relationship.create(resource, RelationshipType.LIST, listOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, createOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, getOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, updateOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, deleteOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, listOperation),
+                Relationship.create(resource, RelationshipType.OPERATION, namedOperation),
+                Relationship.create(resource, RelationshipType.RESOURCE, child1),
 
-                new Relationship(namedOperation, RelationshipType.BOUND, resource.getId(), resource),
-                new Relationship(createOperation, RelationshipType.BOUND, resource.getId(), resource),
-                new Relationship(getOperation, RelationshipType.BOUND, resource.getId(), resource),
-                new Relationship(updateOperation, RelationshipType.BOUND, resource.getId(), resource),
-                new Relationship(deleteOperation, RelationshipType.BOUND, resource.getId(), resource),
-                new Relationship(listOperation, RelationshipType.BOUND, resource.getId(), resource),
+                Relationship.create(namedOperation, RelationshipType.BOUND, resource),
+                Relationship.create(createOperation, RelationshipType.BOUND, resource),
+                Relationship.create(getOperation, RelationshipType.BOUND, resource),
+                Relationship.create(updateOperation, RelationshipType.BOUND, resource),
+                Relationship.create(deleteOperation, RelationshipType.BOUND, resource),
+                Relationship.create(listOperation, RelationshipType.BOUND, resource),
 
-                new Relationship(child1, RelationshipType.BOUND, resource.getId(), resource)
+                Relationship.create(child1, RelationshipType.BOUND, resource)
         ));
     }
 
@@ -306,9 +305,9 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = method.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(method, RelationshipType.INPUT, input.getId(), input),
-                new Relationship(method, RelationshipType.OUTPUT, output.getId(), output),
-                new Relationship(method, RelationshipType.ERROR, error.getId(), error)));
+                Relationship.create(method, RelationshipType.INPUT, input),
+                Relationship.create(method, RelationshipType.OUTPUT, output),
+                Relationship.create(method, RelationshipType.ERROR, error)));
     }
 
     @Test
@@ -333,8 +332,8 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = target.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(target, RelationshipType.MEMBER_CONTAINER, list.getId(), list),
-                new Relationship(target, RelationshipType.MEMBER_TARGET, string.getId(), string)));
+                Relationship.create(target, RelationshipType.MEMBER_CONTAINER, list),
+                Relationship.create(target, RelationshipType.MEMBER_TARGET, string)));
     }
 
     @Test
@@ -350,7 +349,7 @@ public class NeighborVisitorTest {
         List<Relationship> relationships = target.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
-                new Relationship(target, RelationshipType.MEMBER_CONTAINER, ShapeId.from("ns.foo#List"), null),
-                new Relationship(target, RelationshipType.MEMBER_TARGET, ShapeId.from("ns.foo#String"), null)));
+                Relationship.createInvalid(target, RelationshipType.MEMBER_CONTAINER, ShapeId.from("ns.foo#List")),
+                Relationship.createInvalid(target, RelationshipType.MEMBER_TARGET, ShapeId.from("ns.foo#String"))));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/RelationshipTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/RelationshipTest.java
@@ -15,13 +15,10 @@
 
 package software.amazon.smithy.model.neighbor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -32,7 +29,7 @@ public class RelationshipTest {
     public void hasShortCtor() {
         Shape member = MemberShape.builder().id("ns.foo#List$member").target("ns.foo#String").build();
         Shape target = StringShape.builder().id("ns.foo#String").build();
-        Relationship relationship = new Relationship(member, RelationshipType.MEMBER_TARGET, target);
+        Relationship relationship = Relationship.create(member, RelationshipType.MEMBER_TARGET, target);
 
         assertSame(member, relationship.getShape());
         assertSame(RelationshipType.MEMBER_TARGET, relationship.getRelationshipType());
@@ -44,7 +41,7 @@ public class RelationshipTest {
     public void getters() {
         Shape member = MemberShape.builder().id("ns.foo#List$member").target("ns.foo#String").build();
         Shape target = StringShape.builder().id("ns.foo#String").build();
-        Relationship relationship = new Relationship(member, RelationshipType.MEMBER_TARGET, target.getId(), target);
+        Relationship relationship = Relationship.create(member, RelationshipType.MEMBER_TARGET, target);
 
         assertSame(member, relationship.getShape());
         assertSame(RelationshipType.MEMBER_TARGET, relationship.getRelationshipType());
@@ -53,27 +50,16 @@ public class RelationshipTest {
     }
 
     @Test
-    public void throwsOnMissMatchedNeighborShapeAndId() {
-        Throwable thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            Shape member = MemberShape.builder().id("ns.foo#List$member").target("ns.foo#String").build();
-            Shape target = StringShape.builder().id("ns.foo#String").build();
-            new Relationship(member, RelationshipType.MEMBER_TARGET, target.getId().withMember("bad"), target);
-        });
-
-        assertThat(thrown.getMessage(), containsString("neighborShapeId must be the same as neighborShape#getId()"));
-    }
-
-    @Test
     public void equalsAndHashCode() {
         Shape member = MemberShape.builder().id("ns.foo#List$member").target("ns.foo#String").build();
         Shape target = StringShape.builder().id("ns.foo#String").build();
         Shape otherString = StringShape.builder().id("ns.foo#String2").build();
-        Relationship r1 = new Relationship(member, RelationshipType.MEMBER_TARGET, target.getId(), target);
-        Relationship r2 = new Relationship(member, RelationshipType.MEMBER_TARGET, target.getId(), target);
-        Relationship r3 = new Relationship(target, RelationshipType.MEMBER_TARGET, target.getId(), target);
-        Relationship r4 = new Relationship(member, RelationshipType.READ, target.getId(), target);
-        Relationship r5 = new Relationship(member, RelationshipType.MEMBER_TARGET, otherString.getId(), otherString);
-        Relationship r6 = new Relationship(member, RelationshipType.MEMBER_TARGET, target.getId(), null);
+        Relationship r1 = Relationship.create(member, RelationshipType.MEMBER_TARGET, target);
+        Relationship r2 = Relationship.create(member, RelationshipType.MEMBER_TARGET, target);
+        Relationship r3 = Relationship.create(target, RelationshipType.MEMBER_TARGET, target);
+        Relationship r4 = Relationship.create(member, RelationshipType.READ, target);
+        Relationship r5 = Relationship.create(member, RelationshipType.MEMBER_TARGET, otherString);
+        Relationship r6 = Relationship.createInvalid(member, RelationshipType.MEMBER_TARGET, target.getId());
 
         assertNotEquals(r1, "foo");
         assertEquals(r1, r2);


### PR DESCRIPTION
1. Update the selector parser to reuse enum definition metadata when
   adding relationship tokens. As relationships are added, they will
   automatically be made available to selectors.
2. Update the selector parser to reuse the ShapeType enum when
   populating tokens. As shape types are added, they will automatically
   be made available to selectors.
3. The label and direction of relationships are now available on
   relationships. This metadata is reused in various places. The
   direction is either directed or inverted. A directed relationship are
   the only kinds of relationships used when running PathFinder.
4. Relationshp types now have two named constructors to make it easier
   to understand their intent and to prevent the possibility of creating
   an invalid relationship where the neighbor shape ID doesn't equal the
   actual neighbor's shape ID.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
