### PR TITLE
Add environment variables to smithy-build.json

### DIFF
--- a/docs/source/guides/building-models/build-config.rst
+++ b/docs/source/guides/building-models/build-config.rst
@@ -627,6 +627,53 @@ but keeps the shape if it has any of the provided tags:
         }
 
 
+.. _build_envars:
+
+Environment variables
+=====================
+
+Strings in ``smithy-build.json`` files can contain environment variable place
+holders that are expanded at load-time into the value of a Java system
+property or environment variable. The syntax of a placeholder is
+``${NAME}`` where "NAME" is the name of the system property or environment
+variable. A placeholder can be escaped using a backslash (``\``) before the
+"$". For example, ``\${FOO}`` expands to the literal string ``${FOO}``.
+A non-existent system property or environment variable will cause the file
+to fail to load. System property values take precedence over environment
+variables.
+
+Consider the following ``smithy-build.json`` file:
+
+.. code-block:: json
+
+    {
+      "version": "1.0",
+      "projections": {
+        "a": {
+          "transforms": [
+            {"${NAME_KEY}": "includeByTag", "args": ["${FOO}", "\\${BAZ}"]}
+          ]
+        }
+      }
+    }
+
+Assuming that ``NAME_KEY`` is a system property set to "name", and ``FOO`` is an
+environment variable set to "hi", this file is equivalent to:
+
+.. code-block:: json
+
+    {
+      "version": "1.0",
+      "projections": {
+        "a": {
+          "transforms": [
+            {"name": "includeByTag", "args": ["Hi", "${BAZ}"]}
+          ]
+        }
+      }
+    }
+
+
 .. _plugins:
 
 Plugins

--- a/smithy-build/README.md
+++ b/smithy-build/README.md
@@ -487,6 +487,50 @@ but keeps the shape if it has any of the provided tags:
 ```
 
 
+## Environment variables
+
+Strings in `smithy-build.json` files can contain environment variable place
+holders that are expanded at load-time into the value of a Java system
+property or environment variable. The syntax of a placeholder is
+`${NAME}` where "NAME" is the name of the system property or environment
+variable. A placeholder can be escaped using a backslash (\\) before the
+"$". For example, `\\${FOO}` expands to the literal string `${FOO}`.
+A non-existent system property or environment variable will cause the file
+to fail to load. System property values take precedence over environment
+variables.
+
+Consider the following `smithy-build.json` file:
+
+```json
+{
+  "version": "1.0",
+  "projections": {
+    "a": {
+      "transforms": [
+        {"${NAME_KEY}": "includeByTag", "args": ["${FOO}", "\\${BAZ}"]}
+      ]
+    }
+  }
+}
+```
+
+Assuming that `NAME_KEY` is a system property set to "name", and `FOO` is an
+environment variable set to "hi", this file is equivalent to:
+
+```json
+{
+  "version": "1.0",
+  "projections": {
+    "a": {
+      "transforms": [
+        {"name": "includeByTag", "args": ["Hi", "${BAZ}"]}
+      ]
+    }
+  }
+}
+```
+
+
 ## Plugins
 
 Plugins are defined in either the top-level "plugins" key-value pair of the

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
@@ -20,11 +20,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelSyntaxException;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.utils.IoUtils;
@@ -65,7 +70,7 @@ final class ConfigLoader {
     }
 
     private static Node loadWithJson(Path path, String contents) {
-        return Node.parseJsonWithComments(contents, path.toString());
+        return Node.parseJsonWithComments(contents, path.toString()).accept(new VariableExpander());
     }
 
     private static SmithyBuildConfig load(ObjectNode node) {
@@ -126,5 +131,64 @@ final class ConfigLoader {
         return container.getMembers().entrySet().stream()
                 .map(entry -> Pair.of(entry.getKey().getValue(), entry.getValue().expectObjectNode()))
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+    }
+
+    /**
+     * Expands ${NAME} values inside of strings to a {@code System} property
+     * or an environment variable.
+     */
+    private static final class VariableExpander extends NodeVisitor.Default<Node> {
+
+        private static final Pattern INLINE = Pattern.compile("(?:^|[^\\\\])\\$\\{(.+)}");
+        private static final Pattern ESCAPED_INLINE = Pattern.compile("\\\\\\$");
+
+        @Override
+        protected Node getDefault(Node node) {
+            return node;
+        }
+
+        @Override
+        public Node arrayNode(ArrayNode node) {
+            return node.getElements().stream().map(element -> element.accept(this)).collect(ArrayNode.collect());
+        }
+
+        @Override
+        public Node objectNode(ObjectNode node) {
+            return node.getMembers().entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey().accept(this), entry.getValue().accept(this)))
+                    .collect(ObjectNode.collect(pair -> pair.getLeft().expectStringNode(), Pair::getRight));
+        }
+
+        @Override
+        public Node stringNode(StringNode node) {
+            Matcher matcher = INLINE.matcher(node.getValue());
+            StringBuffer builder = new StringBuffer();
+
+            while (matcher.find()) {
+                String variable = matcher.group(1);
+                String replacement = expand(node.getSourceLocation(), variable);
+                matcher.appendReplacement(builder, replacement);
+            }
+
+            matcher.appendTail(builder);
+
+            // Remove escaped variables.
+            String result = ESCAPED_INLINE.matcher(builder.toString()).replaceAll("\\$");
+
+            return new StringNode(result, node.getSourceLocation());
+        }
+
+        private static String expand(SourceLocation sourceLocation, String variable) {
+            String replacement = Optional.ofNullable(System.getProperty(variable))
+                    .orElseGet(() -> System.getenv(variable));
+
+            if (replacement == null) {
+                throw new SmithyBuildException(String.format(
+                        "Unable to expand variable `" + variable + "` to an environment variable or system "
+                        + "property: %s", sourceLocation));
+            }
+
+            return replacement;
+        }
     }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "projections": {
+    "a": {
+      "transforms": [
+        {"${NAME_KEY}": "includeByTag", "args": ["${FOO}", "\\${BAZ}"]}
+      ]
+    }
+  }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-invalid-env.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-invalid-env.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "projections": {
+    "${INVALID_KEY_DOES_NOT_EXIST}": {}
+  }
+}


### PR DESCRIPTION
This commit updates smithy-build.json to support system
property/environment variable placeholders in object keys and string
values. A placeholder is in the form of `${NAME}` and can be escaped
using a backslash before the `$`. An exception is thrown if a value
cannot be resolved to a system property or environment variable.

Adding support for environment variables makes it easier to integrate
smithy-build.json files with other build tooling that might be wrapping
it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
