### PR TITLE
Allow authType to be specified

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -97,8 +97,7 @@ final class AddAuthorizers implements OpenApiMapper {
                 if (converter.getAuthSchemeName().equals(scheme)) {
                     SecurityScheme createdScheme = converter.createSecurityScheme(context);
                     SecurityScheme.Builder schemeBuilder = createdScheme.toBuilder();
-                    schemeBuilder.putExtension(
-                            CLIENT_EXTENSION_NAME, determineApiGatewayClientName(authorizer.getScheme()));
+                    schemeBuilder.putExtension(CLIENT_EXTENSION_NAME, authorizer.getAuthType());
 
                     ObjectNode authorizerNode = Node.objectNodeBuilder()
                             .withOptionalMember("type", authorizer.getType().map(Node::from))
@@ -123,14 +122,5 @@ final class AddAuthorizers implements OpenApiMapper {
 
         builder.components(components.build());
         return builder.build();
-    }
-
-    // TODO: should this also allow overrides via configuration properties?
-    private static String determineApiGatewayClientName(String value) {
-        if (value.equals("aws.v4")) {
-            return "awsSigv4";
-        } else {
-            return "custom";
-        }
     }
 }

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/custom-auth-type-authorizer.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/custom-auth-type-authorizer.json
@@ -1,0 +1,19 @@
+{
+    "smithy": "0.4.0",
+    "ns.foo": {
+        "shapes": {
+            "SomeService": {
+                "type": "service",
+                "version": "2018-03-17",
+                "protocols": [{"name": "aws.rest-json", "auth": ["aws.v4"]}],
+                "aws.apigateway#authorizer": "sigv4",
+                "aws.apigateway#authorizers": {
+                    "sigv4": {
+                        "scheme": "aws.v4",
+                        "customAuthType": "myCustomType"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerDefinition.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerDefinition.java
@@ -213,8 +213,8 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         AuthorizerDefinition that = (AuthorizerDefinition) o;
         return scheme.equals(that.scheme)
                && Objects.equals(type, that.type)
-               && authType.equals(that.authType)
                && Objects.equals(uri, that.uri)
+               && Objects.equals(authType, that.authType)
                && Objects.equals(credentials, that.credentials)
                && Objects.equals(identitySource, that.identitySource)
                && Objects.equals(identityValidationExpression, that.identityValidationExpression)

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerDefinition.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerDefinition.java
@@ -33,19 +33,23 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * @see AuthorizersTrait
  */
 public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<AuthorizerDefinition> {
+    private static final String SIGV4_AUTH_TYPE = "awsSigv4";
+    private static final String DEFAULT_AUTH_TYPE = "custom";
     private static final String SCHEME_KEY = "scheme";
     private static final String TYPE_KEY = "type";
+    private static final String AUTH_TYPE_KEY = "customAuthType";
     private static final String URI_KEY = "uri";
     private static final String CREDENTIALS_KEY = "credentials";
     private static final String IDENTITY_SOURCE_KEY = "identitySource";
     private static final String IDENTITY_VALIDATION_EXPRESSION_KEY = "identityValidationExpression";
     private static final String RESULT_TTL_IN_SECONDS = "resultTtlInSeconds";
     private static final List<String> PROPERTIES = ListUtils.of(
-            SCHEME_KEY, TYPE_KEY, URI_KEY, CREDENTIALS_KEY, IDENTITY_SOURCE_KEY,
+            SCHEME_KEY, TYPE_KEY, AUTH_TYPE_KEY, URI_KEY, CREDENTIALS_KEY, IDENTITY_SOURCE_KEY,
             IDENTITY_VALIDATION_EXPRESSION_KEY, RESULT_TTL_IN_SECONDS);
 
     private final String scheme;
     private final String type;
+    private final String authType;
     private final String uri;
     private final String credentials;
     private final String identitySource;
@@ -56,6 +60,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         scheme = SmithyBuilder.requiredState(SCHEME_KEY, builder.scheme);
         type = builder.type;
         uri = builder.uri;
+        authType = builder.authType;
         credentials = builder.credentials;
         identitySource = builder.identitySource;
         identityValidationExpression = builder.identityValidationExpression;
@@ -103,6 +108,25 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
      */
     public Optional<String> getUri() {
         return Optional.ofNullable(uri);
+    }
+
+    /**
+     * Gets the authType of the authorizer.
+     *
+     * <p>This value is not used directly by APIGateway but will be used for
+     * OpenAPI exports. This will default to "awsSigV4" if your scheme is
+     * "aws.v4", or "custom" otherwise.</p>
+     *
+     * @return Returns the authType.
+     */
+    public String getAuthType() {
+        if (authType != null) {
+            return authType;
+        } else if (scheme.equals("aws.v4")) {
+            return SIGV4_AUTH_TYPE;
+        } else {
+            return DEFAULT_AUTH_TYPE;
+        }
     }
 
     /**
@@ -156,6 +180,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
                 .scheme(scheme)
                 .type(type)
                 .uri(uri)
+                .authType(authType)
                 .credentials(credentials)
                 .identitySource(identitySource)
                 .identityValidationExpression(identityValidationExpression)
@@ -167,6 +192,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         return Node.objectNodeBuilder()
                 .withMember(SCHEME_KEY, Node.from(getScheme()))
                 .withOptionalMember(TYPE_KEY, getType().map(Node::from))
+                .withOptionalMember(AUTH_TYPE_KEY, Optional.ofNullable(authType).map(Node::from))
                 .withOptionalMember(URI_KEY, getUri().map(Node::from))
                 .withOptionalMember(CREDENTIALS_KEY, getCredentials().map(Node::from))
                 .withOptionalMember(IDENTITY_SOURCE_KEY, getIdentitySource().map(Node::from))
@@ -187,6 +213,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         AuthorizerDefinition that = (AuthorizerDefinition) o;
         return scheme.equals(that.scheme)
                && Objects.equals(type, that.type)
+               && authType.equals(that.authType)
                && Objects.equals(uri, that.uri)
                && Objects.equals(credentials, that.credentials)
                && Objects.equals(identitySource, that.identitySource)
@@ -206,6 +233,9 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         node.getStringMember(TYPE_KEY)
                 .map(StringNode::getValue)
                 .ifPresent(builder::type);
+        node.getStringMember(AUTH_TYPE_KEY)
+                .map(StringNode::getValue)
+                .ifPresent(builder::authType);
         node.getStringMember(URI_KEY)
                 .map(StringNode::getValue)
                 .ifPresent(builder::uri);
@@ -231,6 +261,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
     public static final class Builder implements SmithyBuilder<AuthorizerDefinition> {
         private String scheme;
         private String type;
+        private String authType;
         private String uri;
         private String credentials;
         private String identitySource;
@@ -267,6 +298,21 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
          */
         public Builder type(String type) {
             this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets the authType of the authorizer.
+         *
+         * <p>This value is not used directly by APIGateway but will be used
+         * for OpenAPI exports. This will default to "awsSigV4" if your scheme
+         * is "aws.v4", or "custom" otherwise.</p>
+         *
+         * @param authType the auth type (e.g. awsSigV4)
+         * @return Returns the builder.
+         */
+        public Builder authType(String authType) {
+            this.authType = authType;
             return this;
         }
 

--- a/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/aws/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -31,6 +31,10 @@
             "target": "smithy.api#String",
             "documentation": "The type of the authorizer. If specifying information beyond the scheme, this value is required. The value must be \"token\", for an authorizer with the caller identity embedded in an authorization token, or \"request\", for an authorizer with the caller identity contained in request parameters."
           },
+          "customAuthType": {
+            "target": "smithy.api#String",
+            "documentation": "This value is not used directly by APIGateway but will be used for OpenAPI exports. This will default to \"awsSigV4\" if your scheme is \"aws.v4\", or \"custom\" otherwise."
+          },
           "uri": {
             "target": "smithy.api#String",
             "documentation": "The Uniform Resource Identifier (URI) of the authorizer Lambda function"

--- a/docs/source/spec/amazon-apigateway.rst
+++ b/docs/source/spec/amazon-apigateway.rst
@@ -119,6 +119,11 @@ An *authorizer* definition is an object that supports the following properties:
         authorizer with the caller identity embedded in an authorization token,
         or "request", for an authorizer with the caller identity contained in
         request parameters.
+    * - customAuthType
+      - ``string``
+      - The ``authType`` of the authorizer. This value is used in APIGateway
+        exports as ``x-amazon-apigateway-authtype``. This value is set to
+        ``custom`` by default, or ``awsSigv4`` if your scheme is ``aws.v4``.
     * - uri
       - ``string``
       - Specifies the authorizer's Uniform Resource Identifier


### PR DESCRIPTION
This lets customers specify the `authType` themselves. Previously we
had always set it to `awsSigv4` or `custom` (depending on the
scheme), and that behavior is still the default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.