### PR TITLE
Allow specifying xml namespace prefix

### DIFF
--- a/docs/source/spec/xml.rst
+++ b/docs/source/spec/xml.rst
@@ -221,8 +221,9 @@ following document:
     ``-``. Values for an ``xmlName`` adhere to the following ABNF.
 
 .. productionlist:: smithy
-    xml_name       :(ALPHA / "_")
+    name           :(ALPHA / "_")
                    :*(ALPHA / DIGIT / "-" / "_")
+    xml_name       :name / (name ":" name)
 
 
 .. _xmlNamespace-trait:
@@ -365,6 +366,15 @@ following document:
         <baz:bar>def</baz:bar>
     </MyStructure>
 
+.. note::
+
+    Values for the ``prefix`` option must start with a letter (lower/upper
+    case) or ``_``, followed by letters (lower/upper case), digits, ``_``, or
+    ``-``. Values for ``prefix`` adhere to the following ABNF.
+
+.. productionlist:: smithy
+    prefix         :(ALPHA / "_")
+                   :*(ALPHA / DIGIT / "-" / "_")
 
 .. _xml-examples:
 

--- a/docs/source/spec/xml.rst
+++ b/docs/source/spec/xml.rst
@@ -221,9 +221,9 @@ following document:
     ``-``. Values for an ``xmlName`` adhere to the following ABNF.
 
 .. productionlist:: smithy
-    name           :(ALPHA / "_")
+    xml_identifier :(ALPHA / "_")
                    :*(ALPHA / DIGIT / "-" / "_")
-    xml_name       :name / (name ":" name)
+    xml_name       :xml_identifier / (xml_identifier ":" xml_identifier)
 
 
 .. _xmlNamespace-trait:
@@ -373,8 +373,8 @@ following document:
     ``-``. Values for ``prefix`` adhere to the following ABNF.
 
 .. productionlist:: smithy
-    prefix         :(ALPHA / "_")
-                   :*(ALPHA / DIGIT / "-" / "_")
+    xml_prefix      :(ALPHA / "_")
+                    :*(ALPHA / DIGIT / "-" / "_")
 
 .. _xml-examples:
 

--- a/docs/source/spec/xml.rst
+++ b/docs/source/spec/xml.rst
@@ -252,6 +252,9 @@ The ``xmlNamespace`` trait is an object that contains the following properties:
     * - uri
       - ``string`` value containing a valid URI
       - **Required**. The namespace URI for scoping this XML element.
+    * - prefix
+      - ``string`` value
+      - The prefix for elements from this namespace.
 
 Given the following structure definition,
 
@@ -304,6 +307,62 @@ following document:
     <MyStructure xmlns="http//foo.com">
         <foo>abc</foo>
         <bar>def</bar>
