### PR TITLE
Add toBuilder to PluginContext

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/PluginContext.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/PluginContext.java
@@ -34,11 +34,12 @@ import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Context object used in plugin execution.
  */
-public final class PluginContext {
+public final class PluginContext implements ToSmithyBuilder<PluginContext> {
     private final ProjectionConfig projection;
     private final String projectionName;
     private final Model model;
@@ -237,6 +238,19 @@ public final class PluginContext {
         // This accounts for "jar:file:" and "file:".
         int position = location.indexOf("file:");
         return position == -1 ? 0 : position + "file:".length();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder()
+                .projection(projectionName, projection)
+                .model(model)
+                .originalModel(originalModel)
+                .events(events)
+                .settings(settings)
+                .fileManifest(fileManifest)
+                .pluginClassLoader(pluginClassLoader)
+                .sources(sources);
     }
 
     /**

--- a/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
@@ -3,11 +3,13 @@ package software.amazon.smithy.build;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.ProjectionConfig;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.ListUtils;
@@ -60,5 +62,25 @@ public class PluginContextTest {
 
         assertThat(context.getNonTraitShapes(), equalTo(scrubbed));
         assertThat(context.getNonTraitShapes(), equalTo(scrubbed)); // trigger loading from cache
+    }
+
+    @Test
+    public void convertsToBuilder() {
+        PluginContext context = PluginContext.builder()
+                .projection("foo", ProjectionConfig.builder().build())
+                .fileManifest(new MockManifest())
+                .model(Model.builder().build())
+                .originalModel(Model.builder().build())
+                .settings(Node.objectNode().withMember("foo", "bar"))
+                .build();
+        PluginContext context2 = context.toBuilder().build();
+
+        assertThat(context.getProjectionName(), equalTo(context2.getProjectionName()));
+        assertThat(context.getProjection(), equalTo(context2.getProjection()));
+        assertThat(context.getModel(), equalTo(context2.getModel()));
+        assertThat(context.getOriginalModel(), equalTo(context2.getOriginalModel()));
+        assertThat(context.getFileManifest(), is(context2.getFileManifest()));
+        assertThat(context.getSources(), equalTo(context2.getSources()));
+        assertThat(context.getEvents(), equalTo(context2.getEvents()));
     }
 }


### PR DESCRIPTION
Some abstractions might want to use the PluginContext as a way to
provide configuration options when building artifacts. This commit makes
it easier to modify specific parts of the PluginContext as needed
without needing to manually copy properties that haven't changed over.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
