### PR TITLE
Escape popped state content

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -551,7 +551,8 @@ public class CodeWriter {
             } else {
                 // Sections can be added that are just placeholders. In those cases,
                 // do not write anything unless the section emitted a non-empty string.
-                writeOptional(result);
+                // Note that this has already been formatted, so escape "$".
+                writeOptional(result.replace("$", "$$"));
             }
         }
 

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -497,4 +497,12 @@ public class CodeWriterTest {
 
         assertThat(result, equalTo("public 1 2 3 4 5 {\n    hi();\n}\n"));
     }
+
+    @Test
+    public void poppedSectionsEscapeDollars() {
+        CodeWriter writer = CodeWriter.createDefault();
+        String result = writer.pushState("foo").write("$$Hello").popState().toString();
+
+        assertThat(result, equalTo("$Hello\n"));
+    }
 }


### PR DESCRIPTION
The contents of captured named states needs to be escaped when writing
it to ensure that any "$" signs that may have been escaped or expanded
in the original content are passed through as-is.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
