### PR TITLE
Update ScrubTraitDefinitions prelude interaction

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.8.0"
+    version = "0.8.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
@@ -63,6 +63,6 @@ final class ScrubTraitDefinitions {
     }
 
     private static boolean notPublicPreludeShape(Shape shape) {
-        return !Prelude.isPublicPreludeShape(shape.getId());
+        return !(Prelude.isPublicPreludeShape(shape.getId()) && !shape.hasTrait(TraitDefinition.class));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
@@ -59,5 +59,8 @@ public class ScrubTraitDefinitionsTest {
         assertThat(index.getShape(ShapeId.from("smithy.api#BigInteger")), Matchers.not(Optional.empty()));
         assertThat(index.getShape(ShapeId.from("smithy.api#BigDecimal")), Matchers.not(Optional.empty()));
         assertThat(index.getShape(ShapeId.from("smithy.api#Timestamp")), Matchers.not(Optional.empty()));
+
+        // Make sure public prelude trait definition shapes were removed.
+        assertThat(index.getShape(ShapeId.from("smithy.api#length")), Matchers.is(Optional.empty()));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/scrub-trait-def.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/scrub-trait-def.json
@@ -36,7 +36,10 @@
             "qux": {
                 "trait": true,
                 "type": "list",
-                "member": {"target": "BarString"}
+                "member": {"target": "BarString"},
+                "length": {
+                    "min": 1
+                }
             },
 
             "lorem": {


### PR DESCRIPTION
This commit updates the ScrubTraitDefinitions model transformer to
remove trait definition shapes from the prelude like intended.

Also includes a version bump to `0.8.1`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
