### PR TITLE
Configure Gradle for Maven Central publishing

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/build.gradle.kts
+++ b/aws/smithy-aws-apigateway-openapi/build.gradle.kts
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+description = "This module provides support for converting the Amazon API Gateway " +
+        "Smithy traits when converting a Smithy model to OpenAPI3."
+extra["displayName"] = "Smithy :: Amazon API Gateway OpenAPI Support"
 extra["moduleName"] = "software.amazon.smithy.aws.apigateway.openapi"
 
 dependencies {

--- a/aws/smithy-aws-traits/build.gradle.kts
+++ b/aws/smithy-aws-traits/build.gradle.kts
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+description = "This module provides Smithy traits and validators that are used by most AWS services."
+extra["displayName"] = "Smithy :: AWS Core Traits"
 extra["moduleName"] = "software.amazon.smithy.aws.traits"
 
 dependencies {

--- a/codegen/smithy-codegen-core/build.gradle.kts
+++ b/codegen/smithy-codegen-core/build.gradle.kts
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+description = "This module provides a code generation framework for generating clients, " +
+        "servers, documentation, and other artifacts for various languages from Smithy models."
+extra["displayName"] = "Smithy :: Code Generation Framework"
 extra["moduleName"] = "software.amazon.smithy.codegen.core"
 
 dependencies {

--- a/codegen/smithy-codegen-freemarker/build.gradle.kts
+++ b/codegen/smithy-codegen-freemarker/build.gradle.kts
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+description = "This package integrates the Freemarker template system with Smithy's " +
+        "code generation framework."
+extra["displayName"] = "Smithy :: Code Generation Freemarker Support"
 extra["moduleName"] = "software.amazon.smithy.codegen.freemarker"
 
 dependencies {

--- a/docs/source/spec/aws-core.rst
+++ b/docs/source/spec/aws-core.rst
@@ -940,7 +940,7 @@ Each condition key object supports the following key-value pairs:
                 type: "String",
                 documentation: "The Bar string",
                 externalDocumentation: "http://example.com"
-            }})
+            })
         service MyService {
             version: "2017-02-11",
             resources: [MyResource],

--- a/smithy-build/build.gradle.kts
+++ b/smithy-build/build.gradle.kts
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+description = "This module is a library used to validate Smithy models, create filtered " +
+        "projections of a model, and generate build artifacts."
+extra["displayName"] = "Smithy :: Build"
 extra["moduleName"] = "software.amazon.smithy.build"
 
 dependencies {

--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+description = "This module implements the Smithy command line interface."
+extra["displayName"] = "Smithy :: CLI"
 extra["moduleName"] = "software.amazon.smithy.cli"
 
 plugins {

--- a/smithy-diff/build.gradle.kts
+++ b/smithy-diff/build.gradle.kts
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+description = "This module detects differences between two Smithy models, identifying " +
+        "changes that are safe and changes that are backward incompatible."
+extra["displayName"] = "Smithy :: Diff"
 extra["moduleName"] = "software.amazon.smithy.diff"
 
 dependencies {

--- a/smithy-jsonschema/build.gradle.kts
+++ b/smithy-jsonschema/build.gradle.kts
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+description = "This module contains support for converting a Smithy model to JSON Schema."
+extra["displayName"] = "Smithy :: JSON Schema Conversion"
 extra["moduleName"] = "software.amazon.smithy.jsonschema"
 
 dependencies {

--- a/smithy-linters/build.gradle.kts
+++ b/smithy-linters/build.gradle.kts
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+description = "This module provides support for customizable linters declared in the " +
+        "metadata section of a Smithy model."
+extra["displayName"] = "Smithy :: Linters"
 extra["moduleName"] = "software.amazon.smithy.linters"
 
 dependencies {

--- a/smithy-model/build.gradle.kts
+++ b/smithy-model/build.gradle.kts
@@ -13,7 +13,9 @@
  * permissions and limitations under the License.
  */
 
-description = "Smithy :: Model"
+description = "This module provides the core implementation of loading, validating, " +
+        "traversing, mutating, and serializing a Smithy model."
+extra["displayName"] = "Smithy :: Model"
 extra["moduleName"] = "software.amazon.smithy.model"
 
 dependencies {

--- a/smithy-mqtt-traits/build.gradle.kts
+++ b/smithy-mqtt-traits/build.gradle.kts
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+description = "This module provides the implementation of MQTT binding traits for Smithy."
+extra["displayName"] = "Smithy :: MQTT Traits"
 extra["moduleName"] = "software.amazon.smithy.mqtt.traits"
 
 dependencies {

--- a/smithy-openapi/build.gradle.kts
+++ b/smithy-openapi/build.gradle.kts
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+description = "This module contains support for converting a Smithy model to OpenAPI."
+extra["displayName"] = "Smithy :: OpenAPI Conversion"
 extra["moduleName"] = "software.amazon.smithy.openapi"
 
 dependencies {

--- a/smithy-utils/build.gradle.kts
+++ b/smithy-utils/build.gradle.kts
@@ -13,6 +13,6 @@
  * permissions and limitations under the License.
  */
 
-description = "Smithy :: Utilities"
-
+description = "This module contains utility classes and interfaces for Smithy."
+extra["displayName"] = "Smithy :: Utilities"
 extra["moduleName"] = "software.amazon.smithy.utils"


### PR DESCRIPTION
This commit adds support to publish the generated artifacts (jar, pom
sources jar, and javadocs jar) to Maven Central. They are signed using
the standard signing plugin. The generated pom files have been augmented
with additional information for consumers. The nexus-staging plugin is
included to help automate releasing the staged artifacts after testing.
The subprojects' build files have been updated to contain display names
and descriptions for use in the pom files.

This commit also includes a version bump to 0.7.1.

*Issue #, if available:*
#104 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
