### PR TITLE
fix timestamp test cases

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -172,9 +172,15 @@ public class NodeValidationVisitorTest {
                 {"ns.foo#Timestamp", "\"2000-01-12T22:11:12\"", new String[] {"Invalid string value, `2000-01-12T22:11:12`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
                 {"ns.foo#Timestamp", "\"2000-01-12T22:11:12+\"", new String[] {"Invalid string value, `2000-01-12T22:11:12+`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
                 {"ns.foo#Timestamp", "\"200-01-12T22:11:12Z\"", new String[] {"Invalid string value, `200-01-12T22:11:12Z`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
-                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12+01:02\"", new String[] {"Invalid string value, `2000-01-12T22:11:12+01:02`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
-                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12-11:00\"", new String[] {"Invalid string value, `2000-01-12T22:11:12-11:00`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
 
+                // Improperly formatted because the offset is not in formatted correctly
+                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12+01:020\"", new String[] {"Invalid string value, `2000-01-12T22:11:12+01:020`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
+                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12-11:0X\"", new String[] {"Invalid string value, `2000-01-12T22:11:12-11:0X`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
+                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12+05:99\"", new String[] {"Invalid string value, `2000-01-12T22:11:12+05:99`, provided for timestamp, `ns.foo#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
+
+                // Time offsets with non-zero minutes are allowed by RFC 3339 because some timezones require it, e.g. India is UTC+5:30
+                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12-01:02\"", null},
+                {"ns.foo#Timestamp", "\"2000-01-12T22:11:12+05:30\"", null},
 
                 // string
                 {"ns.foo#String1", "\"true\"", null},
@@ -244,7 +250,8 @@ public class NodeValidationVisitorTest {
                 {"ns.foo#DateTime", "1234", new String[] {"Expected a string value for a date-time timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
                 {"ns.foo#DateTime", "\"1985-04-12\"", new String[] {"Invalid string value, `1985-04-12`, provided for timestamp, `ns.foo#DateTime`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
                 {"ns.foo#DateTime", "\"Tuesday, 29 April 2014 18:30:38 GMT\"", new String[] {"Invalid string value, `Tuesday, 29 April 2014 18:30:38 GMT`, provided for timestamp, `ns.foo#DateTime`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
-                {"ns.foo#DateTime", "\"1985-04-12T23:20:50.52-07:00\"", new String[] {"Invalid string value, `1985-04-12T23:20:50.52-07:00`, provided for timestamp, `ns.foo#DateTime`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
+                {"ns.foo#DateTime", "\"1985-04-12T23:20:50.52-07:00_\"", new String[] {"Invalid string value, `1985-04-12T23:20:50.52-07:00_`, provided for timestamp, `ns.foo#DateTime`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
+                {"ns.foo#DateTime", "\"1985-04-12T23:20:50.52-07:00\"", null},
 
                 // epoch seconds
                 {"ns.foo#EpochSeconds", "123", null},
@@ -252,9 +259,9 @@ public class NodeValidationVisitorTest {
 
                 // timestamp member with format.
                 {"ns.foo#TimestampList", "[\"1985-04-12T23:20:50.52Z\"]", null},
-                {"ns.foo#TimestampList", "[\"1985-04-12T23:20:50.52-07:00\"]", new String[] {
-                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00`, provided for timestamp, `smithy.api#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")",
-                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00`, provided for timestamp, `ns.foo#TimestampList$member`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"
+                {"ns.foo#TimestampList", "[\"1985-04-12T23:20:50.52-07:00_\"]", new String[] {
+                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00_`, provided for timestamp, `smithy.api#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")",
+                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00_`, provided for timestamp, `ns.foo#TimestampList$member`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"
                 }},
                 {"ns.foo#TimestampList", "[123]", new String[] {"0: Expected a string value for a date-time timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
 


### PR DESCRIPTION
Trying to get a foothold in the project.

This may be a Java SDK version issue? Not sure. Using 12.

There were several timestamps that are valid per RFC 3339, but the tests were asserting that these were invalid. I double-checked RFC 3339. In any event, when I built master I received test failures and this PR fixed them. If the maintainers do not have test failures then it could be a Java version difference causing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
