### PR TITLE
Add ability to alias referenced symbols

### DIFF
--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
@@ -16,9 +16,7 @@
 package software.amazon.smithy.codegen.core;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -229,13 +227,15 @@ public final class Symbol extends TypedPropertiesBag implements ToSmithyBuilder<
     /**
      * Builds a Symbol.
      */
-    public static final class Builder implements SmithyBuilder<Symbol> {
+    public static final class Builder
+            extends TypedPropertiesBag.Builder<Builder>
+            implements SmithyBuilder<Symbol> {
+
         private String name;
         private String namespace = "";
         private String namespaceDelimiter = "";
         private String definitionFile = "";
         private String declarationFile = "";
-        private Map<String, Object> properties = new HashMap<>();
         private List<SymbolReference> references = new ArrayList<>();
 
         @Override
@@ -264,41 +264,6 @@ public final class Symbol extends TypedPropertiesBag implements ToSmithyBuilder<
         public Builder namespace(String namespace, String namespaceDelimiter) {
             this.namespace = namespace == null ? "" : namespace;
             this.namespaceDelimiter = namespaceDelimiter == null ? "" : namespaceDelimiter;
-            return this;
-        }
-
-        /**
-         * Sets a specific custom property.
-         *
-         * @param key Key to set.
-         * @param value Value to set.
-         * @return Returns the builder.
-         */
-        public Builder putProperty(String key, Object value) {
-            properties.put(key, value);
-            return this;
-        }
-
-        /**
-         * Removes a specific custom property.
-         *
-         * @param key Key to remove.
-         * @return Returns the builder.
-         */
-        public Builder removeProperty(String key) {
-            properties.remove(key);
-            return this;
-        }
-
-        /**
-         * Replaces all of the custom properties.
-         *
-         * @param properties Custom properties to replace with.
-         * @return Returns the builder.
-         */
-        public Builder properties(Map<String, Object> properties) {
-            this.properties.clear();
-            this.properties.putAll(properties);
             return this;
         }
 

--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.codegen.core;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.smithy.utils.MapUtils;
@@ -94,5 +95,50 @@ class TypedPropertiesBag {
     public <T> T expectProperty(String name, Class<T> type) {
         return getProperty(name, type).orElseThrow(() -> new IllegalArgumentException(String.format(
                 "Property `%s` is not part of %s, `%s`", name, getClass().getSimpleName(), this)));
+    }
+
+    /**
+     * Builds a SymbolReference.
+     */
+    abstract static class Builder<T extends Builder> {
+        Map<String, Object> properties = new HashMap<>();
+
+        /**
+         * Sets a specific custom property.
+         *
+         * @param key Key to set.
+         * @param value Value to set.
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public T putProperty(String key, Object value) {
+            properties.put(key, value);
+            return (T) this;
+        }
+
+        /**
+         * Removes a specific custom property.
+         *
+         * @param key Key to remove.
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public T removeProperty(String key) {
+            properties.remove(key);
+            return (T) this;
+        }
+
+        /**
+         * Replaces all of the custom properties.
+         *
+         * @param properties Custom properties to replace with.
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public T properties(Map<String, Object> properties) {
+            this.properties.clear();
+            this.properties.putAll(properties);
+            return (T) this;
+        }
     }
 }

--- a/codegen/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolReferenceTest.java
+++ b/codegen/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolReferenceTest.java
@@ -1,6 +1,7 @@
 package software.amazon.smithy.codegen.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -30,5 +31,28 @@ public class SymbolReferenceTest {
         assertThat(ref1, not(equalTo(ref2)));
         assertThat(ref1, not(equalTo(ref3)));
         assertThat(ref2, not(equalTo(ref3)));
+    }
+
+    @Test
+    public void canAssignAlias() {
+        Symbol symbol = Symbol.builder().name("foo").build();
+        SymbolReference ref1 = SymbolReference.builder().symbol(symbol).alias("$foo").build();
+        SymbolReference ref2 = new SymbolReference(symbol);
+
+        assertThat(ref1, not(equalTo(ref2)));
+        assertThat(ref1.getSymbol().getName(), equalTo("foo"));
+        assertThat(ref1.getAlias(), equalTo("$foo"));
+        assertThat(ref1.toString(), containsString("'$foo'"));
+
+        assertThat(ref2.getSymbol().getName(), equalTo("foo"));
+        assertThat(ref2.getAlias(), equalTo("foo"));
+    }
+
+    @Test
+    public void convertsToBuilder() {
+        Symbol symbol = Symbol.builder().name("foo").build();
+        SymbolReference ref1 = SymbolReference.builder().symbol(symbol).alias("$foo").build();
+
+        assertThat(ref1.toBuilder().build(), equalTo(ref1));
     }
 }


### PR DESCRIPTION
This commit updates SymbolReference to now have an "alias" to allow a
symbol to be referenced with an alias. By default, the alias is assigned
the same value as the name of the referenced symbol. However, some code
generators may wish to alias referenced symbols to ensure that they do
not conflict with generated symbols (for example, you might want to
alias "SmithyStructure" as "$SmithyStructure" because no generated type
would ever start with '$').

Code generators that do not support or need aliases are free to ignore
this added property.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
