### PR TITLE
Remove API Gateway shape name stuttering

### DIFF
--- a/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -134,7 +134,7 @@
             "target": "Templates"
           },
           "responses": {
-            "target": "Responses"
+            "target": "IntegrationResponses"
           }
         },
         "private": true
@@ -161,7 +161,7 @@
             "target": "Templates"
           },
           "responses": {
-            "target": "Responses"
+            "target": "IntegrationResponses"
           }
         },
         "private": true
@@ -225,14 +225,14 @@
         "type": "list",
         "member": {"target": "smithy.api#String"}
       },
-      "Responses": {
+      "IntegrationResponses": {
         "type": "map",
         "documentation": "A map of response identifiers to responses.",
         "key": {"target": "smithy.api#String"},
-        "value": {"target": "Response"},
+        "value": {"target": "IntegrationResponse"},
         "private": true
       },
-      "Response": {
+      "IntegrationResponse": {
         "type": "structure",
         "documentation": "Defines a response and specifies parameter mappings.",
         "members": {


### PR DESCRIPTION
This commit removes the stuttering of a structure and member name from
the API Gateway Response shape. This fixes some warnings when validating
with the stuttered shape name validator.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
