### PR TITLE
Allow paginated config to be shared across service

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -112,6 +112,7 @@ weather service.
         namespace example.weather
 
         /// Provides weather forecasts.
+        /// Triple slash comments attach documentation to shapes.
         service Weather {
           version: "2006-03-01"
         }
@@ -404,11 +405,19 @@ cities, so there's no way we could provide a City identifier.
 
     .. code-tab:: smithy
 
-        // The paginated trait indicates that the operation may
-        // return truncated results.
-        @readonly @collection
+        /// Provides weather forecasts.
         @paginated(inputToken: "nextToken", outputToken: "nextToken",
-                  pageSize: "pageSize", items: "items")
+                   pageSize: "pageSize")
+        service Weather {
+          version: "2006-03-01",
+          resources: [City]
+        }
+
+        // The paginated trait indicates that the operation may
+        // return truncated results. Applying this trait to the service
+        // sets default pagination configuration settings on each operation.
+        @paginated(items: "items")
+        @readonly @collection
         operation ListCities(ListCitiesInput) -> ListCitiesOutput
 
         structure ListCitiesInput {
@@ -444,17 +453,18 @@ cities, so there's no way we could provide a City identifier.
             "smithy": "0.2.0",
             "example.weather": {
                 "shapes": {
+                    "Weather": {
+                        "type": "service",
+                        "version": "2006-03-01",
+                        "resources": ["City"],
+                        "paginated": {"inputToken": "nextToken", "outputToken": "nextToken", "pageSize": "pageSize"}
+                    },
                     "ListCities": {
                         "type": "operation",
                         "input": "ListCitiesInput",
                         "output": "ListCitiesOutput",
                         "readonly": true,
-                        "paginated": {
-                            "inputToken": "nextToken",
-                            "outputToken": "nextToken",
-                            "pageSize": "pageSize",
-                            "items": "items"
-                        }
+                        "paginated": {"items": "items"}
                     },
                     "ListCitiesInput": {
                         "type": "structure",
@@ -539,6 +549,8 @@ service.
     .. code-tab:: smithy
 
         /// Provides weather forecasts.
+        @paginated(inputToken: "nextToken", outputToken: "nextToken",
+                   pageSize: "pageSize")
         service Weather {
           version: "2006-03-01",
           resources: [City],
@@ -608,6 +620,8 @@ Complete example
         namespace example.weather
 
         /// Provides weather forecasts.
+        @paginated(inputToken: "nextToken", outputToken: "nextToken",
+                   pageSize: "pageSize")
         service Weather {
           version: "2006-03-01",
           resources: [City],
@@ -670,8 +684,7 @@ Complete example
         // The paginated trait indicates that the operation may
         // return truncated results.
         @readonly @collection
-        @paginated(inputToken: "nextToken", outputToken: "nextToken",
-                  pageSize: "pageSize", items: "items")
+        @paginated(items: "items")
         operation ListCities(ListCitiesInput) -> ListCitiesOutput
 
         structure ListCitiesInput {
@@ -727,11 +740,22 @@ Complete example
 
         {
             "smithy": "0.2.0",
-            "example.weather":{
-                "shapes":{
-                    "City":{
+            "example.weather": {
+                "shapes": {
+                    "Weather": {
+                        "type":"service",
+                        "version":"2006-03-01",
+                        "operations":[
+                            "GetCurrentTime"
+                        ],
+                        "resources":[
+                            "City"
+                        ],
+                        "paginated": {"inputToken": "nextToken", "outputToken": "nextToken", "pageSize": "pageSize"}
+                    },
+                    "City": {
                         "type":"resource",
-                        "identifiers":{
+                        "identifiers": {
                             "cityId":"CityId"
                         },
                         "read":"GetCity",
@@ -740,56 +764,56 @@ Complete example
                             "Forecast"
                         ]
                     },
-                    "CityCoordinates":{
+                    "CityCoordinates": {
                         "type":"structure",
-                        "members":{
-                            "latitude":{
+                        "members": {
+                            "latitude": {
                                 "target":"Float",
                                 "required":true
                             },
-                            "longitude":{
+                            "longitude": {
                                 "target":"Float",
                                 "required":true
                             }
                         }
                     },
-                    "CityId":{
+                    "CityId": {
                         "type":"string",
                         "pattern":"^[A-Za-z0-9 ]+$"
                     },
-                    "CitySummaries":{
+                    "CitySummaries": {
                         "type":"list",
-                        "member":{
+                        "member": {
                             "target":"CitySummary"
                         }
                     },
-                    "CitySummary":{
+                    "CitySummary": {
                         "type":"structure",
-                        "members":{
-                            "cityId":{
+                        "members": {
+                            "cityId": {
                                 "target":"CityId",
                                 "required":true
                             },
-                            "name":{
+                            "name": {
                                 "target":"String",
                                 "required":true
                             }
                         },
-                        "references":{
-                            "city":{
+                        "references": {
+                            "city": {
                                 "resource":"City",
                                 "service":"Weather"
                             }
                         }
                     },
-                    "Forecast":{
+                    "Forecast": {
                         "type":"resource",
-                        "identifiers":{
+                        "identifiers": {
                             "cityId":"CityId"
                         },
                         "read":"GetForecast"
                     },
-                    "GetCity":{
+                    "GetCity": {
                         "type":"operation",
                         "input":"GetCityInput",
                         "output":"GetCityOutput",
@@ -798,120 +822,105 @@ Complete example
                         ],
                         "readonly":true
                     },
-                    "GetCityInput":{
+                    "GetCityInput": {
                         "type":"structure",
-                        "members":{
-                            "cityId":{
+                        "members": {
+                            "cityId": {
                                 "target":"CityId",
                                 "required":true
                             }
                         }
                     },
-                    "GetCityOutput":{
+                    "GetCityOutput": {
                         "type":"structure",
-                        "members":{
-                            "coordinates":{
+                        "members": {
+                            "coordinates": {
                                 "target":"CityCoordinates",
                                 "required":true
                             },
-                            "name":{
+                            "name": {
                                 "target":"String",
                                 "required":true
                             }
                         }
                     },
-                    "GetCurrentTime":{
+                    "GetCurrentTime": {
                         "type":"operation",
                         "output":"GetCurrentTimeOutput",
                         "readonly":true
                     },
-                    "GetCurrentTimeOutput":{
+                    "GetCurrentTimeOutput": {
                         "type":"structure",
-                        "members":{
-                            "time":{
+                        "members": {
+                            "time": {
                                 "target":"Timestamp",
                                 "required":true
                             }
                         }
                     },
-                    "GetForecast":{
+                    "GetForecast": {
                         "type":"operation",
                         "input":"GetForecastInput",
                         "output":"GetForecastOutput",
                         "readonly":true
                     },
-                    "GetForecastInput":{
+                    "GetForecastInput": {
                         "type":"structure",
-                        "members":{
-                            "cityId":{
+                        "members": {
+                            "cityId": {
                                 "target":"CityId",
                                 "required":true
                             }
                         }
                     },
-                    "GetForecastOutput":{
+                    "GetForecastOutput": {
                         "type":"structure",
-                        "members":{
-                            "chanceOfRain":{
+                        "members": {
+                            "chanceOfRain": {
                                 "target":"Float"
                             }
                         }
                     },
-                    "ListCities":{
+                    "ListCities": {
                         "type":"operation",
                         "input":"ListCitiesInput",
                         "output":"ListCitiesOutput",
-                        "paginated":{
-                            "inputToken":"nextToken",
-                            "outputToken":"nextToken",
-                            "items":"items",
-                            "pageSize":"pageSize"
-                        },
+                        "paginated": {"items":"items"},
                         "readonly":true,
                         "collection":true
                     },
-                    "ListCitiesInput":{
+                    "ListCitiesInput": {
                         "type":"structure",
-                        "members":{
-                            "nextToken":{
+                        "members": {
+                            "nextToken": {
                                 "target":"String"
                             },
-                            "pageSize":{
+                            "pageSize": {
                                 "target":"Integer"
                             }
                         }
                     },
-                    "ListCitiesOutput":{
+                    "ListCitiesOutput": {
                         "type":"structure",
-                        "members":{
-                            "items":{
+                        "members": {
+                            "items": {
                                 "target":"CitySummaries",
                                 "required":true
                             },
-                            "nextToken":{
+                            "nextToken": {
                                 "target":"String"
                             }
                         }
                     },
-                    "NoSuchResource":{
+                    "NoSuchResource": {
                         "type":"structure",
-                        "members":{
-                            "resourceType":{
+                        "members": {
+                            "resourceType": {
                                 "target":"String",
                                 "required":true
                             }
                         },
                         "error":"client"
-                    },
-                    "Weather":{
-                        "type":"service",
-                        "version":"2006-03-01",
-                        "operations":[
-                            "GetCurrentTime"
-                        ],
-                        "resources":[
-                            "City"
-                        ]
                     }
                 }
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -15,26 +15,22 @@
 
 package software.amazon.smithy.model.knowledge;
 
-import static java.lang.String.format;
-
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.model.validation.Severity;
-import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.validators.PaginatedTraitValidator;
 import software.amazon.smithy.utils.OptionalUtils;
 
@@ -50,65 +46,53 @@ import software.amazon.smithy.utils.OptionalUtils;
  * (which makes use of this index).
  */
 public final class PaginatedIndex implements KnowledgeIndex {
-    private final Map<ShapeId, PaginationInfo> idToTraits;
-    private final List<ValidationEvent> events = new ArrayList<>();
+    private final Map<ShapeId, Map<ShapeId, PaginationInfo>> paginationInfo = new HashMap<>();
 
     public PaginatedIndex(Model model) {
         ShapeIndex index = model.getShapeIndex();
+        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
         OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
-        idToTraits = Collections.unmodifiableMap(index.shapes(OperationShape.class)
-                .flatMap(shape -> Trait.flatMapStream(shape, PaginatedTrait.class))
-                .flatMap(pair -> OptionalUtils.stream(create(opIndex, pair.getLeft(), pair.getRight())))
-                .collect(Collectors.toMap(info -> info.getOperation().getId(), Function.identity())));
+
+        index.shapes(ServiceShape.class).forEach(service -> {
+            PaginatedTrait serviceTrait = service.getTrait(PaginatedTrait.class).orElse(null);
+            Map<ShapeId, PaginationInfo> mappings = topDownIndex.getContainedOperations(service).stream()
+                    .flatMap(operation -> Trait.flatMapStream(operation, PaginatedTrait.class))
+                    .flatMap(p -> OptionalUtils.stream(create(service, opIndex, p.left, p.right.merge(serviceTrait))))
+                    .collect(Collectors.toMap(i -> i.getOperation().getId(), Function.identity()));
+            paginationInfo.put(service.getId(), Collections.unmodifiableMap(mappings));
+        });
     }
 
-    private Optional<PaginationInfo> create(OperationIndex opIndex, OperationShape operation, PaginatedTrait trait) {
-        if (!opIndex.getInput(operation.getId()).isPresent()) {
-            events.add(emit(operation, trait, "`paginated` operations require an input"));
-            return Optional.empty();
-        } else if (!opIndex.getOutput(operation.getId()).isPresent()) {
-            events.add(emit(operation, trait, "`paginated` operations require an output"));
+    private Optional<PaginationInfo> create(
+            ServiceShape service,
+            OperationIndex opIndex,
+            OperationShape operation,
+            PaginatedTrait trait
+    ) {
+        StructureShape input = opIndex.getInput(operation.getId()).orElse(null);
+        StructureShape output = opIndex.getOutput(operation.getId()).orElse(null);
+
+        if (input == null || output == null) {
             return Optional.empty();
         }
 
-        StructureShape input = opIndex.getInput(operation.getId()).get();
-        StructureShape output = opIndex.getOutput(operation.getId()).get();
-        if (!input.getMember(trait.getInputToken()).isPresent()) {
-            events.add(emit(operation, trait, format(
-                    "`paginated` trait `inputToken` property references a non-existent member named `%s`",
-                    trait.getInputToken())));
-            return Optional.empty();
-        } else if (!output.getMember(trait.getOutputToken()).isPresent()) {
-            events.add(emit(operation, trait, format(
-                    "`paginated` trait `outputToken` property references a non-existent member named `%s`",
-                    trait.getOutputToken())));
+        MemberShape inputToken = trait.getInputToken().flatMap(input::getMember).orElse(null);
+        MemberShape outputToken = trait.getOutputToken().flatMap(output::getMember).orElse(null);
+
+        if (inputToken == null || outputToken == null) {
             return Optional.empty();
         }
+
+        MemberShape pageSizeMember = trait.getPageSize().flatMap(input::getMember).orElse(null);
+        MemberShape itemsMember = trait.getItems().flatMap(output::getMember).orElse(null);
 
         return Optional.of(new PaginationInfo(
-                operation, input, output, trait,
-                input.getMember(trait.getInputToken()).get(),
-                output.getMember(trait.getOutputToken()).get()));
+                service, operation, input, output, trait,
+                inputToken, outputToken, pageSizeMember, itemsMember));
     }
 
-    public List<ValidationEvent> getValidationEvents() {
-        return Collections.unmodifiableList(events);
-    }
-
-    public Optional<PaginationInfo> getPaginationInfo(ToShapeId operation) {
-        return Optional.ofNullable(idToTraits.get(operation.toShapeId()));
-    }
-
-    public List<PaginationInfo> getAllPaginatedInfo() {
-        return new ArrayList<>(idToTraits.values());
-    }
-
-    private ValidationEvent emit(Shape shape, PaginatedTrait trait, String message) {
-        return ValidationEvent.builder()
-                .eventId("PaginatedTrait")
-                .shapeId(shape.getId())
-                .sourceLocation(trait)
-                .severity(Severity.ERROR)
-                .message(message).build();
+    public Optional<PaginationInfo> getPaginationInfo(ToShapeId service, ToShapeId operation) {
+        return Optional.ofNullable(paginationInfo.get(service.toShapeId()))
+                .flatMap(mappings -> Optional.ofNullable(mappings.get(operation.toShapeId())));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
@@ -18,35 +18,49 @@ package software.amazon.smithy.model.knowledge;
 import java.util.Optional;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 
 /**
- * Resolved and valid pagination information about an operation.
+ * Resolved and valid pagination information about an operation in a service.
  */
 public final class PaginationInfo {
 
+    private final ServiceShape service;
     private final OperationShape operation;
     private final StructureShape input;
     private final StructureShape output;
     private final PaginatedTrait paginatedTrait;
     private final MemberShape inputToken;
     private final MemberShape outputToken;
+    private final MemberShape pageSize;
+    private final MemberShape items;
 
     PaginationInfo(
+            ServiceShape service,
             OperationShape operation,
             StructureShape input,
             StructureShape output,
             PaginatedTrait paginatedTrait,
             MemberShape inputToken,
-            MemberShape outputToken
+            MemberShape outputToken,
+            MemberShape pageSize,
+            MemberShape items
     ) {
+        this.service = service;
         this.operation = operation;
         this.input = input;
         this.output = output;
         this.paginatedTrait = paginatedTrait;
         this.inputToken = inputToken;
         this.outputToken = outputToken;
+        this.pageSize = pageSize;
+        this.items = items;
+    }
+
+    public ServiceShape getService() {
+        return service;
     }
 
     public OperationShape getOperation() {
@@ -61,8 +75,13 @@ public final class PaginationInfo {
         return output;
     }
 
+    /**
+     * Gets the paginated trait of the operation merged with the service.
+     *
+     * @return Returns the resolved paginated trait.
+     */
     public PaginatedTrait getPaginatedTrait() {
-        return paginatedTrait;
+        return paginatedTrait.merge(service.getTrait(PaginatedTrait.class).orElse(null));
     }
 
     public MemberShape getInputTokenMember() {
@@ -74,10 +93,10 @@ public final class PaginationInfo {
     }
 
     public Optional<MemberShape> getItemsMember() {
-        return paginatedTrait.getItems().flatMap(output::getMember);
+        return Optional.ofNullable(items);
     }
 
     public Optional<MemberShape> getPageSizeMember() {
-        return paginatedTrait.getPageSize().flatMap(input::getMember);
+        return Optional.ofNullable(pageSize);
     }
 }

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/smithy-prelude-traits.json
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/smithy-prelude-traits.json
@@ -176,7 +176,7 @@
         "documentation": "Indicates that the items in a list MUST be unique."
       },
       "paginated": {
-        "selector": "operation",
+        "selector": ":each(service, operation)",
         "shape": "PaginatedObject",
         "documentation": "The paginated trait indicates that an operation intentionally limits the number of results returned in a single response and that multiple invocations might be necessary to retrieve all results.",
         "tags": ["diff.error.remove"]
@@ -472,12 +472,10 @@
         "members": {
           "inputToken": {
             "target": "NonEmptyString",
-            "required": true,
             "documentation": "The name of the operation input member that represents the continuation token. When this value is provided as operation input, the service returns results from where the previous response left off. This input member MUST NOT be required and MUST target a string shape."
           },
           "outputToken": {
             "target": "NonEmptyString",
-            "required": true,
             "documentation": "The name of the operation output member that represents the continuation token. When this value is present in operation output, it indicates that there are more results to retrieve. To get the next page of results, the client uses the output token as the input token of the next request. This output member MUST NOT be required and MUST target a string shape."
           },
           "items": {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/PaginatedIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/PaginatedIndexTest.java
@@ -16,10 +16,8 @@
 package software.amazon.smithy.model.knowledge;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -35,10 +33,10 @@ public class PaginatedIndexTest {
                 .assemble();
         Model model = result.getResult().get();
         PaginatedIndex index = model.getKnowledge(PaginatedIndex.class);
+        ShapeId service = ShapeId.from("ns.foo#Service");
 
-        assertThat(index.getValidationEvents(), not(empty()));
-        assertThat(index.getPaginationInfo(ShapeId.from("ns.foo#Valid2")).isPresent(), is(true));
-        PaginationInfo info = index.getPaginationInfo(ShapeId.from("ns.foo#Valid2")).get();
+        assertThat(index.getPaginationInfo(service, ShapeId.from("ns.foo#Valid2")).isPresent(), is(true));
+        PaginationInfo info = index.getPaginationInfo(service, ShapeId.from("ns.foo#Valid2")).get();
         assertThat(info.getOperation().getId(), is(ShapeId.from("ns.foo#Valid2")));
         assertThat(info.getInput().getId(), is(ShapeId.from("ns.foo#ValidInput")));
         assertThat(info.getOutput().getId(), is(ShapeId.from("ns.foo#ValidOutput")));

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
@@ -1,15 +1,20 @@
-[ERROR] ns.foo#Invalid1: `paginated` operations require an input | PaginatedTrait
-[ERROR] ns.foo#Invalid2: `paginated` trait `inputToken` property references a non-existent member named `nextToken` | PaginatedTrait
-[ERROR] ns.foo#Invalid3: `paginated` trait `inputToken` references input member `InputNotString`, a member that targets a integer shape, but inputToken must reference a member that targets a(n) `string`. | PaginatedTrait
-[ERROR] ns.foo#Invalid3: `paginated` trait `outputToken` references output member `InputNotString`, a member that targets a integer shape, but outputToken must reference a member that targets a(n) `string`. | PaginatedTrait
-[ERROR] ns.foo#Invalid4: `paginated` trait `inputToken` must reference an optional input structure member, but found a reference to `ns.foo#NonOptionalInput$nextToken`, a required member. | PaginatedTrait
-[ERROR] ns.foo#Invalid4: `paginated` trait `outputToken` must reference an optional output structure member, but found a reference to `ns.foo#NonOptionalOutput$nextToken`, a required member. | PaginatedTrait
-[ERROR] ns.foo#Invalid4: `paginated` trait `pageSize` must reference an optional input structure member, but found a reference to `ns.foo#NonOptionalInput$pageSize`, a required member. | PaginatedTrait
-[ERROR] ns.foo#Invalid6: `paginated` trait `pageSize` references input member `Invalid6Input`, a member that targets a string shape, but pageSize must reference a member that targets a(n) `integer`. | PaginatedTrait
-[ERROR] ns.foo#Invalid7: `paginated` trait `items` references output member `Invalid7Input`, a member that targets a string shape, but items must reference a member that targets one of the following types: `list`, `map`. | PaginatedTrait
-[ERROR] ns.foo#Invalid8: `paginated` trait `outputToken` property references a non-existent member named `missing` | PaginatedTrait
-[ERROR] ns.foo#InvalidNoOutput: `paginated` operations require an output | PaginatedTrait
+[ERROR] ns.foo#Invalid1: paginated operations require an input | PaginatedTrait
+[ERROR] ns.foo#Invalid2: paginated trait `inputToken` targets a member `nextToken` that does not exist | PaginatedTrait
+[ERROR] ns.foo#Invalid2: paginated trait `outputToken` targets a member `nextToken` that does not exist | PaginatedTrait
+[ERROR] ns.foo#Invalid3: paginated trait `inputToken` member `InputNotString` targets a integer shape, but must target one of the following: [`string`] | PaginatedTrait
+[ERROR] ns.foo#Invalid3: paginated trait `items` targets a member `items` that does not exist | PaginatedTrait
+[ERROR] ns.foo#Invalid3: paginated trait `outputToken` member `OutputNotString` targets a integer shape, but must target one of the following: [`string`] | PaginatedTrait
+[ERROR] ns.foo#Invalid4: paginated trait `inputToken` member `nextToken` must not be required | PaginatedTrait
+[ERROR] ns.foo#Invalid4: paginated trait `outputToken` member `nextToken` must not be required | PaginatedTrait
+[ERROR] ns.foo#Invalid4: paginated trait `pageSize` member `pageSize` must not be required | PaginatedTrait
+[ERROR] ns.foo#Invalid6: paginated trait `pageSize` member `Invalid6Input` targets a string shape, but must target one of the following: [`integer`] | PaginatedTrait
+[ERROR] ns.foo#Invalid7: paginated trait `items` member `Invalid7Input` targets a string shape, but must target one of the following: [`list`, `map`] | PaginatedTrait
+[ERROR] ns.foo#Invalid8: paginated trait `items` targets a member `items` that does not exist | PaginatedTrait
+[ERROR] ns.foo#Invalid8: paginated trait `outputToken` targets a member `missing` that does not exist | PaginatedTrait
+[ERROR] ns.foo#InvalidNoOutput: paginated operations require an output | PaginatedTrait
 [ERROR] ns.foo#UnresolvedInput$nextToken: member shape targets an unresolved shape `ns.foo#Missing` | Target
 [ERROR] ns.foo#UnresolvedInput$pageSize: member shape targets an unresolved shape `ns.foo#Missing` | Target
 [ERROR] ns.foo#UnresolvedOutput$items: member shape targets an unresolved shape `ns.foo#Missing` | Target
 [ERROR] ns.foo#UnresolvedOutput$nextToken: member shape targets an unresolved shape `ns.foo#Missing` | Target
+[ERROR] ns.foo#Invalid9: When bound within the `ns.foo#Service` service, paginated trait `inputToken` is not configured | PaginatedTrait
+[ERROR] ns.foo#Invalid9: When bound within the `ns.foo#Service` service, paginated trait `outputToken` is not configured | PaginatedTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
@@ -2,6 +2,15 @@
     "smithy": "0.2.0",
     "ns.foo": {
         "shapes": {
+            "Service": {
+                "type": "service",
+                "version": "2019-06-27",
+                "operations": [
+                    "Valid1", "Valid2", "Valid3",
+                    "Invalid1", "Invalid2", "Invalid3", "Invalid4", "Invalid5", "Invalid6", "Invalid7", "Invalid8",
+                    "Invalid9"
+                ]
+            },
             "Valid1": {
                 "type": "operation",
                 "readonly": true,
@@ -270,6 +279,12 @@
                         "target": "smithy.api#String"
                     }
                 }
+            },
+            "Invalid9": {
+                "type": "operation",
+                "paginated": true,
+                "input": "ValidInput",
+                "output": "ValidOutput"
             },
             "ValidInput": {
                 "type": "structure",


### PR DESCRIPTION
This commit updates the paginated trait so that it can be attached to a
service to provide default configuration settings for the entire
service. The inputToken and outputToken members are now optional, but
must be resolved to a value when a paginted operation is bound to a service.
This should help keep services consistent with how they paginated while
still allowing specific operations to override settings when needed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
