### PR TITLE
Disable URLConnection cache in CLI

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -124,7 +124,7 @@ public final class BuildCommand implements Command {
     }
 
     private ValidatedResult<Model> buildModel(ClassLoader classLoader, List<String> models, Arguments arguments) {
-        ModelAssembler assembler = Model.assembler(classLoader);
+        ModelAssembler assembler = CommandUtils.createModelAssembler(classLoader);
         CommandUtils.handleModelDiscovery(arguments, assembler, classLoader);
         CommandUtils.handleUnknownTraitsOption(arguments, assembler);
         models.forEach(assembler::addImport);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.SmithyCli;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
 
 final class CommandUtils {
@@ -37,6 +38,10 @@ final class CommandUtils {
             LOGGER.fine("Ignoring unknown traits");
             assembler.putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
         }
+    }
+
+    static ModelAssembler createModelAssembler(ClassLoader classLoader) {
+        return Model.assembler(classLoader).putProperty(ModelAssembler.DISABLE_JAR_CACHE, true);
     }
 
     static void handleModelDiscovery(Arguments arguments, ModelAssembler assembler, ClassLoader baseLoader) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -58,7 +58,7 @@ public final class DiffCommand implements Command {
         List<String> newModels = arguments.repeatedParameter("--new");
         LOGGER.info(String.format("Setting 'new' Smithy models: %s", String.join(" ", newModels)));
 
-        ModelAssembler assembler = Model.assembler(classLoader);
+        ModelAssembler assembler = CommandUtils.createModelAssembler(classLoader);
         Model oldModel = loadModel("old", assembler, oldModels);
         assembler.reset();
         Model newModel = loadModel("new", assembler, newModels);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -54,7 +54,7 @@ public final class ValidateCommand implements Command {
         List<String> models = arguments.positionalArguments();
         LOGGER.info(String.format("Validating Smithy model sources: %s", models));
 
-        ModelAssembler assembler = Model.assembler(classLoader);
+        ModelAssembler assembler = CommandUtils.createModelAssembler(classLoader);
         CommandUtils.handleModelDiscovery(arguments, assembler, classLoader);
         CommandUtils.handleUnknownTraitsOption(arguments, assembler);
 


### PR DESCRIPTION
When running Smithy in a build tool like Gradle, Smithy is run multiple
times within a thread. Java's URLConnection has a cache built-in for
loading JARs, and when a JAR is updated during a Smithy build, it can
cause checksum exceptions when attempting to load that same JAR from a
subsequent run through the cache. This commit disables the cache when
running Smithy through the CLI to prevent this issue (Gradle runs Smithy
via the CLI in a thread).

(I couldn't find a way to test this other than manually test that it fixed the issues I was running into when using it with the Gradle plugin)