### PR TITLE
Remove ability to customize security name

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
+++ b/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
@@ -38,7 +38,7 @@ public class AddAuthorizersTest {
         OpenApi result = OpenApiConverter.create()
                 .classLoader(getClass().getClassLoader())
                 .convert(model, ShapeId.from("ns.foo#SomeService"));
-        SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("sigv4");
+        SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("aws.v4");
 
         assertThat(sigV4.getType(), equalTo("apiKey"));
         assertThat(sigV4.getName().get(), equalTo("Authorization"));

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -386,7 +386,7 @@
       }
     },
     "securitySchemes": {
-      "sigv4": {
+      "aws.v4": {
         "type": "apiKey",
         "description": "AWS Signature Version 4 authentication",
         "name": "Authorization",
@@ -402,7 +402,7 @@
   },
   "security": [
     {
-      "sigv4": [ ]
+      "aws.v4": [ ]
     },
     {
       "http-basic": [ ]

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -286,26 +286,6 @@ openapi.substitutions (``Map<String, any>``)
             }
         }
 
-openapi.security.name.* (string)
-    Provides a custom mapping for what a Smithy authentication scheme should
-    be called when used as an OpenAPI security name. ``openapi.security.name.``
-    is a prefix key where any text that comes after is used to refer to the
-    name of a Smithy authentication scheme. For example, the following
-    configuration names the ``aws.v4`` authentication scheme to ``SigV4!``
-    in OpenAPI:
-
-    .. code-block:: json
-
-        {
-            "version": "1.0",
-            "plugins": {
-                "openapi": {
-                    "service": "smithy.example#Weather",
-                    "openapi.security.name.aws.v4": "SigV4!"
-                }
-            }
-        }
-
 
 JSON schema configuration settings
 ==================================

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConstants.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConstants.java
@@ -104,18 +104,6 @@ public final class OpenApiConstants {
     public static final String IGNORE_UNSUPPORTED_TRAITS = "openapi.ignoreUnsupportedTraits";
 
     /**
-     * The prefix used to provide a custom OpenAPI security scheme name for
-     * Smithy authentication schemes, specifically, keys with this prefix
-     * can change the key used to register a security scheme in the
-     * "#/components/securitySchemes" section of the model.
-     *
-     * <p>By default, if no security scheme name is found using this prefix
-     * concatenated with the Smithy authentication scheme name, then the name
-     * of the Smithy authentication scheme is used.
-     */
-    public static final String SECURITY_NAME_PREFIX = "openapi.security.name.";
-
-    /**
      * Defines a map of String to any Node value to find and replace in the
      * generated OpenAPI model.
      *

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.openapi.fromsmithy;
 import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.model.SecurityScheme;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
@@ -51,22 +50,14 @@ public interface SecuritySchemeConverter {
      * Get the name that should be used for this security scheme throughout
      * the model.
      *
-     * <p>By default, this method will return the following value:
-     *
-     * <ul>
-     *     <li>Returns the value of "openapi.security.name.AUTHNAME" from
-     *     the config object if present, where "AUTHNAME" is the return value
-     *     of {@link #getAuthSchemeName()}.</li>
-     *     <li>Returns the result of {@link #getAuthSchemeName()}</li>
-     * </ul>
+     * <p>By default, this method will return the result of
+     * {@link #getAuthSchemeName()}
      *
      * @param context Conversion context.
      * @return The Smithy security authentication scheme name.
      */
     default String getSecurityName(Context context) {
-        return context.getConfig().getStringMemberOrDefault(
-                OpenApiConstants.SECURITY_NAME_PREFIX + getAuthSchemeName(),
-                getAuthSchemeName());
+        return getAuthSchemeName();
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.openapi.fromsmithy.security;
 
 import java.util.Set;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
@@ -34,12 +33,6 @@ public final class AwsV4 implements SecuritySchemeConverter {
     @Override
     public String getAuthSchemeName() {
         return "aws.v4";
-    }
-
-    @Override
-    public String getSecurityName(Context context) {
-        return context.getConfig().getStringMemberOrDefault(
-                OpenApiConstants.SECURITY_NAME_PREFIX + getAuthSchemeName(), "sigv4");
     }
 
     @Override

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.openapi.fromsmithy.security;
 
-import software.amazon.smithy.openapi.OpenApiConstants;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
@@ -31,12 +30,6 @@ public final class XApiKey implements SecuritySchemeConverter {
     @Override
     public String getAuthSchemeName() {
         return "http-x-api-key";
-    }
-
-    @Override
-    public String getSecurityName(Context context) {
-        return context.getConfig().getStringMemberOrDefault(
-                OpenApiConstants.SECURITY_NAME_PREFIX + getAuthSchemeName(), "api_key");
     }
 
     @Override

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
@@ -40,7 +40,7 @@
         },
         "security": [
           {
-            "sigv4": [ ]
+            "aws.v4": [ ]
           },
           {
             "http-basic": []
@@ -56,7 +56,7 @@
         "description": "HTTP Basic authentication",
         "scheme": "Basic"
       },
-      "sigv4": {
+      "aws.v4": {
         "type": "apiKey",
         "description": "AWS Signature Version 4 authentication",
         "name": "Authorization",
@@ -67,7 +67,7 @@
   },
   "security": [
     {
-      "sigv4": [ ]
+      "aws.v4": [ ]
     }
   ]
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/awsv4-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/awsv4-security.openapi.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "sigv4": {
+      "aws.v4": {
         "type": "apiKey",
         "description": "AWS Signature Version 4 authentication",
         "name": "Authorization",
@@ -29,7 +29,7 @@
   },
   "security": [
     {
-      "sigv4": [ ]
+      "aws.v4": [ ]
     }
   ]
 }


### PR DESCRIPTION
Customizing the security scheme name of an auth scheme in OpenAPI adds
unnecessary complexity since the names are arbitrary.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
