### PR TITLE
Make shape ID serialization consistent

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/test-model.json
@@ -159,6 +159,9 @@
                     "a": {
                         "target": "MyString",
                         "required": true
+                    },
+                    "c": {
+                        "target": "ns.shapes#String"
                     }
                 },
                 "documentation": "abc"
@@ -173,6 +176,41 @@
             "a": {
                 "type": "structure",
                 "trait": true
+            },
+            "OperationNeedingAbsoluteShapeIds": {
+                "type": "operation",
+                "idempotent": true,
+                "input": "ns.shapes#Structure",
+                "output": "ns.shapes#Structure",
+                "errors": ["ns.shapes#ErrorStructure"]
+            },
+            "ResourceNeedingAbsoluteShapeIds": {
+                "type": "resource",
+                "identifiers": {"id": "ns.baz#String"},
+                "read": "ns.resource.needing.ids#GetResourceNeedingAbsoluteShapeIds"
+            }
+        }
+    },
+    "ns.resource.needing.ids": {
+        "shapes": {
+            "GetResourceNeedingAbsoluteShapeIds": {
+                "type": "operation",
+                "readonly": true,
+                "input": "GetResourceNeedingAbsoluteShapeIdsInput",
+                "output": "GetResourceNeedingAbsoluteShapeIdsOutput"
+            },
+            "GetResourceNeedingAbsoluteShapeIdsInput": {
+                "type": "structure",
+                "members": {
+                    "id": {
+                        "target": "ns.baz#String",
+                        "required": true
+                    }
+                }
+            },
+            "GetResourceNeedingAbsoluteShapeIdsOutput": {
+                "type": "structure",
+                "members": {}
             }
         }
     },
@@ -250,6 +288,10 @@
                         "target": "String"
                     }
                 }
+            },
+            "ErrorStructure": {
+                "type": "structure",
+                "error": "client"
             },
             "TaggedUnion": {
                 "type": "union",


### PR DESCRIPTION
Shape ID serialization was inconsistent in that members would use
relative IDs when possible, while direct targets from things like input,
output, and operations would always use absolute IDs. This commit
updates model serialization to use relative shape IDs when possible.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
