### PR TITLE
Update root package javadoc to aggregate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,3 +183,18 @@ subprojects {
         }
     }
 }
+
+/*
+ * Javadoc
+ * ====================================================
+ *
+ * Configure javadoc to collect sources and construct
+ * its classpath from the main sourceset of each
+ * subproject.
+ */
+tasks.javadoc {
+    title = "Smithy API $version"
+    setDestinationDir(file("$buildDir/docs/javadoc/latest"))
+    source(project.subprojects.map { project(it.name).sourceSets.main.get().allJava })
+    classpath = files(project.subprojects.map { project(it.name).sourceSets.main.get().compileClasspath })
+}


### PR DESCRIPTION
Since the root Smithy package has no source, this commit overrides
the root package's javadoc task to aggregate the javadocs of each
subproject.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
