### PR TITLE
Make Trait methods less likely to conflict

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/ChangedShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/ChangedShape.java
@@ -148,17 +148,17 @@ public final class ChangedShape<S extends Shape> implements FromSourceLocation {
     private static Map<String, Pair<Trait, Trait>> findTraitDifferences(Shape oldShape, Shape newShape) {
         Map<String, Pair<Trait, Trait>> changes = new HashMap<>();
         for (Trait oldTrait : oldShape.getAllTraits().values()) {
-            Trait newTrait = newShape.findTrait(oldTrait.getName()).orElse(null);
+            Trait newTrait = newShape.findTrait(oldTrait.getTraitName()).orElse(null);
             if (newTrait == null) {
-                changes.put(oldTrait.getName(), (Pair.of(oldTrait, null)));
+                changes.put(oldTrait.getTraitName(), (Pair.of(oldTrait, null)));
             } else if (!newTrait.equals(oldTrait)) {
-                changes.put(newTrait.getName(), Pair.of(oldTrait, newTrait));
+                changes.put(newTrait.getTraitName(), Pair.of(oldTrait, newTrait));
             }
         }
         // Find traits that were added.
         newShape.getAllTraits().values().stream()
-                .filter(newTrait -> !oldShape.findTrait(newTrait.getName()).isPresent())
-                .forEach(newTrait -> changes.put(newTrait.getName(), Pair.of(null, newTrait)));
+                .filter(newTrait -> !oldShape.findTrait(newTrait.getTraitName()).isPresent())
+                .forEach(newTrait -> changes.put(newTrait.getTraitName(), Pair.of(null, newTrait)));
 
         return changes;
     }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AbstractLengthAndRangeValidator.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AbstractLengthAndRangeValidator.java
@@ -64,13 +64,13 @@ abstract class AbstractLengthAndRangeValidator<T extends Trait> extends Abstract
         if (newMin.compareTo(oldMin) > 0) {
             events.add(error(change.getNewShape(), String.format(
                     "%s trait value `min` was made more restrictive by raising from %s to %s",
-                    newTrait.getName(), oldMin, newMin)));
+                    newTrait.getTraitName(), oldMin, newMin)));
         }
 
         if (newMax != null && (oldMax == null || oldMax.compareTo(newMax) > 0)) {
             events.add(error(change.getNewShape(), String.format(
                     "%s trait value `max` was made more restrictive by lowering from %s to %s",
-                    newTrait.getName(), oldMax, newMax)));
+                    newTrait.getTraitName(), oldMax, newMax)));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
@@ -149,7 +149,7 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
             throw new IllegalArgumentException("trait must not be null");
         }
 
-        traits.put(trait.getName(), trait);
+        traits.put(trait.getTraitName(), trait);
         return (B) this;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -211,8 +211,8 @@ public final class ModelSerializer {
         private ObjectNode withTraits(Shape shape, ObjectNode node) {
             return node.merge(shape.getAllTraits().values().stream()
                     .filter(traitFilter)
-                    .sorted(Comparator.comparing(Trait::getName))
-                    .collect(ObjectNode.collectStringKeys(Trait::getName, Trait::toNode)));
+                    .sorted(Comparator.comparing(Trait::getTraitName))
+                    .collect(ObjectNode.collectStringKeys(Trait::getTraitName, Trait::toNode)));
         }
 
         @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AbstractTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AbstractTrait.java
