### PR TITLE
Add API Gateway and OpenAPI docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.7.0,<=1.8.0
-pygments==2.2.0
+pygments==2.4.2
 sphinx-tabs==1.1.7

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -1,0 +1,578 @@
+============================
+Converting Smithy to OpenAPI
+============================
+
+This guide describes how Smithy models can be converted to `OpenAPI`_
+specifications.
+
+.. contents:: Table of contents
+    :depth: 2
+    :local:
+    :backlinks: none
+
+------------
+Introduction
+------------
+
+OpenAPI is a standard for describing REST APIs. While Smithy has it's own
+interface definition language that's completely independent of OpenAPI,
+there are many use cases for authoring API models in Smithy and converting
+them to OpenAPI using both ad-hoc and automated workflows. For example,
+integration with `Amazon API Gateway`_, access to OpenAPI tools like
+SwaggerUI, or access to OpenAPI client and server code generators when
+Smithy generators are not available.
+
+Smithy models can be converted to OpenAPI through smithy-build using the
+``openapi`` plugin or through code using the
+`software.amazon.smithy:openapi <https://search.maven.org/search?q=g:software.amazon.smithy%20and%20a:openapi>`_
+Java package.
+
+--------------------------------------
+Differences between Smithy and OpenAPI
+--------------------------------------
+
+Smithy and OpenAPI take very different approaches to modeling APIs. Smithy is
+*protocol agnostic*, which means it focuses on the interfaces and abstractions
+that are provided to end-users rather than how the data is sent over the wire.
+While Smithy can define RESTful APIs, OpenAPI *specializes* in defining *only*
+RESTful APIs. Both approaches have their own strengths and weaknesses. For
+example, while Smithy can define a much broader set of functionality and
+services, it requires abstractions that have their own underlying complexity.
+OpenAPI is more permissive in the kinds of services it can describe, making it
+easier to adapt to existing web services, but at the same time making it possible
+to author APIs that provide a poor customer experience when using clients in
+strongly-typed languages.
+
+
+Unsupported features
+====================
+
+Converting a Smithy model to OpenAPI results in a trimmed-down, lossy
+representation of a model for a specific HTTP protocol. Various features in
+a Smithy model are not currently supported in the OpenAPI conversion:
+
+* :ref:`HTTP prefix headers <httpPrefixHeaders-trait>`: "Prefix headers"
+  are used in Smithy to bind all headers under a common prefix into a
+  single property of the input or output of an API operation. This can
+  be used for things like Amazon S3's `x-amz-meta-* headers`_. OpenAPI
+  does not currently support this kind of header.
+* :ref:`greedy-labels`: Greedy labels are used in HTTP URIs to act as a
+  placeholder for multiple segments of a URI (for example,
+  ``/foo/{baz+}/bar``). Some OpenAPI vendors/tooling support greedy labels
+  (for example, Amazon API Gateway) while other do not. The converter will
+  pass greedy labels through into the OpenAPI document by default, but they
+  can be forbidden through the ``openapi.forbidGreedyLabels`` flag.
+* :ref:`Event streams <event-streams>`: Event streams are a way of sending
+  many different messages over a stream. This is not currently implemented
+  in the converter (see `#80 <https://github.com/awslabs/smithy/issues/80>`_).
+* Streaming: Smithy allows blob and string shapes to be marked as
+  streaming, meaning that their contents should not be loaded into
+  memory by clients or servers. This is not currently something supported
+  as a built-in feature of OpenAPI (we could potentially add an extension
+  to mark a specific type as streaming).
+* :ref:`Custom traits <trait-definition>`: Custom traits defined in a Smithy
+  model are not converted and added to the OpenAPI specification. Copying
+  Smithy traits into OpenAPI as extensions requires the use of a custom
+  ``software.amazon.smithy.openapi.fromsmithy.OpenApiExtension``.
+* Non-RESTful routing: HTTP routing schemes that aren't based on
+  methods and unique URIs are not supported in OpenAPI (for example,
+  routing to operations based on a specific header or query string
+  parameter).
+* Non-HTTP protocols: Protocols that do not send requests over HTTP are
+  not supported with OpenAPI (for example, an MQTT-based protocol modeled
+  with Smithy would need to also support an HTTP-based protocol to be
+  converted to OpenAPI).
+* Resources: Smithy resource metadata is not carried over into the OpenAPI
+  specification.
+
+---------------------------------------
+Converting to OpenAPI with smithy-build
+---------------------------------------
+
+The ``openapi`` plugin contained in the ``software.amazon.smithy:openapi``
+package can be used with smithy-build and the `Smithy Gradle plugin`_ to build
+OpenAPI specifications from Smithy models.
+
+The following example shows how to configure Gradle to build an OpenAPI
+specification from a Smithy model using a buildscript dependency:
+
+.. code-block:: kotlin
+    :caption: build.gradle.kts
+    :name: smithy-build-gradle
+
+    plugins {
+        java
+        id("software.amazon.smithy").version("0.2.0")
+    }
+
+    buildscript {
+        dependencies {
+            classpath("software.amazon.smithy:openapi:0.5.4")
+        }
+    }
+
+The Smithy Gradle plugin relies on a ``smithy-build.json`` file found at the
+root of a project to define the actual process of building the OpenAPI
+specification. The following example defines a ``smithy-build.json`` file
+that builds an OpenAPI specification from a service for the
+``smithy.example#Weather`` service using the ``aws-rest-json-1.1`` protocol:
+
+.. code-block:: json
+    :caption: smithy-build.json
+    :name: smithy-build-json
+
+    {
+        "version": "1.0",
+        "plugins": {
+            "openapi": {
+                "service": "smithy.example#Weather",
+                "protocol": "aws-rest-json-1.1"
+            }
+        }
+    }
+
+.. important::
+
+    A buildscript dependency on "software.amazon.smithy:openapi:0.5.4" is
+    required in order for smithy-build to map the "openapi" plugin name to the
+    correct Java library implementation.
+
+
+OpenAPI configuration settings
+==============================
+
+The ``openapi`` plugin is highly configurable to support different OpenAPI
+tools and vendors.
+
+
+.. tip::
+
+    You typically only need to configure the ``service`` and
+    ``protocol`` settings to create a valid OpenAPI specification.
+
+The following key-value pairs are supported:
+
+service (string)
+    **Required**. The Smithy service :ref:`shape ID <shape-id>` to convert.
+
+protocol (string)
+    The protocol name to use when converting Smithy to OpenAPI (for example,
+    ``aws-rest-json-1.1``.
+
+    Smithy will try to match the provided protocol name with an implementation
+    of ``software.amazon.smithy.openapi.fromsmithy.OpenApiProtocol``
+    registered with a service provider implementation of
+    ``software.amazon.smithy.openapi.fromsmithy.CoreExtension``.
+
+openapi.tags (boolean)
+    Whether or not to include Smithy :ref:`tags <tags-trait>` in the result.
+
+openapi.supportedTags ([string])
+    Limits the exported ``openapi.tags`` to a specific set of tags. The value
+    must be a list of strings. This property requires that ``openapi.tags``
+    is set to ``true`` in order to have an effect.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "openapi.tags": true,
+                    "openapi.supportedTags": ["foo", "baz", "bar"]
+                }
+            }
+        }
+
+openapi.defaultBlobFormat (string)
+    Sets the default format property used when converting blob shapes in
+    Smithy to strings in OpenAPI. Defaults to "byte", meaning Base64 encoded.
+
+openapi.use.xml (boolean)
+    Enables converting Smithy XML traits to OpenAPI XML properties. (this
+    feature is not yet implemented).
+
+openapi.keepUnusedComponents (boolean)
+    Set to ``true`` to prevent unused components from being removed from the
+    created specification.
+
+openapi.aws.jsonContentType (string)
+    Sets the media-type to associate with the JSON payload of ``aws.json-*``
+    and ``aws.rest-json-*`` protocols
+
+openapi.forbidGreedyLabels (boolean)
+    Set to true to forbid greedy URI labels. By default, greedy labels will
+    appear as-is in the path generated for an operation. For example,
+    "/{foo+}".
+
+openapi.onHttpPrefixHeaders (string)
+    Specifies what to do when the :ref:`httpPrefixHeaders-trait` is found in
+    a model. OpenAPI does not support ``httpPrefixHeaders``. By default, the
+    conversion will fail when this trait is encountered, but this behavior
+    can be customized using the following values for the ``openapi.onHttpPrefixHeaders``
+    setting:
+
+    * FAIL: The default setting that causes the build to fail.
+    * WARN: The header is omitted from the OpenAPI model and a warning is logged.
+
+    .. note::
+
+        Additional values may be supported by other mappers or protocols.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "openapi.onHttpPrefixHeaders": "WARN"
+                }
+            }
+        }
+
+openapi.ignoreUnsupportedTrait (boolean)
+    Emits warnings rather than failing when unsupported traits like
+    ``eventStream`` are encountered.
+
+openapi.disablePrimitiveInlining (boolean)
+    Disables the automatic inlining of primitive ``$ref`` targets.
+
+    Inlining these primitive references helps to make the generated
+    OpenAPI models more idiomatic while leaving complex types as-is so that
+    they support recursive types.
+
+    A *primitive reference* is considered one of the following OpenAPI types:
+
+    * integer
+    * number
+    * boolean
+    * string
+
+    A *primitive collection* is an array that has an "items"  property that
+    targets a primitive reference, or an object with no "properties" and an
+    "additionalProperties" reference that targets a primitive type.
+
+openapi.substitutions (``Map<String, any>``)
+    Defines a map of strings to any JSON value to find and replace in the
+    generated OpenAPI model.
+
+    This allows for placeholders to appear in the value of Smithy traits that
+    can be converted at build-time to an appropriate value.
+
+    String values are replaced if the string in its entirety matches
+    one of the keys provided in the ``openapi.substitutions`` map. The
+    corresponding value is then substituted for the string-- this could even
+    result in a string changing into an object, array, etc.
+
+    The following example will find all strings with a value of "REPLACE_ME"
+    and replace the string with an array value of
+    ``["this is a", " replacement"]`` and replace all strings with a value
+    of ``ANOTHER_REPLACEMENT`` with ``Hello!!!``:
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "openapi.substitutions": {
+                        "REPLACE_ME": ["this is a", " replacement"],
+                        "ANOTHER_REPLACEMENT": "Hello!!!"
+                    }
+                }
+            }
+        }
+
+openapi.security.name.* (string)
+    Provides a custom mapping for what a Smithy authentication scheme should
+    be called when used as an OpenAPI security name. ``openapi.security.name.``
+    is a prefix key where any text that comes after is used to refer to the
+    name of a Smithy authentication scheme. For example, the following
+    configuration names the ``aws.v4`` authentication scheme to ``SigV4!``
+    in OpenAPI:
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "openapi.security.name.aws.v4": "SigV4!"
+                }
+            }
+        }
+
+
+JSON schema configuration settings
+==================================
+
+stripNamespaces (boolean)
+    Strips Smithy namespaces from the converted shape ID that is generated
+    in the definitions map of a JSON Schema document for a shape. This
+    requires that shape names across all namespaces are unique.
+
+includePrivateShapes (boolean)
+    Includes shapes marked with the :ref:`private-trait`.
+
+useJsonName (boolean)
+    Uses the value of the :ref:`jsonName-trait` when creating JSON schema
+    properties for structure and union shapes.
+
+    TODO: This is enabled automatically with AWS protocols?
+
+defaultTimestampFormat (string)
+    Sets the assumed :ref:`timestampFormat-trait` value for timestamps with
+    no explicit timestampFormat trait. The provided value is expected to be
+    a string. Defaults to "date-time" if not set. Can be set to "date-time",
+    "epoch-seconds", or "http-date".
+
+unionStrategy (string)
+    Configures how Smithy union shapes are converted to JSON Schema.
+
+    This property must be a string set to one of the following values:
+
+    * oneOf: Converts to a schema that uses "oneOf". This is the
+      default setting used if not configured.
+    * object: Converts to an empty object "{}".
+    * structure: Converts to an object with properties just like a
+      structure.
+
+schemaDocumentExtensions (``Map<String, any>``)
+    Adds custom top-level key-value pairs to the created OpenAPI specification.
+
+
+Amazon API Gateway extensions
+=============================
+
+Smithy models can be converted to OpenAPI specifications that contain
+`Amazon API Gateway extensions`_ for defining things like integrations. These
+API Gateway extensions are automatically picked up by Smithy by adding a
+dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
+
+.. code-block:: kotlin
+    :caption: build.gradle.kts
+    :name: apigateway-build-gradle
+
+    buildscript {
+        dependencies {
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.5.4")
+        }
+    }
+
+
+Binary types
+------------
+
+The list of binary media types used by an API need to be specified for
+API Gateway in a top-level extension named `x-amazon-apigateway-binary-media-types`_.
+Smithy will automatically detect every media type used in a service by
+collecting all of the :ref:`mediaType-trait` values for all members marked
+with :ref:`httppayload-trait`.
+
+
+.. _apigateway-request-validators:
+
+Request validators
+------------------
+
+Amazon API Gateway can perform request validation before forwarding a request
+to an integration. You can opt-in to this feature using the
+``aws.apigateway#requestValidator`` trait.
+
+Smithy will populate the value of the `x-amazon-apigateway-request-validators`_
+and `x-amazon-apigateway-request-validator`_ OpenAPI extensions using the
+``aws.apigateway#requestValidator`` traits found in a service. The
+``aws.apigateway#requestValidator`` trait can be applied to a service to
+enable a specific kind of request validation on all operations within a
+service. It can also be applied to an operation to set a specific validator
+for the operation.
+
+Smithy defines the following canned request validators:
+
+full
+    Creates a request validator configured as
+
+    .. code-block:: json
+
+        {
+            "validateRequestBody": true,
+            "validateRequestParameters": true
+        }
+
+params-only
+    Creates a request validator configured as
+
+    .. code-block:: json
+
+        {
+            "validateRequestBody": false,
+            "validateRequestParameters": true
+        }
+
+body-only
+    Creates a request validator configured as
+
+    .. code-block:: json
+
+        {
+            "validateRequestBody": true,
+            "validateRequestParameters": false
+        }
+
+Smithy will gather all of the utilized request validators and add their
+declarations in a top-level ``x-amazon-apigateway-request-validators``
+OpenAPI extension.
+
+
+.. _apigateway-integrations:
+
+Integrations
+------------
+
+Smithy models can specify the backend integration configuration that
+Amazon API Gateway uses to for an operation.
+
+* ``aws.apigateway#integration`` trait defines an API Gateway integration
+  that calls an actual backend.
+* ``aws.apigateway#mockIntegration`` defines an API Gateway mock integration
+  that doesn't call a backend.
+
+If the trait is applied to a service shape, then all operations in the service
+use the integration. If the trait is defined on a resource shape, then all
+operations of the resource and all child resources use the integration. If
+the trait is applied to an operation, then the operation uses a specific
+integration that overrides any integration inherited from a resource or
+service.
+
+
+CORS functionality
+------------------
+
+TODO
+
+
+Security schemes
+----------------
+
+TODO
+
+
+AWS CloudFormation substitutions
+--------------------------------
+
+OpenAPI specifications used with Amazon API Gateway are commonly deployed
+through AWS CloudFormation. Values within an OpenAPI specification for things
+like the region a service is deployed and resources used within the service
+are often unknown until deployment-time. CloudFormation offers the ability
+to use `intrinsic functions`_ in a JSON document to resolve, find, and
+replace this unknown data at deployment-time.
+
+When the ``software.amazon.smithy:smithy-aws-apigateway-openapi`` library
+is loaded on the classpath, Smithy will treat specific, well-known parts
+of an OpenAPI specification as an `Fn::Sub`_. This allows Smithy models
+to refer to variables that aren't available until a stack is created
+using the format of ``${x}`` where "x" is the variable name.
+
+Smithy will automatically wrap the following locations of an OpenAPI
+specification in an ``Fn::Sub`` if the value contained in the location
+uses the ``Fn::Sub`` variable syntax (``*`` means any value):
+
+- ``components/securitySchemes/*/x-amazon-apigateway-authorizer/providerARNs/*``
+- ``components/securitySchemes/*/x-amazon-apigateway-authorizer/authorizerCredentials``
+- ``components/securitySchemes/*/x-amazon-apigateway-authorizer/authorizerUri``
+- ``paths/*/*/x-amazon-apigateway-integration/connectionId``
+- ``paths/*/*/x-amazon-apigateway-integration/credentials``
+- ``paths/*/*/x-amazon-apigateway-integration/uri``
+
+.. note::
+
+    This functionality can be disabled by setting the ``apigateway.disableCloudFormationSubstitution``
+    OpenAPI configuration property to ``true``.
+
+
+Amazon Cognito user pools
+-------------------------
+
+TODO
+
+
+Other traits that influence API Gateway
+---------------------------------------
+
+``aws.api#service``
+    TODO
+
+``protocols``
+    TODO
+
+``aws.apigateway#apiKeySource``
+    Specifies the source of the caller identifier that will be used to
+    throttle API methods that require a key. This trait is converted into
+    the `x-amazon-apigateway-api-key-source`_ OpenAPI extension.
+
+``aws.apigateway#authorizers``
+    Lambda authorizers to attach to the authentication schemes defined on
+    this service.
+
+    TODO: add more information
+
+-------------------------------
+Converting to OpenAPI with code
+-------------------------------
+
+Developers that need more advanced control over the Smithy to OpenAPI
+conversion can use the ``software.amazon.smithy:openapi`` Java library
+to perform the conversion.
+
+First, you'll need to get a copy of the library. The following example
+shows how to install ``software.amazon.smithy:openapi`` through Gradle:
+
+.. code-block:: kotlin
+    :caption: build.gradle.kts
+    :name: code-build-gradle
+
+    buildscript {
+        dependencies {
+            classpath("software.amazon.smithy:openapi:0.5.4")
+        }
+    }
+
+Next, you need to create and configure an ``OpenApiConverter``:
+
+.. code-block:: java
+
+    import software.amazon.smithy.model.shapes.ShapeId;
+    import software.amazon.smithy.openapi.fromsmithy.OpenApiConstants;
+    import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+    import software.amazon.smithy.openapi.fromsmithy.model.OpenApi;
+
+    OpenApiConverter converter = OpenApiConverter.create();
+
+    // Add any necessary settings...
+    converter.putSetting(OpenApiConstants.PROTOCOL, "aws-rest-json-1.1");
+
+    // Create a shape ID that points to the service.
+    ShapeId serviceShapeId = ShapeId.from("smithy.example#Weather");
+
+    OpenApi result = converter.convert(myModel, serviceShapeId);
+
+The conversion process is highly extensible through
+``software.amazon.smithy.openapi.fromsmithy.CoreExtension``
+`service providers`_. See the Javadocs for more information.
+
+.. _OpenAPI: https://github.com/OAI/OpenAPI-Specification
+.. _Amazon API Gateway: https://aws.amazon.com/api-gateway/
+.. _x-amz-meta-* headers: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
+.. _Amazon API Gateway extensions: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html
+.. _service providers: https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html
+.. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin
+.. _x-amazon-apigateway-binary-media-types: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-binary-media-types.html
+.. _x-amazon-apigateway-request-validators: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html
+.. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validator.html
+.. _intrinsic functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
+.. _`Fn::Sub`: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html
+.. _x-amazon-apigateway-api-key-source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-api-key-source.html

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -7,3 +7,4 @@ Smithy Guides
 
     evolving-models
     style-guide
