### PR TITLE
Allow using path expressions in paginator outputs

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -4045,7 +4045,7 @@ settings from a service.
             }
         }
 
-The values for ``outputToken`` and ``items`` are paths. Paths are a series of
+The values for ``outputToken`` and ``items`` are paths. *Paths* are a series of
 identifiers separated by dots (``.``) where each identifier represents a
 member name in a structure. The first member name MUST correspond to a member
 of the output structure and each subsequent member name MUST correspond to a
@@ -4056,7 +4056,7 @@ following ABNF.
     path    :`identifier` *("." `identifier`)
 
 The following example defines a paginated operation which uses a result
-wrapper where the output token and items are indicated with paths.
+wrapper where the output token and items are referenced by paths.
 
 .. tabs::
 
@@ -4064,7 +4064,7 @@ wrapper where the output token and items are indicated with paths.
 
         namespace smithy.example
 
-        @collection @readonly
+        @readonly
         @paginated(inputToken: "nextToken", outputToken: "result.nextToken",
                    pageSize: "maxResults", items: "result.foos")
         operation GetFoos(GetFoosInput) -> GetFoosOutput
@@ -4101,7 +4101,6 @@ wrapper where the output token and items are indicated with paths.
                         "input" :"GetFoosInput",
                         "output": "GetFoosOutput",
                         "readonly": true,
-                        "collection": true,
                         "paginated": {
                             "inputToken": "nextToken",
                             "outputToken": "result.nextToken",

--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3883,7 +3883,7 @@ The ``paginated`` trait is an object that contains the following properties:
         the service that contains the operation.
     * - outputToken
       - ``string``
-      - The name of the operation output member that contains an optional
+      - The path to the operation output member that contains an optional
         continuation token. When this value is present in operation output,
         it indicates that there are more results to retrieve. To get the next
         page of results, the client passes the received output continuation
@@ -3896,7 +3896,7 @@ The ``paginated`` trait is an object that contains the following properties:
         the service that contains the operation.
     * - items
       - ``string``
-      - The name of a top-level output member of the operation that contains
+      - The path to an output member of the operation that contains
         the data that is being paginated across many responses. The named
         output member, if specified, MUST target a list or map.
     * - pageSize
@@ -4040,6 +4040,112 @@ settings from a service.
                         "readonly": true,
                         "collection": true,
                         "paginated": {"items": "foos"}
+                    }
+                }
+            }
+        }
+
+The values for ``outputToken`` and ``items`` are paths. Paths are a series of
+identifiers separated by dots (``.``) where each identifier represents a
+member name in a structure. The first member name MUST correspond to a member
+of the output structure and each subsequent member name MUST correspond to a
+member in the previously referenced structure. Paths MUST adhere to the
+following ABNF.
+
+.. productionlist:: smithy
+    path    :`identifier` *("." `identifier`)
+
+The following example defines a paginated operation which uses a result
+wrapper where the output token and items are indicated with paths.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        namespace smithy.example
+
+        @collection @readonly
+        @paginated(inputToken: "nextToken", outputToken: "result.nextToken",
+                   pageSize: "maxResults", items: "result.foos")
+        operation GetFoos(GetFoosInput) -> GetFoosOutput
+
+        structure GetFoosInput {
+            maxResults: Integer,
+            nextToken: String
+        }
+
+        structure GetFoosOutput {
+            @required
+            result: ResultWrapper
+        }
+
+        structure ResultWrapper {
+            nextToken: String,
+
+            @required
+            foos: StringList,
+        }
+
+        list StringList {
+            member: String
+        }
+
+    .. code-tab:: json
+
+        {
+            "smithy": "0.4.0",
+            "smithy.example": {
+                "shapes": {
+                    "GetFoos": {
+                        "type": "operation",
+                        "input" :"GetFoosInput",
+                        "output": "GetFoosOutput",
+                        "readonly": true,
+                        "collection": true,
+                        "paginated": {
+                            "inputToken": "nextToken",
+                            "outputToken": "result.nextToken",
+                            "pageSize": "maxResults",
+                            "items": "result.foos"
+                        }
+                    },
+                    "GetFoosInput": {
+                        "type": "structure",
+                        "members": {
+                            "maxResults": {
+                                "target": "Integer"
+                            }
+                            "nextToken": {
+                                "target": "String"
+                            }
+                        }
+                    },
+                    "GetFoosOutput": {
+                        "type": "structure",
+                        "members": {
+                            "result": {
+                                "target": "ResultWrapper",
+                                "required": true
+                            }
+                        }
+                    },
+                    "ResultWrapper": {
+                        "type": "structure",
+                        "members": {
+                            "nextToken": {
+                                "target": "String"
+                            },
+                            "foos": {
+                                "target": "StringList",
+                                "required": true
+                            }
+                        }
+                    },
+                    "StringList": {
+                        "type": "list",
+                        "member": {
+                            "target": "String"
+                        }
                     }
                 }
             }

--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -4045,7 +4045,7 @@ settings from a service.
             }
         }
 
