### PR TITLE
Add selectors to validators and fix namespaces

### DIFF
--- a/docs/source/spec/validation.rst
+++ b/docs/source/spec/validation.rst
@@ -84,9 +84,14 @@ objects that are used to constrain a model. Each object in the
       - Provides a list of the namespaces that are targeted by the validator.
         The validator will ignore any validation events encountered that are
         not specific to the given namespaces.
+    * - selector
+      - ``string``
+      - A valid :ref:`selector <selectors>` that causes the validator to only
+        validate shapes that match the selector. The validator will ignore any
+        validation events encountered that do not satisfy the selector.
     * - configuration
       - ``object``
-      - Object that provides validator configuraton. The available properties
+      - Object that provides validator configuration. The available properties
         are defined by each validator. Validators MAY require that specific
         configuration properties are provided.
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorFromDefinitionFactory.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorFromDefinitionFactory.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.loader;
 import static java.lang.String.format;
 
 import java.util.Objects;
-import java.util.stream.Collectors;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -46,6 +45,6 @@ final class ValidatorFromDefinitionFactory {
     }
 
     private Validator mapValidator(ValidatorDefinition definition, Validator upstream) {
-        return model -> upstream.validate(model).stream().map(definition::map).collect(Collectors.toList());
+        return model -> definition.map(model, upstream.validate(model));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
@@ -1,0 +1,61 @@
+package software.amazon.smithy.model.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.Validator;
+import software.amazon.smithy.model.validation.ValidatorFactory;
+
+public class ValidatorDefinitionTest {
+    @Test
+    public void mapsAndFiltersOverShapes() {
+        List<ValidationEvent> events = Model.assembler()
+                .addImport(getClass().getResource("validator-filtering-and-mapping.smithy"))
+                .validatorFactory(new ValidatorFactory() {
+                    @Override
+                    public List<Validator> loadBuiltinValidators() {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public Optional<Validator> createValidator(String name, ObjectNode configuration) {
+                        return name.equals("hello")
+                               ? Optional.of(
+                                       model -> model.getShapeIndex().shapes()
+                                               .map(shape -> ValidationEvent.builder()
+                                                       .eventId(name)
+                                                       .shape(shape)
+                                                       .severity(Severity.WARNING)
+                                                       .message("Hello!")
+                                                       .build())
+                                               .collect(Collectors.toList()))
+                               : Optional.empty();
+                    }
+                })
+                .assemble()
+                .getValidationEvents();
+
+        assertThat(events, not(empty()));
+        Assertions.assertEquals(2, events.stream().filter(e -> e.getEventId().equals("hello")).count());
+        Assertions.assertEquals(4, events.stream().filter(e -> e.getEventId().equals("custom")).count());
+
+        // Ensure that template expansion works.
+        for (ValidationEvent event : events) {
+            if (event.getEventId().equals("custom")) {
+                assertThat(event.getMessage(), equalTo("Test Hello!"));
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorLoaderTest.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.model.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class ValidatorLoaderTest {
+    @Test
+    public void loadsAppropriateSourceLocations() {
+        List<ValidationEvent> events = Model.assembler()
+                .addImport(getClass().getResource("invalid-validation-selector.json"))
+                .assemble()
+                .getValidationEvents();
+
+        assertThat(events, not(empty()));
+        Assertions.assertTrue(events.stream().anyMatch(e -> e.getMessage().contains("Invalid validator selector")));
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid-validation-selector.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid-validation-selector.json
@@ -1,0 +1,11 @@
+{
+  "smithy": "0.1.0",
+  "metadata": {
+    "validators": [
+      {
+        "name": "Foo",
+        "selector": "!@#!@@!%"
+      }
+    ]
+  }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/validator-filtering-and-mapping.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/validator-filtering-and-mapping.smithy
@@ -1,0 +1,25 @@
+namespace smithy.example
+
+metadata validators = [
+  { // Picks up two shapes
+    name: hello,
+    selector: ":test(string, integer)"
+  },
+  { // Picks up no shapes
+    name: hello,
+    namespaces: ["not.smithy.example"]
+  },
+  { // Picks up 4 shapes
+    name: hello,
+    id: custom,
+    message: "Test {super}"
+  },
+]
+
+string MyString
+
+integer MyList
+
+boolean MyBoolean
+
+long MyLong


### PR DESCRIPTION
This commit updates the validator logic to properly ignore shapes that
fall outside of the specified namespaces or that don't match a validator
definition selector. Lots more tests were added to ensure that validator
mapping and filtering works.

*Issue #, if available:*

Closes #68

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
