### PR TITLE
Make httpHeader value validation produce dangers

### DIFF
--- a/docs/source/spec/http.rst
+++ b/docs/source/spec/http.rst
@@ -519,7 +519,7 @@ Serialization rules:
 Restricted HTTP headers
 -----------------------
 
-Various HTTP headers are not allowed for the ``httpHeader`` and
+Various HTTP headers are highly discouraged for the ``httpHeader`` and
 ``httpPrefixHeaders`` traits.
 
 .. list-table::

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpHeaderTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpHeaderTrait.java
@@ -15,12 +15,9 @@
 
 package software.amazon.smithy.model.traits;
 
-import java.util.Locale;
-import java.util.Set;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Binds a member to an HTTP header.
@@ -28,32 +25,11 @@ import software.amazon.smithy.utils.SetUtils;
 public final class HttpHeaderTrait extends StringTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#httpHeader");
 
-    private static final Set<String> BLACKLIST = SetUtils.of(
-            "authorization",
-            "connection",
-            "content-length",
-            "expect",
-            "host",
-            "max-forwards",
-            "proxy-authenticate",
-            "server",
-            "te",
-            "trailer",
-            "transfer-encoding",
-            "upgrade",
-            "user-agent",
-            "www-authenticate",
-            "x-forwarded-for");
-
     public HttpHeaderTrait(String value, SourceLocation sourceLocation) {
         super(ID, value, sourceLocation);
 
         if (getValue().isEmpty()) {
             throw new SourceException("httpHeader field name binding must not be empty", getSourceLocation());
-        }
-
-        if (BLACKLIST.contains(getValue().toLowerCase(Locale.US))) {
-            throw new SourceException("httpHeader cannot be set to `" + getValue() + "`", getSourceLocation());
         }
     }
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.errors
@@ -22,7 +22,7 @@
 [ERROR] ns.foo#KInput: `httpHeader` field name binding conflicts found for the `x-foo` header in the following structure members: `a`, `b` | HttpHeaderTrait
 [ERROR] ns.foo#KInput: `httpQuery` parameter name binding conflicts found for the `foo` parameter in the following structure members: `c`, `d` | HttpQueryTrait
 [ERROR] ns.foo#L: Operation URI, `/k`, conflicts with other operation URIs in the same service: [`ns.foo#K` (/k)] | HttpUriConflict
-[ERROR] ns.foo#MInput$a: Error creating trait `httpHeader`: httpHeader cannot be set to `Authorization` | Model
+[DANGER] ns.foo#MInput$a: httpHeader cannot be set to `Authorization` | HttpHeaderTrait
 [ERROR] ns.foo#NInput$a: This `a` structure member is marked with the `httpLabel` trait, but no corresponding `http` URI label could be found when used as the input of the `ns.foo#N` operation. | HttpLabelTrait
 [ERROR] ns.foo#OInput$a: Members with the `httpLabel` trait must be required. | HttpLabelTrait
 [ERROR] ns.foo#PInput$a: The `a` structure member corresponds to a greedy label when used as the input of the `ns.foo#P` operation. This member targets (integer: `ns.foo#Integer`), but greedy labels must target string shapes. | HttpLabelTrait


### PR DESCRIPTION
This moves the validation for the value of the httpHeader trait to
the HttpHeaderTraitValidator and makes that validation a DANGER
instead of an ERROR so that it can be overridden if necesessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.