+    </MyStructure>
+
+Given the following definition with a prefix:
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        @xmlNamespace(uri: "http://foo.com", prefix: "bar")
+        structure MyStructure {
+            foo: String,
+            @xmlName("baz:bar")
+            bar: String,
+        }
+
+    .. code-tab:: json
+
+        {
+            "smithy": "0.4.0",
+            "smithy.example": {
+                "shapes": {
+                    "MyStructure": {
+                        "type": "structure",
+                        "members": {
+                            "foo": {
+                                "target": "String"
+                            },
+                            "bar": {
+                                "target": "String",
+                                "xmlName": "baz:bar"
+                            }
+                        },
+                        "xmlNamespace": {
+                            "uri": "http://foo.com",
+                            "prefix": "baz"
+                        }
+                    }
+                }
+            }
+        }
+
+and the following values provided for ``MyStructure``,
+
+::
+
+    "foo" = "abc"
+    "bar" = "def"
+
+the XML representation of the value would be serialized with the
+following document:
+
+.. code-block:: xml
+
+    <MyStructure xmlns:baz="http//foo.com">
+        <foo>abc</foo>
+        <baz:bar>def</baz:bar>
     </MyStructure>
 
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlNamespaceTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlNamespaceTrait.java
@@ -70,11 +70,10 @@ public final class XmlNamespaceTrait extends AbstractTrait implements ToSmithyBu
 
     @Override
     public Builder toBuilder() {
-        Builder traitBuilder = builder()
+        return builder()
                 .sourceLocation(getSourceLocation())
-                .uri(getUri());
-        getPrefix().ifPresent(traitBuilder::prefix);
-        return traitBuilder;
+                .uri(uri)
+                .prefix(prefix);
     }
 
     /**
@@ -92,7 +91,7 @@ public final class XmlNamespaceTrait extends AbstractTrait implements ToSmithyBu
         }
 
         public Builder prefix(String prefix) {
-            this.prefix = Objects.requireNonNull(prefix);
+            this.prefix = prefix;
             return this;
         }
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -166,6 +166,9 @@ structure xmlNamespace {
     /// The namespace URI for scoping this XML element.
     @required
     uri: NonEmptyString,
+    /// The prefix for the given namespace.
+    @pattern("^[a-zA-Z_][a-zA-Z_0-9-]*$")
+    prefix: NonEmptyString,
 }
 
 @private

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -156,7 +156,7 @@ structure xmlFlattened {}
 /// used in the model.
 @trait
 @tags(["diff.error.const"])
-@pattern("^[a-zA-Z_][a-zA-Z_0-9-]*$")
+@pattern("^[a-zA-Z_][a-zA-Z_0-9-]*(:[a-zA-Z_][a-zA-Z_0-9-]*)?$")
 string xmlName
 
 /// Adds an xmlns namespace definition URI to an XML element.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/XmlNameTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/XmlNameTraitTest.java
@@ -38,4 +38,17 @@ public class XmlNameTraitTest {
         assertThat(xmlNameTrait.getValue(), equalTo("Text"));
         assertThat(xmlNameTrait.toNode(), equalTo(node));
     }
+
+    @Test
+    public void loadsWithColonInValue() {
+        Node node = Node.from("xsi:type");
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Optional<Trait> trait = provider.createTrait(ShapeId.from("smithy.api#xmlName"), ShapeId.from("ns.qux#foo"), node);
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(XmlNameTrait.class));
+        XmlNameTrait xmlNameTrait = (XmlNameTrait) trait.get();
+        assertThat(xmlNameTrait.getValue(), equalTo("xsi:type"));
+        assertThat(xmlNameTrait.toNode(), equalTo(node));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/XmlNamespaceTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/XmlNamespaceTraitTest.java
@@ -55,4 +55,21 @@ public class XmlNamespaceTraitTest {
 
         assertFalse(serialized.getMember("prefix").isPresent());
     }
+
+    @Test
+    public void loadsTraitWithPrefix() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        ObjectNode node = Node.objectNode()
+                .withMember("uri", Node.from("https://www.amazon.com"))
+                .withMember("prefix", Node.from("xsi"));
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#xmlNamespace"), ShapeId.from("ns.qux#foo"), node);
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(XmlNamespaceTrait.class));
+        XmlNamespaceTrait xmlNamespace = (XmlNamespaceTrait) trait.get();
+
+        assertThat(xmlNamespace.getUri(), equalTo("https://www.amazon.com"));
+        assertTrue(xmlNamespace.getPrefix().isPresent());
+        assertThat(xmlNamespace.getPrefix().get(), equalTo("xsi"));
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-name.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-name.errors
@@ -1,0 +1,1 @@
+[ERROR] ns.foo#InvalidName$a: Error validating trait `xmlName`: String value provided for `smithy.api#xmlName` must match regular expression: ^[a-zA-Z_][a-zA-Z_0-9-]*(:[a-zA-Z_][a-zA-Z_0-9-]*)?$ | TraitValue

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-name.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-name.json
@@ -1,0 +1,34 @@
+{
+    "smithy": "0.4.0",
+    "ns.foo": {
+        "shapes": {
+            "ValidName1": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "target": "smithy.api#String",
+                        "smithy.api#xmlName": "customname"
+                    }
+                }
+            },
+            "ValidName2": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "target": "smithy.api#String",
+                        "smithy.api#xmlName": "customprefix:customname"
+                    }
+                }
+            },
+            "InvalidName": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "target": "smithy.api#String",
+                        "smithy.api#xmlName": "too:many:colons"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-namespace.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-namespace.json
@@ -13,6 +13,18 @@
           "uri": "http://foo.com"
         }
       },
+      "ValidNamespace2": {
+        "type": "structure",
+        "members": {
+          "a": {
+            "target": "String"
+          }
+        },
+        "smithy.api#xmlNamespace": {
+          "uri": "http://www.w3.org/2001/XMLSchema-instance",
+          "prefix": "xsi"
+        }
+      },
       "InvalidNamespace": {
         "type": "structure",
         "members": {


### PR DESCRIPTION
This updates the xmlnamespace trait to allow specifying a prefix to
pull the namespace into. It further updates the pattern for the
xmlname trait to allow specifying a name with a prefix, e.g.
`myprefix:myname`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.