### PR TITLE
Add method to write class resource to manifest

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/FileManifestTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/FileManifestTest.java
@@ -110,4 +110,12 @@ public class FileManifestTest {
         assertThat(Files.isRegularFile(outputDirectory.resolve("foo/file.txt")), is(true));
         assertThat(new String(Files.readAllBytes(outputDirectory.resolve("foo/file.txt"))), equalTo("The contents"));
     }
+
+    @Test
+    public void writesClassResources() {
+        FileManifest a = FileManifest.create(outputDirectory);
+        a.writeFile("test.txt", getClass(), "simple-config.json");
+
+        assertThat(Files.isRegularFile(outputDirectory.resolve("test.txt")), is(true));
+    }
 }


### PR DESCRIPTION
Writing a class resource to a file manifest by calling
getClass().getResourceAsStream("...") will trip up static analysis tools
like SpotBugs since the InputStream is never closed. This commit adds
methods to write resources from a class into a FileManifest that avoid
this issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
