### PR TITLE
Allow comments in Smithy manifest

### DIFF
--- a/smithy-build/README.md
+++ b/smithy-build/README.md
@@ -538,6 +538,6 @@ model *and* all of the newly added shapes, traits, and metadata.
 
 The manifest file is a newline (`\n`) separated file that contains the
 relative path from the manifest file to each model file created by the
-sources plugin. A Smithy manifest file is stored in a JAR as
-`META-INF/smithy/manifest`. All model names referenced by the manifest are
-relative to `META-INF/smithy/`.
+sources plugin. Lines that start with a number sign (#) are comments and are
+ignored. A Smithy manifest file is stored in a JAR as `META-INF/smithy/manifest`.
+All model names referenced by the manifest are relative to `META-INF/smithy/`.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelDiscovery.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelDiscovery.java
@@ -56,6 +56,7 @@ import java.util.regex.Pattern;
  *
  * <ul>
  *     <li>Empty lines are ignored.</li>
+ *     <li>Lines that start with a number sign (#) are comments and are ignored.</li>
  *     <li>Lines must contain only ASCII characters </li>
  *     <li>Lines must not start with "/" or end with "/". Models are resolved
  *     as relative resources to the manifest URL and expected to be
@@ -223,11 +224,14 @@ public final class ModelDiscovery {
                 if (line == null) {
                     break;
                 } else if (!line.isEmpty()) {
-                    if (!isValidateResourceLine(line)) {
+                    if (line.charAt(0) == '#') {
+                        // Ignore comments.
+                    } else if (!isValidateResourceLine(line)) {
                         throw new ModelManifestException(format(
                                 "Illegal Smithy model manifest syntax found in `%s`: `%s`", location, line));
+                    } else {
+                        models.add(line);
                     }
-                    models.add(line);
                 }
             }
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelDiscoveryTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelDiscoveryTest.java
@@ -49,6 +49,19 @@ public class ModelDiscoveryTest {
     }
 
     @Test
+    public void skipsCommentLines() throws IOException {
+        URL manifest = getClass().getResource("manifest-valid-with-comments");
+        String prefix = manifest.toString().substring(0, manifest.toString().length() - "manifest".length());
+        List<URL> models = ModelDiscovery.findModels(manifest);
+
+        assertThat(models, contains(
+                new URL(prefix + "foo.smithy"),
+                new URL(prefix + "baz/bar/example.json"),
+                new URL(prefix + "test"),
+                new URL(prefix + "test2")));
+    }
+
+    @Test
     public void prohibitsLeadingSlash() {
         Assertions.assertThrows(ModelManifestException.class, () -> {
             URL manifest = getClass().getResource("manifest-prohibits-leading-slash");

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/manifest-valid-with-comments
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/manifest-valid-with-comments
@@ -1,0 +1,17 @@
+# Hello!!!!
+foo.smithy
+# Can you hear me?
+baz/bar/example.json
+# is it late there?
+test
+
+
+
+
+test
+test2
+# Am I getting
+#
+#through
+#to
+# you


### PR DESCRIPTION
1. Comments are also supported in the Java ServiceLoader
2. Comments allow for future metadata in manifests. For example, imagine if we were to create a compiled version of the models stored in a JAR that removes the need to load and parse Smithy models at runtime. Rather, some special form of comment could be added that tooling that understands it could load the class and load models in a more performant way.

Just as an example:

```
# !compiled: com.foo.baz.CompiledModelDiscovery
foo.smithy
baz.smithy
```