### PR TITLE
Add controlPlane and dataPlane traits

### DIFF
--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ControlPlaneTrait.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ControlPlaneTrait.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.BooleanTrait;
+
+public final class ControlPlaneTrait extends BooleanTrait {
+    public static final ShapeId ID = ShapeId.from("aws.api#controlPlane");
+
+    public ControlPlaneTrait(SourceLocation sourceLocation) {
+        super(ID, sourceLocation);
+    }
+
+    public ControlPlaneTrait() {
+        this(SourceLocation.NONE);
+    }
+
+    public static final class Provider extends BooleanTrait.Provider<ControlPlaneTrait> {
+        public Provider() {
+            super(ID, ControlPlaneTrait::new);
+        }
+    }
+}

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/DataPlaneTrait.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/DataPlaneTrait.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.BooleanTrait;
+
+public final class DataPlaneTrait extends BooleanTrait {
+    public static final ShapeId ID = ShapeId.from("aws.api#dataPlane");
+
+    public DataPlaneTrait(SourceLocation sourceLocation) {
+        super(ID, sourceLocation);
+    }
+
+    public DataPlaneTrait() {
+        this(SourceLocation.NONE);
+    }
+
+    public static final class Provider extends BooleanTrait.Provider<DataPlaneTrait> {
+        public Provider() {
+            super(ID, DataPlaneTrait::new);
+        }
+    }
+}

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.KnowledgeIndex;
+import software.amazon.smithy.model.selector.PathFinder;
+import software.amazon.smithy.model.selector.Selector;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+
+/**
+ * Determines if a service, resource, or operation are considered
+ * part of the data plane or control plane.
+ *
+ * <p>The plane is inherited from the top-down and can be overridden
+ * per shape. For example, if a service shape has the
+ * {@code aws.api#controlPlane} shape, then every shape within the closure
+ * of the service inherits this property. If a resource shape defines a
+ * {@code aws.api#controlPlane} or {@code aws.api#dataPlane} trait, then all
+ * shapes within the closure of the resource inherit it. If an operation is
+ * marked with the {@code aws.api#dataPlane} trait, it overrides any plane
+ * traits of the service or resource its bound within.
+ */
+public final class PlaneIndex implements KnowledgeIndex {
+    private static final Selector SELECTOR = Selector.parse(":test(operation, resource)");
+
+    private final Map<ShapeId, Plane> servicePlanes = new HashMap<>();
+    private final PathFinder pathFinder;
+
+    private enum Plane { CONTROL, DATA }
+
+    public PlaneIndex(Model model) {
+        pathFinder = PathFinder.create(model);
+
+        model.getShapeIndex().shapes(ServiceShape.class).forEach(service -> {
+            Plane plane = extractPlane(service);
+            if (plane != null) {
+                servicePlanes.put(service.getId(), plane);
+            }
+        });
+    }
+
+    /**
+     * Checks if the given service shape is part of the control plane.
+     *
+     * @param service Service to check.
+     * @return Returns true if the service is part of the control plane.
+     */
+    public boolean isControlPlane(ToShapeId service) {
+        return servicePlanes.getOrDefault(service.toShapeId(), null) == Plane.CONTROL;
+    }
+
+    /**
+     * Checks if the given shape within a service is part of the control plane.
+     *
+     * @param service Service to check.
+     * @param operationOrResource Operation or resource within the service to check.
+     * @return Returns true if the shape is part of the control plane.
+     */
+    public boolean isControlPlane(ToShapeId service, ToShapeId operationOrResource) {
+        return resolvePlane(service, operationOrResource.toShapeId()) == Plane.CONTROL;
+    }
+
+    /**
+     * Checks if the given service shape is part of the data plane.
+     *
+     * @param service Service to check.
+     * @return Returns true if the service is part of the data plane.
+     */
+    public boolean isDataPlane(ToShapeId service) {
+        return servicePlanes.getOrDefault(service.toShapeId(), null) == Plane.DATA;
+    }
+
+    /**
+     * Checks if the given shape within a service is part of the data plane.
+     *
+     * @param service Service to check.
+     * @param operationOrResource Operation or resource within the service to check.
+     * @return Returns true if the shape is part of the data plane.
+     */
+    public boolean isDataPlane(ToShapeId service, ToShapeId operationOrResource) {
+        return resolvePlane(service, operationOrResource.toShapeId()) == Plane.DATA;
+    }
+
+    /**
+     * Checks if the given service shape has defined its plane.
+     *
+     * @param service Service to check.
+     * @return Returns true if the service has defined its plane.
+     */
+    public boolean isPlaneDefined(ToShapeId service) {
+        return servicePlanes.containsKey(service.toShapeId());
+    }
+
+    /**
+     * Checks if the given shape within a service has a resolvable plane.
+     *
+     * @param service Service to check.
+     * @param operationOrResource Operation or resource within the service to check.
+     * @return Returns true if the shape has a resolvable plane.
+     */
+    public boolean isPlaneDefined(ToShapeId service, ToShapeId operationOrResource) {
+        return resolvePlane(service, operationOrResource.toShapeId()) != null;
+    }
+
+    private Plane resolvePlane(ToShapeId service, ShapeId operationOrResource) {
+        Plane result = null;
+
+        for (PathFinder.Path path : pathFinder.search(service, SELECTOR)) {
+            for (Shape shape : path.getShapes()) {
+                Plane nextPlane = extractPlane(shape);
+                if (nextPlane != null) {
+                    result = nextPlane;
+                }
+                if (shape.getId().equals(operationOrResource)) {
+                    return result;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Plane extractPlane(Shape shape) {
+        if (shape.hasTrait(ControlPlaneTrait.class)) {
+            return Plane.CONTROL;
+        } else if (shape.hasTrait(DataPlaneTrait.class)) {
+            return Plane.DATA;
+        } else {
+            return null;
+        }
+    }
+}

--- a/aws/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/aws/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -1,6 +1,8 @@
 software.amazon.smithy.aws.traits.ArnTrait$Provider
 software.amazon.smithy.aws.traits.ArnReferenceTrait$Provider
 software.amazon.smithy.aws.traits.CognitoUserPoolsSettingsTrait$Provider
+software.amazon.smithy.aws.traits.ControlPlaneTrait$Provider
+software.amazon.smithy.aws.traits.DataPlaneTrait$Provider
 software.amazon.smithy.aws.traits.DataTrait$Provider
 software.amazon.smithy.aws.traits.ServiceTrait$Provider
 software.amazon.smithy.aws.traits.UnsignedPayloadTrait$Provider

--- a/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
+++ b/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
@@ -117,6 +117,22 @@
         "documentation": "Configures an Amazon Cognito User Pools auth scheme.",
         "tags": ["internal"]
       },
+      "controlPlane": {
+        "trait": {
+          "selector": ":test(service, resource, operation)",
+          "conflicts": ["aws.api#dataPlane"]
+        },
+        "type": "structure",
+        "documentation": "Defines a service, resource, or operation as operating on the control plane."
+      },
+      "dataPlane": {
+        "trait": {
+          "selector": ":test(service, resource, operation)",
+          "conflicts": ["aws.api#controlPlane"]
+        },
+        "type": "structure",
+        "documentation": "Defines a service, resource, or operation as operating on the data plane."
+      },
       "ArnNamespace": {
         "type": "string",
         "pattern": "^[a-z0-9.\\-]{1,63}$",

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/PlaneIndexTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/PlaneIndexTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class PlaneIndexTest {
+    @Test
+    public void computesControlPlaneVsDataPlane() {
+        Model model = Model.assembler()
+                .discoverModels(PlaneIndexTest.class.getClassLoader())
+                .addImport(PlaneIndexTest.class.getResource("planes.json"))
+                .assemble()
+                .unwrap();
+
+        ShapeId service = ShapeId.from("smithy.example#Service");
+        PlaneIndex index = model.getKnowledge(PlaneIndex.class);
+        assertTrue(index.isControlPlane(service));
+        assertFalse(index.isDataPlane(service));
+        assertTrue(index.isPlaneDefined(service));
+
+        assertFalse(index.isControlPlane(service, ShapeId.from("smithy.example#Operation1")));
+        assertTrue(index.isDataPlane(service, ShapeId.from("smithy.example#Operation1")));
+        assertTrue(index.isPlaneDefined(service, ShapeId.from("smithy.example#Operation1")));
+
+        assertTrue(index.isControlPlane(service, ShapeId.from("smithy.example#Operation2")));
+        assertTrue(index.isControlPlane(service, ShapeId.from("smithy.example#Operation3")));
+        assertTrue(index.isDataPlane(service, ShapeId.from("smithy.example#Operation4")));
+        assertTrue(index.isControlPlane(service, ShapeId.from("smithy.example#Operation5")));
+        assertTrue(index.isControlPlane(service, ShapeId.from("smithy.example#Operation6")));
+        assertTrue(index.isControlPlane(service, ShapeId.from("smithy.example#Operation7")));
+        assertTrue(index.isDataPlane(service, ShapeId.from("smithy.example#Operation8")));
+
+        assertTrue(index.isControlPlane(service, ShapeId.from("smithy.example#Resource1")));
+        assertTrue(index.isDataPlane(service, ShapeId.from("smithy.example#Resource2")));
+
+        // ID that doesn't exist.
+        assertFalse(index.isDataPlane(service, ShapeId.from("smithy.example#InvalidOperationId")));
+
+        // Service that doesn't exist.
+        assertFalse(index.isControlPlane(ShapeId.from("foo.baz#Invalid")));
+        assertFalse(index.isDataPlane(ShapeId.from("foo.baz#Invalid")));
+        assertFalse(index.isPlaneDefined(ShapeId.from("foo.baz#Invalid")));
+    }
+}

--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/planes.json
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/planes.json
@@ -1,0 +1,53 @@
+{
+    "smithy": "0.3.0",
+    "smithy.example": {
+        "shapes": {
+            "Service": {
+                "type": "service",
+                "version": "2018-03-17",
+                "resources": ["Resource1"],
+                "operations": ["Operation1", "Operation2", "Operation3"],
+                "aws.api#controlPlane": true
+            },
+            "Operation1": {
+                "type": "operation",
+                "aws.api#dataPlane": true
+            },
+            "Operation2": {
+                "type": "operation",
+                "aws.api#controlPlane": true
+            },
+            "Operation3": {
+                "type": "operation"
+            },
+            "Resource1": {
+                "type": "resource",
+                "resources": ["Resource2"],
+                "operations": ["Operation4", "Operation5", "Operation6"]
+            },
+            "Operation4": {
+                "type": "operation",
+                "aws.api#dataPlane": true
+            },
+            "Operation5": {
+                "type": "operation",
+                "aws.api#controlPlane": true
+            },
+            "Operation6": {
+                "type": "operation"
+            },
+            "Resource2": {
+                "type": "resource",
+                "aws.api#dataPlane": true,
+                "operations": ["Operation7", "Operation8"]
+            },
+            "Operation7": {
+                "type": "operation",
+                "aws.api#controlPlane": true
+            },
+            "Operation8": {
+                "type": "operation"
+            }
+        }
+    }
+}

--- a/docs/source/spec/aws-core.rst
+++ b/docs/source/spec/aws-core.rst
@@ -716,6 +716,102 @@ applied through the ``aws.api#data`` trait.
         permissions.
 
 
+.. _aws.api#controlPlane-trait:
+
+------------------------------
+``aws.api#controlPlane`` trait
+------------------------------
+
+Summary
+    Indicates that a service, resource, or operation is considered part of
+    the *control plane*.
+Trait selector
+    ``:test(service, resource, operation)``
+Value type
+    Annotation trait
+Conflicts with
+    :ref:`aws.api#dataPlane-trait`
+
+This trait is effectively inherited by shapes bound within a service or
+resource. When applied to a service or resource shape, all resources and
+operations bound within the shape are also considered part of the control
+plane unless an operation or resource is marked with the
+:ref:`aws.api#dataPlane-trait`.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        use aws.api#controlPlane
+
+        @controlPlane
+        operation PutThings(PutThingsInput) -> PutThingsOutput
+
+    .. code-tab:: json
+
+        {
+            "smithy": "0.3.0",
+            "smithy.example": {
+                "shapes": {
+                    "PutThings": {
+                        "type": "operation",
+                        "input": "PutThingsInput",
+                        "output": "PutThingsOutput",
+                        "aws.api#controlPlane": true
+                    }
+                }
+            }
+        }
+
+
+.. _aws.api#dataPlane-trait:
+
+---------------------------
+``aws.api#dataPlane`` trait
+---------------------------
+
+Summary
+    Indicates that a service, resource, or operation is considered part of
+    the *data plane*.
+Trait selector
+    ``:test(service, resource, operation)``
+Value type
+    Annotation trait
+Conflicts with
+    :ref:`aws.api#controlPlane-trait`
+
+This trait is effectively inherited by shapes bound within a service or
+resource. When applied to a service or resource shape, all resources and
+operations bound within the shape are also considered part of the data
+plane unless an operation or resource is marked with the
+:ref:`aws.api#controlPlane-trait`.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        use aws.api#controlPlane
+
+        @dataPlane
+        operation PutThings(PutThingsInput) -> PutThingsOutput
+
+    .. code-tab:: json
+
+        {
+            "smithy": "0.3.0",
+            "smithy.example": {
+                "shapes": {
+                    "PutThings": {
+                        "type": "operation",
+                        "input": "PutThingsInput",
+                        "output": "PutThingsOutput",
+                        "aws.api#dataPlane": true
+                    }
+                }
+            }
+        }
+
+
 .. _aws.api#unsignedPayload-trait:
 
 ---------------------------------


### PR DESCRIPTION
This commit adds the `aws.api#controlPlane` and `aws.api#dataPlane` traits. By making these traits instead of tags, we can more easily query for them using existing abstractions and more easily validate their constraints using trait features.

TODO: We need to followup with a good definition of what control plane and data plane actually mean.

Closes #30

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