@@ -32,8 +32,8 @@ import software.amazon.smithy.model.node.ToNode;
  */
 public abstract class AbstractTrait implements Trait {
 
-    private final String name;
-    private final SourceLocation sourceLocation;
+    private final String traitName;
+    private final SourceLocation traitSourceLocation;
     private int cachedHashCode = 0;
     private Node nodeCache;
 
@@ -42,24 +42,24 @@ public abstract class AbstractTrait implements Trait {
      * @param sourceLocation Where the trait was defined.
      */
     public AbstractTrait(String name, FromSourceLocation sourceLocation) {
-        this.name = Objects.requireNonNull(name, "name was not set on trait");
-        this.sourceLocation = Objects.requireNonNull(sourceLocation, "sourceLocation was not set on trait")
+        this.traitName = Objects.requireNonNull(name, "name was not set on trait");
+        this.traitSourceLocation = Objects.requireNonNull(sourceLocation, "sourceLocation was not set on trait")
                 .getSourceLocation();
     }
 
     @Override
-    public final String getName() {
-        return name;
+    public final String getTraitName() {
+        return traitName;
     }
 
     @Override
     public final SourceLocation getSourceLocation() {
-        return sourceLocation;
+        return traitSourceLocation;
     }
 
     @Override
     public String toString() {
-        return String.format("Trait `%s`, defined at %s", getName(), getSourceLocation());
+        return String.format("Trait `%s`, defined at %s", getTraitName(), getSourceLocation());
     }
 
     @Override
@@ -69,13 +69,13 @@ public abstract class AbstractTrait implements Trait {
         }
 
         Trait b = (Trait) other;
-        return this == other || (getName().equals(b.getName()) && toNode().equals(b.toNode()));
+        return this == other || (getTraitName().equals(b.getTraitName()) && toNode().equals(b.toNode()));
     }
 
     @Override
     public int hashCode() {
         if (cachedHashCode == 0) {
-            cachedHashCode = getName().hashCode() * 17 + toNode().hashCode();
+            cachedHashCode = getTraitName().hashCode() * 17 + toNode().hashCode();
         }
         return cachedHashCode;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
@@ -52,21 +52,18 @@ import software.amazon.smithy.utils.Pair;
  */
 public interface Trait extends FromSourceLocation, ToNode {
     /**
-     * Gets the fully qualified name of the trait as it appears in models.
+     * Gets the fully qualified name of the trait.
      *
-     * <p>Built-in traits may or may not omit a namespace. Namespaces, if
-     * present, will always come before the trait name, separated by a "#"
-     * character. For example, {@code foo.bar#baz}, is a valid custom trait
-     * name, {@code deprecated} is a valid built-in trait name, and so is
-     * {@code smithy.api#deprecated}.
+     * <p>All traits should contain a namespace. Namespaces, if come before
+     * the trait name, separated by a "#" character. For example,
+     * {@code foo.bar#baz}, is a valid trait name. Do not attempt to parse
+     * the name and namespace yourself; use the {@link #getTraitNamespace()}
+     * and {@link #getRelativeTraitName()} method to get specific parts
+     * of the trait name.
      *
-     * <p>The returned name might not contain a namespace. Use the
-     * {@link #getNamespace()} and {@link #getRelativeName()} to safely
-     * access parts of the trait name.
-     *
-     * @return Returns the name of the trait.
+     * @return Returns the fully-qualified name of the trait.
      */
-    String getName();
+    String getTraitName();
 
     /**
      * Gets the namespace of the trait (e.g., {@code smithy.api}.
@@ -76,8 +73,8 @@ public interface Trait extends FromSourceLocation, ToNode {
      *
      * @return Returns the namespace of the trait.
      */
-    default String getNamespace() {
-        String name = getName();
+    default String getTraitNamespace() {
+        String name = getTraitName();
         int index = name.indexOf("#");
         return index == -1 ? Prelude.NAMESPACE : name.substring(0, index);
     }
@@ -88,8 +85,8 @@ public interface Trait extends FromSourceLocation, ToNode {
      *
      * @return Returns the relative name of the trait.
      */
-    default String getRelativeName() {
-        String name = getName();
+    default String getRelativeTraitName() {
+        String name = getTraitName();
         int index = name.indexOf("#");
         if (index == -1) {
             return name;
@@ -98,23 +95,6 @@ public interface Trait extends FromSourceLocation, ToNode {
         } else {
             return name.substring(index + 1);
         }
-    }
-
-    /**
-     * Returns true if the name of the trait matches the given name.
-     *
-     * <p>If the provided {@code traitName} value does not contain a
-     * namespace, this method with automatically prepend the "smithy.api#"
-     * namespace. This makes checking if a trait name matches a given trait
-     * easier since you can perform both an absolute check and a relative
-     * check with the same method.
-     *
-     * @param traitName Trait name to check.
-     * @return True if the trait has a name that matches the given string.
-     */
-    default boolean matchesTraitName(String traitName) {
-        return getName().equals(traitName)
-               || getNamespace().equals(Prelude.NAMESPACE) && getRelativeName().equals(traitName);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveTraitDefinitions.java
@@ -43,6 +43,6 @@ final class RemoveTraitDefinitions {
         // Remove any traits that are an instance of the removed trait definitions.
         return transformer.removeTraitsIf(
                 builder.build(),
-                (shape, trait) -> fullyQualifiedTraitNames.contains(trait.getName()));
+                (shape, trait) -> fullyQualifiedTraitNames.contains(trait.getTraitName()));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventStreamValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventStreamValidator.java
@@ -83,7 +83,7 @@ public class EventStreamValidator extends AbstractValidator {
             // The operation has no input/output, so this is the only check.
             return ListUtils.of(error(operation, trait, String.format(
                     "Operation has the `%s` but does not define an %s structure.",
-                    trait.getRelativeName(), inputOrOutputName)));
+                    trait.getRelativeTraitName(), inputOrOutputName)));
         }
 
         StructureShape struct = index.getShape(inputOutput).flatMap(Shape::asStructureShape).orElse(null);
@@ -97,14 +97,14 @@ public class EventStreamValidator extends AbstractValidator {
             // Stop because member-specific validation can't be performed.
             return ListUtils.of(error(operation, trait, String.format(
                     "Operation %s member `%s` was not found for the `%s` trait.",
-                    inputOrOutputName, member, trait.getRelativeName())));
+                    inputOrOutputName, member, trait.getRelativeTraitName())));
         }
 
         List<ValidationEvent> events = new ArrayList<>();
         if (actualMember.isRequired()) {
             events.add(error(operation, trait, String.format(
                     "Operation %s member `%s` is referenced by an `%s` trait, so it cannot be marked as required.",
-                    inputOrOutputName, actualMember.getId(), trait.getRelativeName())));
+                    inputOrOutputName, actualMember.getId(), trait.getRelativeTraitName())));
         }
 
         // Additional event stream specific validation can't be performed,
