### PR TITLE
Add and remove members to index automatically

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
@@ -15,7 +15,10 @@
 
 package software.amazon.smithy.model.shapes;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.function.Consumer;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -46,6 +49,11 @@ public abstract class CollectionShape extends Shape {
     }
 
     @Override
+    public Collection<MemberShape> members() {
+        return Collections.singletonList(member);
+    }
+
+    @Override
     public boolean equals(Object other) {
         return super.equals(other) && getMember().equals(((CollectionShape) other).getMember());
     }
@@ -69,6 +77,38 @@ public abstract class CollectionShape extends Shape {
         public B member(MemberShape member) {
             this.member = Objects.requireNonNull(member);
             return (B) this;
+        }
+
+        /**
+         * Sets the member of the collection.
+         * @param target Target of the member.
+         * @return Returns the builder.
+         */
+        public B member(ShapeId target) {
+            return member(target, null);
+        }
+
+        /**
+         * Sets the member of the collection.
+         *
+         * @param target Target of the member.
+         * @param memberUpdater Consumer that can update the created member shape.
+         * @return Returns the builder.
+         */
+        public B member(ShapeId target, Consumer<MemberShape.Builder> memberUpdater) {
+            if (getId() == null) {
+                throw new IllegalStateException("An id must be set before setting a member with a target");
+            }
+
+            MemberShape.Builder builder = MemberShape.builder()
+                    .target(target)
+                    .id(getId().withMember("member"));
+
+            if (memberUpdater != null) {
+                memberUpdater.accept(builder);
+            }
+
+            return member(builder.build());
         }
 
         @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
@@ -15,8 +15,11 @@
 
 package software.amazon.smithy.model.shapes;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -86,6 +89,11 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
     }
 
     @Override