+    converting-to-openapi

--- a/docs/source/spec/amazon-apigateway.rst
+++ b/docs/source/spec/amazon-apigateway.rst
@@ -1,0 +1,860 @@
+===============================
+Amazon API Gateway Integrations
+===============================
+
+Smithy can integrate with Amazon API Gateway using traits, authentication
+schemes, and OpenAPI specifications.
+
+.. contents:: Table of contents
+    :depth: 2
+    :local:
+    :backlinks: none
+
+-------------------------
+Amazon API Gateway traits
+-------------------------
+
+.. _aws.apigateway#apiKeySource-trait:
+
+``aws.apigateway#apiKeySource`` trait
+=====================================
+
+Summary
+    Specifies the source of the caller identifier that will be used to
+    throttle API methods that require a key.
+Trait selector
+    ``service``
+Value type
+    ``string`` set to one of the following values:
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 20 80
+
+        * - Value
+          - Description
+        * - HEADER
+          - for receiving the API key from the X-API-Key header of a request
+        * - AUTHORIZER
+          - for receiving the API key from the UsageIdentifierKey
+            from a Lambda authorizer (formerly known as a custom authorizer)
+See also
+    - `Create and Use Usage Plans with API Keys`_ for more on usage plans and
+      API keys
+    - `Choose an API Key Source`_ for information on choosing a source
+    - `x-amazon-apigateway-api-key-source`_ for how this relates to OpenAPI
+
+The following example sets the ``X-API-Key`` header as the API key source.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        $version: "0.1.0"
+        namespace smithy.example
+
+        @aws.apigateway#apiKeySource(HEADER)
+        service Weather {
+          version: "2018-03-17"
+        }
+
+    .. code-tab:: json
+
+        {
+          "smithy": "0.1.0",
+          "smithy.example": {
+            "shapes": {
+              "Weather": {
+                "type": "service",
+                "version": "2018-03-17",
+                "aws.apigateway#apiKeySource": "HEADER"
+              }
+            }
+          }
+        }
+
+.. note::
+
+    This trait should be considered internal-only and not exposed to your
+    customers.
+
+
+.. _aws.apigateway#authorizers-trait:
+
+``aws.apigateway#authorizers`` trait
+====================================
+
+Summary
+    `Lambda authorizers`_ to attach to the authentication schemes defined on
+    this service.
+Trait selector
+    ``service[trait|protocols]``
+
+    *A service shape that has the protocols trait*
+Value type
+    Map of x names to *authorizer* definitions. The key used as the authorizer
+    name MUST reference one of the ``auth`` schemes of the :ref:`protocols-trait`
+    attached to the service.
+
+An *authorizer* definition is an object that supports the following properties:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - type
+      - ``string``
+      - **Required**. The type of the authorizer. This is a required property
+        and the value must be "token", for an authorizer with the caller
+        identity embedded in an authorization token, or "request", for an
+        authorizer with the caller identity contained in request parameters.
+    * - uri
+      - ``string``
+      - **Required.** Specifies the authorizer's Uniform Resource Identifier
+        (URI). For ``token`` or ``request`` authorizers, this must be a
+        well-formed Lambda function URI, for example,
+        ``arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:{account_id}:function:{lambda_function_name}/invocations``.
+        In general, the URI has this form ``arn:aws:apigateway:{region}:lambda:path/{service_api}``,
+        where ``{region}`` is the same as the region hosting the Lambda
+        function, path indicates that the remaining substring in the URI
+        should be treated as the path to the resource, including the initial
+        ``/``. For Lambda functions, this is usually of the form
+        ``/2015-03-31/functions/[FunctionARN]/invocations``.
+    * - clientType
+      - ``string``
+      - The client authentication type. A value identifying the category of
+        authorizer, such as "oauth2" or "awsSigv4".
+
+        .. note::
+
+            This is the equivalent of setting the `x-amazon-apigateway-authtype`_
+            extension property in OpenAPI.
+    * - credentials
+      - ``string``
+      - Specifies the required credentials as an IAM role for API Gateway to
+        invoke the authorizer. To specify an IAM role for API Gateway to
+        assume, use the role's Amazon Resource Name (ARN). This value MUST
+        be omitted in order to use resource-based permissions on the
+        Lambda function.
+    * - identitySource
+      - ``string``
+      - The identity source for which authorization is requested.
+
+        For a ``token`` or ``cognito_user_pools`` authorizer, this is required
+        and specifies the request header mapping expression for the custom
+        header holding the authorization token submitted by the client. For
+        example, if the token header name is Auth, the header mapping
+        expression is ``method.request.header.Auth``.
+
+        For the ``request`` authorizer, this is required when authorization
+        caching is enabled. The value is a comma-separated string of one or
+        more mapping expressions of the specified request parameters. For
+        example, if an Auth header and a Name query string parameter are
+        defined as identity sources, this value is ``method.request.header.Auth, method.request.querystring.Name``.
+        These parameters will be used to derive the authorization caching
+        key and to perform runtime validation of the ``request`` authorizer
+        by verifying all of the identity-related request parameters are
+        present, not null and non-empty. Only when this is true does the
+        authorizer invoke the authorizer Lambda function, otherwise, it
+        returns a 401 Unauthorized response without calling the Lambda
+        function. The valid value is a string of comma-separated mapping
+        expressions of the specified request parameters. When the
+        authorization caching is not enabled, this property is optional.
+    * - identityValidationExpression
+      - ``string``
+      - A validation expression for the incoming identity token. For ``token``
+        authorizers, this value is a regular expression. API Gateway will
+        match the aud field of the incoming token from the client against
+        the specified regular expression. It will invoke the authorizer's
+        Lambda function when there is a match. Otherwise, it will return a
+        401 Unauthorized response without calling the Lambda function. The
+        validation expression does not apply to the ``request`` authorizer.
+    * - resultTtlInSeconds
+      - ``integer``
+      - The TTL in seconds of cached authorizer results. If it equals 0,
+        authorization caching is disabled. If it is greater than 0,
+        API Gateway will cache authorizer responses. If this field is not set,
+        the default value is 300. The maximum value is 3600, or 1 hour.
+
+..
+    TODO: Add IDL example
+
+.. code-block:: json
+
+    {
+        "smithy": "0.1.0",
+        "ns.foo": {
+            "shapes": {
+                "Weather": {
+                    "type": "service",
+                    "version": "2018-03-17",
+                    "protocols": [
+                        {
+                            "name": "aws.rest-json",
+                            "auth": ["aws.v4"]
+                        }
+                    ],
+                    "aws.apigateway#authorizers": {
+                        "aws.v4": {
+                            "clientType": "awsSigV4",
+                            "type": "request",
+                            "uri": "arn:foo:baz",
+                            "credentials": "arn:foo:bar",
+                            "identitySource": "mapping.expression",
+                            "identityValidationExpression": "[A-Z]+",
+                            "resultTtlInSeconds":100
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+.. note::
+
+    This trait should be considered internal-only and not exposed to your
+    customers.
+
+
+.. _aws.apigateway#requestValidator-trait:
+
+``aws.apigateway#requestValidator`` trait
+=========================================
+
+Summary
+    Opts-in to Amazon API Gateway request validation for a service or
+    operation.
+Trait selector
+    ``:test(service, operation)``
+Value type
+    ``string`` value set to one of the following:
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 20 80
+
+        * - Value
+          - Description
+        * - full
+          - The parameters and body of a request are validated.
+        * - params-only
+          - Only the parameters of a request are validated.
+        * - body-only
+          - Only the body of a request is validated.
+See also
+    - `Enable Request Validation in API Gateway`_ for more information
+    - :ref:`apigateway-request-validators` for information on how this converts
+      to OpenAPI
+    - `x-amazon-apigateway-request-validator`_ for more on how this converts
+      to OpenAPI
+    - `x-amazon-apigateway-request-validators`_ for more on how this converts
+      to OpenAPI
+
+Then following example enables request validation on a service:
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        $version: "0.1.0"
+        namespace smithy.example
+
+        @aws.apigateway#requestValidator(full)
+        service Weather {
+          version: "2018-03-17"
+        }
+
+    .. code-tab:: json
+
+        {
+          "smithy": "0.1.0",
+          "smithy.example": {
+            "shapes": {
+              "Weather": {
+                "type": "service",
+                "version": "2018-03-17",
+                "aws.apigateway#requestValidator": "full"
+              }
+            }
+          }
+        }
+
+.. note::
+
+    This trait should be considered internal-only and not exposed to your
+    customers.
+
+
+.. _aws.apigateway#integration-trait:
+
+``aws.apigateway#integration`` trait
+====================================
+
+Summary
+    Defines an `API Gateway integration`_ that integrates with an actual
+    backend.
+Trait selector
+    ``:test(service, operation)``
+Value type
+    ``object`` value.
+See also
+    - :ref:`apigateway-integrations` for information on how this converts
+      to OpenAPI
+    - `API Gateway Integration`_ for in-depth API documentation
+    - `x-amazon-apigateway-integration`_ for details on how this looks
+      to OpenAPI
+
+The ``aws.apigateway#integration`` trait is an object that supports the
+following properties:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - type
+      - ``string``
+      - **Required.** The type of integration with the specified backend.
+        Valid values are:
+
+        - ``http`` or ``http_proxy``: for integration with an HTTP backend
+        - ``aws_proxy``: for integration with AWS Lambda functions
+        - ``aws``: for integration with AWS Lambda functions or other AWS
+          services such as Amazon DynamoDB, Amazon Simple Notification Service
+          or Amazon Simple Queue Service.
+    * - uri
+      - ``string``
+      - **Required.** The endpoint URI of the backend. For integrations of
+        the ``aws`` type, this is an ARN value. For the HTTP integration,
+        this is the URL of the HTTP endpoint including the ``https`` or
+        ``http`` scheme.
+    * - httpMethod
+      - ``string``
+      - **Required.** Specifies the integration's HTTP method type
+        (for example, ``POST``). For Lambda function invocations, the value
+        must be ``POST``.
+    * - credentials
+      - ``string``
+      - Specifies the credentials required for the integration, if any. For
+        AWS IAM role-based credentials, specify the ARN of an appropriate
+        IAM role. If unspecified, credentials will default to resource-based
+        permissions that must be added manually to allow the API to access
+        the resource. For more information, see
+        `Granting Permissions Using a Resource Policy`_.
+    * - passThroughBehavior
+      - ``string``
+      - Specifies how a request payload of unmapped content type is passed
+        through the integration request without modification. Supported
+        values are ``when_no_templates``, ``when_no_match``, and ``never``.
+        For more information, see `Integration.passthroughBehavior`_.
+    * - contentHandling
+      - :ref:`ContentHandling string <apigateway-content-handling>`
+      - Request payload content handling.
+    * - timeoutInMillis
+      - ``integer``
+      - Integration timeouts between 50 ms and 29,000 ms.
+    * - connectionId
+      - ``string``
+      - The ID of a `VpcLink`_ for the private integration.
+    * - connectionType
+      - ``string``
+      - The type of the network connection to the integration endpoint.
+        The valid value is ``INTERNET`` for connections through the public
+        routable internet or ``VPC_LINK`` for private connections between
+        API Gateway and a network load balancer in a VPC. The default
+        value is ``INTERNET``.
+    * - cacheNamespace
+      - ``string``
+      - An API-specific tag group of related cached parameters.
+    * - cacheKeyParameters
+      - ``[string]``
+      - A list of request parameter names whose values are to be cached.
+    * - requestParameters
+      - ``Map`` of :ref:`apigateway-requestParameters` to request parameters
+      - Specifies mappings from method request parameters to integration
+        request parameters. Supported request parameters are querystring,
+        path, header, and body.
+    * - requestTemplates
+      - ``Map`` of media types to :ref:`apigateway-requestTemplates`
+      - Mapping templates for a request payload of specified media types.
+    * - responses
+      - ``Map`` of response codes to :ref:`apigateway-responses`
+      - Defines the method's responses and specifies desired parameter
+        mappings or payload mappings from integration responses to method
+        responses.
+
+The following example defines an integration that is applied to every
+operation within the service.
+
+..
+    TODO: Add Smithy example
+
+.. code-block:: json
+
+    {
+        "smithy": "0.1.0",
+        "smithy.example": {
+            "shapes": {
+                "Weather": {
+                    "type": "service",
+                    "version": "2018-03-17",
+                    "protocols": [{"name": "aws.rest-json", "auth": ["aws.v4"]}],
+                    "aws.apigateway#integration": {
+                        "type": "aws",
+                        "uri" : "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:012345678901:function:HelloWorld/invocations",
+                        "httpMethod" : "POST",
+                        "credentials" : "arn:aws:iam::012345678901:role/apigateway-invoke-lambda-exec-role",
+                        "requestTemplates" : {
+                            "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+                            "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+                        },
+                        "requestParameters" : {
+                            "integration.request.path.stage" : "method.request.querystring.version",
+                            "integration.request.querystring.provider" : "method.request.querystring.vendor"
+                        },
+                        "cacheNamespace" : "cache namespace",
+                        "cacheKeyParameters" : [],
+                        "responses" : {
+                            "2\\d{2}" : {
+                                "statusCode" : "200",
+                                "responseParameters" : {
+                                    "method.response.header.requestId" : "integration.response.header.cid"
+                                },
+                                "responseTemplates" : {
+                                    "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+                                    "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+                                }
+                            },
+                            "302" : {
+                                "statusCode" : "302",
+                                "responseParameters" : {
+                                    "method.response.header.Location" : "integration.response.body.redirect.url"
+                                }
+                            },
+                            "default" : {
+                                "statusCode" : "400",
+                                "responseParameters" : {
+                                    "method.response.header.test-method-response-header" : "'static value'"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+.. note::
+
+    This trait should be considered internal-only and not exposed to your
+    customers.
+
+
+.. _aws.apigateway#mockIntegration-trait:
+
+``aws.apigateway#mockIntegration`` trait
+========================================
+
+Summary
+    Defines an `API Gateway integration`_ that returns a mock response.
+Trait selector
+    ``:test(service, operation)``
+Value type
+    ``object`` value.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - passThroughBehavior
+      - ``string``
+      - Specifies how a request payload of unmapped content type is passed
+        through the integration request without modification. Supported
+        values are ``when_no_templates``, ``when_no_match``, and ``never``.
+        For more information, see `Integration.passthroughBehavior`_.
+    * - requestParameters
+      - ``Map`` of :ref:`apigateway-requestParameters` to request parameters
+      - Specifies mappings from method request parameters to integration
+        request parameters. Supported request parameters are querystring,
+        path, header, and body.
+    * - requestTemplates
+      - ``Map`` of media types to :ref:`apigateway-requestTemplates`
+      - Mapping templates for a request payload of specified media types.
+    * - responses
+      - ``Map`` of response codes to :ref:`apigateway-responses`
+      - Defines the method's responses and specifies desired parameter
+        mappings or payload mappings from integration responses to method
+        responses.
+
+The following example defines an operation that uses a mock integration.
+
+..
+    TODO: Add smithy example
+
+.. code-block:: json
+
+    {
+        "smithy": "0.1.0",
+        "smithy.example": {
+            "shapes": {
+                "MyOperation": {
+                    "type": "operation",
+                    "http": {"method": "POST", "uri": "/2"},
+                    "aws.apigateway#mockIntegration": {
+                        "requestTemplates" : {
+                            "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+                            "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+                        },
+                        "requestParameters" : {
+                            "integration.request.path.stage" : "method.request.querystring.version",
+                            "integration.request.querystring.provider" : "method.request.querystring.vendor"
+                        },
+                        "responses" : {
+                            "2\\d{2}" : {
+                                "statusCode" : "200",
+                                "responseParameters" : {
+                                    "method.response.header.requestId" : "integration.response.header.cid"
+                                },
+                                "responseTemplates" : {
+                                    "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+                                    "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+                                }
+                            },
+                            "302" : {
+                                "statusCode" : "302",
+                                "responseParameters" : {
+                                    "method.response.header.Location" : "integration.response.body.redirect.url"
+                                }
+                            },
+                            "default" : {
+                                "statusCode" : "400",
+                                "responseParameters" : {
+                                    "method.response.header.test-method-response-header" : "'static value'"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+.. note::
+
+    This trait should be considered internal-only and not exposed to your
+    customers.
+
+
+Shared trait data types
+=======================
+
+The following shapes are used throughout the Smithy API Gateway traits
+definitions.
+
+
+.. _apigateway-content-handling:
+
+ContentHandling string
+----------------------
+
+Defines the payload conversion handling of a request or response.
+Valid values are:
+
+- CONVERT_TO_TEXT: for converting a binary payload into a
+  Base64-encoded string or converting a text payload into a
+  utf-8-encoded string or passing through the text payload natively
+  without modification
+- CONVERT_TO_BINARY: for converting a text payload into
+  Base64-decoded blob or passing through a binary payload natively
+  without modification.
+
+
+.. _apigateway-requestParameters:
+
+requestParameters object
+------------------------
+
+Specifies mappings from named method request parameters to integration
+request parameters. The method request parameters must be defined before
+they are referenced.
+
+**Properties**
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 10 60
+
+    * - Property
+      - Type
+      - Description
+    * - ``integration.request.<param-type>.<param-name>``
+      - string
+      - The value must be a predefined method request parameter of the
+        ``method.request.<param-type>.<param-name>`` format, where
+        ``<param-type>`` can be querystring, path, header, or body. For
+        the body parameter, the ``<param-name>`` is a JSON path expression
+        without the ``$.`` prefix.
+
+The following request parameter mappings example translates a method
+request's query (version), header (x-user-id) and path (service)
+parameters to the integration request's query (stage),
+header (x-userid), and path parameters (op), respectively.
+
+.. code-block:: json
+
+    {
+        "requestParameters" : {
+            "integration.request.querystring.stage" : "method.request.querystring.version",
+            "integration.request.header.x-userid" : "method.request.header.x-user-id",
+            "integration.request.path.op" : "method.request.path.service"
+        }
+    }
+
+
+.. _apigateway-requestTemplates:
+
+requestTemplates object
+-----------------------
+
+Specifies mapping templates for a request payload of the specified media types.
+
+**Properties**
+
+.. list-table::
+    :header-rows: 1
+    :widths: 15 15 70
+
+    * - Property
+      - Type
+      - Description
+    * - ``<Media type>``
+      - string
+      - A `mapping template <mapping templates>`_.
+
+The following example sets mapping templates for a request payload of the
+``application/json`` and ``application/xml`` media types.
+
+.. code-block:: json
+
+    {
+        "requestTemplates" : {
+            "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+            "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+        }
+    }
+
+
+.. _apigateway-responses:
+
+responses object
+----------------
+
+Defines the method's responses and specifies parameter mappings or payload
+mappings from integration responses to method responses.
+
+**Properties**
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 10 70
+
+    * - Property
+      - Type
+      - Description
+    * - ``<Response status pattern>``
+      - :ref:`Response object <apigateway-response-object>`
+      - Selection regular expression used to match the integration response
+        to the method response. For HTTP integrations, this regex applies to
+        the integration response status code. For Lambda invocations, the
+        regex applies to the errorMessage field of the error information
+        object returned by AWS Lambda as a failure response body when the
+        Lambda function execution throws an exception.
+
+        .. note::
+
+            The Response status pattern property name refers to a response
+            status code or regular expression describing a group of response
+            status codes. It does not correspond to any identifier of an
+            `IntegrationResponse`_ resource in the API Gateway REST API.
+
+The following example shows a list of responses from ``2xx`` and ``302``
+responses. For the ``2xx`` response, the method response is mapped from
+the integration response's payload of the ``application/json`` or
+``application/xml`` media type. This response uses the supplied mapping
+templates. For the ``302`` response, the method response returns a
+``Location`` header whose value is derived from the ``redirect.url``
+property on the integration response's payload.
+
+.. code-block:: json
+
+    {
+        "responses" : {
+            "2\\d{2}" : {
+                "statusCode" : "200",
+                "responseTemplates" : {
+                    "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+                    "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+                }
+            },
+            "302" : {
+                "statusCode" : "302",
+                "responseParameters" : {
+                    "method.response.header.Location": "integration.response.body.redirect.url"
+                }
+            }
+        }
+    }
+
+
+.. _apigateway-response-object:
+
+response object
+---------------
+
+Defines a response and specifies parameter mappings or payload mappings from
+the integration response to the method response.
+
+**Properties**
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 10 60
+
+    * - Property
+      - Type
+      - Description
+    * - statusCode
+      - string
+      - HTTP status code for the method response; for example, "200". This
+        must correspond to a matching response in the OpenAPI Operation
+        responses field.
+    * - responseTemplates
+      - :ref:`Response templates object <apigateway-response-templates-object>`
+      - Specifies media type-specific mapping templates for the response's
+        payload.
+    * - responseParameters
+      - :ref:`Response parameters object <apigateway-response-parameters-object>`
+      - Specifies parameter mappings for the response. Only the header and
+        body parameters of the integration response can be mapped to the header
+        parameters of the method.
+    * - contentHandling
+      - :ref:`ContentHandling string <apigateway-content-handling>`
+      - Response payload content handling.
+
+The following example defines a 302 response for the method that derives a
+payload of the ``application/json`` or ``application/xml`` media type from the
+backend. The response uses the supplied mapping templates and returns the
+redirect URL from the integration response in the method's Location header.
+
+.. code-block:: json
+
+    {
+        "statusCode" : "302",
+        "responseTemplates" : {
+             "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+             "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+        },
+        "responseParameters" : {
+            "method.response.header.Location": "integration.response.body.redirect.url"
+        }
+    }
+
+
+.. _apigateway-response-templates-object:
+
+Response templates object
+-------------------------
+
+Specifies mapping templates for a response payload of the specified
+media types.
+
+**Properties**
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 10 60
+
+    * - Property
+      - Type
+      - Description
+    * - ``<Media type>``
+      - string
+      - Specifies a mapping template to transform the integration response
+        body to the method response body for a given media type. For
+        information about creating a mapping template, see
+        `mapping Templates`_. An example of a media type is
+        ``application/json``.
+
+The following example sets mapping templates for a request payload of the
+``application/json`` and ``application/xml`` media types.
+
+.. code-block:: json
+
+    {
+        "responseTemplates" : {
+            "application/json" : "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+            "application/xml" : "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+        }
+    }
+
+
+.. _apigateway-response-parameters-object:
+
+Response parameters object
+--------------------------
+
+Specifies mappings from integration method response parameters to method
+response parameters. Only the ``header`` and ``body`` types of the integration
+response parameters can be mapped to the ``header`` type of the method
+response.
+
+**Properties**
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 10 60
+
+    * - Property
+      - Type
+      - Description
+    * - ``method.response.header.<param-name>``
+      - string
+      - The named parameter value can be derived from the header and body
+        types of the integration response parameters only.
+
+The following example maps ``body`` and ``header`` parameters of the
+integration response to two ``header`` parameters of the method response.
+
+.. code-block:: json
+
+    {
+        "responseParameters" : {
+            "method.response.header.Location" : "integration.response.body.redirect.url",
+            "method.response.header.x-user-id" : "integration.response.header.x-userid"
+        }
+    }
+
+
+.. _Enable Request Validation in API Gateway: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html
+.. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.requestValidator.html
+.. _x-amazon-apigateway-request-validators: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html
+.. _Granting Permissions Using a Resource Policy: https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#intro-permission-model-access-policy
+.. _Integration.passthroughBehavior: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/#passthroughBehavior
+.. _VpcLink: https://docs.aws.amazon.com/apigateway/api-reference/resource/vpc-link/
+.. _x-amazon-apigateway-integration: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration.html
+.. _API Gateway integration: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
+.. _Lambda authorizers: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html
+.. _x-amazon-apigateway-authtype: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authtype.html
+.. _Create and Use Usage Plans with API Keys: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html
+.. _Choose an API Key Source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html
+.. _x-amazon-apigateway-api-key-source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-api-key-source.html
+.. _IntegrationResponse: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration-response/
+.. _mapping Templates: https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings

--- a/docs/source/spec/http.rst
+++ b/docs/source/spec/http.rst
@@ -324,6 +324,8 @@ Given a pattern of ``/path?requiredKey=requiredValue`` and an endpoint of
         is not "requiredValue" .
 
 
+.. _greedy-labels:
+
 Greedy labels
 ~~~~~~~~~~~~~
 

--- a/docs/source/spec/index.rst
+++ b/docs/source/spec/index.rst
@@ -79,6 +79,7 @@ AWS specifications
     :maxdepth: 1
 
     aws-core
+    amazon-apigateway
 
 AWS-specific specifications are defined below.
 
@@ -87,3 +88,5 @@ AWS-specific specifications are defined below.
 
     * - :doc:`aws-core`
       - Defines core traits used to integrate Smithy models with AWS.
+    * - :doc:`amazon-apigateway`
+      - Defines Amazon API Gateway traits and integrations.

--- a/docs/themes/smithy/static/default.css_t
+++ b/docs/themes/smithy/static/default.css_t
@@ -207,6 +207,11 @@ dd {
   margin-left: 2em;
 }
 
+dd > ul {
+  padding-left: 0;
+  list-style-position: inside;
+}
+
 hr {
   height: 0.25em;
   padding: 0;
@@ -235,6 +240,9 @@ a:hover, .reference.external:hover {
 .headerlink {
   margin-left: 1em;
   display: none;
+  font-size: 18px;
+  vertical-align: super;
+  line-height: 0;
 }
 
 *:hover > .headerlink {
@@ -334,7 +342,8 @@ header {
 
 #page-navigation .site-search .search-input {
   padding: 0 1em;
-  color: #777;
+  color: #fff;
+  background-color: #14529B;
   border: solid 1px rgba(23, 30, 38, 0.2);
   border-radius: 3px;
   width: 180px;

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConstants.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConstants.java
@@ -30,7 +30,8 @@ public final class JsonSchemaConstants {
     /** Includes shapes marked with the {@code private} trait. */
     public static final String SMITHY_INCLUDE_PRIVATE_SHAPES = "includePrivateShapes";
 
-    /** Uses the value of the jsonName trait when creating JSON schema
+    /**
+     * Uses the value of the jsonName trait when creating JSON schema
      * properties for structure and union shapes.
      *
      * <p>This property has no effect if a {@link PropertyNamingStrategy} is
@@ -76,7 +77,7 @@ public final class JsonSchemaConstants {
      * <p>Defaults to "#/definitions" if no value is specified. OpenAPI
      * artifacts will want to use "#/components/schemas".
      */
-    public static final String DEFINITION_POINTER = "definitionsPointer";
+    public static final String DEFINITION_POINTER = "definitionPointer";
 
     /**
      * Adds custom key-value pairs to the JSON Schema document generated from

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConstants.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConstants.java
@@ -24,8 +24,11 @@ public final class OpenApiConstants {
     /** The supported version of OpenAPI. */
     public static final String VERSION = "3.0.2";
 
-    /** The Smithy service Shape ID being converted. */
+    /** The Smithy service Shape ID to convert. */
     public static final String SERVICE = "service";
+
+    /** The protocol name to use when converting Smithy to OpenAPI. */
+    public static final String PROTOCOL = "protocol";
 
     /** Whether or not to include tags in the result. */
     public static final String OPEN_API_TAGS = "openapi.tags";
@@ -98,7 +101,7 @@ public final class OpenApiConstants {
     public static final String ON_HTTP_PREFIX_HEADERS_WARN = "WARN";
 
     /** Ignores unsupported trait like eventStream and logs them rather than fail. */
-    public static final String IGNORE_UNSUPPORTED_TRAIT = "openapi.ignoreUnsupportedTrait";
+    public static final String IGNORE_UNSUPPORTED_TRAITS = "openapi.ignoreUnsupportedTraits";
 
     /**
      * The prefix used to provide a custom OpenAPI security scheme name for

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
@@ -18,6 +18,8 @@ package software.amazon.smithy.openapi.fromsmithy;
 import java.util.Optional;
 import java.util.Set;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.pattern.UriPattern;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
@@ -42,6 +44,17 @@ public interface OpenApiProtocol {
      * @return Returns the supported protocol names.
      */
     Set<String> getProtocolNames();
+
+    /**
+     * Configures protocol-specific default values when they are not present
+     * in the configuration context. Only values that are not explicitly set
+     * are modified as a result of calling this method.
+     *
+     * @return Returns a map of property names to their default values to set.
+     */
+    default ObjectNode getDefaultSettings() {
+        return Node.objectNode();
+    }
 
     /**
      * Creates an operation entry, including the method, URI, and operation

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraits.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraits.java
@@ -63,7 +63,7 @@ public final class UnsupportedTraits implements OpenApiMapper {
                        + "model directly, they have no direct corollary in OpenAPI and can not be included in "
                        + "the generated model.");
 
-        if (context.getConfig().getBooleanMemberOrDefault(OpenApiConstants.IGNORE_UNSUPPORTED_TRAIT)) {
+        if (context.getConfig().getBooleanMemberOrDefault(OpenApiConstants.IGNORE_UNSUPPORTED_TRAITS)) {
             LOGGER.warning(message.toString());
         } else {
             throw new OpenApiException(message.toString());

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJsonProtocol.java
@@ -17,8 +17,11 @@ package software.amazon.smithy.openapi.fromsmithy.protocols;
 
 import java.util.List;
 import java.util.Set;
+import software.amazon.smithy.jsonschema.JsonSchemaConstants;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIndex;
@@ -35,6 +38,11 @@ public final class AwsRestJsonProtocol extends AbstractRestProtocol {
     @Override
     public Set<String> getProtocolNames() {
         return SetUtils.of("aws.rest-json", "aws.rest-json-1.0", "aws.rest-json-1.1");
+    }
+
+    @Override
+    public ObjectNode getDefaultSettings() {
+        return Node.objectNode().withMember(JsonSchemaConstants.SMITHY_USE_JSON_NAME, true);
     }
 
     @Override

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraitsPluginTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraitsPluginTest.java
@@ -29,7 +29,7 @@ public class UnsupportedTraitsPluginTest {
     @Test
     public void logsWhenUnsupportedTraitsAreFound() {
         OpenApiConverter.create()
-                .putSetting(OpenApiConstants.IGNORE_UNSUPPORTED_TRAIT, true)
+                .putSetting(OpenApiConstants.IGNORE_UNSUPPORTED_TRAITS, true)
                 .convert(model, ShapeId.from("smithy.example#Streaming"));
     }
 

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/aws-rest-json-uses-jsonname.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/aws-rest-json-uses-jsonname.json
@@ -1,0 +1,36 @@
+{
+  "smithy": "0.1.0",
+  "smithy.example": {
+    "shapes": {
+      "Service": {
+        "type": "service",
+        "version": "2006-03-01",
+        "protocols": [{"name": "aws.rest-json"}],
+        "operations": [
+          "CreateDocument"
+        ]
+      },
+      "CreateDocument": {
+        "type": "operation",
+        "input": "CreateDocumentInput",
+        "http": {
+          "uri": "/document",
+          "method": "POST"
+        }
+      },
+      "CreateDocumentInput": {
+        "type": "structure",
+        "members": {
+          "abc": {
+            "target": "String",
+            "jsonName": "Abc"
+          },
+          "def": {
+            "target": "Integer",
+            "jsonName": "Def"
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/aws-rest-json-uses-jsonname.openapi.inlined.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/aws-rest-json-uses-jsonname.openapi.inlined.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/document": {
+      "post": {
+        "operationId": "CreateDocument",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Abc": {
+                    "type": "string"
+                  },
+                  "Def": {
+                    "type": "number",
+                    "format": "int32",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "CreateDocument response"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the start of the documentation for OpenAPI integration
and API Gateway traits. There are a number of TODO items in the
documentation that can be filled in later.

While working on the docs, a few typos and usability issues were
discovered with the OpenAPI conversion process. Some of these changes
were typo fixes, and the most notable change is that protocol
implementations can now set default parameters (for example,
aws-rest-json-1.1 can now automatically opt-in to using the jsonName
trait for defining member names).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
