### PR TITLE
Add helper to EnumTrait to check if has names

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
@@ -54,6 +54,18 @@ public final class EnumTrait extends AbstractTrait implements ToSmithyBuilder<En
         return constants;
     }
 
+    /**
+     * Checks if all of the constants of an enum define a name.
+     *
+     * <p>Note that either all constants must have a name or no constants can
+     * have a name.
+     *
+     * @return Returns true if all constants define a name.
+     */
+    public boolean hasNames() {
+        return constants.values().stream().allMatch(body -> body.getName().isPresent());
+    }
+
     @Override
     protected Node createNode() {
         return constants.entrySet().stream()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/EnumTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/EnumTraitTest.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.traits;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -44,5 +45,13 @@ public class EnumTraitTest {
             TraitFactory provider = TraitFactory.createServiceFactory();
             provider.createTrait(ShapeId.from("smithy.api#enum"), ShapeId.from("ns.qux#foo"), Node.objectNode());
         });
+    }
+
+    @Test
+    public void checksIfAllDefineNames() {
+        Node node = Node.parse("{\"foo\": {\"name\": \"FOO\"}, \"bam\": {\"name\": \"BAM\"}}");
+        EnumTrait trait = new EnumTrait.Provider().createTrait(ShapeId.from("ns.foo#baz"), node);
+
+        assertThat(trait.hasNames(), is(true));
     }
 }


### PR DESCRIPTION
This EnumTrait helper function checks if the trait provides a name for
each enum constant. This is useful since it will often determine whether
or not a concrete type should be generated for the enum string or if
codegen should just rely on a normal string type.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
