### PR TITLE
Add ability to vary authorizers per/operation

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
+++ b/aws/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.apigateway.openapi;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -38,12 +39,13 @@ public class AddAuthorizersTest {
         OpenApi result = OpenApiConverter.create()
                 .classLoader(getClass().getClassLoader())
                 .convert(model, ShapeId.from("ns.foo#SomeService"));
-        SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("aws.v4");
+        SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("sigv4");
 
+        assertThat(result.getComponents().getSecuritySchemes().get("aws.v4"), nullValue());
         assertThat(sigV4.getType(), equalTo("apiKey"));
         assertThat(sigV4.getName().get(), equalTo("Authorization"));
         assertThat(sigV4.getIn().get(), equalTo("header"));
-        assertThat(sigV4.getExtension("x-amazon-apigateway-authtype").get(), equalTo(Node.from("awsSigV4")));
+        assertThat(sigV4.getExtension("x-amazon-apigateway-authtype").get(), equalTo(Node.from("awsSigv4")));
         ObjectNode authorizer = sigV4.getExtension("x-amazon-apigateway-authorizer").get().expectObjectNode();
         assertThat(authorizer.getStringMember("type").get().getValue(), equalTo("request"));
         assertThat(authorizer.getStringMember("authorizerUri").get().getValue(), equalTo("arn:foo:baz"));

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/authorizers.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/authorizers.json
@@ -6,9 +6,10 @@
         "type": "service",
         "version": "2018-03-17",
         "protocols": [{"name": "aws.rest-json", "auth": ["aws.v4"]}],
+        "aws.apigateway#authorizer": "sigv4",
         "aws.apigateway#authorizers": {
-          "aws.v4": {
-            "clientType": "awsSigV4",
+          "sigv4": {
+            "scheme": "aws.v4",
             "type": "request",
             "uri": "arn:foo:baz",
             "credentials": "arn:foo:bar",

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/Authorizer.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/Authorizer.java
@@ -33,7 +33,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * @see AuthorizersTrait
  */
 public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
-    private static final String CLIENT_TYPE_KEY = "clientType";
+    private static final String SCHEME_KEY = "scheme";
     private static final String TYPE_KEY = "type";
     private static final String URI_KEY = "uri";
     private static final String CREDENTIALS_KEY = "credentials";
@@ -41,10 +41,10 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
     private static final String IDENTITY_VALIDATION_EXPRESSION_KEY = "identityValidationExpression";
     private static final String RESULT_TTL_IN_SECONDS = "resultTtlInSeconds";
     private static final List<String> PROPERTIES = ListUtils.of(
-            CLIENT_TYPE_KEY, TYPE_KEY, URI_KEY, CREDENTIALS_KEY, IDENTITY_SOURCE_KEY,
+            SCHEME_KEY, TYPE_KEY, URI_KEY, CREDENTIALS_KEY, IDENTITY_SOURCE_KEY,
             IDENTITY_VALIDATION_EXPRESSION_KEY, RESULT_TTL_IN_SECONDS);
 
-    private final String clientType;
+    private final String scheme;
     private final String type;
     private final String uri;
     private final String credentials;
@@ -53,8 +53,8 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
     private final Integer resultTtlInSeconds;
 
     private Authorizer(Builder builder) {
-        clientType = builder.clientType;
         type = SmithyBuilder.requiredState(TYPE_KEY, builder.type);
+        scheme = SmithyBuilder.requiredState(SCHEME_KEY, builder.scheme);
         uri = SmithyBuilder.requiredState(URI_KEY, builder.uri);
         credentials = builder.credentials;
         identitySource = builder.identitySource;
@@ -72,15 +72,12 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
     }
 
     /**
-     * Gets the client authentication type.
-     *
-     * <p>A value identifying the category of authorizer, such
-     * as "oauth2" or "awsSigv4."
+     * Gets the Smithy scheme used as the client authentication type.
      *
      * @return Returns the optionally defined client authentication type.
      */
-    public Optional<String> getClientType() {
-        return Optional.ofNullable(clientType);
+    public String getScheme() {
+        return scheme;
     }
 
     /**
@@ -155,7 +152,7 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
     @Override
     public Builder toBuilder() {
         return builder()
-                .clientType(clientType)
+                .scheme(scheme)
                 .type(type)
                 .uri(uri)
                 .credentials(credentials)
@@ -167,8 +164,8 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
     @Override
     public Node toNode() {
         return Node.objectNodeBuilder()
-                .withOptionalMember(CLIENT_TYPE_KEY, getClientType().map(Node::from))
                 .withMember(TYPE_KEY, Node.from(getType()))
+                .withMember(SCHEME_KEY, Node.from(getScheme()))
                 .withMember(URI_KEY, Node.from(getUri()))
                 .withOptionalMember(CREDENTIALS_KEY, getCredentials().map(Node::from))
                 .withOptionalMember(IDENTITY_SOURCE_KEY, getIdentitySource().map(Node::from))
@@ -187,7 +184,7 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
         }
 
         Authorizer that = (Authorizer) o;
-        return Objects.equals(clientType, that.clientType)
+        return Objects.equals(scheme, that.scheme)
                && type.equals(that.type)
                && uri.equals(that.uri)
                && Objects.equals(credentials, that.credentials)
@@ -198,15 +195,15 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientType, type, uri);
+        return Objects.hash(scheme, type, uri);
     }
 
     static Authorizer fromNode(ObjectNode node) {
         node.warnIfAdditionalProperties(PROPERTIES);
         Builder builder = builder();
-        node.getStringMember(CLIENT_TYPE_KEY)
+        node.getStringMember(SCHEME_KEY)
                 .map(StringNode::getValue)
-                .ifPresent(builder::clientType);
+                .ifPresent(builder::scheme);
         builder.type(node.expectMember(TYPE_KEY).expectStringNode().getValue());
         builder.uri(node.expectMember(URI_KEY).expectStringNode().getValue());
         node.getStringMember(CREDENTIALS_KEY)
@@ -229,7 +226,7 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
      * Builder used to create an {@link Authorizer}.
      */
     public static final class Builder implements SmithyBuilder<Authorizer> {
-        private String clientType;
+        private String scheme;
         private String type;
         private String uri;
         private String credentials;
@@ -243,13 +240,13 @@ public final class Authorizer implements ToNode, ToSmithyBuilder<Authorizer> {
         }
 
         /**
-         * Sets the client authentication type.
+         * Sets the client authentication scheme name.
          *
-         * @param clientType Client authentication type such as "oauth2" or "awsSigv4."
+         * @param scheme Client authentication scheme (e.g., aws.v4).
          * @return Returns the builder.
          */
-        public Builder clientType(String clientType) {
-            this.clientType = clientType;
+        public Builder scheme(String scheme) {
+            this.scheme = scheme;
             return this;
         }
 

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerIndex.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits.apigateway;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.KnowledgeIndex;
+import software.amazon.smithy.model.selector.PathFinder;
+import software.amazon.smithy.model.selector.Selector;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+
+/**
+ * Computes the effective authorizers of each resource and
+ * operation in a service.
+ *
+ * <p>An effective authorizer of an operation first checks if the
+ * operation has the authorizer trait, then the resource an operation
+ * is bound to, then the service.
+ */
+public class AuthorizerIndex implements KnowledgeIndex {
+
+    private static final Selector SELECTOR = Selector.parse("operation");
+
+    /** Mapping of service shapes to a map of shape -> authorizer name. */
+    private final Map<ShapeId, Map<ShapeId, String>> authorizers = new HashMap<>();
+
+    /** Mapping of service shapes to a authorizer traits. */
+    private final Map<ShapeId, AuthorizersTrait> authorizerTraits = new HashMap<>();
+
+    public AuthorizerIndex(Model model) {
+        PathFinder finder = PathFinder.create(model);
+
+        model.getShapeIndex().shapes(ServiceShape.class).forEach(service -> {
+            service.getTrait(AuthorizersTrait.class).ifPresent(trait -> authorizerTraits.put(service.getId(), trait));
+            Map<ShapeId, String> serviceMap = new HashMap<>();
+            authorizers.put(service.getId(), serviceMap);
+
+            // Account for the edge case of no operations on the service.
+            service.getTrait(AuthorizerTrait.class)
+                    .ifPresent(trait -> serviceMap.put(service.getId(), trait.getValue()));
+
+            for (PathFinder.Path path : finder.search(service, SELECTOR)) {
+                String effectiveAuthorizer = null;
+                for (Shape shape : path.getShapes()) {
+                    if (shape.isServiceShape() || shape.isResourceShape() || shape.isOperationShape()) {
+                        effectiveAuthorizer = getNullableAuthorizerValue(shape, effectiveAuthorizer);
+                        if (effectiveAuthorizer != null) {
+                            serviceMap.put(shape.getId(), effectiveAuthorizer);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    private static String getNullableAuthorizerValue(Shape shape, String previous) {
+        return shape.getTrait(AuthorizerTrait.class).map(AuthorizerTrait::getValue).orElse(previous);
+    }
+
+    /**
+     * Gets the effective authorizer name of a specific resource or operation
+     * within a service.
+     *
+     * @param service Service shape to query.
+     * @param shape Resource or operation shape ID to query.
+     * @return Returns the optionally resolved authorizer name.
+     */
+    public Optional<String> getAuthorizer(ToShapeId service, ToShapeId shape) {
+        return Optional.ofNullable(authorizers.get(service.toShapeId()))
+                .flatMap(mappings -> Optional.ofNullable(mappings.get(shape.toShapeId())));
+    }
+
+    /**
+     * Gets the effective authorizer name of a service.
+     *
+     * @param service Service shape to query.
+     * @return Returns the optionally resolved authorizer name.
+     */
+    public Optional<String> getAuthorizer(ToShapeId service) {
+        return getAuthorizer(service, service);
+    }
+
+    /**
+     * Gets the effective authorizer structure value of a service.
+     *
+     * @param service Service shape to query.
+     * @return Returns the optionally resolved authorizer name.
+     */
+    public Optional<Authorizer> getAuthorizerValue(ToShapeId service) {
+        return getAuthorizerValue(service, service);
+    }
+
+    /**
+     * Gets the effective authorizer structure value of a shape in a service.
+     *
+     * @param service Service shape to query.
+     * @param shape Shape to get the authorizer of within the service.
+     * @return Returns the optionally resolved authorizer name.
+     */
+    public Optional<Authorizer> getAuthorizerValue(ToShapeId service, ToShapeId shape) {
+        return getAuthorizer(service, shape)
+                .flatMap(name -> Optional.ofNullable(authorizerTraits.get(service.toShapeId()))
+                        .flatMap(trait -> trait.getAuthorizer(name)));
+    }
+}

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerTrait.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerTrait.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits.apigateway;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.traits.StringTrait;
+
+/**
+ * Attaches an API Gateway authorizer to a service, resource, or operation.
+ */
+public final class AuthorizerTrait extends StringTrait {
+    public static final String NAME = "aws.apigateway#authorizer";
+
+    public AuthorizerTrait(String value, SourceLocation sourceLocation) {
+        super(NAME, value, sourceLocation);
+    }
+
+    public AuthorizerTrait(String value) {
+        this(value, SourceLocation.NONE);
+    }
+
+    public static final class Provider extends StringTrait.Provider<AuthorizerTrait> {
+        public Provider() {
+            super(NAME, AuthorizerTrait::new);
+        }
+    }
+}

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTrait.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTrait.java
@@ -34,11 +34,12 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * values that correspond to Smithy authorization definitions.
  *
  * <p>The key in each key-value pair of the {@code aws.apigateway#authorizers}
- * trait must correspond to the name of an authorization scheme of the
- * service the trait is bound to. When used to generate and OpenAPI model,
- * the {@code aws.apigateway#authorizers} trait is used to add the
- * {@code x-amazon-apigateway-authorizer} OpenAPI extension to the
- * generated security scheme.
+ * trait is an arbitrary name that's used to associate authorizer definitions
+ * to operations. The {@code scheme} property of an authorizer must correspond
+ * to the name of an authorization scheme of the service the trait is bound to.
+ * When used to generate and OpenAPI model, the {@code aws.apigateway#authorizers}
+ * trait is used to add the {@code x-amazon-apigateway-authorizer} OpenAPI
+ * extension to the generated security scheme.
  *
  * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html">API Gateway Authorizers</a>
  */
@@ -122,8 +123,7 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
         /**
          * Adds an authorizer.
          *
-         * @param name Name of the authorizer that must correspond to
-         *  an authentication scheme name.
+         * @param name Name of the authorizer to add.
          * @param authorizer Authorizer definition.
          * @return Returns the builder.
          */

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitValidator.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitValidator.java
@@ -15,43 +15,58 @@
 
 package software.amazon.smithy.aws.traits.apigateway;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.traits.ProtocolsTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidationUtils;
+import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SetUtils;
 
 /**
- * Each authorizers must match one of the authentication schemes on the service.
+ * Each authorizer resolved within a service must use a scheme that
+ * matches one of the schemes of the protocols of the service.
  */
 public class AuthorizersTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         return model.getShapeIndex().shapes(ServiceShape.class)
-                .flatMap(this::validateService)
+                .flatMap(service -> OptionalUtils.stream(validateService(service)))
                 .collect(Collectors.toList());
     }
 
-    private Stream<ValidationEvent> validateService(ServiceShape service) {
+    private Optional<ValidationEvent> validateService(ServiceShape service) {
         Set<String> schemeNames = service.getTrait(ProtocolsTrait.class)
                 .map(ProtocolsTrait::getAllAuthSchemes)
                 .orElse(SetUtils.of());
-        Set<String> authorizerNames = service.getTrait(AuthorizersTrait.class)
-                .map(AuthorizersTrait::getAllAuthorizers)
-                .map(map -> new HashSet<>(map.keySet()))
-                .orElseGet(HashSet::new);
 
-        authorizerNames.removeAll(schemeNames);
-        return authorizerNames.stream().map(name -> error(service, String.format(
-                "Invalid `%s` entry `%s` does not match one of the `protocols` trait `auth` schemes defined "
-                + "on the service: [%s]",
-                AuthorizersTrait.NAME, name, ValidationUtils.tickedList(schemeNames))));
+        // Create a comma separated string of authorizer names to schemes.
+        String invalidMappings = service.getTrait(AuthorizersTrait.class)
+                .map(AuthorizersTrait::getAllAuthorizers)
+                .orElseGet(HashMap::new)
+                .entrySet().stream()
+                .filter(entry -> !schemeNames.contains(entry.getValue().getScheme()))
+                .map(entry -> entry.getKey() + " -> " + entry.getValue().getScheme())
+                .sorted()
+                .collect(Collectors.joining(", "));
+
+        if (invalidMappings.isEmpty()) {
+            return Optional.empty();
+        }
+
+        AuthorizersTrait authorizersTrait = service.getTrait(AuthorizersTrait.class).get();
+        return Optional.of(error(service, authorizersTrait, String.format(
+                "Each `scheme` of the `%s` trait must target one of the auth schemes defined in the "
+                + "`protocols` trait of a service (i.e., [%s]). The following mappings of authorizer names to "
+                + "schemes are invalid: %s",
+                AuthorizersTrait.NAME,
+                ValidationUtils.tickedList(schemeNames),
+                invalidMappings)));
     }
 }

--- a/aws/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/aws/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -9,6 +9,7 @@ software.amazon.smithy.aws.traits.iam.ConditionKeysTrait$Provider
 software.amazon.smithy.aws.traits.iam.DefineConditionKeysTrait$Provider
 software.amazon.smithy.aws.traits.iam.DisableConditionKeyInferenceTrait$Provider
 software.amazon.smithy.aws.traits.iam.RequiredActionsTrait$Provider
+software.amazon.smithy.aws.traits.apigateway.AuthorizerTrait$Provider
 software.amazon.smithy.aws.traits.apigateway.AuthorizersTrait$Provider
 software.amazon.smithy.aws.traits.apigateway.RequestValidatorTrait$Provider
 software.amazon.smithy.aws.traits.apigateway.ApiKeySourceTrait$Provider

--- a/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -15,6 +15,12 @@
         "documentation": "Lambda authorizers to attach to the authentication schemes defined on this service.",
         "tags": ["internal"]
       },
+      "authorizer": {
+        "selector": ":test(service, resource, operation)",
+        "shape": "smithy.api#String",
+        "documentation": "Attaches an authorizer to a service, resource, or operation.",
+        "tags": ["internal"]
+      },
       "requestValidator": {
         "selector": ":test(service, operation)",
         "shape": "smithy.api#String",
@@ -49,9 +55,10 @@
         "private": true,
         "documentation": "An object that associates an authorizer and associated metadata with an authentication mechanism.",
         "members": {
-          "clientType": {
+          "scheme": {
+            "required": true,
             "target": "smithy.api#String",
-            "documentation": "The client authentication type. A value identifying the category of authorizer, such as \"oauth2\" or \"awsSigv4\"."
+            "documentation": "The Smithy authentication scheme used by the client (e.g, aws.v4)."
           },
           "type": {
             "target": "smithy.api#String",

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerIndexTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerIndexTest.java
@@ -1,0 +1,61 @@
+package software.amazon.smithy.aws.traits.apigateway;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class AuthorizerIndexTest {
+    @Test
+    public void computesAuthorizers() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("effective-authorizers.smithy"))
+                .assemble()
+                .unwrap();
+
+        AuthorizerIndex index = model.getKnowledge(AuthorizerIndex.class);
+        ShapeId serviceA = ShapeId.from("smithy.example#ServiceA");
+        ShapeId serviceB = ShapeId.from("smithy.example#ServiceB");
+        ShapeId resourceA = ShapeId.from("smithy.example#ResourceA");
+        ShapeId resourceB = ShapeId.from("smithy.example#ResourceB");
+        ShapeId operationA = ShapeId.from("smithy.example#OperationA");
+        ShapeId operationB = ShapeId.from("smithy.example#OperationB");
+        ShapeId operationC = ShapeId.from("smithy.example#OperationC");
+        ShapeId operationD = ShapeId.from("smithy.example#OperationD");
+        ShapeId operationE = ShapeId.from("smithy.example#OperationE");
+        ShapeId operationF = ShapeId.from("smithy.example#OperationF");
+
+        // Resolves service value.
+        assertThat(index.getAuthorizer(serviceA).get(), equalTo("foo"));
+        assertThat(index.getAuthorizerValue(serviceA).map(Authorizer::getScheme), equalTo(Optional.of("aws.v4")));
+        assertThat(index.getAuthorizer(serviceB), equalTo(Optional.empty()));
+        assertThat(index.getAuthorizerValue(serviceB), equalTo(Optional.empty()));
+
+        // Resolves top-level operations.
+        assertThat(index.getAuthorizer(serviceA, operationA).get(), equalTo("foo"));
+        assertThat(index.getAuthorizer(serviceA, operationB).get(), equalTo("baz"));
+        assertThat(index.getAuthorizer(serviceB, operationA), equalTo(Optional.empty()));
+        assertThat(index.getAuthorizer(serviceA, operationB).get(), equalTo("baz"));
+
+        // Resolves top-level resources.
+        assertThat(index.getAuthorizer(serviceA, resourceA).get(), equalTo("foo"));
+        assertThat(index.getAuthorizer(serviceB, resourceA), equalTo(Optional.empty()));
+        assertThat(index.getAuthorizer(serviceA, resourceB).get(), equalTo("baz"));
+        assertThat(index.getAuthorizer(serviceB, resourceB).get(), equalTo("baz"));
+
+        // Resolves nested operations.
+        assertThat(index.getAuthorizer(serviceA, operationC).get(), equalTo("foo"));
+        assertThat(index.getAuthorizer(serviceA, operationD).get(), equalTo("baz"));
+        assertThat(index.getAuthorizer(serviceA, operationE).get(), equalTo("baz"));
+        assertThat(index.getAuthorizer(serviceA, operationF).get(), equalTo("foo"));
+
+        assertThat(index.getAuthorizer(serviceB, operationC), equalTo(Optional.empty()));
+        assertThat(index.getAuthorizer(serviceB, operationD).get(), equalTo("baz"));
+        assertThat(index.getAuthorizer(serviceB, operationE).get(), equalTo("baz"));
+        assertThat(index.getAuthorizer(serviceB, operationF).get(), equalTo("foo"));
+    }
+}

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitTest.java
@@ -18,7 +18,7 @@ public class AuthorizersTraitTest {
         ShapeId id = ShapeId.from("smithy.example#Foo");
         ObjectNode node = Node.objectNodeBuilder()
                 .withMember("aws.v4", Node.objectNodeBuilder()
-                        .withMember("clientType", "awsSigV4")
+                        .withMember("scheme", "aws.v4")
                         .withMember("type", "request")
                         .withMember("uri", "arn:foo:baz")
                         .withMember("credentials", "arn:foo:bar")

--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/effective-authorizers.smithy
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/effective-authorizers.smithy
@@ -1,0 +1,55 @@
+namespace smithy.example
+
+@protocols([{name: aws-rest-json, auth: [aws.v4]}])
+@aws.apigateway#authorizer("foo")
+@aws.apigateway#authorizers(
+    foo: {scheme: aws.v4, type: aws, uri: "arn:foo"},
+    baz: {scheme: aws.v4, type: aws, uri: "arn:foo"})
+service ServiceA {
+  version: "2019-06-17",
+  operations: [OperationA, OperationB],
+  resources: [ResourceA, ResourceB],
+}
+
+// Inherits the authorizer of ServiceA
+operation OperationA()
+
+// Overrides the authorizer of ServiceA
+@aws.apigateway#authorizer("baz")
+operation OperationB()
+
+// Inherits the authorizer of ServiceA
+resource ResourceA {
+  operations: [OperationC, OperationD]
+}
+
+// Inherits the authorizer of ServiceA
+operation OperationC()
+
+// Overrides the authorizer of ServiceA
+@aws.apigateway#authorizer("baz")
+operation OperationD()
+
+// Overrides the authorizer of ServiceA
+@aws.apigateway#authorizer("baz")
+resource ResourceB {
+  operations: [OperationE, OperationF]
+}
+
+// Inherits the authorizer of ResourceB
+operation OperationE()
+
+// Overrides the authorizer of ResourceB
+@aws.apigateway#authorizer("foo")
+operation OperationF()
+
+
+@protocols([{name: aws-rest-json, auth: [aws.v4]}])
+@aws.apigateway#authorizers(
+    foo: {scheme: aws.v4, type: aws, uri: "arn:foo"},
+    baz: {scheme: aws.v4, type: aws, uri: "arn:foo"})
+service ServiceB {
+  version: "2019-06-17",
+  operations: [OperationA, OperationB],
+  resources: [ResourceA, ResourceB],
+}

--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/errorfiles/invalid-authorizers.errors
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/errorfiles/invalid-authorizers.errors
@@ -1,2 +1,1 @@
-[ERROR] ns.foo#SomeService: Invalid `aws.apigateway#authorizers` entry `another` does not match one of the `protocols` trait `auth` schemes defined on the service: [`aws.v4`] | AuthorizersTrait
-[ERROR] ns.foo#SomeService: Invalid `aws.apigateway#authorizers` entry `invalid` does not match one of the `protocols` trait `auth` schemes defined on the service: [`aws.v4`] | AuthorizersTrait
+[ERROR] ns.foo#SomeService: Each `scheme` of the `aws.apigateway#authorizers` trait must target one of the auth schemes defined in the `protocols` trait of a service (i.e., [`aws.v4`]). The following mappings of authorizer names to schemes are invalid: another -> another, invalid -> invalid | AuthorizersTrait

--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/errorfiles/invalid-authorizers.json
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/errorfiles/invalid-authorizers.json
@@ -8,17 +8,17 @@
         "protocols": [{"name": "aws.rest-json", "auth": ["aws.v4"]}],
         "aws.apigateway#authorizers": {
           "invalid": {
-            "clientType": "awsSigV4",
+            "scheme": "invalid",
             "type": "request",
             "uri": "arn:foo:baz"
           },
           "another": {
-            "clientType": "awsSigV4",
+            "scheme": "another",
             "type": "token",
             "uri": "arn:foo:baz"
           },
           "aws.v4": {
-            "clientType": "awsSigV4",
+            "scheme": "aws.v4",
             "type": "request",
             "uri": "arn:foo:baz",
             "credentials": "arn:foo:bar",

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -119,7 +119,7 @@ that builds an OpenAPI specification from a service for the
 
 .. code-block:: json
     :caption: smithy-build.json
-    :name: smithy-build-json
+    :name: open-api-smithy-build-json
 
     {
         "version": "1.0",

--- a/docs/source/spec/amazon-apigateway.rst
+++ b/docs/source/spec/amazon-apigateway.rst
@@ -92,9 +92,9 @@ Trait selector
 
     *A service shape that has the protocols trait*
 Value type
-    Map of x names to *authorizer* definitions. The key used as the authorizer
-    name MUST reference one of the ``auth`` schemes of the :ref:`protocols-trait`
-    attached to the service.
+    Map of arbitrary names to *authorizer* definitions. These authorizer
+    definitions are applied to a service, resource, or operation using the
+    :ref:`aws.apigateway#authorizer-trait`.
 
 An *authorizer* definition is an object that supports the following properties:
 
@@ -111,6 +111,11 @@ An *authorizer* definition is an object that supports the following properties:
         and the value must be "token", for an authorizer with the caller
         identity embedded in an authorization token, or "request", for an
         authorizer with the caller identity contained in request parameters.
+    * - scheme
+      - ``string``
+      - **Required**. A Smithy authentication scheme name that identifies how
+        a client authenticates. This value MUST reference one of the ``auth``
+        schemes of the :ref:`protocols-trait` attached to the service.
     * - uri
       - ``string``
       - **Required.** Specifies the authorizer's Uniform Resource Identifier
@@ -123,15 +128,6 @@ An *authorizer* definition is an object that supports the following properties:
         should be treated as the path to the resource, including the initial
         ``/``. For Lambda functions, this is usually of the form
         ``/2015-03-31/functions/[FunctionARN]/invocations``.
-    * - clientType
-      - ``string``
-      - The client authentication type. A value identifying the category of
-        authorizer, such as "oauth2" or "awsSigv4".
-
-        .. note::
-
-            This is the equivalent of setting the `x-amazon-apigateway-authtype`_
-            extension property in OpenAPI.
     * - credentials
       - ``string``
       - Specifies the required credentials as an IAM role for API Gateway to
@@ -197,9 +193,10 @@ An *authorizer* definition is an object that supports the following properties:
                             "auth": ["aws.v4"]
                         }
                     ],
+                    "aws.apigateway#authorizer": "arbitrary-name",
                     "aws.apigateway#authorizers": {
-                        "aws.v4": {
-                            "clientType": "awsSigV4",
+                        "arbitrary-name": {
+                            "scheme": "aws.v4",
                             "type": "request",
                             "uri": "arn:foo:baz",
                             "credentials": "arn:foo:bar",
@@ -212,6 +209,30 @@ An *authorizer* definition is an object that supports the following properties:
             }
         }
     }
+
+.. note::
+
+    This trait should be considered internal-only and not exposed to your
+    customers.
+
+
+.. _aws.apigateway#authorizer-trait:
+
+``aws.apigateway#authorizer`` trait
+====================================
+
+Summary
+    Applies a Lambda authorizer to a service, resource, or operation.
+    Authorizers are resolved hierarchically: an operation inherits
+    the effective authorizer applied to a parent resource or operation.
+Trait selector
+    ``:each(service, resource, operation)``
+
+    *A service, resource, or operation*
+Value type
+    String value that MUST reference one of the keys in the
+    :ref:`aws.apigateway#authorizers-trait` of the service that contains
+    the shape.
 
 .. note::
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
@@ -213,6 +214,27 @@ public final class PathFinder {
         @Override
         public Relationship get(int index) {
             return relationships.get(index);
+        }
+
+        /**
+         * Gets a list of all shapes in the path including the starting
+         * shape all the way to the last shape.
+         *
+         * <p>The returned list does not return the last element (the
+         * end shape targeted by the last neighbor) if it does not exist.
+         *
+         * @return Returns the list of shapes.
+         */
+        public List<Shape> getShapes() {
+            List<Shape> results = relationships.stream()
+                    .map(Relationship::getShape)
+                    .collect(Collectors.toList());
+            Relationship last = relationships.get(relationships.size() - 1);
+            if (last.getNeighborShape().isPresent()) {
+                results.add(last.getNeighborShape().get());
+            }
+
+            return results;
         }
 
         /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
@@ -47,23 +47,8 @@ public interface SecuritySchemeConverter {
     SecurityScheme createSecurityScheme(Context context);
 
     /**
-     * Get the name that should be used for this security scheme throughout
-     * the model.
-     *
-     * <p>By default, this method will return the result of
-     * {@link #getAuthSchemeName()}
-     *
-     * @param context Conversion context.
-     * @return The Smithy security authentication scheme name.
-     */
-    default String getSecurityName(Context context) {
-        return getAuthSchemeName();
-    }
-
-    /**
      * Creates a "security" requirements property to apply to an operation
-     * or top-level service using the return value of {@link #getSecurityName}
-     * as the security scheme name.
+     * or top-level service using the Smithy auth scheme name as the key.
      *
      * <p>The default implementation will return an empty list.
      *

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ComponentsObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ComponentsObject.java
@@ -229,6 +229,11 @@ public final class ComponentsObject extends Component implements ToSmithyBuilder
             return this;
         }
 
+        public Builder removeSecurityScheme(String name) {
+            securitySchemes.remove(name);
+            return this;
+        }
+
         public Builder links(Map<String, LinkObject> links) {
             this.links.clear();
             this.links.putAll(links);

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.openapi.model;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -199,6 +200,12 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
 
         public Builder addSecurity(Map<String, List<String>> requirement) {
             this.security.add(requirement);
+            return this;
+        }
+
+        public Builder security(Collection<Map<String, List<String>>> security) {
+            this.security.clear();
+            this.security.addAll(security);
             return this;
         }
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponentsTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponentsTest.java
@@ -7,8 +7,11 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.openapi.OpenApiConstants;
+import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.openapi.model.SecurityScheme;
 
 public class RemoveUnusedComponentsTest {
     private static Model model;
@@ -41,5 +44,23 @@ public class RemoveUnusedComponentsTest {
 
         // The input structure remains in the output even though it's unreferenced.
         Assertions.assertFalse(result.getComponents().getSchemas().isEmpty());
+    }
+
+    @Test
+    public void removesUnusedSchemes() {
+        OpenApi result = OpenApiConverter.create()
+                .addOpenApiMapper(new OpenApiMapper() {
+                    @Override
+                    public OpenApi after(Context context, OpenApi openapi) {
+                        return openapi.toBuilder()
+                                .components(openapi.getComponents().toBuilder()
+                                        .putSecurityScheme("foo", SecurityScheme.builder().type("apiKey").build())
+                                        .build())
+                                .build();
+                    }
+                })
+                .convert(model, ShapeId.from("smithy.example#Small"));
+
+        Assertions.assertFalse(result.getComponents().getSecuritySchemes().keySet().contains("foo"));
     }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/small-service.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/small-service.smithy
@@ -1,6 +1,6 @@
 namespace smithy.example
 
-@protocols([{"name": "aws.rest-json"}])
+@protocols([{"name": "aws.rest-json", auth: [aws.v4]}])
 service Small {
   version: "2018-01-01",
   operations: [SmallOperation]


### PR DESCRIPTION
This commit updates the API Gateway traits to allow Lambda authorizers
to vary per/operation. Authorizers are now only attached to an operation
when the `authorizer` trait is used on a service, resource, or operation.
The OpenApiMapper interface was updated to make this simpler so that you
can now map over the security requirements object of an operation and
rename them from the underlying Smithy authentication scheme (e.g.,
aws.v4) to the custom authorizer security scheme.

Included with this change is an update to the
RemoveUnusedComponents mapper to ensure that any unused security
definitions are stripped from the resulting spec.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
