### PR TITLE
Add method to get non-trait shapes

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
@@ -8,6 +8,8 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.ProjectionConfig;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeIndex;
+import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.ListUtils;
 
 public class PluginContextTest {
@@ -41,5 +43,22 @@ public class PluginContextTest {
                 .build();
 
         assertThat(context.getSources(), contains(Paths.get("/foo/baz")));
+    }
+
+    @Test
+    public void createsNonTraitShapeIndex() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-model.json"))
+                .assemble()
+                .unwrap();
+        ShapeIndex scrubbed = ModelTransformer.create().getNonTraitShapes(model);
+        PluginContext context = PluginContext.builder()
+                .fileManifest(new MockManifest())
+                .model(model)
+                .sources(ListUtils.of(Paths.get("/foo/baz")))
+                .build();
+
+        assertThat(context.getNonTraitShapes(), equalTo(scrubbed));
+        assertThat(context.getNonTraitShapes(), equalTo(scrubbed)); // trigger loading from cache
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
@@ -26,6 +26,8 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIndex;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.ReadonlyTrait;
 
 public class ModelTransformerTest {
 
@@ -44,6 +46,18 @@ public class ModelTransformerTest {
                           Matchers.is(Optional.empty()));
         assertThat(index.getShape(operation).get().asOperationShape().map(OperationShape::getErrors),
                           Matchers.equalTo(Optional.of(Collections.emptyList())));
+    }
+
+    @Test
+    public void removesTraitShapesButNotTraitUsage() {
+        ModelTransformer transformer = ModelTransformer.create();
+        Model model = createTestModel();
+        ShapeIndex index = transformer.getNonTraitShapes(model);
+        ShapeId operation = ShapeId.from("ns.foo#MyOperation");
+
+        assertThat(index.getShape(operation), Matchers.not(Optional.empty()));
+        assertThat(index.getShape(operation).get().getTrait(ReadonlyTrait.class), Matchers.not(Optional.empty()));
+        assertThat(index.getShape(EnumTrait.ID), Matchers.equalTo(Optional.empty()));
     }
 
     private Model createTestModel() {


### PR DESCRIPTION
This commit adds a method to ModelTransformer to get all shapes from a
model that are not only used as part of a trait or definition of a
trait. This makes it easier for code generators to get a shape index
that contains only shapes that they typically want to generate.

A convenience method was added to PluginContext to make this more
apparent when implementing SmithyBuild plugins. The result is also
cached since it can be an expensive thing to compute.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
