### PR TITLE
Add abstraction over Symbols

### DIFF
--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.codegen.core;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import software.amazon.smithy.utils.ListUtils;
@@ -58,7 +59,8 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * }
  * </pre>
  */
-public final class Symbol extends TypedPropertiesBag implements ToSmithyBuilder<Symbol> {
+public final class Symbol extends TypedPropertiesBag
+        implements SymbolContainer, SymbolDependencyContainer, ToSmithyBuilder<Symbol> {
     private final String namespace;
     private final String namespaceDelimiter;
     private final String name;
@@ -187,18 +189,14 @@ public final class Symbol extends TypedPropertiesBag implements ToSmithyBuilder<
         return references;
     }
 
-    /**
-     * Gets the list of dependencies that this symbol introduces.
-     *
-     * <p>A dependency is a dependency on another package that the symbol
-     * requires. It is quite different from a reference since a reference
-     * only refers to a symbol; a reference provides no context as to whether
-     * or not a dependency is required or the dependency's coordinates.
-     *
-     * @return Returns the Symbol's dependencies.
-     */
+    @Override
     public List<SymbolDependency> getDependencies() {
         return dependencies;
+    }
+
+    @Override
+    public List<Symbol> getSymbols() {
+        return Collections.singletonList(this);
     }
 
     @Override
@@ -364,13 +362,24 @@ public final class Symbol extends TypedPropertiesBag implements ToSmithyBuilder<
         }
 
         /**
+         * Replaces the symbol dependencies of the symbol.
+         *
+         * @param container Dependencies to set.
+         * @return Returns the builder.
+         */
+        public Builder dependencies(SymbolDependencyContainer container) {
+            this.dependencies.clear();
+            return addDependency(container);
+        }
+
+        /**
          * Add a symbol dependency.
          *
          * @param dependency Symbol dependency to add.
          * @return Returns the builder.
          */
-        public Builder addDependency(SymbolDependency dependency) {
-            dependencies.add(dependency);
+        public Builder addDependency(SymbolDependencyContainer dependency) {
+            dependencies.addAll(dependency.getDependencies());
             return this;
         }
 

--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolContainer.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolContainer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import java.util.List;
+
+/**
+ * A holder for {@link Symbol} objects.
+ */
+public interface SymbolContainer {
+    /**
+     * Returns any {@link Symbol} objects contained in the object.
+     *
+     * @return Returns a collection of {@code Symbol}s.
+     */
+    List<Symbol> getSymbols();
+}

--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.codegen.core;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -66,7 +68,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * suggestion.
  */
 public final class SymbolDependency extends TypedPropertiesBag
-        implements ToSmithyBuilder<SymbolDependency>, Comparable<SymbolDependency> {
+        implements SymbolDependencyContainer, ToSmithyBuilder<SymbolDependency>, Comparable<SymbolDependency> {
 
     private final String dependencyType;
     private final String packageName;
@@ -185,6 +187,11 @@ public final class SymbolDependency extends TypedPropertiesBag
      */
     public String getVersion() {
         return version;
+    }
+
+    @Override
+    public List<SymbolDependency> getDependencies() {
+        return Collections.singletonList(this);
     }
 
     @Override

--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependencyContainer.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependencyContainer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import java.util.List;
+
+/**
+ * A container for {@link SymbolDependency} objects.
+ */
+public interface SymbolDependencyContainer {
+    /**
+     * Gets the list of dependencies that this object introduces.
+     *
+     * <p>A dependency is a dependency on another package that a Symbol
+     * or type requires. It is quite different from a reference since a
+     * reference only refers to a symbol; a reference provides no context
+     * as to whether or not a dependency is required or the dependency's
+     * coordinates.
+     *
+     * @return Returns the dependencies.
+     */
+    List<SymbolDependency> getDependencies();
+}

--- a/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolReference.java
+++ b/codegen/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolReference.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.codegen.core;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -42,7 +43,9 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * {@link ContextOption#USE} options, meaning that the reference is
  * necessary both when defining and when using a symbol.
  */
-public final class SymbolReference extends TypedPropertiesBag implements ToSmithyBuilder<SymbolReference> {
+public final class SymbolReference
+        extends TypedPropertiesBag
+        implements SymbolContainer, SymbolDependencyContainer, ToSmithyBuilder<SymbolReference> {
 
     /**
      * Top-level interface for all {@code SymbolReference} options.
@@ -151,6 +154,16 @@ public final class SymbolReference extends TypedPropertiesBag implements ToSmith
      */
     public boolean hasOption(Option option) {
         return options.contains(option);
+    }
+
+    @Override
+    public List<Symbol> getSymbols() {
+        return Collections.singletonList(getSymbol());
+    }
+
+    @Override
+    public List<SymbolDependency> getDependencies() {
+        return symbol.getDependencies();
     }
 
     @Override


### PR DESCRIPTION
A SymbolContainer is an abstraction over Symbols that allows for more
easily creating and aggregating Symbols together.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
