### PR TITLE
Allow plugins to be run serially

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.9.0"
+    version = "0.9.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/docs/source/guides/building-models/gradle-plugin.rst
+++ b/docs/source/guides/building-models/gradle-plugin.rst
@@ -153,7 +153,7 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
         }
 
         dependencies {
-            api("software.amazon.smithy:smithy-model:0.9.0")
+            api("software.amazon.smithy:smithy-model:0.9.1")
 
             // These are just examples of dependencies. This model has a dependency on
             // a "common" model package and uses the external AWS traits.
@@ -196,7 +196,7 @@ build that uses the "external" projection.
                 mavenCentral()
             }
             dependencies {
-                classpath("software.amazon.smithy:smithy-aws-traits:0.9.0")
+                classpath("software.amazon.smithy:smithy-aws-traits:0.9.1")
 
                 // Take a dependency on the internal model package. This
                 // dependency *must* be a buildscript only dependency to ensure
@@ -220,7 +220,7 @@ build that uses the "external" projection.
         }
 
         dependencies {
-            api("software.amazon.smithy:smithy-model:0.9.0")
+            api("software.amazon.smithy:smithy-model:0.9.1")
 
             // Any dependencies that the projected model needs must be (re)declared
             // here. For example, let's assume that the smithy-aws-traits package is
@@ -331,7 +331,7 @@ The above Smithy plugin also requires a ``buildscript`` dependency in
 
                 // This dependency is required in order to apply the "openapi"
                 // plugin in smithy-build.json
-                classpath("software.amazon.smithy:smithy-openapi:0.9.0")
+                classpath("software.amazon.smithy:smithy-openapi:0.9.1")
             }
         }
 

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -106,7 +106,7 @@ specification from a Smithy model using a buildscript dependency:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.0")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.1")
         }
     }
 
@@ -132,7 +132,7 @@ that builds an OpenAPI specification from a service for the
 
 .. important::
 
-    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.0" is
+    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.1" is
     required in order for smithy-build to map the "openapi" plugin name to the
     correct Java library implementation.
 
@@ -338,7 +338,7 @@ dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.0")
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.1")
         }
     }
 
@@ -516,7 +516,7 @@ shows how to install ``software.amazon.smithy:smithy-openapi`` through Gradle:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.0")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.1")
         }
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -153,6 +153,11 @@ final class SmithyBuildImpl {
     SmithyBuildResult applyAllProjections() {
         Model resolvedModel = createBaseModel();
         SmithyBuildResult.Builder builder = SmithyBuildResult.builder();
+
+        // The projections are being split up here because we need to be able to break out non-parallelizeable plugins.
+        // Right now the only parallelization that occurs is at the projection level though, which is why the split is
+        // here instead of somewhere else.
+        // TODO: Run all parallelizeable plugins across all projections in parallel, followed by all serial plugins
         Map<String, ProjectionConfig> serialProjections = new TreeMap<>();
         Map<String, ProjectionConfig> parallelProjections = new TreeMap<>();
         config.getProjections().entrySet().stream()

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildPlugin.java
@@ -62,6 +62,19 @@ public interface SmithyBuildPlugin {
     }
 
     /**
+     * Plugins can choose whether or not projections they are in can be run in
+     * parallel with other projections.
+     *
+     * <p>By default plugins allow parallel execution.</p>
+     *
+     * @return Returns true if the plugin should be run serially, false if it
+     *  can be run in parallel with other plugins.
+     */
+    default boolean isSerial() {
+        return false;
+    }
+
+    /**
      * Executes the plugin, creating any number of artifacts.
      *
      * @param context Plugin context for build execution.

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test1ParallelPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test1ParallelPlugin.java
@@ -1,0 +1,18 @@
+package software.amazon.smithy.build;
+
+public class Test1ParallelPlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "test1Parallel";
+    }
+
+    @Override
+    public boolean isSerial() {
+        return false;
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        context.getFileManifest().writeFile("hello1Parallel", String.format("%s", System.currentTimeMillis()));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test1SerialPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test1SerialPlugin.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.build;
+
+import java.util.concurrent.TimeUnit;
+
+public class Test1SerialPlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "test1Serial";
+    }
+
+    @Override
+    public boolean isSerial() {
+        return true;
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        context.getFileManifest().writeFile("hello1Serial", String.format("%s", System.currentTimeMillis()));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test2ParallelPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test2ParallelPlugin.java
@@ -1,0 +1,18 @@
+package software.amazon.smithy.build;
+
+public class Test2ParallelPlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "test2Parallel";
+    }
+
+    @Override
+    public boolean isSerial() {
+        return false;
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        context.getFileManifest().writeFile("hello2Parallel", String.format("%s", System.currentTimeMillis()));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test2SerialPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test2SerialPlugin.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.build;
+
+import java.util.concurrent.TimeUnit;
+
+public class Test2SerialPlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "testSerial2";
+    }
+
+    @Override
+    public boolean isSerial() {
+        return true;
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        context.getFileManifest().writeFile("hello2Serial", String.format("%s", System.currentTimeMillis()));
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/applies-serial-plugins.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/applies-serial-plugins.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "projections": {
+    "source": {
+      "plugins": {
+        "test1Parallel": {"hello": "there"},
+        "test1Serial": {"hello": "foo"},
+        "test2Parallel": {"hello": "bar"}
+      }
+    },
+    "a": {
+      "plugins": {
+        "test1Serial": {"hello": "foo"},
+        "test2Serial": {"hello": "bar"}
+      }
+    },
+    "b": {
+      "plugins": {
+        "test1Parallel": {"hello": "there"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change allows plugins to declare that they cannot be run in parallel
with other plugins. Any projection with such plugins will be run serially.
Parallelizeable projections will then be run in parallel afterwards.

Note that plugins already ran serially with respect to other plugins in the
same projection, and that behavior persists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.