@@ -144,7 +144,7 @@ public class EventStreamValidator extends AbstractValidator {
             return ListUtils.of(error(operation, trait, String.format(
                     "Operation %s member `%s` is referenced by the `%s` trait, so it must target a structure "
                     + "or union, but found %s, a %s.",
-                    inputOrOutputName, member.getId(), trait.getRelativeName(),
+                    inputOrOutputName, member.getId(), trait.getRelativeTraitName(),
                     referencedMember.getId(), referencedMember.getType())));
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExclusiveStructureMemberTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExclusiveStructureMemberTraitValidator.java
@@ -48,12 +48,14 @@ public class ExclusiveStructureMemberTraitValidator extends AbstractValidator {
         return shape.getAllMembers().values().stream()
                 .flatMap(member -> member.getAllTraits().values().stream())
                 .filter(trait -> isExclusive(model, trait))
-                .flatMap(t -> OptionalUtils.stream(validateExclusiveTrait(shape, t.getName())))
+                .flatMap(t -> OptionalUtils.stream(validateExclusiveTrait(shape, t.getTraitName())))
                 .collect(Collectors.toList());
     }
 
     private boolean isExclusive(Model model, Trait trait) {
-        return model.getTraitDefinition(trait.getName()).map(TraitDefinition::isStructurallyExclusive).orElse(false);
+        return model.getTraitDefinition(trait.getTraitName())
+                .map(TraitDefinition::isStructurallyExclusive)
+                .orElse(false);
     }
 
     private Optional<ValidationEvent> validateExclusiveTrait(StructureShape shape, String traitName) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitConflictValidator.java
@@ -39,7 +39,7 @@ public final class TraitConflictValidator extends AbstractValidator {
                     Map<String, Trait> traits = shape.getAllTraits();
                     Map<String, List<String>> conflicts = new HashMap<>();
                     traits.forEach((k, v) -> {
-                        model.getTraitDefinition(v.getName()).ifPresent(definition -> {
+                        model.getTraitDefinition(v.getTraitName()).ifPresent(definition -> {
                             definition.getConflicts().forEach(conflict -> {
                                 if (traits.containsKey(conflict)) {
                                     conflicts.computeIfAbsent(k, key -> new ArrayList<>()).add(conflict);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
@@ -49,7 +49,7 @@ public final class TraitTargetValidator extends AbstractValidator {
                 .map(check -> error(check.shape, String.format(
                         "Trait `%s` cannot be applied to `%s`. This trait may only be applied to shapes "
                         + "that match the following selector: %s",
-                        Trait.getIdiomaticTraitName(check.trait.getName()),
+                        Trait.getIdiomaticTraitName(check.trait.getTraitName()),
                         check.shape.getId(), check.selector)))
                 .collect(Collectors.toList());
     }
@@ -72,7 +72,7 @@ public final class TraitTargetValidator extends AbstractValidator {
     }
 
     private Selector resolveSelector(Trait trait, Model model) {
-        return model.getTraitDefinition(trait.getName())
+        return model.getTraitDefinition(trait.getTraitName())
                 .map(TraitDefinition::getSelector)
                 .orElse(Selector.IDENTITY);
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitValueValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitValueValidator.java
@@ -46,7 +46,7 @@ public final class TraitValueValidator implements Validator {
                 // Get pairs of <Shape, Trait>
                 .flatMap(shape -> shape.getAllTraits().values().stream().map(t -> Pair.of(shape, t)))
                 // Get a triple of Shape, Trait, TraitDefinition.
-                .flatMap(pair -> OptionalUtils.stream(model.getTraitDefinition(pair.getRight().getName())
+                .flatMap(pair -> OptionalUtils.stream(model.getTraitDefinition(pair.getRight().getTraitName())
                         .map(traitDefinition -> Triple.fromPair(pair, traitDefinition))))
                 .flatMap(triple -> validateTrait(model.getShapeIndex(), triple.left, triple.middle, triple.right)
                         .stream())
@@ -70,7 +70,7 @@ public final class TraitValueValidator implements Validator {
                     .sourceLocation(trait)
                     .shapeId(targetShape.getId())
                     .message("Value provided for boolean trait `%s` can only be set to true. "
-                             + "Found %s", Trait.getIdiomaticTraitName(trait.getName()), trait.toNode().getType())
+                             + "Found %s", Trait.getIdiomaticTraitName(trait.getTraitName()), trait.toNode().getType())
                     .build());
         }
 
@@ -86,7 +86,7 @@ public final class TraitValueValidator implements Validator {
                 .value(trait.toNode())
                 .eventShapeId(targetShape.getId())
                 .eventId(NAME)
-                .startingContext("Error validating trait `" + Trait.getIdiomaticTraitName(trait.getName()) + "`")
+                .startingContext("Error validating trait `" + Trait.getIdiomaticTraitName(trait.getTraitName()) + "`")
                 .build();
 
         return schema.accept(cases);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -133,7 +133,7 @@ public class ModelSerializerTest {
                 .build();
         Model model = Model.assembler().addShape(shape).assemble().unwrap();
         ModelSerializer serializer = ModelSerializer.builder()
-                .traitFilter(trait -> trait.matchesTraitName("documentation"))
+                .traitFilter(trait -> trait.getTraitName().equals("smithy.api#documentation"))
                 .build();
         ObjectNode obj = serializer.serialize(model)
                 .expectMember("ns.foo").expectObjectNode()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
@@ -71,7 +71,7 @@ public class ShapeTest {
             this.sourceLocation = sourceLocation != null ? sourceLocation : SourceLocation.none();
         }
 
-        public String getName() {
+        public String getTraitName() {
             return name;
         }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/TraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/TraitTest.java
@@ -27,15 +27,15 @@ public class TraitTest {
     public void returnsEmptyStringForNamespaceWhenEmpty() {
         Trait trait = new DynamicTrait("#foo", Node.from(true));
 
-        assertThat(trait.getRelativeName(), equalTo("foo"));
-        assertThat(trait.getNamespace(), equalTo(""));
+        assertThat(trait.getRelativeTraitName(), equalTo("foo"));
+        assertThat(trait.getTraitNamespace(), equalTo(""));
     }
 
     @Test
     public void returnsDefaultNamespaceWhenNotPresent() {
         Trait trait = new DynamicTrait("foo", Node.from(true));
 
-        assertThat(trait.getNamespace(), equalTo(Prelude.NAMESPACE));
+        assertThat(trait.getTraitNamespace(), equalTo(Prelude.NAMESPACE));
     }
 
     @Test
@@ -43,21 +43,21 @@ public class TraitTest {
         // foo# is invalid. We can't get the relative name for this.
         Trait trait = new DynamicTrait("foo#", Node.from(true));
 
-        assertThat(trait.getRelativeName(), equalTo(""));
+        assertThat(trait.getRelativeTraitName(), equalTo(""));
     }
 
     @Test
     public void doesNotSubstringRelativeNameWhenNoNamespace() {
         Trait trait = new DynamicTrait("foo", Node.from(true));
 
-        assertThat(trait.getRelativeName(), equalTo("foo"));
+        assertThat(trait.getRelativeTraitName(), equalTo("foo"));
     }
 
     @Test
     public void providesValidNamespaceAndRelativeTraitName() {
         Trait trait = new DynamicTrait("foo#bar", Node.from(true));
 
-        assertThat(trait.getNamespace(), equalTo("foo"));
-        assertThat(trait.getRelativeName(), equalTo("bar"));
+        assertThat(trait.getTraitNamespace(), equalTo("foo"));
+        assertThat(trait.getRelativeTraitName(), equalTo("bar"));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
@@ -47,7 +47,8 @@ public class FilterTraitsTest {
                 .build();
         Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShapes(a, b).build()).build();
         ModelTransformer transformer = ModelTransformer.create();
-        Model result = transformer.filterTraits(model, (shape, trait) -> !trait.matchesTraitName("sensitive"));
+        Model result = transformer.filterTraits(
+                model, (shape, trait) -> !trait.getTraitName().equals("smithy.api#sensitive"));
         ShapeIndex index = result.getShapeIndex();
 
         assertThat(index.shapes().count(), Matchers.is(2L));
@@ -69,8 +70,8 @@ public class FilterTraitsTest {
         Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(a).build()).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.filterTraits(
-                model, (shape, trait) -> !trait.matchesTraitName("sensitive")
-                                         && !trait.matchesTraitName("documentation"));
+                model, (shape, trait) -> !trait.getTraitName().equals("smithy.api#sensitive")
+                                         && !trait.getTraitName().equals("smithy.api#documentation"));
         ShapeIndex index = result.getShapeIndex();
 
         assertThat(index.shapes().count(), Matchers.is(1L));

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/TopicBinding.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/TopicBinding.java
@@ -200,7 +200,7 @@ public class TopicBinding<T extends Trait> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operation.getId(), mqttTrait.getName());
+        return Objects.hash(operation.getId(), mqttTrait.getTraitName());
     }
 
     @Override
@@ -208,7 +208,7 @@ public class TopicBinding<T extends Trait> {
         return "TopicBinding{"
                + "operation=" + operation.getId()
                + ", input=" + getInput().map(Shape::getId).map(ShapeId::toString).orElse("null")
-               + ", mqttTrait=" + mqttTrait.getName()
+               + ", mqttTrait=" + mqttTrait.getTraitName()
                + ", topic=" + topic
                + ", payloadShape=" + String.valueOf(payloadShape)
                + '}';

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicConflictValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicConflictValidator.java
@@ -73,7 +73,7 @@ public final class MqttTopicConflictValidator extends AbstractValidator {
     private String createConflictingBindingDescriptor(TopicBinding<? extends Trait> binding) {
         return String.format(
                 "`%s` trait payload %s of `%s`",
-                Trait.getIdiomaticTraitName(binding.getMqttTrait().getName()),
+                Trait.getIdiomaticTraitName(binding.getMqttTrait().getTraitName()),
                 binding.getPayloadShape().map(Shape::getId).map(id -> "`" + id + "`").orElse("N/A"),
                 binding.getOperation().getId());
     }

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
@@ -81,7 +81,7 @@ public class MqttTopicLabelValidator extends AbstractValidator {
         if (!labels.isEmpty() && input == null) {
             return Collections.singletonList(error(topics.operation, topics.trait, String.format(
                     "Operation MQTT trait, `%s`, contains topic labels, [%s], but the operation has no input",
-                    Trait.getIdiomaticTraitName(topics.trait.getName()),
+                    Trait.getIdiomaticTraitName(topics.trait.getTraitName()),
                     ValidationUtils.tickedList(labels))));
         }
 
@@ -101,7 +101,7 @@ public class MqttTopicLabelValidator extends AbstractValidator {
                             + "used as part of the input of the `%s` operation, a corresponding label cannot be "
                             + "found in the `%s` trait",
                             topics.operation.getId(),
-                            Trait.getIdiomaticTraitName(topics.trait.getName()))));
+                            Trait.getIdiomaticTraitName(topics.trait.getTraitName()))));
                 }
             }
         }
@@ -110,7 +110,7 @@ public class MqttTopicLabelValidator extends AbstractValidator {
             events.add(error(topics.operation, topics.trait, String.format(
                     "The `%s` trait contains the following topic labels that could not be found in the input "
                     + "structure of the operation or were not marked with the `smithy.mqtt#topicLabel` trait: [%s]",
-                    Trait.getIdiomaticTraitName(topics.trait.getName()),
+                    Trait.getIdiomaticTraitName(topics.trait.getTraitName()),
                     ValidationUtils.tickedList(labels))));
         }
 

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttUnsupportedErrorsValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttUnsupportedErrorsValidator.java
@@ -49,6 +49,6 @@ public final class MqttUnsupportedErrorsValidator extends AbstractValidator {
                 .filter(trait -> trait instanceof PublishTrait || trait instanceof SubscribeTrait)
                 .map(trait -> danger(shape, trait, String.format(
                         "Operations marked with the `%s` trait do not support errors.",
-                        Trait.getIdiomaticTraitName(trait.getName()))));
+                        Trait.getIdiomaticTraitName(trait.getTraitName()))));
     }
 }


### PR DESCRIPTION
This commit updates the Trait interface to include a "trait" qualifier
in methods defined on the interface to help protect against naming
conflicts with concrete and generated Trait implementations. Because all
traits should have a namespace and you can still find a trait by name
without a namespace using a Shape, the matchesTraitName method was
removed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
