### PR TITLE
Include global plugins in serial/parallel choice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ dist: trusty
 
 install: /bin/true
 
-script: ./gradlew -q clean build
+script: ./gradlew clean build

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -166,7 +166,7 @@ final class SmithyBuildImpl {
                 .sorted(Comparator.comparing(Map.Entry::getKey))
                 .forEach(e -> {
                     // Check to see if any of the plugins in the projection require the projection be run serially
-                    boolean isSerial = e.getValue().getPlugins().keySet().stream().anyMatch(pluginName -> {
+                    boolean isSerial = resolvePlugins(e.getValue()).keySet().stream().anyMatch(pluginName -> {
                         Optional<SmithyBuildPlugin> plugin = pluginFactory.apply(pluginName);
                         return plugin.isPresent() && plugin.get().isSerial();
                     });

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/applies-global-serial-plugins.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/applies-global-serial-plugins.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "projections": {
+    "a": {
+      "plugins": {
+        "test1Parallel": {"hello": "there"}
+      }
+    },
+    "b": {
+      "plugins": {
+        "test2Parallel": {"hello": "there"}
+      }
+    }
+  },
+  "plugins": {
+    "test1Serial": {"hello": "foo"}
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Previously global plugins were not being included in the determination of
whether a projection was serial or parallel.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.