### PR TITLE
Correct Smithy code syntax error in docs

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -1548,7 +1548,7 @@ For example, given the following model,
         @readonly
         operation GetForecast(GetForecastInput) -> GetForecastOutput
 
-        structure GetForecastInput: {
+        structure GetForecastInput {
           @required
           forecastId: ForecastId,
         }


### PR DESCRIPTION


```diff
-        structure GetForecastInput: {
+        structure GetForecastInput {
          @required
          forecastId: ForecastId,
        }
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
