### PR TITLE
Update CamelCase Member Shape Validation

### DIFF
--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
@@ -23,10 +23,12 @@ import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidatorService;
+import software.amazon.smithy.utils.FunctionalUtils;
 
 /**
  * Emits a validation event if shapes at a specific location do not match the
@@ -67,6 +69,7 @@ public final class CamelCaseValidator extends AbstractValidator {
 
         // Normal shapes are expected to be upper camel.
         model.getShapeIndex().shapes()
+                .filter(FunctionalUtils.not(Shape::isMemberShape))
                 .filter(shape -> !shape.hasTrait(TraitDefinition.class))
                 .filter(shape -> !getPattern(UPPER).matcher(shape.getId().getName()).find())
                 .map(shape -> danger(shape, format("%s shape name, `%s`, is not %s camel case",

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.errors
@@ -8,3 +8,7 @@
 [DANGER] ns.foo#snake_case: string shape name, `snake_case`, is not upper camel case | OppositeOfDefaults
 [DANGER] ns.foo#InvalidTrait: string trait definition, `InvalidTrait`, is not lower camel case | DefaultCamelCase
 [DANGER] ns.foo#InvalidTrait: string trait definition, `InvalidTrait`, is not lower camel case | OppositeOfDefaults
+[DANGER] ns.foo#upperStructureTrait$UpperCamelCase: Member shape member name, `UpperCamelCase`, is not lower camel case | DefaultCamelCase
+[DANGER] ns.foo#upperStructureTrait$snake_case: Member shape member name, `snake_case`, is not lower camel case | DefaultCamelCase
+[DANGER] ns.foo#upperStructureTrait$snake_case: Member shape member name, `snake_case`, is not upper camel case | OppositeOfDefaults
+[DANGER] ns.foo#lowerStructureTrait$lowerCamelCase: Member shape member name, `lowerCamelCase`, is not upper camel case | OppositeOfDefaults

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.json
@@ -25,6 +25,27 @@
                 "trait": true,
                 "type": "string"
             },
+            "lowerStructureTrait": {
+                "trait": true,
+                "type": "structure",
+                "members": {
+                    "lowerCamelCase": {
+                        "target": "Foo"
+                    }
+                }
+            },
+            "upperStructureTrait": {
+                "trait": true,
+                "type": "structure",
+                "members": {
+                    "UpperCamelCase": {
+                        "target": "Foo"
+                    },
+                    "snake_case": {
+                        "target": "Foo"
+                    }
+                }
+            },
             "Foo": {
                 "type": "string"
             },


### PR DESCRIPTION
This commit updates the CamelCase validator to not apply the UpperCamel
validation to member shapes, as they are already validated based on the
memberNames setting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
