### PR TITLE
Add examples trait to prelude

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
@@ -646,11 +646,6 @@ final class LoaderVisitor {
             if (definition != null) {
                 traitName = definition.getFullyQualifiedName();
                 value = coerceTraitValue(value, definition);
-            } else if (trait.name.equals("examples") || trait.name.equals("smithy.api#examples")) {
-                // TODO: Add a document type or something.
-                // The examples trait is not part of the prelude because we have no document type and this
-                // trait requires a free-form document value to model example input and output.
-                traitName = "smithy.api#examples";
             } else {
                 onUnresolvedTraitName(shapeBuilder, trait);
                 continue;

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/smithy-prelude-traits.json
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/smithy-prelude-traits.json
@@ -37,6 +37,11 @@
         "shape": "Uri",
         "documentation": "Links a service or operation to a URL that contains additional documentation."
       },
+      "examples": {
+        "selector": "operation",
+        "shape": "ExamplesList",
+        "documentation": "Provides example inputs and outputs for operations."
+      },
       "error": {
         "selector": "structure",
         "shape": "ErrorKind",
@@ -573,6 +578,21 @@
             "required": true,
             "documentation": "A host prefix pattern for the operation. Labels defined in the host pattern are used to bind top-level operation input members to the host."
           }
+        },
+        "private": true
+      },
+      "ExamplesList": {
+        "type": "list",
+        "member": {"target": "Example"},
+        "private": true
+      },
+      "Example": {
+        "type": "structure",
+        "members": {
+          "title": {"required":  true, "target": "smithy.api#String"},
+          "documentation": {"target": "smithy.api#String"},
+          "input": {"target": "smithy.api#Document"},
+          "output": {"target": "smithy.api#Document"}
         },
         "private": true
       }


### PR DESCRIPTION
This commit adds the examples trait to the prelude and removes the
special case handling from the LoaderVisitor. This is now possible with
the introduction of the document type.

Closes #83

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
