### PR TITLE
Remove single-quoted strings from the IDL

### DIFF
--- a/docs/source/spec/language-specification.rst
+++ b/docs/source/spec/language-specification.rst
@@ -418,26 +418,18 @@ or to escape an escape (using ``\\``).
 .. productionlist:: smithy
     text                :`unquoted_text` / `quoted_text` / `text_block`
     unquoted_text       :(ALPHA / "_") *(ALPHA / DIGIT / "_" / "$" / "." / "#")
-    quoted_text         :`single_quoted_text` / `double_quoted_text`
-    single_quoted_text  :"'" *`single_quoted_char` "'"
-    single_quoted_char  :%x20-26
-                        :/ %x28-5B
-                        :/ %x5D-10FFFF
-                        :/ `escaped_char`
-                        :/ `preserved_single`
     escaped_char        :`escape` (`escape` / "'" / DQUOTE / "b" / "f" / "n" / "r" / "t" / "/" / `unicode_escape`)
     unicode_escape      :"u" `hex` `hex` `hex` `hex`
     hex                 : DIGIT / %x41-46 / %x61-66
-    preserved_single    :`escape` (%x20-26 / %x28-5B / %x5D-10FFFF)
-    double_quoted_text  :DQUOTE *`double_quoted_char` DQUOTE
-    double_quoted_char  :%x20-21
+    quoted_text         :DQUOTE *`quoted_char` DQUOTE
+    quoted_char         :%x20-21
                         :/ %x23-5B
                         :/ %x5D-10FFFF
                         :/ `escaped_char`
                         :/ `preserved_double`
     preserved_double    :`escape` (%x20-21 / %x23-5B / %x5D-10FFFF)
     escape              :%x5C ; backslash
