### PR TITLE
Minor improvements to CLI

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/BuildParameterBuilder.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/BuildParameterBuilder.java
@@ -109,6 +109,26 @@ public final class BuildParameterBuilder {
     }
 
     /**
+     * Adds a collection of "source" model files only if they exist.
+     *
+     * @param sources Sources to add.
+     * @return Returns the builder.
+     */
+    public BuildParameterBuilder addSourcesIfExists(Collection<String> sources) {
+        if (sources != null) {
+            for (String source : sources) {
+                if (!source.isEmpty() && Files.exists(Paths.get(source))) {
+                    this.sources.addAll(sources);
+                } else {
+                    LOGGER.info("Skipping source that does not exist: " + source);
+                }
+            }
+        }
+
+        return this;
+    }
+
+    /**
      * Sets the build classpath.
      *
      * @param buildClasspath Classpath to set.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
@@ -42,7 +42,9 @@ import java.util.logging.SimpleFormatter;
  *     <li>--help | -h: Prints subcommand help text.</li>
  *     <li>--debug: Prints debug information, including exception stack traces.</li>
  *     <li>--no-color: Explicitly disables ANSI colors.</li>
+ *     <li>--force-color: Explicitly enables ANSI colors.</li>
  *     <li>--stacktrace: Prints the stacktrace of any CLI exception that is thrown.</li>
+ *     <li>--quiet-logs: Disables writing log messages to STDOUT.</li>
  * </ul>
  *
  * <p>Why are we not using a library for this? Because parsing command line
@@ -54,8 +56,10 @@ import java.util.logging.SimpleFormatter;
 public final class Cli {
     public static final String HELP = "--help";
     public static final String NO_COLOR = "--no-color";
+    public static final String FORCE_COLOR = "--force-color";
     public static final String DEBUG = "--debug";
     public static final String STACKTRACE = "--stacktrace";
+    public static final String QUIET_LOGS = "--quiet-logs";
     private static final SimpleDateFormat FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
 
     private final String applicationName;
@@ -125,6 +129,8 @@ public final class Cli {
                 // Use the --no-color argument to globally disable ANSI colors.
                 if (parsedArguments.has(NO_COLOR)) {
                     Colors.setUseAnsiColors(false);
+                } else if (parsedArguments.has(FORCE_COLOR)) {
+                    Colors.setUseAnsiColors(true);
                 }
                 // Automatically handle --help output for subcommands.
                 if (parsedArguments.has(HELP)) {
@@ -143,7 +149,7 @@ public final class Cli {
     }
 
     private void configureLogging(String[] args) {
-        if (configureLogging) {
+        if (configureLogging && !hasArgument(args, QUIET_LOGS)) {
             Handler handler = getConsoleHandler();
             if (hasArgument(args, DEBUG)) {
                 handler.setFormatter(new DebugFormatter());
@@ -275,7 +281,7 @@ public final class Cli {
             table.put("  " + name + "  ", parser.getPositionalHelp().orElse(""));
         });
 
-        body.append(createTable(table).trim());
+        body.append("  ").append(createTable(table).trim());
 
         String help = command.getHelp();
         if (!help.isEmpty()) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Parser.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Parser.java
@@ -246,10 +246,12 @@ public final class Parser {
 
         private Builder() {
             // Always include --help, --debug, --stacktrace, and --no-color options.
-            option("--help", "-h", "Print this help");
-            option("--debug", "Display debug information");
-            option("--stacktrace", "Display a stacktrace on error");
-            option("--no-color", "Explicitly disable ANSI colors");
+            option(Cli.HELP, "-h", "Print this help");
+            option(Cli.DEBUG, "Display debug information");
+            option(Cli.STACKTRACE, "Display a stacktrace on error");
+            option(Cli.NO_COLOR, "Explicitly disable ANSI colors");
+            option(Cli.FORCE_COLOR, "Explicitly enables ANSI colors");
+            option(Cli.QUIET_LOGS, "Disables writing log messages to STDOUT");
         }
 
         @Override

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BuildParameterBuilderTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BuildParameterBuilderTest.java
@@ -150,6 +150,15 @@ public class BuildParameterBuilderTest {
     }
 
     @Test
+    public void skipsSourcesThatDoNotExsit() {
+        BuildParameterBuilder.Result result = new BuildParameterBuilder()
+                .addSourcesIfExists(ListUtils.of("foo.smithy", "bar.smithy"))
+                .build();
+
+        assertThat(result.args, contains("build"));
+    }
+
+    @Test
     public void projectionBuildUsesCorrectClasspaths() {
         BuildParameterBuilder.Result result = new BuildParameterBuilder()
                 .projectionSource("foo")


### PR DESCRIPTION
This commit adds a method that skips sources when they don't exist,
allows the forcing of ANSI colors, and can disable the printing of log
statements (for example, if a build tool already intercepts and writes
out log statements).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
