### PR TITLE
Remove warning for idempotent POST operations

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.errors
@@ -3,4 +3,3 @@
 [WARNING] ns.foo#G: This operation uses the `POST` method in the `http` trait, but is marked with the readonly trait | HttpMethodSemantics
 [WARNING] ns.foo#H: This operation uses the `DELETE` method in the `http` trait, but is not marked with the idempotent trait | HttpMethodSemantics
 [WARNING] ns.foo#I: This operation uses the `GET` method in the `http` trait, but is not marked with the readonly trait | HttpMethodSemantics
-[WARNING] ns.foo#J: This operation uses the `POST` method in the `http` trait, but is marked with the idempotent trait | HttpMethodSemantics


### PR DESCRIPTION
This commit removes the warning that was issued for POST operations
marked with the idempotent trait. The idempotent trait applied to POST
seems like it will be common enough that it will be encountered in
normal use, and applying the idempotent trait to the operation is a
strong signal that it was intentional. Emitting a warning for something
that is within reason and intentional is just noise.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
