### PR TITLE
Expose content-type resolution API

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -227,6 +228,42 @@ public class HttpBindingIndexTest {
 
         assertThat(HttpBindingIndex.hasHttpRequestBindings(shape), is(true));
         assertThat(HttpBindingIndex.hasHttpResponseBindings(shape), is(true));
+    }
+
+    @Test
+    public void resolvesStructureBodyContentType() {
+        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithStructurePayload");
+        Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
+
+        assertThat(contentType, equalTo(Optional.of("application/json")));
+    }
+
+    @Test
+    public void resolvesStringBodyContentType() {
+        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        ShapeId operation = ShapeId.from("ns.foo#ServiceOperationExplicitMembers");
+        Optional<String> contentType = index.determineRequestContentType(operation, "application/json");
+
+        assertThat(contentType, equalTo(Optional.of("text/plain")));
+    }
+
+    @Test
+    public void resolvesBlobBodyContentType() {
+        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithBlobPayload");
+        Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
+
+        assertThat(contentType, equalTo(Optional.of("application/octet-stream")));
+    }
+
+    @Test
+    public void resolvesMediaTypeContentType() {
+        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithMediaType");
+        Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
+
+        assertThat(contentType, equalTo(Optional.of("application/xml")));
     }
 
     private static MemberShape expectMember(Model model, String id) {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/http-index.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/http-index.json
@@ -112,6 +112,70 @@
                     }
                 }
             },
+            "ServiceOperationWithStructurePayload": {
+                "type": "operation",
+                "output": "ServiceOperationWithStructurePayloadOutput",
+                "http": {
+                    "uri": "/ServiceOperationWithStructurePayload",
+                    "method": "POST",
+                    "code": 200
+                }
+            },
+            "ServiceOperationWithStructurePayloadOutput": {
+                "type": "structure",
+                "members": {
+                    "baz": {
+                        "target": "StructurePayload",
+                        "httpPayload": true
+                    }
+                }
+            },
+            "ServiceOperationWithMediaType": {
+                "type": "operation",
+                "output": "ServiceOperationWithMediaTypeOutput",
+                "http": {
+                    "uri": "/ServiceOperationWithMediaType",
+                    "method": "POST",
+                    "code": 200
+                }
+            },
+            "ServiceOperationWithMediaTypeOutput": {
+                "type": "structure",
+                "members": {
+                    "baz": {
+                        "target": "XmlBlob",
+                        "httpPayload": true
+                    }
+                }
+            },
+            "ServiceOperationWithBlobPayload": {
+                "type": "operation",
+                "output": "ServiceOperationWithBlobPayloadOutput",
+                "http": {
+                    "uri": "/ServiceOperationWithMediaType",
+                    "method": "POST",
+                    "code": 200
+                }
+            },
+            "ServiceOperationWithBlobPayloadOutput": {
+                "type": "structure",
+                "members": {
+                    "baz": {
+                        "target": "Blob",
+                        "httpPayload": true
+                    }
+                }
+            },
+            "XmlBlob": {
+                "type": "blob",
+                "mediaType": "application/xml"
+            },
+            "StructurePayload": {
+                "type": "structure",
+                "members": {
+                    "foo": {"target": "String"}
+                }
+            },
             "WithLabels": {
                 "type": "operation",
                 "input": "WithLabelsInput",

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/ModelUtils.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/ModelUtils.java
@@ -20,7 +20,6 @@ import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
-import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.model.ParameterObject;
@@ -32,6 +31,7 @@ import software.amazon.smithy.openapi.model.ParameterObject;
  * public if needed.
  */
 final class ModelUtils {
+
     private ModelUtils() {}
 
     /**
@@ -47,29 +47,6 @@ final class ModelUtils {
     static <T extends Trait> Optional<T> getMemberTrait(Context context, Shape shape, Class<T> trait) {
         return shape.asMemberShape()
                 .flatMap(member -> member.getMemberTrait(context.getModel().getShapeIndex(), trait));
-    }
-
-    /**
-     * Gets the mediaType trait value of the shape targeted by a member.
-     *
-     * @param context Context used to resolve targets.
-     * @param member Members to resolve.
-     * @return Returns the resolved media type.
-     */
-    static String getMediaType(Context context, MemberShape member) {
-        return getMemberTrait(context, member, MediaTypeTrait.class)
-                .map(MediaTypeTrait::getValue)
-                .orElseGet(() -> context.getModel().getShapeIndex().getShape(member.getTarget())
-                        .map(target -> {
-                            if (target.isStringShape()) {
-                                return "text/plain";
-                            } else if (target.isBlobShape()) {
-                                return "application/octet-stream";
-                            } else {
-                                return "application/octet-stream";
-                            }
-                        })
-                        .orElse("application/octet-stream"));
     }
 
     /**


### PR DESCRIPTION
This commit adds support for exposing content-type resolution of
operations that use HTTP bindings. It supports resolving the request or
response content-type of structured payloads, blob payloads, string
payloads, payloads with a @mediaType trait, and operations with no
payloads at all.

This functionality is now used in the OpenAPI conversions, and can be
used in protocol code generators too.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