-The values for ``outputToken`` and ``items`` are paths. *Paths* are a series of
+The values for ``outputToken`` and ``items`` are paths. :dfn:`Paths` are a series of
 identifiers separated by dots (``.``) where each identifier represents a
 member name in a structure. The first member name MUST correspond to a member
 of the output structure and each subsequent member name MUST correspond to a

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -131,6 +131,12 @@ public final class PaginatedTraitValidator extends AbstractValidator {
                    : Collections.emptyList();
         }
 
+        if (!validator.pathsAllowed() && memberPath.split("\\.").length != 1) {
+            return Collections.singletonList(error(operation, trait, String.format(
+                    "%spaginated trait `%s` does not allow path values", prefix, validator.propertyName()
+            )));
+        }
+
         MemberShape member = validator.getMember(index, opIndex, operation, trait).orElse(null);
         if (member == null) {
             return Collections.singletonList(error(operation, trait, String.format(
@@ -154,6 +160,13 @@ public final class PaginatedTraitValidator extends AbstractValidator {
                     ValidationUtils.tickedList(validator.validTargets()))));
         }
 
+        if (validator.pathsAllowed() && memberPath.split("\\.").length > 2) {
+            events.add(warning(operation, trait, String.format(
+                    "%spaginated trait `%s` should not include a path with more than two parts",
+                    prefix, validator.propertyName()
+            )));
+        }
+
         return events;
     }
 
@@ -171,9 +184,18 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         abstract Optional<MemberShape> getMember(
                 ShapeIndex index, OperationIndex opIndex, OperationShape operation, PaginatedTrait trait
         );
+
+        boolean pathsAllowed() {
+            return false;
+        }
     }
 
     private abstract static class OutputPropertyValidator extends PropertyValidator {
+
+        @Override
+        boolean pathsAllowed() {
+            return true;
+        }
 
         Optional<MemberShape> getMember(
                 ShapeIndex index, OperationIndex opIndex, OperationShape operation, PaginatedTrait trait

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
@@ -61,6 +62,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
     private static final Set<ShapeType> ITEM_SHAPES = SetUtils.of(ShapeType.LIST, ShapeType.MAP);
     private static final Set<ShapeType> PAGE_SHAPES = SetUtils.of(ShapeType.INTEGER);
     private static final Set<ShapeType> STRING_SET = SetUtils.of(ShapeType.STRING);
+    private static final java.util.regex.Pattern PATH_PATTERN = Pattern.compile("\\.");
 
     @Override
     public List<ValidationEvent> validate(Model model) {
@@ -131,7 +133,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
                    : Collections.emptyList();
         }
 
-        if (!validator.pathsAllowed() && memberPath.split("\\.").length != 1) {
+        if (!validator.pathsAllowed() && memberPath.contains(".")) {
             return Collections.singletonList(error(operation, trait, String.format(
                     "%spaginated trait `%s` does not allow path values", prefix, validator.propertyName()
             )));
@@ -160,7 +162,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
                     ValidationUtils.tickedList(validator.validTargets()))));
         }
 
