### PR TITLE
Add documentation comments

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -111,6 +111,7 @@ weather service.
 
         namespace example.weather
 
+        /// Provides weather forecasts.
         service Weather {
           version: "2006-03-01"
         }
@@ -155,6 +156,7 @@ identifiers, operations, and any number of child resources.
 
         namespace example.weather
 
+        /// Provides weather forecasts.
         service Weather {
           version: "2006-03-01",
           resources: [City]
@@ -536,6 +538,7 @@ service.
 
     .. code-tab:: smithy
 
+        /// Provides weather forecasts.
         service Weather {
           version: "2006-03-01",
           resources: [City],
@@ -604,6 +607,7 @@ Complete example
 
         namespace example.weather
 
+        /// Provides weather forecasts.
         service Weather {
           version: "2006-03-01",
           resources: [City],

--- a/docs/source/smithy.py
+++ b/docs/source/smithy.py
@@ -14,20 +14,16 @@ class HTMLTranslator(SphinxHTMLTranslator):
     def visit_productionlist(self, node):
         # type: (nodes.Node) -> None
         self.body.append(self.starttag(node, 'pre'))
-        names = []
-        for production in node:
-            names.append(production['tokenname'])
-        maxlen = max(len(name) for name in names)
         lastname = None
         for production in node:
             if production['tokenname']:
                 if lastname is not None:
                     self.body.append('\n')
-                lastname = production['tokenname'].ljust(maxlen)
+                lastname = production['tokenname']
                 self.body.append(self.starttag(production, 'strong', ''))
-                self.body.append(lastname + '</strong> = ')
+                self.body.append(lastname + "</strong> =\n    ")
             elif lastname is not None:
-                self.body.append('%s   ' % (' ' * len(lastname)))
+                self.body.append('  ')
             production.walkabout(self)
             self.body.append('\n')
         self.body.append('</pre>\n')

--- a/docs/source/spec/selectors.rst
+++ b/docs/source/spec/selectors.rst
@@ -517,10 +517,7 @@ Selectors are defined by the following ABNF_ grammar.
 
 .. productionlist:: selectors
     selector             :`selector_expression` *(`selector_expression`)
-    selector_expression  :`shape_types`
-                         :/ `attr`
-                         :/ `function_expression`
-                         :/ `neighbors`
+    selector_expression  :`shape_types` / `attr` / `function_expression` / `neighbors`
     shape_types          :"*"
                          :/ "blob"
                          :/ "boolean"
@@ -561,22 +558,17 @@ Selectors are defined by the following ABNF_ grammar.
                          :/ "operation"
                          :/ "resource"
                          :/ "bound"
-    attr                   :"[" `attr_key`
-                           :*(`comparator` `attr_value` ["i"]) "]"
-    attr_key               :`id_attribute`
-                           :/ `trait_attribute`
-                           :/ `service_attribute`
+    attr                   :"[" `attr_key` *(`comparator` `attr_value` ["i"]) "]"
+    attr_key               :`id_attribute` / `trait_attribute` / `service_attribute`
     id_attribute           :"id" ["|" ("namespace" / "name" / "member")]
     trait_attribute        :"trait" "|" `attr_value` *("|" `attr_value`)
     attr_value             :`attr_identifier` / `selector_text`
-    attr_identifier        :1*(ALPHA / DIGIT / "_")
-                           :*(ALPHA / DIGIT / "_" / "-" / "." / "#")
+    attr_identifier        :1*(ALPHA / DIGIT / "_") *(ALPHA / DIGIT / "_" / "-" / "." / "#")
     service_attribute      :"service|version"
     comparator            :"^=" / "$=" / "*=" / "="
     function_expression   :":" `function` "(" `selector` *("," `selector`) ")"
     function              :"each" / "test" / "of" / "not"
-    selector_text         :`selector_single_quoted_text`
-                          :/ `selector_double_quoted_text`
+    selector_text         :`selector_single_quoted_text` / `selector_double_quoted_text`
     selector_single_quoted_text    :"'" 1*`selector_single_quoted_char` "'"
     selector_double_quoted_text    :DQUOTE 1*`selector_double_quoted_char` DQUOTE
     selector_single_quoted_char    :%x20-26 / %x28-5B / %x5D-10FFFF ; Excludes (')

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
@@ -115,8 +115,9 @@ final class LoaderUtils {
      * @param name Name of the trait definition.
      * @param node Value that contains the definition.
      * @param visitor Visitor to add the loaded definition to.
+     * @param docs External documentation string to inject into the definition.
      */
-    static void loadTraitDefinition(String namespace, String name, Node node, LoaderVisitor visitor) {
+    static void loadTraitDefinition(String namespace, String name, Node node, LoaderVisitor visitor, String docs) {
         ObjectNode members = node.expectObjectNode("Trait definitions must be defined using object nodes.");
         members.warnIfAdditionalProperties(TRAIT_DEFINITION_PROPERTY_NAMES);
         validateTraitDefinitionName(name, node);
@@ -124,6 +125,10 @@ final class LoaderUtils {
         TraitDefinition.Builder builder = TraitDefinition.builder()
                 .name(namespace + "#" + name)
                 .sourceLocation(node.getSourceLocation());
+
+        if (docs != null) {
+            builder.documentation(docs);
+        }
 
         members.getMember(TraitDefinition.SELECTOR_KEY)
                 .map(LoaderUtils::loadSelector)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/NodeModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/NodeModelLoader.java
@@ -268,7 +268,7 @@ final class NodeModelLoader implements ModelLoader {
     private void loadTraitDefs(LoaderVisitor visitor, String namespace, ObjectNode members) {
         for (Map.Entry<StringNode, Node> entry : members.getMembers().entrySet()) {
             try {
-                LoaderUtils.loadTraitDefinition(namespace, entry.getKey().getValue(), entry.getValue(), visitor);
+                LoaderUtils.loadTraitDefinition(namespace, entry.getKey().getValue(), entry.getValue(), visitor, null);
             } catch (SourceException e) {
                 visitor.onError(ValidationEvent.fromSourceException(e));
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/SmithyModelLexer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/SmithyModelLexer.java
@@ -57,6 +57,7 @@ final class SmithyModelLexer implements Iterator<SmithyModelLexer.Token> {
     enum TokenType {
         NEWLINE("\n"),
         WS("\\s+"),
+        DOC("///[^\\n]*"),
         COMMENT("//[^\\n]*"),
         RETURN(Pattern.quote("->")),
         DOLLAR(Pattern.quote("$")),
@@ -113,6 +114,17 @@ final class SmithyModelLexer implements Iterator<SmithyModelLexer.Token> {
             return errorMessage != null
                    ? String.format("ERROR(%s, %d:%d)", errorMessage, line, column)
                    : String.format("%s(%s, %d:%d)", type.name(), lexeme, line, column);
+        }
+
+        public String getDocContents() {
+            if (type != TokenType.DOC) {
+                throw new IllegalStateException("Not a doc comment token");
+            }
+
+            // Strip "///" and a leading space if present.
+            return lexeme.startsWith("/// ")
+                     ? lexeme.substring(4)
+                     : lexeme.substring(3);
         }
     }
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-on-eof.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-on-eof.smithy
@@ -1,0 +1,2 @@
+// Parse error at line 2, column 1 near `/// Invalid!`: Found a documentation comment that doesn't document anything
+/// Invalid!

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-on-metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-on-metadata.smithy
@@ -1,0 +1,3 @@
+// Parse error at line 2, column 1 near `/// Invalid docs!`: Documentation cannot be applied to `metadata`
+/// Invalid docs!
+metadata foo = "baz"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-on-namespace.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-on-namespace.smithy
@@ -1,0 +1,3 @@
+// Parse error at line 2, column 1 near `/// Invalid docs!`: Documentation cannot be applied to `namespace`
+/// Invalid docs!
+namespace foo.baz

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-trailing-in-member.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/doc-targets/docs-trailing-in-member.smithy
@@ -1,0 +1,7 @@
+// Parse error at line 6, column 4 near `/// Hello!`: Documentation cannot be applied to `}`
+namespace foo.baz
+
+structure Foo {
+   baz: String,
+   /// Hello!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/trait-on-eof.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/trait-on-eof.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 1 near `deprecated`: Found a trait doesn't apply to anything
+namespace com.foo
+
+@deprecated

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/trait-trailing.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/trait-trailing.smithy
@@ -1,0 +1,8 @@
+// Parse error at line 7, column 3 near `deprecated`: Traits cannot be applied to `}`
+namespace com.foo
+
+structure Foo {
+  baz: String,
+
+  @deprecated
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-before-docs.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-before-docs.smithy
@@ -1,0 +1,6 @@
+// Parse error at line 4, column 1 near `deprecated`: Traits cannot be applied to `/// Baz`
+namespace smithy.example
+
+@deprecated
+/// Baz
+string MyString

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-on-apply.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-on-apply.smithy
@@ -1,0 +1,5 @@
+// Parse error at line 4, column 1 near `deprecated`: Traits cannot be applied to `apply`
+namespace com.foo
+
+@deprecated
+apply Foo @deprecated

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-on-metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-on-metadata.smithy
@@ -1,0 +1,5 @@
+// Parse error at line 4, column 1 near `deprecated`: Traits cannot be applied to `metadata`
+namespace com.foo
+
+@deprecated
+metadata foo = bar

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-on-namespace.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/trait-targets/traits-on-namespace.smithy
@@ -1,0 +1,5 @@
+// Parse error at line 4, column 1 near `deprecated`: Traits cannot be applied to `namespace`
+namespace com.foo
+
+@deprecated
+namespace com.bar

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/traits-on-apply.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/traits-on-apply.smithy
@@ -1,5 +1,0 @@
-// Parse error at line 5, column 1 near `apply`: Traits cannot be applied to a `apply` definition
-namespace com.foo
-
-@deprecated
-apply Foo @deprecated

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/traits-on-metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/traits-on-metadata.smithy
@@ -1,5 +1,0 @@
-// Parse error at line 5, column 1 near `metadata`: Traits cannot be applied to a `metadata` definition
-namespace com.foo
-
-@deprecated
-metadata foo = bar

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/traits-on-namespace.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/traits-on-namespace.smithy
@@ -1,5 +1,0 @@
-// Parse error at line 5, column 1 near `namespace`: Traits cannot be applied to a `namespace` definition
-namespace com.foo
-
-@deprecated
-namespace com.bar

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/doc-comments.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/doc-comments.json
@@ -1,0 +1,24 @@
+{
+  "smithy": "0.1.0",
+  "smithy.example": {
+    "shapes": {
+      "MyString": {
+        "type": "string",
+        "documentation": "Foo\nbaz\nBar!"
+      },
+      "MyStructure": {
+        "type": "structure",
+        "documentation": "Structure",
+        "members": {
+          "foo": {"target": "String", "documentation": "Docs on member!"},
+          "baz": {"target": "String", "documentation": "Docs on another member!"}
+        }
+      }
+    },
+    "traitDefs": {
+      "MyTrait": {
+        "documentation": "The documentation\nof this trait!"
+      }
+    }
+  }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/doc-comments.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/doc-comments.smithy
@@ -1,0 +1,19 @@
+namespace smithy.example
+
+/// Foo
+/// baz
+/// Bar!
+string MyString
+
+/// Structure
+structure MyStructure {
+    /// Docs on member!
+    foo: String,
+
+    /// Docs on another member!
+    baz: String,
+}
+
+/// The documentation
+/// of this trait!
+trait MyTrait {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/list-and-sets.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/list-and-sets.smithy
@@ -2,7 +2,7 @@ namespace com.example
 
 string String
 
-///////////// lists //////////////
+// ----- lists ------
 
 list A {member: smithy.api#String}
 list B {member:String}
@@ -40,7 +40,7 @@ list G
 member: String
 }
 
-///////////// sets //////////////
+//---- sets -----
 
 set H {member: smithy.api#String}
 set I{member:String}


### PR DESCRIPTION
Closes #60

Also cleans up the validation of traits so that we check that the trait
is applied to something valid rather than check that there are no
pending traits for invalid targets.

This commit cleans up the grammar and presentation of the grammar to
make it more readable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