-    text_block          :DQUOTE DQUOTE DQUOTE `br` `double_quoted_char` DQUOTE DQUOTE DQUOTE
+    text_block          :DQUOTE DQUOTE DQUOTE `br` `quoted_char` DQUOTE DQUOTE DQUOTE
 
 New lines in strings are normalized from CR (\u000D) and CRLF (\u000D\u000A)
 to LF (\u000A). This ensures that strings defined in a Smithy model are

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/SmithyModelLexer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/SmithyModelLexer.java
@@ -221,9 +221,6 @@ final class SmithyModelLexer implements Iterator<SmithyModelLexer.Token> {
             case '"':
                 // Parse double quoted strings.
                 return parseToken(TokenType.QUOTED, this::parseQuotes);
-            case '\'':
-                // Parse single quoted strings.
-                return parseToken(TokenType.QUOTED, this::parseSingleQuotes);
             case '-':
                 // Return "->" or negative number.
                 if (peekChar() == '>') {
@@ -353,21 +350,6 @@ final class SmithyModelLexer implements Iterator<SmithyModelLexer.Token> {
         return input.substring(startPosition, position + 1);
     }
 
-    private String parseSingleQuotes() {
-        int startPosition = position;
-
-        while (true) {
-            char next = consume();
-            if (next == '\'') {
-                break;
-            } else if (next == '\\') {
-                consume();
-            }
-        }
-
-        return parseStringContents(input.substring(startPosition, position + 1));
-    }
-
     private String parseQuotes() {
         int startPosition = position;
         boolean triple = peekChar() == '"' && peekChar(2) == '"';
@@ -470,9 +452,6 @@ final class SmithyModelLexer implements Iterator<SmithyModelLexer.Token> {
                     switch (c) {
                         case '"':
                             result.append('"');
-                            continue;
-                        case '\'':
-                            result.append('\'');
                             continue;
                         case '\\':
                             result.append('\\');

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/LoaderVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/LoaderVisitorTest.java
@@ -231,7 +231,7 @@ public class LoaderVisitorTest {
                 .addUnparsedModel("test.smithy", "namespace smithy.example\n"
                                                  + "@foo(true)\n"
                                                  + "string MyString\n"
-                                                 + "@trait(selector: '*')\n"
+                                                 + "@trait(selector: \"*\")\n"
                                                  + "structure foo {}\n")
                 .assemble()
                 .unwrap();
@@ -245,7 +245,7 @@ public class LoaderVisitorTest {
                 .addUnparsedModel("test.smithy", "namespace smithy.example\n"
                                                  + "@foo\n"
                                                  + "string MyString\n"
-                                                 + "@trait(selector: '*')"
+                                                 + "@trait(selector: \"*\")"
                                                  + traitType + "\n")
                 .assemble()
                 .unwrap();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/SmithyModelLexerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/SmithyModelLexerTest.java
@@ -61,37 +61,8 @@ public class SmithyModelLexerTest {
                 Arguments.of("\"foo\\\r\nbaz\"", "foobaz"),
                 Arguments.of("\"\\\r\"", ""),
                 Arguments.of("\"\\\n\"", ""),
-                Arguments.of("\"\\'\"", "'"),
                 Arguments.of("\"\\\"\"", "\""),
                 Arguments.of("\"\\ud83d\\ude00\"", "\uD83D\uDE00"),
-
-                // single quotes
-                Arguments.of("'foo'", "foo"),
-                Arguments.of("'foo\\\\bar'", "foo\\bar"),
-                Arguments.of("'\t'", "\t"),
-                Arguments.of("'\r'", "\n"),
-                Arguments.of("'\n'", "\n"),
-                Arguments.of("'\b'", "\b"),
-                Arguments.of("'\f'", "\f"),
-                Arguments.of("'\\t'", "\t"),
-                Arguments.of("'\\r'", "\r"),
-                Arguments.of("'\\n'", "\n"),
-                Arguments.of("'\\b'", "\b"),
-                Arguments.of("'\\f'", "\f"),
-                Arguments.of("'\\uffff'", "\uffff"),
-                Arguments.of("'\\u000A'", "\n"),
-                Arguments.of("'\\u000D\\u000A'", "\r\n"),
-                Arguments.of("'\r\\u000A\r\n'", "\n\n\n"),
-                Arguments.of("'\\''", "'"),
-                Arguments.of("'foo\\\\'", "foo\\"),
-                Arguments.of("'\\/'", "/"),
-                Arguments.of("'foo\\\nbaz'", "foobaz"),
-                Arguments.of("'foo\\\rbaz'", "foobaz"),
-                Arguments.of("'foo\\\r\nbaz'", "foobaz"),
-                Arguments.of("'\\\r'", ""),
-                Arguments.of("'\\\n'", ""),
-                Arguments.of("'\\''", "'"),
-                Arguments.of("'\\\"'", "\""),
 
                 // Text blocks
                 Arguments.of("\"\"\"\nfoo\"\"\"", "foo"),
@@ -140,15 +111,6 @@ public class SmithyModelLexerTest {
                 Arguments.of("\"\\uaaa\"", "Invalid unclosed unicode escape"),
                 Arguments.of("\"\\uaaat\"", "Invalid unicode escape character: `t`"),
 
-                // Now for SQUOTE.
-                Arguments.of("'\\ '", "Invalid escape found in string: `\\ `"),
-                Arguments.of("'\\a'", "Invalid escape found in string: `\\a`"),
-                Arguments.of("'\\ua'", "Invalid unclosed unicode escape"),
-                Arguments.of("'\\ua'", "Invalid unclosed unicode escape"),
-                Arguments.of("'\\uaa'", "Invalid unclosed unicode escape"),
-                Arguments.of("'\\uaaa'", "Invalid unclosed unicode escape"),
-                Arguments.of("'\\uaaat'", "Invalid unicode escape character: `t`"),
-
                 // Text blocks
                 Arguments.of("\"\"\"foo\"\"\"", "text block must start with a new line"),
                 Arguments.of("\"\"\"\"\"\"", "text block is empty"));
@@ -178,14 +140,14 @@ public class SmithyModelLexerTest {
         return Stream.of(
                 Arguments.of("foo baz", new String[]{"1:1", "1:5"}),
                 Arguments.of("foo\n baz", new String[]{"1:1", "2:2"}),
-                Arguments.of("'foo\n  \nbaz' bar", new String[]{"1:1", "3:6"}),
-                Arguments.of("'foo\n  \nbaz'   bar", new String[]{"1:1", "3:8"}),
+                Arguments.of("\"foo\n  \nbaz\" bar", new String[]{"1:1", "3:6"}),
+                Arguments.of("\"foo\n  \nbaz\"   bar", new String[]{"1:1", "3:8"}),
                 Arguments.of("\"\"\"\nfoo\"\"\"  baz", new String[]{"1:1", "2:9"}),
-                Arguments.of("'foo\n ' '\nbaz '   'bar'", new String[]{"1:1", "2:4", "3:9"}),
-                Arguments.of("'foo\r\n\r\\n\\t' boo", new String[]{"1:1", "3:7"}),
-                Arguments.of("\"\"\"\n  Foo\\\n  Baz\"\"\" 'bar'", new String[]{"1:1", "3:10"}),
-                Arguments.of("\"\"\"\r  Foo\\\r  Baz\"\"\" 'bar'", new String[]{"1:1", "3:10"}),
-                Arguments.of("\"\"\"\r\n  Foo\\\r\n  Baz\"\"\" 'bar'", new String[]{"1:1", "3:10"}));
+                Arguments.of("\"foo\n \" \"\nbaz \"   \"bar\"", new String[]{"1:1", "2:4", "3:9"}),
+                Arguments.of("\"foo\r\n\r\\n\\t\" boo", new String[]{"1:1", "3:7"}),
+                Arguments.of("\"\"\"\n  Foo\\\n  Baz\"\"\" \"bar\"", new String[]{"1:1", "3:10"}),
+                Arguments.of("\"\"\"\r  Foo\\\r  Baz\"\"\" \"bar\"", new String[]{"1:1", "3:10"}),
+                Arguments.of("\"\"\"\r\n  Foo\\\r\n  Baz\"\"\" \"bar\"", new String[]{"1:1", "3:10"}));
     }
 
     @ParameterizedTest

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/annotation-unclosed-object2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/annotation-unclosed-object2.smithy
@@ -1,4 +1,4 @@
 // Parse error at line 4, column 1 near `string`: Expected RPAREN
 namespace com.foo
-@foo('bar'
+@foo("bar"
 string MyString

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/metadata.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/metadata.json
@@ -56,11 +56,9 @@
         ]
       }
     },
-    "foo.2": "def",
     "foo.20": {
       "a": "b"
     },
-    "foo.3": "def",
     "foo.4": "def",
     "foo.5": "def",
     "foo.6": "def",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/metadata.smithy
@@ -1,7 +1,5 @@
 metadata foo = "abc"
 metadata "foo.1" = "def"
-metadata "foo.2" = 'def'
-metadata "foo.3"='def'
 metadata foo.4="def"
 metadata foo.5   =    "def"
 metadata "foo.6"   =    "def"
@@ -25,12 +23,12 @@ metadata foo.13 = {}
 metadata foo.14 = {abc: 123}
 metadata foo.15 = {abc: "def"}
 metadata foo.16 = {abc: "def", foo: "baz"}
-metadata foo.17 = {'abc': 'def', "foo": "baz"}
+metadata foo.17 = {"abc": "def", "foo": "baz"}
 
 metadata foo.18 = {
-'abc'
+"abc"
 :
-'def'
+"def"
 ,
 "foo"
 :

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
@@ -27,17 +27,13 @@
       },
       "F": {
         "type": "string",
-        "smithy.api#documentation": "\nHello! This is a test.\n\nIs it working? Is \"This\" the 'expected' result?\nIs this a backslash? \"\\\"."
+        "smithy.api#documentation": "\nHello! This is a test.\n\nIgnore these tokens: {}[](),:->$version//<> +10 -10 =\n\nIs it working? Is \"This\" the 'expected' result?\nIs this a backslash? \"\\\"."
       },
       "Foo": {
         "type": "resource",
         "identifiers": {
           "abc": "smithy.api#String"
         }
-      },
-      "G": {
-        "type": "string",
-        "smithy.api#documentation": "\nHello! This is a test.\n\nIgnore these tokens: {}[](),:->$version//<> +10 -10 =\n\nIs it working? Is 'This' the \"expected\" result?\nIs this a backslash? '\\'."
       },
       "H": {
         "type": "string",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
@@ -33,18 +33,11 @@ string E
 @documentation("
 Hello! This is a test.
 
+Ignore these tokens: {}[](),:->$version//<> +10 -10 =
+
 Is it working? Is \"This\" the 'expected' result?
 Is this a backslash? \"\\\".")
 string F
-
-@documentation('
-Hello! This is a test.
-
-Ignore these tokens: {}[](),:->$version//<> +10 -10 =
-
-Is it working? Is \'This\' the "expected" result?
-Is this a backslash? \'\\\'.')
-string G
 
 // Unquoted string resolves to a shape ID
 
@@ -86,18 +79,18 @@ string N
 
 // List with quoted values.
 
-@tags(['a', "b", 'c'])
+@tags(["a", "b", "c"])
 string O
 
 // List with quoted values spanning multiple lines.
 
 @tags(
 [
-'a'
+"a"
 ,
 "b"
 ,
-'c'
+"c"
 ]
 )
 string P


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This removes the ability to specify strings using single quotes in the
Smithy IDL. While convenient, having the option to use one style or the
other often leads to projects using both, which harms readability.
Double quotes are kept instead of single quotes due to the frequency of
apostrophes in English text and because they are commonly the only
option in programming languages. There is also slightly less ambiguity,
as it may be difficult to distinguish between a single double quote
character vs two single quote characters depending on font choice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.