### PR TITLE
Allow state override

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -302,7 +302,7 @@ import java.util.regex.Pattern;
  *
  * <pre>{@code
  * CodeWriter writer = CodeWriter.createDefault();
- * writer.onSection("example", text -> writer.write("Intercepted: " + text"));
+ * writer.onSection("example", text -> writer.write("Intercepted: " + text));
  * writer.pushState("example");
  * writer.write("Original contents");
  * writer.popState();
@@ -326,7 +326,7 @@ import java.util.regex.Pattern;
  *
  * <pre>{@code
  * CodeWriter writer = CodeWriter.createDefault();
- * writer.onSection("example", text -> writer.write("Intercepted: " + text"));
+ * writer.onSection("example", text -> writer.write("Intercepted: " + text));
  * writer.write("Leading text...${L@example}...Trailing text...", "foo");
  * System.out.println(writer.toString());
  * // Outputs: "Leading text...Intercepted: foo...Trailing text...\n"
@@ -535,8 +535,8 @@ public class CodeWriter {
             String result = getTrimmedPoppedStateContents(popped);
 
             if (popped.interceptors.containsKey(popped.sectionName)) {
-                List<Consumer<String>> interceptors = popped.interceptors.get(popped.sectionName);
-                for (Consumer<String> interceptor : interceptors) {
+                List<Consumer<Object>> interceptors = popped.interceptors.get(popped.sectionName);
+                for (Consumer<Object> interceptor : interceptors) {
                     result = expandSection("__" + popped.sectionName, result, interceptor);
                 }
             }
@@ -602,7 +602,7 @@ public class CodeWriter {
      * @param interceptor The function to intercept with.
      * @return Returns the CodeWriter.
      */
-    public CodeWriter onSection(String sectionName, Consumer<String> interceptor) {
+    public CodeWriter onSection(String sectionName, Consumer<Object> interceptor) {
         currentState.putInterceptor(sectionName, interceptor);
         return this;
     }
@@ -1032,7 +1032,7 @@ public class CodeWriter {
     }
 
     // Used only by CodeFormatter to expand inline argument sections.
-    String expandSection(String sectionName, String defaultContent, Consumer<String> writerConsumer) {
+    String expandSection(String sectionName, String defaultContent, Consumer<Object> writerConsumer) {
         StringBuilder buffer = new StringBuilder();
         pushState(sectionName);
         currentState.isInline = true;
@@ -1065,7 +1065,7 @@ public class CodeWriter {
         private boolean copiedContext = false;
 
         /** The interceptors map implements a simple copy on write pattern. */
-        private Map<String, List<Consumer<String>>> interceptors = MapUtils.of();
+        private Map<String, List<Consumer<Object>>> interceptors = MapUtils.of();
         private boolean copiedInterceptors = false;
 
         State() {}
@@ -1105,7 +1105,7 @@ public class CodeWriter {
             }
         }
 
-        void putInterceptor(String section, Consumer<String> interceptor) {
+        void putInterceptor(String section, Consumer<Object> interceptor) {
             if (!copiedInterceptors) {
                 interceptors = new HashMap<>(interceptors);
                 copiedInterceptors = true;

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -494,7 +494,7 @@ public class CodeWriter {
      * @param sectionName Name of the section to set on the state.
      * @return Returns the code writer.
      */
-    public final CodeWriter pushState(String sectionName) {
+    public CodeWriter pushState(String sectionName) {
         currentState = new State(currentState);
         states.push(currentState);
 
@@ -523,7 +523,7 @@ public class CodeWriter {
      * @return Returns the CodeWriter.
      * @throws IllegalStateException if there a no states to pop.
      */
-    public final CodeWriter popState() {
+    public CodeWriter popState() {
         if (states.size() == 1) {
             throw new IllegalStateException("Cannot pop CodeWriter state because at the root state");
         }


### PR DESCRIPTION
Make CodeWriters intercept Object instead of String
    
    This commit makes CodeWriter section interceptors deal with Object
    instead of String. This allows for the toString() method of the
    intercepted text to be wrapped by classes that extend from CodeWriter in
    order to determine if any side effects from the original content should
    take effect or be discarded. The general idea is that if toString() was
    called on the original content of an intercepted section, then original
    contents are also going to be written to the CodeWriter, meaning any
    side effects should also occur (for example, adding imports).

Allow pushState and popState to be overridden
    
    When extending CodeWriter, you might need to also track state like
    imports in a corresponding stack. This is now possible since pushState
    and popState can be overridden.