+    public Collection<MemberShape> members() {
+        return ListUtils.of(key, value);
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (!super.equals(other)) {
             return false;
@@ -134,6 +142,72 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
             } else {
                 throw new IllegalStateException("Invalid member given to MapShape builder: " + member.getId());
             }
+        }
+
+        /**
+         * Sets the key member of the map.
+         *
+         * @param target Target of the member.
+         * @return Returns the builder.
+         */
+        public Builder key(ShapeId target) {
+            return key(target, null);
+        }
+
+        /**
+         * Sets the key member of the map.
+         *
+         * @param target Target of the member.
+         * @param memberUpdater Consumer that can update the created member shape.
+         * @return Returns the builder.
+         */
+        public Builder key(ShapeId target, Consumer<MemberShape.Builder> memberUpdater) {
+            if (getId() == null) {
+                throw new IllegalStateException("An id must be set before setting a member with a target");
+            }
+
+            MemberShape.Builder builder = MemberShape.builder()
+                    .target(target)
+                    .id(getId().withMember("key"));
+
+            if (memberUpdater != null) {
+                memberUpdater.accept(builder);
+            }
+
+            return key(builder.build());
+        }
+
+        /**
+         * Sets the value member of the map.
+         *
+         * @param target Target of the member.
+         * @return Returns the builder.
+         */
+        public Builder value(ShapeId target) {
+            return value(target, null);
+        }
+
+        /**
+         * Sets the value member of the map.
+         *
+         * @param target Target of the member.
+         * @param memberUpdater Consumer that can updated the created member shape.
+         * @return Returns the builder.
+         */
+        public Builder value(ShapeId target, Consumer<MemberShape.Builder> memberUpdater) {
+            if (getId() == null) {
+                throw new IllegalStateException("An id must be set before setting a member with a target");
+            }
+
+            MemberShape.Builder builder = MemberShape.builder()
+                    .target(target)
+                    .id(getId().withMember("value"));
+
+            if (memberUpdater != null) {
+                memberUpdater.accept(builder);
+            }
+
+            return value(builder.build());
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.shapes;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+/**
+ * Abstract classes shared by structure and union shapes.
+ */
+abstract class NamedMembersShape extends Shape {
+
+    private final Map<String, MemberShape> members;
+
+    NamedMembersShape(NamedMembersShape.Builder<?, ?> builder) {
+        super(builder, false);
+        assert builder.members != null;
+
+        // Copy the members to make them immutable and ensure that each
+        // member has a valid ID that is prefixed with the shape ID.
+        members = Collections.unmodifiableMap(new TreeMap<>(builder.members));
+
+        members.forEach((key, value) -> {
+            ShapeId expected = getId().withMember(key);
+            if (!value.getId().equals(expected)) {
+                throw new IllegalArgumentException(String.format(
+                        "Expected the `%s` member of `%s` to have an ID of `%s` but found `%s`",
+                        key, getId(), expected, value.getId()));
+            }
+        });
+    }
+
+    /**
+     * Gets the members of the shape.
+     *
+     * @return Returns the immutable member map.
+     */
+    public Map<String, MemberShape> getAllMembers() {
+        return members;
+    }
+
+    /**
+     * Returns a list of member names.
+     *
+     * @return Returns list of member names.
+     */
+    public List<String> getMemberNames() {
+        return new ArrayList<>(members.keySet());
+    }
+
+    /**
+     * Get a specific member by name.
+     *
+     * @param name Name of the member to retrieve.
+     * @return Returns the optional member.
+     */
+    public Optional<MemberShape> getMember(String name) {
+        return Optional.ofNullable(members.get(name));
+    }
+
+    @Override
+    public Collection<MemberShape> members() {
+        return members.values();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other) && members.equals(((NamedMembersShape) other).members);
+    }
+
+    /**
+     * Builder used to create a List or Set shape.
+     * @param <B> Concrete builder type.
+     * @param <S> Shape type being created.
+     */
+    abstract static class Builder<B extends Builder, S extends NamedMembersShape> extends AbstractShapeBuilder<B, S> {
+
+        Map<String, MemberShape> members = new HashMap<>();
+
+        /**
+         * Replaces the members of the builder.
+         *
+         * @param members Members to add to the builder.
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public B members(Collection<MemberShape> members) {
+            this.members.clear();
+            for (MemberShape member : members) {
+                addMember(member);
+            }
+            return (B) this;
+        }
+
+        /**
+         * Removes all members from the shape.
+         *
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public B clearMembers() {
+            members.clear();
+            return (B) this;
+        }
+
+        /**
+         * Adds a member to the builder.
+         *
+         * @param member Shape targeted by the member.
+         * @return Returns the builder.
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        public B addMember(MemberShape member) {
+            members.put(member.getMemberName(), member);
+            return (B) this;
+        }
+
+        /**
+         * Adds a member to the builder.
+         *
+         * @param memberName Member name to add.
+         * @param target Target of the member.
+         * @return Returns the builder.
+         */
+        public B addMember(String memberName, ShapeId target) {
+            return addMember(memberName, target, null);
+        }
+
+        /**
+         * Adds a member to the builder.
+         *
+         * @param memberName Member name to add.
+         * @param target Target of the member.
+         * @param memberUpdater Consumer that can update the created member shape.
+         * @return Returns the builder.
+         */
+        public B addMember(String memberName, ShapeId target, Consumer<MemberShape.Builder> memberUpdater) {
+            if (getId() == null) {
+                throw new IllegalStateException("An id must be set before setting a member with a target");
+            }
+
+            MemberShape.Builder builder = MemberShape.builder().target(target).id(getId().withMember(memberName));
+
+            if (memberUpdater != null) {
+                memberUpdater.accept(builder);
+            }
+
+            return addMember(builder.build());
+        }
+
+        /**
+         * Removes a member by name.
+         *
+         * @param member Member name to remove.
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public B removeMember(String member) {
+            members.remove(member);
+            return (B) this;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.model.shapes;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -553,6 +554,15 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
      */
     public final boolean isTimestampShape() {
         return getType() == ShapeType.TIMESTAMP;
+    }
+
+    /**
+     * Gets all of the members contained in the shape.
+     *
+     * @return Returns the members contained in the shape (if any).
+     */
+    public Collection<MemberShape> members() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
@@ -15,38 +15,16 @@
 
 package software.amazon.smithy.model.shapes;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Structure shape that maps shape names to members.
  */
-public final class StructureShape extends Shape implements ToSmithyBuilder<StructureShape> {
-
-    private final Map<String, MemberShape> members;
+public final class StructureShape extends NamedMembersShape implements ToSmithyBuilder<StructureShape> {
 
     private StructureShape(Builder builder) {
-        super(builder, false);
-        assert builder.members != null;
-
-        // Copy the members to make them immutable and ensure that each
-        // member has a valid ID that is prefixed with the structure ID.
-        members = Collections.unmodifiableMap(new LinkedHashMap<>(builder.members));
-        members.forEach((key, value) -> {
-            ShapeId expected = getId().withMember(key);
-            if (!value.getId().equals(expected)) {
-                throw new IllegalArgumentException(String.format(
-                        "Expected the `%s` member of `%s` to have an ID of `%s` but found `%s`",
-                        key, getId(), expected, value.getId()));
-            }
-        });
+        super(builder);
     }
 
     /**
@@ -72,45 +50,9 @@ public final class StructureShape extends Shape implements ToSmithyBuilder<Struc
     }
 
     /**
-     * Gets the members of the structure.
-     *
-     * @return Returns the immutable member map.
-     */
-    public Map<String, MemberShape> getAllMembers() {
-        return members;
-    }
-
-    /**
-     * Returns a list of member names in the order in which they were added.
-     *
-     * @return Returns list of member names.
-     */
-    public List<String> getMemberNames() {
-        return new ArrayList<>(members.keySet());
-    }
-
-    /**
-     * Get a specific member by name.
-     *
-     * @param name Name of the member to retrieve.
-     * @return Returns the optional member.
-     */
-    public Optional<MemberShape> getMember(String name) {
-        return Optional.ofNullable(members.get(name));
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return super.equals(other) && members.equals(((StructureShape) other).members);
-    }
-
-    /**
      * Builder used to create a {@link StructureShape}.
      */
-    public static final class Builder extends AbstractShapeBuilder<Builder, StructureShape> {
-
-        private Map<String, MemberShape> members = new LinkedHashMap<>();
-
+    public static final class Builder extends NamedMembersShape.Builder<Builder, StructureShape> {
         @Override
         public StructureShape build() {
             return new StructureShape(this);
@@ -119,51 +61,6 @@ public final class StructureShape extends Shape implements ToSmithyBuilder<Struc
         @Override
         public ShapeType getShapeType() {
             return ShapeType.STRUCTURE;
-        }
-
-        /**
-         * Replaces the members of the builder.
-         *
-         * @param structureMembers Members to add to the builder.
-         * @return Returns the builder.
-         */
-        public Builder members(Collection<MemberShape> structureMembers) {
-            members.clear();
-            Objects.requireNonNull(structureMembers).forEach(this::addMember);
-            return this;
-        }
-
-        /**
-         * Removes all members from the structure.
-         *
-         * @return Returns the builder.
-         */
-        public Builder clearMembers() {
-            members.clear();
-            return this;
-        }
-
-        /**
-         * Adds a member to the builder.
-         *
-         * @param member StructureMember targeted by the member.
-         * @return Returns the builder.
-         */
-        @Override
-        public Builder addMember(MemberShape member) {
-            members.put(member.getMemberName(), member);
-            return this;
-        }
-
-        /**
-         * Removes a member by name.
-         *
-         * @param member Member name to remove.
-         * @return Returns the builder.
-         */
-        public Builder removeMember(String member) {
-            members.remove(member);
-            return this;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
@@ -15,39 +15,16 @@
 
 package software.amazon.smithy.model.shapes;
 
-import static java.lang.String.format;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Tagged union shape that maps member names to member definitions.
  */
-public final class UnionShape extends Shape implements ToSmithyBuilder<UnionShape> {
-    private final Map<String, MemberShape> members;
+public final class UnionShape extends NamedMembersShape implements ToSmithyBuilder<UnionShape> {
 
     private UnionShape(Builder builder) {
-        super(builder, false);
-        if (builder.members.isEmpty()) {
-            throw new SourceException("union shapes require at least one member", builder.source);
-        }
-
-        builder.members.forEach((key, value) -> {
-            ShapeId expected = getId().withMember(key);
-            if (!value.getId().equals(expected)) {
-                throw new IllegalArgumentException(
-                        format("Expected the `%s` member of `%s` to have an ID of `%s` but found `%s`",
-                               key, getId(), expected, value.getId()));
-            }
-        });
-
-        members = new LinkedHashMap<>(builder.members);
+        super(builder);
     }
 
     public static Builder builder() {
@@ -70,53 +47,9 @@ public final class UnionShape extends Shape implements ToSmithyBuilder<UnionShap
     }
 
     /**
-     * Returns true if the union is empty and contains no members.
-     *
-     * @return Returns true if empty.
-     */
-    public boolean isEmpty() {
-        return members.isEmpty();
-    }
-
-    /**
-     * Gets a member by name, case-sensitively.
-     *
-     * @param tag Name of the member to retrieve.
-     * @return Returns the member wrapped in an {@link Optional}.
-     */
-    public Optional<MemberShape> getMember(String tag) {
-        return Optional.ofNullable(members.get(tag));
-    }
-
-    /**
-     * Returns a list of member names in the order in which they were added.
-     *
-     * @return Returns list of member names.
-     */
-    public List<String> getMemberNames() {
-        return new ArrayList<>(members.keySet());
-    }
-
-    /**
-     * Gets the member mapping of the union.
-     *
-     * @return Returns the members.
-     */
-    public Map<String, MemberShape> getAllMembers() {
-        return members;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return super.equals(other) && members.equals(((UnionShape) other).members);
-    }
-
-    /**
      * Builder used to create a {@link UnionShape}.
      */
-    public static final class Builder extends AbstractShapeBuilder<Builder, UnionShape> {
-        private final Map<String, MemberShape> members = new LinkedHashMap<>();
-
+    public static final class Builder extends NamedMembersShape.Builder<Builder, UnionShape> {
         @Override
         public UnionShape build() {
             return new UnionShape(this);
@@ -125,28 +58,6 @@ public final class UnionShape extends Shape implements ToSmithyBuilder<UnionShap
         @Override
         public ShapeType getShapeType() {
             return ShapeType.UNION;
-        }
-
-        public Builder members(Collection<MemberShape> members) {
-            clearMembers();
-            members.forEach(this::addMember);
-            return this;
-        }
-
-        @Override
-        public Builder addMember(MemberShape member) {
-            members.put(member.getMemberName(), member);
-            return this;
-        }
-
-        public Builder removeMember(String member) {
-            members.remove(member);
-            return this;
-        }
-
-        public Builder clearMembers() {
-            members.clear();
-            return this;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MarkAndSweep.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MarkAndSweep.java
@@ -86,14 +86,12 @@ final class MarkAndSweep {
         private final NeighborProvider reverseProvider;
         private final Model model;
         private final Set<Shape> markedForRemoval = new HashSet<>();
-        private final RemoveShapes.ShapeRemovalVisitor removalVisitor;
         private final Predicate<Shape> sweepFilter;
 
         MarkerContext(NeighborProvider reverseProvider, Model model, Predicate<Shape> sweepFilter) {
             this.reverseProvider = reverseProvider;
             this.model = model;
             this.sweepFilter = sweepFilter;
-            removalVisitor = new RemoveShapes.ShapeRemovalVisitor();
         }
 
         /**
@@ -118,7 +116,7 @@ final class MarkAndSweep {
         void markShape(Shape shape) {
             if (sweepFilter.test(shape)) {
                 markedForRemoval.add(shape);
-                markedForRemoval.addAll(shape.accept(removalVisitor));
+                markedForRemoval.addAll(shape.members());
             }
         }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
@@ -42,24 +42,37 @@ public class BottomUpNeighborVisitorTest {
     @Test
     public void dataShape() {
         Shape shape = BlobShape.builder().id("ns.foo#name").build();
-        Shape listMemberShape = MemberShape.builder().target(shape.getId())
+        MemberShape listMemberShape = MemberShape.builder()
+                .target(shape.getId())
                 .id("ns.foo#list$member")
                 .build();
-        Shape mapKeyShape = MemberShape.builder().target(shape.getId())
+        ListShape listShape = ListShape.builder().id("ns.foo#list").member(listMemberShape).build();
+
+        MemberShape mapKeyShape = MemberShape.builder()
+                .target(shape.getId())
                 .id("ns.foo#map$key")
                 .build();
-        Shape mapValueShape = MemberShape.builder().target(shape.getId())
+        MemberShape mapValueShape = MemberShape.builder()
+                .target(shape.getId())
                 .id("ns.foo#map$value")
                 .build();
-        Shape structureMemberShape = MemberShape.builder().target(shape.getId())
+        MapShape mapShape = MapShape.builder()
+                .id(mapKeyShape.getId().withoutMember())
+                .key(mapKeyShape)
+                .value(mapValueShape)
+                .build();
+
+        MemberShape structureMemberShape = MemberShape.builder()
+                .target(shape.getId())
                 .id("ns.foo#structure$aMember")
                 .build();
+        StructureShape structureShape = StructureShape.builder()
+                .id(structureMemberShape.getId().withoutMember())
+                .addMember(structureMemberShape)
+                .build();
+
         ShapeIndex shapeIndex = ShapeIndex.builder()
-                .addShape(shape)
-                .addShape(listMemberShape)
-                .addShape(mapKeyShape)
-                .addShape(mapValueShape)
-                .addShape(structureMemberShape)
+                .addShapes(shape, listShape, mapShape, structureShape)
                 .build();
         NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
@@ -88,10 +88,7 @@ public class NeighborVisitorTest {
         Shape string = StringShape.builder().id("ns.foo#String").build();
         ListShape list = ListShape.builder()
                 .id("ns.foo#name")
-                .member(MemberShape.builder()
-                        .id("ns.foo#name$member")
-                        .target(string.getId())
-                        .build())
+                .member(string.getId())
                 .build();
         ShapeIndex shapeIndex = ShapeIndex.builder().addShape(list).addShape(string).build();
         NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/PathFinderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/PathFinderTest.java
@@ -54,7 +54,7 @@ public class PathFinderTest {
                 .build();
 
         List<String> result1 = formatPaths(PathFinder.create(index).search(struct, "string"));
-        assertThat(result1, contains(
+        assertThat(result1, containsInAnyOrder(
                 "[id|a.b#Struct] -[member]-> [id|a.b#Struct$baz] > [id|a.b#String]",
                 "[id|a.b#Struct] -[member]-> [id|a.b#Struct$foo] > [id|a.b#List] -[member]-> [id|a.b#List$member] > [id|a.b#String]"
         ));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ListShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ListShapeTest.java
@@ -15,11 +15,14 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.traits.SensitiveTrait;
 
 public class ListShapeTest {
     @Test
@@ -105,5 +108,38 @@ public class ListShapeTest {
         ListShape shape2 = ListShape.builder().id("ns.foo#bar").member(member2).build();
 
         assertNotEquals(shape1, shape2);
+    }
+
+    @Test
+    public void addMemberWithTarget() {
+        ListShape shape = ListShape.builder()
+                .id("ns.foo#bar")
+                .member(ShapeId.from("ns.foo#bam"))
+                .build();
+
+        assertEquals(shape.getMember(),
+                     MemberShape.builder().id(shape.getId().withMember("member")).target("ns.foo#bam").build());
+    }
+
+    @Test
+    public void addMemberWithConsumer() {
+        ListShape shape = ListShape.builder()
+                .id("ns.foo#bar")
+                .member(ShapeId.from("ns.foo#bam"), builder -> builder.addTrait(new SensitiveTrait()))
+                .build();
+
+        assertEquals(shape.getMember(),
+                     MemberShape.builder()
+                             .id(shape.getId().withMember("member"))
+                             .target("ns.foo#bam")
+                             .addTrait(new SensitiveTrait())
+                             .build());
+    }
+
+    @Test
+    public void returnsMembers() {
+        ListShape shape = ListShape.builder().id("ns.foo#bar").member(ShapeId.from("ns.foo#bam")).build();
+
+        assertThat(shape.members(), hasSize(1));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MapShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MapShapeTest.java
@@ -15,10 +15,13 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.traits.SensitiveTrait;
 
 public class MapShapeTest {
     @Test
@@ -41,5 +44,52 @@ public class MapShapeTest {
                     .value(MemberShape.builder().id("ns.foo#bar$value").target("ns.foo#bam").build())
                     .build();
         });
+    }
+
+    @Test
+    public void addMemberWithTarget() {
+        MapShape shape = MapShape.builder()
+                .id("ns.foo#bar")
+                .key(ShapeId.from("ns.foo#bam"))
+                .value(ShapeId.from("ns.foo#bam"))
+                .build();
+
+        assertEquals(shape.getKey(),
+                     MemberShape.builder().id(shape.getId().withMember("key")).target("ns.foo#bam").build());
+        assertEquals(shape.getValue(),
+                     MemberShape.builder().id(shape.getId().withMember("value")).target("ns.foo#bam").build());
+    }
+
+    @Test
+    public void addMemberWithConsumer() {
+        MapShape shape = MapShape.builder()
+                .id("ns.foo#bar")
+                .key(ShapeId.from("ns.foo#bam"), builder -> builder.addTrait(new SensitiveTrait()))
+                .value(ShapeId.from("ns.foo#bam"), builder -> builder.addTrait(new SensitiveTrait()))
+                .build();
+
+        assertEquals(shape.getKey(),
+                     MemberShape.builder()
+                             .id(shape.getId().withMember("key"))
+                             .target("ns.foo#bam")
+                             .addTrait(new SensitiveTrait())
+                             .build());
+        assertEquals(shape.getValue(),
+                     MemberShape.builder()
+                             .id(shape.getId().withMember("value"))
+                             .target("ns.foo#bam")
+                             .addTrait(new SensitiveTrait())
+                             .build());
+    }
+
+    @Test
+    public void returnsMembers() {
+        MapShape shape = MapShape.builder()
+                .id("ns.foo#bar")
+                .key(ShapeId.from("ns.foo#bam"))
+                .value(ShapeId.from("ns.foo#bam"))
+                .build();
+
+        assertThat(shape.members(), hasSize(2));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
@@ -36,32 +36,6 @@ import software.amazon.smithy.model.traits.Trait;
 
 public class ShapeTest {
 
-    private static final class SubShape extends Shape {
-        private SubShape(final Builder builder) {
-            super(builder, false);
-        }
-
-        public static Builder builder() {
-            return new Builder();
-        }
-
-        public <R> R accept(final ShapeVisitor<R> cases) {
-            throw new UnsupportedOperationException();
-        }
-
-        public static final class Builder extends AbstractShapeBuilder<Builder, SubShape> {
-            @Override
-            public SubShape build() {
-                return new SubShape(this);
-            }
-
-            @Override
-            public ShapeType getShapeType() {
-                return ShapeType.STRUCTURE;
-            }
-        }
-    }
-
     private static class MyTrait implements Trait {
         private ShapeId id;
         private SourceLocation sourceLocation;
@@ -99,7 +73,7 @@ public class ShapeTest {
 
     @Test
     public void requiresShapeId() {
-        Assertions.assertThrows(IllegalStateException.class, () -> SubShape.builder().build());
+        Assertions.assertThrows(IllegalStateException.class, () -> StringShape.builder().build());
     }
 
     @Test
@@ -114,14 +88,14 @@ public class ShapeTest {
 
     @Test
     public void castsToString() {
-        Shape shape = SubShape.builder().id("ns.foo#baz").build();
+        Shape shape = StringShape.builder().id("ns.foo#baz").build();
 
-        assertEquals("(structure: `ns.foo#baz`)", shape.toString());
+        assertEquals("(string: `ns.foo#baz`)", shape.toString());
     }
 
     @Test
     public void hasSource() {
-        Shape shape = SubShape.builder().id("ns.foo#baz").source("foo", 1, 2).build();
+        Shape shape = StringShape.builder().id("ns.foo#baz").source("foo", 1, 2).build();
 
         assertEquals("foo", shape.getSourceLocation().getFilename());
         assertEquals(1, shape.getSourceLocation().getLine());
@@ -130,7 +104,7 @@ public class ShapeTest {
 
     @Test
     public void sourceCannotBeNull() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> SubShape.builder().source(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringShape.builder().source(null));
     }
 
     @Test
@@ -139,7 +113,7 @@ public class ShapeTest {
         MyTrait otherTrait = new OtherTrait(ShapeId.from("foo.baz#other"), null);
         ShapeId id = ShapeId.from("ns.foo#baz");
         DocumentationTrait documentationTrait = new DocumentationTrait("docs", SourceLocation.NONE);
-        Shape shape = SubShape.builder()
+        Shape shape = StringShape.builder()
                 .id(id)
                 .addTrait(trait)
                 .addTrait(otherTrait)
@@ -178,7 +152,7 @@ public class ShapeTest {
     @Test
     public void traitsMustNotBeNull() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            SubShape.builder().id("ns.foo#baz").addTrait(null);
+            StringShape.builder().id("ns.foo#baz").addTrait(null);
         });
     }
 
@@ -186,7 +160,7 @@ public class ShapeTest {
     public void removesTraits() {
         MyTrait trait = new MyTrait(ShapeId.from("foo.baz#foo"), null);
         MyTrait otherTrait = new OtherTrait(ShapeId.from("foo.baz#other"), null);
-        Shape shape = SubShape.builder()
+        Shape shape = StringShape.builder()
                 .id("ns.foo#baz")
                 .addTrait(trait)
                 .addTrait(otherTrait)
@@ -216,8 +190,8 @@ public class ShapeTest {
     public void differentTraitNamesNotEqual() {
         MyTrait traitA = new MyTrait(ShapeId.from("foo.baz#foo"), null);
         MyTrait traitB = new MyTrait(ShapeId.from("foo.baz#other"), null);
-        Shape shapeA = SubShape.builder().id("ns.foo#baz").addTrait(traitA).build();
-        Shape shapeB = SubShape.builder().id("ns.foo#baz").addTrait(traitB).build();
+        Shape shapeA = StringShape.builder().id("ns.foo#baz").addTrait(traitA).build();
+        Shape shapeB = StringShape.builder().id("ns.foo#baz").addTrait(traitB).build();
 
         assertNotEquals(shapeA, shapeB);
     }
@@ -226,31 +200,31 @@ public class ShapeTest {
     public void differentTraitsNotEqual() {
         MyTrait traitA = new MyTrait(ShapeId.from("foo.ba#foo"), null);
         MyTrait traitB = new OtherTrait(ShapeId.from("foo.baz#other"), null);
-        Shape shapeA = SubShape.builder().id("ns.foo#baz").addTrait(traitA).build();
-        Shape shapeB = SubShape.builder().id("ns.foo#baz").addTrait(traitB).build();
+        Shape shapeA = StringShape.builder().id("ns.foo#baz").addTrait(traitA).build();
+        Shape shapeB = StringShape.builder().id("ns.foo#baz").addTrait(traitB).build();
 
         assertNotEquals(shapeA, shapeB);
     }
 
     @Test
     public void differentIdsAreNotEqual() {
-        Shape shapeA = SubShape.builder().id("ns.foo#baz").build();
-        Shape shapeB = SubShape.builder().id("ns.foo#bar").build();
+        Shape shapeA = StringShape.builder().id("ns.foo#baz").build();
+        Shape shapeB = StringShape.builder().id("ns.foo#bar").build();
 
         assertNotEquals(shapeA, shapeB);
     }
 
     @Test
     public void sameInstanceIsEqual() {
-        Shape shapeA = SubShape.builder().id("ns.foo#baz").build();
+        Shape shapeA = StringShape.builder().id("ns.foo#baz").build();
 
         assertEquals(shapeA, shapeA);
     }
 
     @Test
     public void sameValueIsEqual() {
-        Shape shapeA = SubShape.builder().id("ns.foo#baz").build();
-        Shape shapeB = SubShape.builder().id("ns.foo#baz").build();
+        Shape shapeA = StringShape.builder().id("ns.foo#baz").build();
+        Shape shapeB = StringShape.builder().id("ns.foo#baz").build();
 
         assertEquals(shapeA, shapeB);
     }
@@ -258,8 +232,8 @@ public class ShapeTest {
     @Test
     public void samesTraitsIsEqual() {
         MyTrait traitA = new MyTrait(ShapeId.from("foo.baz#foo"), null);
-        Shape shapeA = SubShape.builder().id("ns.foo#baz").addTrait(traitA).build();
-        Shape shapeB = SubShape.builder().id("ns.foo#baz").addTrait(traitA).build();
+        Shape shapeA = StringShape.builder().id("ns.foo#baz").addTrait(traitA).build();
+        Shape shapeB = StringShape.builder().id("ns.foo#baz").addTrait(traitA).build();
 
         assertEquals(shapeA, shapeB);
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
@@ -15,10 +15,13 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.traits.SensitiveTrait;
 
 public class StructureShapeTest {
     @Test
@@ -33,5 +36,42 @@ public class StructureShapeTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             StructureShape.builder().id("ns.foo#bar$baz").build();
         });
+    }
+
+    @Test
+    public void addMemberWithTarget() {
+        StructureShape shape = StructureShape.builder()
+                .id("ns.foo#bar")
+                .addMember("foo", ShapeId.from("ns.foo#bam"))
+                .build();
+
+        assertEquals(shape.getMember("foo").get(),
+                     MemberShape.builder().id(shape.getId().withMember("foo")).target("ns.foo#bam").build());
+    }
+
+    @Test
+    public void addMemberWithConsumer() {
+        StructureShape shape = StructureShape.builder()
+                .id("ns.foo#bar")
+                .addMember("foo", ShapeId.from("ns.foo#bam"), builder -> builder.addTrait(new SensitiveTrait()))
+                .build();
+
+        assertEquals(shape.getMember("foo").get(),
+                     MemberShape.builder()
+                             .id(shape.getId().withMember("foo"))
+                             .target("ns.foo#bam")
+                             .addTrait(new SensitiveTrait())
+                             .build());
+    }
+
+    @Test
+    public void returnsMembers() {
+        StructureShape shape = StructureShape.builder()
+                .id("ns.foo#bar")
+                .addMember("foo", ShapeId.from("ns.foo#bam"))
+                .addMember("baz", ShapeId.from("ns.foo#bam"))
+                .build();
+
+        assertThat(shape.members(), hasSize(2));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/EffectiveTraitQueryTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/EffectiveTraitQueryTest.java
@@ -32,19 +32,16 @@ public class EffectiveTraitQueryTest {
         Shape stringShape = StringShape.builder().id("foo.bar#Baz")
                 .addTrait(new SensitiveTrait())
                 .build();
-        MemberShape member = MemberShape.builder()
-                .id("foo.baz#Container$member")
-                .target(stringShape)
-                .build();
+        ListShape list = ListShape.builder().id("foo.bar#List").member(stringShape.getId()).build();
         ShapeIndex index = ShapeIndex.builder()
-                .addShapes(stringShape, member)
+                .addShapes(stringShape, list)
                 .build();
         EffectiveTraitQuery query = EffectiveTraitQuery.builder()
                 .shapeIndex(index)
                 .traitClass(SensitiveTrait.class)
                 .build();
 
-        assertTrue(query.isTraitApplied(member));
+        assertTrue(query.isTraitApplied(list.getMember()));
     }
 
     @Test

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-query-timestamp-format.openapi.inlined.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-query-timestamp-format.openapi.inlined.json
@@ -18,6 +18,13 @@
             }
           },
           {
+            "name": "query2",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
             "name": "query3",
             "in": "query",
             "style": "form",
@@ -29,13 +36,6 @@
               }
             },
             "explode": true
-          },
-          {
-            "name": "query2",
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
           }
         ],
         "responses": {

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-query-timestamp-format.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-query-timestamp-format.openapi.json
@@ -18,6 +18,13 @@
             }
           },
           {
+            "name": "query2",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SmithyExampleOperationInputTimestamp2Member"
+            }
+          },
+          {
             "name": "query3",
             "in": "query",
             "style": "form",
@@ -29,13 +36,6 @@
               }
             },
             "explode": true
-          },
-          {
-            "name": "query2",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/SmithyExampleOperationInputTimestamp2Member"
-            }
           }
         ],
         "responses": {

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -116,19 +116,19 @@
             "required": true
           },
           {
-            "name": "timeQuery",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
             "name": "query",
             "in": "query",
             "schema": {
               "type": "number",
               "format": "int32"
+            }
+          },
+          {
+            "name": "timeQuery",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
           },
           {

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.not-inlined.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.not-inlined.json
@@ -103,18 +103,18 @@
             "required": true
           },
           {
+            "name": "query",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ExampleRestPutPayloadInputQueryMember"
+            }
+          },
+          {
             "name": "timeQuery",
             "in": "query",
             "schema": {
               "type": "string",
               "format": "date-time"
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/ExampleRestPutPayloadInputQueryMember"
             }
           },
           {


### PR DESCRIPTION
This commit updates the ShapeIndex to automatically add and remove
members from shapes that have members. This required some extra
functionality be introduced to shapes which then in turn resulted in
cleanup in other places in the codebase.

1. ShapeIndex now automatically adds and removes members when shapes are
   added.
2. There is now a members() method on all shapes to return the members
   contained in the shape (if any). Shapes that have no members just
   return an empty collection by default, and shapes that do contain
   members override the abstract method.
3. Because members are now less important to contain a reference to
   outside of their containing shapes (since you don't need to
   explicitly add them to a shape index), you can now automatically
   create member shapes for container shapes by just passing in the
   target of the member or passing both the target and a consumer that
   accepts the created MemberShape.Builder type. This removes the need
   to create the right shape ID for the shape (suffixing with "$" + the
   member name).
4. ShapeIndex doesn't really need a ConcurrentHashMap to cache different
   groups of shape types. The code that was used for that was overly
   complicated and likely made it slower rather than faster (the
   majority of models will use the prelude and will have more than 50
   shapes, so the optimizations that were in place don't really make
   sense any more).
5. Because there's so much shared code between StructureShape and
   UnionShape, I created an abstract class for their shape and builders
   to make them simpler to maintain.
6. A couple model transformations were updated to use the new members()
   method.
7. Members of structures and unions are now sorted rather than maintain
   insert order. Nothing should ever depend on a stable order based on
   inserts since Smithy models can be loaded and aggregated from
   multiple sources.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
