### PR TITLE
Disable authentication on generated CORS options

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.apigateway.openapi;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -137,6 +138,7 @@ final class AddCorsPreflightIntegration implements OpenApiMapper {
             String path, PathItem pathItem, Map<CorsHeader, String> headers) {
         return OperationObject.builder()
                 .tags(ListUtils.of("CORS"))
+                .security(Collections.emptyList())
                 .description("Handles CORS-preflight requests")
                 .operationId(createOperationId(path))
                 .putResponse("200", createPreflightResponse(headers))

--- a/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/aws/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -234,6 +234,7 @@
             }
           }
         },
+        "security": [],
         "x-amazon-apigateway-integration": {
           "passThroughBehavior": "when_no_match",
           "requestTemplates": {
@@ -336,6 +337,7 @@
             }
           }
         },
+        "security": [],
         "x-amazon-apigateway-integration": {
           "passThroughBehavior": "when_no_match",
           "requestTemplates": {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.openapi.fromsmithy.mappers;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -143,7 +144,7 @@ public class RemoveUnusedComponents implements OpenApiMapper {
 
         for (PathItem path : openapi.getPaths().values()) {
             for (OperationObject operation : path.getOperations().values()) {
-                for (Map<String, List<String>> entry : operation.getSecurity()) {
+                for (Map<String, List<String>> entry : operation.getSecurity().orElse(Collections.emptyList())) {
                     used.addAll(entry.keySet());
                 }
             }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -206,7 +207,7 @@ public class OpenApiConverterTest {
                 .convert(model, ShapeId.from("smithy.example#Service"));
 
         assertThat(result.getSecurity(), empty());
-        assertThat(result.getPaths().get("/2").getGet().get().getSecurity(), empty());
+        assertThat(result.getPaths().get("/2").getGet().get().getSecurity().orElse(Collections.emptyList()), empty());
     }
 
     private static final class ConstantSecurity implements OpenApiMapper {
@@ -231,6 +232,6 @@ public class OpenApiConverterTest {
                 .convert(model, ShapeId.from("smithy.example#Service"));
 
         assertThat(result.getSecurity().get(0).keySet(), contains("foo_baz"));
-        assertThat(result.getPaths().get("/2").getGet().get().getSecurity().get(0).keySet(), contains("foo_baz"));
+        assertThat(result.getPaths().get("/2").getGet().get().getSecurity().get().get(0).keySet(), contains("foo_baz"));
     }
 }


### PR DESCRIPTION
CORS preflight options checks are sent without authentication, and so
the generated OPTIONS integrations should have an empty
"security" list.

To enable this, I made the list of security settings an `Optional` to distinguish between an empty list and a list that wasn't set. This is a bit odd in terms of the rest of the code base where we simply don't serialize empty lists. It's needed so that we can special case the OPTIONS methods from the general "security" setting. The alternative is to explicitly set the "security" setting on every method, which seems like it would be error prone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.