-        if (validator.pathsAllowed() && memberPath.split("\\.").length > 2) {
+        if (validator.pathsAllowed() && PATH_PATTERN.split(memberPath).length > 2) {
             events.add(warning(operation, trait, String.format(
                     "%spaginated trait `%s` should not include a path with more than two parts",
                     prefix, validator.propertyName()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -164,7 +164,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
 
         if (validator.pathsAllowed() && PATH_PATTERN.split(memberPath).length > 2) {
             events.add(warning(operation, trait, String.format(
-                    "%spaginated trait `%s` should not include a path with more than two parts",
+                    "%spaginated trait `%s` contains a path with more than two parts, which can make your API "
+                        + "cumbersome to use",
                     prefix, validator.propertyName()
             )));
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/PaginatedTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/PaginatedTraitTest.java
@@ -97,4 +97,35 @@ public class PaginatedTraitTest {
         assertThat(trait3.getPageSize(), equalTo(Optional.of("bar")));
         assertThat(trait3.getItems(), equalTo(Optional.of("baz")));
     }
+
+    @Test
+    public void allowsNestedOutputToken() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Node node = Node.objectNode()
+                .withMember("inputToken", Node.from("inputToken"))
+                .withMember("outputToken", Node.from("result.outputToken"));
+
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#paginated"), ShapeId.from("ns.qux#foo"), node);
+        assertThat(trait.isPresent(), is(true));
+        assertThat(trait.get(), instanceOf(PaginatedTrait.class));
+        PaginatedTrait paginatedTrait = (PaginatedTrait) trait.get();
+        assertThat(paginatedTrait.getOutputToken(), equalTo(Optional.of("result.outputToken")));
+    }
+
+    @Test
+    public void allowsNestedOutputItems() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Node node = Node.objectNode()
+                .withMember("items", Node.from("result.items"))
+                .withMember("inputToken", Node.from("inputToken"))
+                .withMember("outputToken", Node.from("outputToken"));
+
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#paginated"), ShapeId.from("ns.qux#foo"), node);
+        assertThat(trait.isPresent(), is(true));
+        assertThat(trait.get(), instanceOf(PaginatedTrait.class));
+        PaginatedTrait paginatedTrait = (PaginatedTrait) trait.get();
+        assertThat(paginatedTrait.getItems(), equalTo(Optional.of("result.items")));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/PaginatedTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/PaginatedTraitTest.java
@@ -104,9 +104,9 @@ public class PaginatedTraitTest {
         Node node = Node.objectNode()
                 .withMember("inputToken", Node.from("inputToken"))
                 .withMember("outputToken", Node.from("result.outputToken"));
-
         Optional<Trait> trait = provider.createTrait(
                 ShapeId.from("smithy.api#paginated"), ShapeId.from("ns.qux#foo"), node);
+
         assertThat(trait.isPresent(), is(true));
         assertThat(trait.get(), instanceOf(PaginatedTrait.class));
         PaginatedTrait paginatedTrait = (PaginatedTrait) trait.get();
@@ -120,9 +120,9 @@ public class PaginatedTraitTest {
                 .withMember("items", Node.from("result.items"))
                 .withMember("inputToken", Node.from("inputToken"))
                 .withMember("outputToken", Node.from("outputToken"));
-
         Optional<Trait> trait = provider.createTrait(
                 ShapeId.from("smithy.api#paginated"), ShapeId.from("ns.qux#foo"), node);
+
         assertThat(trait.isPresent(), is(true));
         assertThat(trait.get(), instanceOf(PaginatedTrait.class));
         PaginatedTrait paginatedTrait = (PaginatedTrait) trait.get();

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
@@ -18,7 +18,7 @@
 [ERROR] ns.foo#UnresolvedOutput$nextToken: member shape targets an unresolved shape `ns.foo#Missing` | Target
 [ERROR] ns.foo#Invalid9: When bound within the `ns.foo#Service` service, paginated trait `inputToken` is not configured | PaginatedTrait
 [ERROR] ns.foo#Invalid9: When bound within the `ns.foo#Service` service, paginated trait `outputToken` is not configured | PaginatedTrait
-[WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `items` should not include a path with more than two parts | PaginatedTrait
-[WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `outputToken` should not include a path with more than two parts | PaginatedTrait
+[WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `items` contains a path with more than two parts, which can make your API cumbersome to use | PaginatedTrait
+[WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `outputToken` contains a path with more than two parts, which can make your API cumbersome to use | PaginatedTrait
 [ERROR] ns.foo#InvalidNestedInput: paginated trait `inputToken` does not allow path values | PaginatedTrait
 [ERROR] ns.foo#InvalidNestedInput: paginated trait `pageSize` does not allow path values | PaginatedTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
@@ -18,3 +18,7 @@
 [ERROR] ns.foo#UnresolvedOutput$nextToken: member shape targets an unresolved shape `ns.foo#Missing` | Target
 [ERROR] ns.foo#Invalid9: When bound within the `ns.foo#Service` service, paginated trait `inputToken` is not configured | PaginatedTrait
 [ERROR] ns.foo#Invalid9: When bound within the `ns.foo#Service` service, paginated trait `outputToken` is not configured | PaginatedTrait
+[WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `items` should not include a path with more than two parts | PaginatedTrait
+[WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `outputToken` should not include a path with more than two parts | PaginatedTrait
+[ERROR] ns.foo#InvalidNestedInput: paginated trait `inputToken` does not allow path values | PaginatedTrait
+[ERROR] ns.foo#InvalidNestedInput: paginated trait `pageSize` does not allow path values | PaginatedTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
@@ -55,6 +55,25 @@
                 "input": "ValidInput",
                 "output": "ValidWrappedOutput"
             },
+            "DeeplyNestedOutputOperation": {
+                "type": "operation",
+                "readonly": true,
+                "paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "output.result.nextToken",
+                    "items": "output.result.items"
+                },
+                "input": "ValidInput",
+                "output": "DeeplyNestedOutput"
+            },
+            "DeeplyNestedOutput": {
+                "type": "structure",
+                "members": {
+                    "output": {
+                        "target": "ValidWrappedOutput"
+                    }
+                }
+            },
             "ValidWrappedOutput": {
                 "type": "structure",
                 "members": {
@@ -304,6 +323,25 @@
                 "paginated": true,
                 "input": "ValidInput",
                 "output": "ValidOutput"
+            },
+            "InvalidNestedInput": {
+                "type": "operation",
+                "paginated": {
+                    "inputToken": "input.nextToken",
+                    "outputToken": "nextToken",
+                    "items": "items",
+                    "pageSize": "input.pageSize"
+                },
+                "input": "NestedInput",
+                "output": "ValidOutput"
+            },
+            "NestedInput": {
+                "type": "structure",
+                "members": {
+                    "input": {
+                        "target": "ValidInput"
+                    }
+                }
             },
             "ValidInput": {
                 "type": "structure",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
@@ -44,6 +44,25 @@
                 "input": "ValidInput3",
                 "output": "ValidOutput3"
             },
+            "ValidNestedOutputOperation": {
+                "type": "operation",
+                "readonly": true,
+                "paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "result.nextToken",
+                    "items": "result.items"
+                },
+                "input": "ValidInput",
+                "output": "ValidWrappedOutput"
+            },
+            "ValidWrappedOutput": {
+                "type": "structure",
+                "members": {
+                    "result": {
+                        "target": "ValidOutput"
+                    }
+                }
+            },
             "ValidInput3": {
                 "type": "structure",
                 "members": {


### PR DESCRIPTION
*Description of changes:*

This allows the use of path expressions in paginator outputs. This enables
customers to have result wrapper shapes, which is a common pattern in XML
protocols.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.