### PR TITLE
Add method to gather dependencies

### DIFF
--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java
@@ -144,8 +144,18 @@ public final class SymbolDependency extends TypedPropertiesBag
                         Collectors.toMap(
                                 SymbolDependency::getPackageName,
                                 Function.identity(),
-                                versionMergeFunction,
+                                guardedMerge(versionMergeFunction),
                                 TreeMap::new)));
+    }
+
+    private static BinaryOperator<SymbolDependency> guardedMerge(BinaryOperator<SymbolDependency> original) {
+        return (a, b) -> {
+            if (a.getVersion().equals(b.getVersion())) {
+                return b;
+            } else {
+                return original.apply(a, b);
+            }
+        };
     }
 
     /**

--- a/codegen/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolDependencyTest.java
+++ b/codegen/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolDependencyTest.java
@@ -68,6 +68,7 @@ public class SymbolDependencyTest {
     @Test
     public void gathersDependencies() {
         SymbolDependency a = SymbolDependency.builder().dependencyType("a").packageName("a").version("1").build();
+        SymbolDependency aDuplicate = a.toBuilder().build();
         SymbolDependency a2 = SymbolDependency.builder().dependencyType("a").packageName("a2").version("1").build();
         SymbolDependency a3 = SymbolDependency.builder().dependencyType("a2").packageName("a").version("1").build();
         SymbolDependency b = SymbolDependency.builder().dependencyType("b").packageName("b").version("1").build();
@@ -75,12 +76,12 @@ public class SymbolDependencyTest {
         SymbolDependency c = SymbolDependency.builder().dependencyType("b").packageName("c").version("1").build();
 
         Assertions.assertThrows(CodegenException.class, () -> {
-            SymbolDependency.gatherDependencies(Stream.of(a, a2, a3, b, b2, c));
+            SymbolDependency.gatherDependencies(Stream.of(a, aDuplicate, a2, a3, b, b2, c));
         });
 
         List<Pair<SymbolDependency, SymbolDependency>> conflicts = new ArrayList<>();
         Map<String, Map<String, SymbolDependency>> result = SymbolDependency.gatherDependencies(
-                Stream.of(a, a2, a3, b, b2, c),
+                Stream.of(a, aDuplicate, a2, a3, b, b2, c),
                 (sa, sb) -> {
                     conflicts.add(Pair.of(sa, sb));
                     return sb;

--- a/codegen/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolDependencyTest.java
+++ b/codegen/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolDependencyTest.java
@@ -3,11 +3,17 @@ package software.amazon.smithy.codegen.core;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.Pair;
 
 public class SymbolDependencyTest {
     @Test
@@ -57,5 +63,42 @@ public class SymbolDependencyTest {
         Collections.sort(dependencies);
 
         assertThat(dependencies, contains(a, a2, a3, b, b2, c));
+    }
+
+    @Test
+    public void gathersDependencies() {
+        SymbolDependency a = SymbolDependency.builder().dependencyType("a").packageName("a").version("1").build();
+        SymbolDependency a2 = SymbolDependency.builder().dependencyType("a").packageName("a2").version("1").build();
+        SymbolDependency a3 = SymbolDependency.builder().dependencyType("a2").packageName("a").version("1").build();
+        SymbolDependency b = SymbolDependency.builder().dependencyType("b").packageName("b").version("1").build();
+        SymbolDependency b2 = SymbolDependency.builder().dependencyType("b").packageName("b").version("2").build();
+        SymbolDependency c = SymbolDependency.builder().dependencyType("b").packageName("c").version("1").build();
+
+        Assertions.assertThrows(CodegenException.class, () -> {
+            SymbolDependency.gatherDependencies(Stream.of(a, a2, a3, b, b2, c));
+        });
+
+        List<Pair<SymbolDependency, SymbolDependency>> conflicts = new ArrayList<>();
+        Map<String, Map<String, SymbolDependency>> result = SymbolDependency.gatherDependencies(
+                Stream.of(a, a2, a3, b, b2, c),
+                (sa, sb) -> {
+                    conflicts.add(Pair.of(sa, sb));
+                    return sb;
+                });
+
+        assertThat(conflicts, contains(Pair.of(b, b2)));
+        assertThat(result, hasKey("a"));
+        assertThat(result, hasKey("a2"));
+        assertThat(result, hasKey("b"));
+        assertThat(result.get("a"), hasKey("a"));
+        assertThat(result.get("a"), hasKey("a2"));
+        assertThat(result.get("a").get("a"), equalTo(a));
+        assertThat(result.get("a").get("a2"), equalTo(a2));
+        assertThat(result.get("a2"), hasKey("a"));
+        assertThat(result.get("a2").get("a"), equalTo(a3));
+        assertThat(result.get("b"), hasKey("b"));
+        assertThat(result.get("b").get("b"), equalTo(b2));
+        assertThat(result.get("b"), hasKey("c"));
+        assertThat(result.get("b").get("c"), equalTo(c));
     }
 }


### PR DESCRIPTION
This commit adds a couple helper methods used to aggregate symbol
dependencies into a map of maps. By default, conflicting package
versions will throw when two packages conflict. The merge behavior
can be customized by providing a custom merge function (for example, it
can de-conflict, throw, implement a better, picking strategy, etc.).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
