### PR TITLE
Deprecate ShapeIndex in favor of Model

### DIFF
--- a/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidators.java
+++ b/aws/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidators.java
@@ -66,7 +66,7 @@ final class AddRequestValidators implements OpenApiMapper {
     @Override
     public OpenApi after(Context context, OpenApi openapi) {
         // Find each known request validator on operation shapes.
-        Set<String> validators = context.getModel().getShapeIndex().shapes(OperationShape.class)
+        Set<String> validators = context.getModel().shapes(OperationShape.class)
                 .flatMap(shape -> OptionalUtils.stream(shape.getTrait(RequestValidatorTrait.class)))
                 .map(RequestValidatorTrait::getValue)
                 .filter(KNOWN_VALIDATORS::containsKey)

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
@@ -47,14 +47,14 @@ public final class ArnIndex implements KnowledgeIndex {
 
     public ArnIndex(Model model) {
         // Pre-compute the ARN services.
-        arnServices = unmodifiableMap(model.getShapeIndex().shapes(ServiceShape.class)
+        arnServices = unmodifiableMap(model.shapes(ServiceShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, ServiceTrait.class))
                 .map(pair -> Pair.of(pair.getLeft().getId(), resolveServiceArn(pair)))
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight)));
 
         // Pre-compute all of the ArnTemplates in a service shape.
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        List<ServiceShape> services = model.getShapeIndex().shapes(ServiceShape.class)
+        List<ServiceShape> services = model.shapes(ServiceShape.class)
                 .filter(shape -> shape.hasTrait(ServiceTrait.class))
                 .collect(Collectors.toList());
 

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
@@ -50,7 +50,7 @@ public final class PlaneIndex implements KnowledgeIndex {
     public PlaneIndex(Model model) {
         pathFinder = PathFinder.create(model);
 
-        model.getShapeIndex().shapes(ServiceShape.class).forEach(service -> {
+        model.shapes(ServiceShape.class).forEach(service -> {
             Plane plane = extractPlane(service);
             if (plane != null) {
                 servicePlanes.put(service.getId(), plane);

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/SdkServiceIdValidator.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/SdkServiceIdValidator.java
@@ -70,7 +70,7 @@ public final class SdkServiceIdValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(service -> Trait.flatMapStream(service, ServiceTrait.class))
                 .flatMap(pair -> OptionalUtils.stream(validateService(pair.getLeft(), pair.getRight())))
                 .collect(toList());

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizerIndex.java
@@ -48,7 +48,7 @@ public class AuthorizerIndex implements KnowledgeIndex {
     public AuthorizerIndex(Model model) {
         PathFinder finder = PathFinder.create(model);
 
-        model.getShapeIndex().shapes(ServiceShape.class).forEach(service -> {
+        model.shapes(ServiceShape.class).forEach(service -> {
             service.getTrait(AuthorizersTrait.class).ifPresent(trait -> authorizerTraits.put(service.getId(), trait));
             Map<ShapeId, String> serviceMap = new HashMap<>();
             authorizers.put(service.getId(), serviceMap);

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitValidator.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitValidator.java
@@ -36,7 +36,7 @@ import software.amazon.smithy.utils.SetUtils;
 public class AuthorizersTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(service -> OptionalUtils.stream(validateService(service)))
                 .collect(Collectors.toList());
     }

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
@@ -32,7 +32,6 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.Trait;
@@ -42,20 +41,19 @@ public final class ClientEndpointDiscoveryIndex implements KnowledgeIndex {
     private final Map<ShapeId, Map<ShapeId, ClientEndpointDiscoveryInfo>> endpointDiscoveryInfo = new HashMap<>();
 
     public ClientEndpointDiscoveryIndex(Model model) {
-        ShapeIndex index = model.getShapeIndex();
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
         OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
 
-        index.shapes(ServiceShape.class)
+        model.shapes(ServiceShape.class)
                 .flatMap(service -> Trait.flatMapStream(service, ClientEndpointDiscoveryTrait.class))
                 .forEach(servicePair -> {
                     ServiceShape service = servicePair.getLeft();
                     ShapeId endpointOperationId = servicePair.getRight().getOperation();
                     ShapeId endpointErrorId = servicePair.getRight().getError();
 
-                    Optional<OperationShape> endpointOperation = index.getShape(endpointOperationId)
+                    Optional<OperationShape> endpointOperation = model.getShape(endpointOperationId)
                             .flatMap(Shape::asOperationShape);
-                    Optional<StructureShape> endpointError = index.getShape(endpointErrorId)
+                    Optional<StructureShape> endpointError = model.getShape(endpointErrorId)
                             .flatMap(Shape::asStructureShape);
 
                     if (endpointOperation.isPresent() && endpointError.isPresent()) {

--- a/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/iam/ConditionKeysValidator.java
+++ b/aws/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/iam/ConditionKeysValidator.java
@@ -43,7 +43,7 @@ public class ConditionKeysValidator extends AbstractValidator {
         ConditionKeysIndex conditionIndex = model.getKnowledge(ConditionKeysIndex.class);
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
 
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .filter(service -> service.hasTrait(ServiceTrait.class))
                 .flatMap(service -> {
                     List<ValidationEvent> results = new ArrayList<>();

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
@@ -43,15 +43,15 @@ public class ArnIndexTest {
     public void loadsFromModel() {
         ArnIndex arnIndex = new ArnIndex(model);
         ShapeId id = ShapeId.from("ns.foo#SomeService");
-        Shape someResource = model.getShapeIndex().getShape(ShapeId.from("ns.foo#SomeResource")).get();
+        Shape someResource = model.getShape(ShapeId.from("ns.foo#SomeResource")).get();
         ArnTrait template1 = ArnTrait.builder()
                 .template("someresource/{someId}")
                 .build();
-        Shape childResource = model.getShapeIndex().getShape(ShapeId.from("ns.foo#ChildResource")).get();
+        Shape childResource = model.getShape(ShapeId.from("ns.foo#ChildResource")).get();
         ArnTrait template2 = ArnTrait.builder()
                 .template("someresource/{someId}/{childId}")
                 .build();
-        Shape rootArnResource = model.getShapeIndex().getShape(ShapeId.from("ns.foo#RootArnResource")).get();
+        Shape rootArnResource = model.getShape(ShapeId.from("ns.foo#RootArnResource")).get();
         ArnTrait template3 = ArnTrait.builder()
                 .template("rootArnResource")
                 .noAccount(true)

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnReferenceTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnReferenceTraitTest.java
@@ -79,8 +79,7 @@ public class ArnReferenceTraitTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        Shape service = result.getShapeIndex()
-                .getShape(ShapeId.from("ns.foo#AbsoluteResourceArn")).get();
+        Shape service = result.expectShape(ShapeId.from("ns.foo#AbsoluteResourceArn"));
         ArnReferenceTrait trait = service.getTrait(ArnReferenceTrait.class).get();
 
         assertThat(trait.getType(), equalTo(Optional.of("AWS::SomeService::AbsoluteResource")));

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/DataTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/DataTraitTest.java
@@ -34,12 +34,12 @@ public class DataTraitTest {
     @Test
     public void loadsWithString() {
         Model model = getModel();
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("ns.foo#A"))
+        assertTrue(model.getShape(ShapeId.from("ns.foo#A"))
                 .flatMap(shape -> shape.getTrait(DataTrait.class))
                 .filter(trait -> trait.getValue().equals("account"))
                 .isPresent());
 
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("ns.foo#B"))
+        assertTrue(model.getShape(ShapeId.from("ns.foo#B"))
                 .flatMap(shape -> shape.getTrait(DataTrait.class))
                 .filter(trait -> trait.getValue().equals("tagging"))
                 .isPresent());

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
@@ -86,8 +86,8 @@ public class ServiceTraitTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        ServiceShape service = result.getShapeIndex()
-                .getShape(ShapeId.from("ns.foo#SomeService")).get()
+        ServiceShape service = result
+                .expectShape(ShapeId.from("ns.foo#SomeService"))
                 .asServiceShape().get();
         ServiceTrait trait = service.getTrait(ServiceTrait.class).get();
 

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/UnsignedPayloadTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/UnsignedPayloadTraitTest.java
@@ -31,12 +31,12 @@ public class UnsignedPayloadTraitTest {
                 .assemble()
                 .unwrap();
 
-        assertTrue(result.getShapeIndex()
+        assertTrue(result
                 .getShape(ShapeId.from("ns.foo#Unsigned1"))
                 .flatMap(shape -> shape.getTrait(UnsignedPayloadTrait.class))
                 .isPresent());
 
-        assertTrue(result.getShapeIndex()
+        assertTrue(result
                 .getShape(ShapeId.from("ns.foo#Unsigned2"))
                 .flatMap(shape -> shape.getTrait(UnsignedPayloadTrait.class))
                 .filter(trait -> trait.getValues().equals(ListUtils.of("aws.v4")))

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/apigateway/IntegrationTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/apigateway/IntegrationTraitTest.java
@@ -50,8 +50,7 @@ public class IntegrationTraitTest {
                 .assemble()
                 .unwrap();
 
-        MockIntegrationTrait trait = model.getShapeIndex().getShape(ShapeId.from("ns.foo#Operation"))
-                .get()
+        MockIntegrationTrait trait = model.expectShape(ShapeId.from("ns.foo#Operation"))
                 .getTrait(MockIntegrationTrait.class)
                 .get();
 

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformerTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformerTest.java
@@ -41,22 +41,22 @@ public class CleanClientDiscoveryTraitTransformerTest {
             return !shape.getId().toString().equals("ns.foo#DescribeEndpoints");
         });
 
-        ServiceShape service = result.getShapeIndex()
+        ServiceShape service = result
                 .getShape(ShapeId.from("ns.foo#FooService"))
                 .flatMap(Shape::asServiceShape)
                 .get();
 
-        OperationShape getOperation = result.getShapeIndex()
+        OperationShape getOperation = result
                 .getShape(ShapeId.from("ns.foo#GetObject"))
                 .flatMap(Shape::asOperationShape)
                 .get();
 
-        OperationShape putOperation = result.getShapeIndex()
+        OperationShape putOperation = result
                 .getShape(ShapeId.from("ns.foo#PutObject"))
                 .flatMap(Shape::asOperationShape)
                 .get();
 
-        MemberShape putId = result.getShapeIndex()
+        MemberShape putId = result
                 .getShape(ShapeId.from("ns.foo#PutObjectInput$Id"))
                 .flatMap(Shape::asMemberShape)
                 .get();
@@ -80,22 +80,22 @@ public class CleanClientDiscoveryTraitTransformerTest {
             return !shape.getId().toString().equals("ns.foo#InvalidEndpointError");
         });
 
-        ServiceShape service = result.getShapeIndex()
+        ServiceShape service = result
                 .getShape(ShapeId.from("ns.foo#FooService"))
                 .flatMap(Shape::asServiceShape)
                 .get();
 
-        OperationShape getOperation = result.getShapeIndex()
+        OperationShape getOperation = result
                 .getShape(ShapeId.from("ns.foo#GetObject"))
                 .flatMap(Shape::asOperationShape)
                 .get();
 
-        OperationShape putOperation = result.getShapeIndex()
+        OperationShape putOperation = result
                 .getShape(ShapeId.from("ns.foo#PutObject"))
                 .flatMap(Shape::asOperationShape)
                 .get();
 
-        MemberShape putId = result.getShapeIndex()
+        MemberShape putId = result
                 .getShape(ShapeId.from("ns.foo#PutObjectInput$Id"))
                 .flatMap(Shape::asMemberShape)
                 .get();
@@ -119,12 +119,12 @@ public class CleanClientDiscoveryTraitTransformerTest {
             return !shape.getId().toString().equals("ns.foo#DescribeEndpointsFoo");
         });
 
-        OperationShape getOperation = result.getShapeIndex()
+        OperationShape getOperation = result
                 .getShape(ShapeId.from("ns.foo#GetObjectFoo"))
                 .flatMap(Shape::asOperationShape)
                 .get();
 
-        OperationShape putOperation = result.getShapeIndex()
+        OperationShape putOperation = result
                 .getShape(ShapeId.from("ns.foo#PutObject"))
                 .flatMap(Shape::asOperationShape)
                 .get();
@@ -145,7 +145,7 @@ public class CleanClientDiscoveryTraitTransformerTest {
             return !shape.getId().toString().equals("ns.foo#DescribeEndpointsFoo");
         });
 
-        MemberShape id = result.getShapeIndex()
+        MemberShape id = result
                 .getShape(ShapeId.from("ns.foo#GetObjectInput$Id"))
                 .flatMap(Shape::asMemberShape)
                 .get();

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTraitTest.java
@@ -31,8 +31,8 @@ public class ClientDiscoveredEndpointTraitTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        OperationShape operation = result.getShapeIndex()
-                .getShape(ShapeId.from("ns.foo#GetObject")).get()
+        OperationShape operation = result
+                .expectShape(ShapeId.from("ns.foo#GetObject"))
                 .asOperationShape().get();
         ClientDiscoveredEndpointTrait trait = operation.getTrait(ClientDiscoveredEndpointTrait.class).get();
 

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTraitTest.java
@@ -40,10 +40,10 @@ public class ClientEndpointDiscoveryIdTraitTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        OperationShape operation = result.getShapeIndex()
-                .getShape(ShapeId.from("ns.foo#GetObject")).get()
+        OperationShape operation = result
+                .expectShape(ShapeId.from("ns.foo#GetObject"))
                 .asOperationShape().get();
-        MemberShape member = result.getShapeIndex()
+        MemberShape member = result
                 .getShape(operation.getInput().get()).get()
                 .asStructureShape().get()
                 .getMember("Id").get();

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTraitTest.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.aws.traits.clientendpointdiscovery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -32,8 +31,8 @@ public class ClientEndpointDiscoveryTraitTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        ServiceShape service = result.getShapeIndex()
-                .getShape(ShapeId.from("ns.foo#FooService")).get()
+        ServiceShape service = result
+                .expectShape(ShapeId.from("ns.foo#FooService"))
                 .asServiceShape().get();
         ClientEndpointDiscoveryTrait trait = service.getTrait(ClientEndpointDiscoveryTrait.class).get();
 

--- a/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/iam/RequiredActionsTraitTest.java
+++ b/aws/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/iam/RequiredActionsTraitTest.java
@@ -33,7 +33,7 @@ public class RequiredActionsTraitTest {
                 .assemble()
                 .unwrap();
 
-        Shape myOperation = result.getShapeIndex().getShape(ShapeId.from("smithy.example#MyOperation")).get();
+        Shape myOperation = result.getShape(ShapeId.from("smithy.example#MyOperation")).get();
 
         assertTrue(myOperation.hasTrait(RequiredActionsTrait.class));
         assertThat(myOperation.getTrait(RequiredActionsTrait.class).get().getValues(), containsInAnyOrder(

--- a/smithy-build/src/main/java/software/amazon/smithy/build/PluginContext.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/PluginContext.java
@@ -49,7 +49,7 @@ public final class PluginContext implements ToSmithyBuilder<PluginContext> {
     private final FileManifest fileManifest;
     private final ClassLoader pluginClassLoader;
     private final Set<Path> sources;
-    private ShapeIndex nonTraitsIndex;
+    private Model nonTraitsModel;
 
     private PluginContext(Builder builder) {
         model = SmithyBuilder.requiredState("model", builder.model);
@@ -148,28 +148,32 @@ public final class PluginContext implements ToSmithyBuilder<PluginContext> {
         return Optional.ofNullable(pluginClassLoader);
     }
 
+    @Deprecated
+    public synchronized ShapeIndex getNonTraitShapes() {
+        return getModelWithoutTraitShapes().getShapeIndex();
+    }
+
     /**
-     * Gets all shapes from a model as a {@code ShapeIndex} where shapes that
-     * define traits or shapes that are only used as part of a trait
-     * definition have been removed.
+     * Creates a new Model where shapes that define traits or shapes
+     * that are only used as part of a trait definition have been removed.
      *
      * <p>This is typically functionality used by code generators when
      * generating data structures from a model. It's useful because it only
      * provides shapes that are used to describe data structures rather than
      * shapes used to describe metadata about the data structures.
      *
-     * <p>Note: this method just calls {@link ModelTransformer#getNonTraitShapes}.
+     * <p>Note: this method just calls {@link ModelTransformer#getModelWithoutTraitShapes}.
      * It's added to {@code PluginContext} to make it more easily available
      * to code generators.
      *
-     * @return Returns a ShapeIndex containing matching shapes.
+     * @return Returns a Model containing matching shapes.
      */
-    public synchronized ShapeIndex getNonTraitShapes() {
-        if (nonTraitsIndex == null) {
-            nonTraitsIndex = ModelTransformer.create().getNonTraitShapes(model);
+    public synchronized Model getModelWithoutTraitShapes() {
+        if (nonTraitsModel == null) {
+            nonTraitsModel = ModelTransformer.create().getModelWithoutTraitShapes(model);
         }
 
-        return nonTraitsIndex;
+        return nonTraitsModel;
     }
 
     /**
@@ -197,8 +201,7 @@ public final class PluginContext implements ToSmithyBuilder<PluginContext> {
      * @return Returns true if this shape is considered a source shape.
      */
     public boolean isSourceShape(ToShapeId shape) {
-        return originalModel == null
-               || isSource(originalModel.getShapeIndex().getShape(shape.toShapeId()).orElse(null));
+        return originalModel == null || isSource(originalModel.getShape(shape.toShapeId()).orElse(null));
     }
 
     /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/plugins/BuildInfoPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/plugins/BuildInfoPlugin.java
@@ -88,7 +88,7 @@ public final class BuildInfoPlugin implements SmithyBuildPlugin {
     }
 
     private static Node findTraitNames(Model model) {
-        return model.getShapeIndex().shapes()
+        return model.shapes()
                 .flatMap(shape -> shape.getAllTraits().keySet().stream())
                 .map(ShapeId::toString)
                 .distinct()
@@ -98,7 +98,7 @@ public final class BuildInfoPlugin implements SmithyBuildPlugin {
     }
 
     private static <T extends Shape> Node findShapeIds(Model model, Class<T> clazz) {
-        return model.getShapeIndex().shapes(clazz)
+        return model.shapes(clazz)
                 .map(Shape::getId)
                 .map(Object::toString)
                 .sorted()

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
@@ -58,10 +58,10 @@ public final class RemoveUnusedShapes implements ProjectionTransformer {
             int currentShapeCount;
 
             do {
-                currentShapeCount = model.getShapeIndex().toSet().size();
+                currentShapeCount = model.toSet().size();
                 model = transformer.removeUnreferencedShapes(model, keepShapesByTag);
                 model = transformer.removeUnreferencedTraitDefinitions(model, keepTraitDefsByTag);
-            } while (currentShapeCount != model.getShapeIndex().toSet().size());
+            } while (currentShapeCount != model.toSet().size());
 
             return model;
         };

--- a/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.ProjectionConfig;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -48,20 +47,20 @@ public class PluginContextTest {
     }
 
     @Test
-    public void createsNonTraitShapeIndex() {
+    public void createsNonTraitModel() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("simple-model.json"))
                 .assemble()
                 .unwrap();
-        ShapeIndex scrubbed = ModelTransformer.create().getNonTraitShapes(model);
+        Model scrubbed = ModelTransformer.create().getModelWithoutTraitShapes(model);
         PluginContext context = PluginContext.builder()
                 .fileManifest(new MockManifest())
                 .model(model)
                 .sources(ListUtils.of(Paths.get("/foo/baz")))
                 .build();
 
-        assertThat(context.getNonTraitShapes(), equalTo(scrubbed));
-        assertThat(context.getNonTraitShapes(), equalTo(scrubbed)); // trigger loading from cache
+        assertThat(context.getModelWithoutTraitShapes(), equalTo(scrubbed));
+        assertThat(context.getModelWithoutTraitShapes(), equalTo(scrubbed)); // trigger loading from cache
     }
 
     @Test

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -96,13 +96,13 @@ public class SmithyBuildTest {
         Model resultA = results.getProjectionResult("a").get().getModel();
         Model resultB = results.getProjectionResult("b").get().getModel();
 
-        assertThat(resultA.getShapeIndex().getShape(ShapeId.from("ns.foo#String1")), not(Optional.empty()));
-        assertThat(resultA.getShapeIndex().getShape(ShapeId.from("ns.foo#String2")), is(Optional.empty()));
-        assertThat(resultA.getShapeIndex().getShape(ShapeId.from("ns.foo#String3")), not(Optional.empty()));
+        assertThat(resultA.getShape(ShapeId.from("ns.foo#String1")), not(Optional.empty()));
+        assertThat(resultA.getShape(ShapeId.from("ns.foo#String2")), is(Optional.empty()));
+        assertThat(resultA.getShape(ShapeId.from("ns.foo#String3")), not(Optional.empty()));
 
-        assertThat(resultB.getShapeIndex().getShape(ShapeId.from("ns.foo#String1")), not(Optional.empty()));
-        assertThat(resultB.getShapeIndex().getShape(ShapeId.from("ns.foo#String2")), not(Optional.empty()));
-        assertThat(resultB.getShapeIndex().getShape(ShapeId.from("ns.foo#String3")), not(Optional.empty()));
+        assertThat(resultB.getShape(ShapeId.from("ns.foo#String1")), not(Optional.empty()));
+        assertThat(resultB.getShape(ShapeId.from("ns.foo#String2")), not(Optional.empty()));
+        assertThat(resultB.getShape(ShapeId.from("ns.foo#String3")), not(Optional.empty()));
     }
 
     @Test
@@ -205,23 +205,23 @@ public class SmithyBuildTest {
         Model resultB = results.getProjectionResult("b").get().getModel();
         Model resultC = results.getProjectionResult("c").get().getModel();
 
-        assertTrue(resultA.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultA.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(SensitiveTrait.class).isPresent());
-        assertFalse(resultA.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertFalse(resultA.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).isPresent());
 
-        assertTrue(resultB.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultB.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(SensitiveTrait.class).isPresent());
-        assertTrue(resultB.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultB.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).isPresent());
-        assertThat(resultB.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertThat(resultB.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).get().getValue(), equalTo("b.json"));
 
-        assertTrue(resultC.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultC.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(SensitiveTrait.class).isPresent());
-        assertTrue(resultC.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultC.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).isPresent());
-        assertThat(resultC.getShapeIndex().getShape(ShapeId.from("com.foo#String")).get()
+        assertThat(resultC.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).get().getValue(), equalTo("c.json"));
     }
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTagTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
@@ -40,17 +39,14 @@ public class ExcludeShapesByTagTest {
                 .id("ns.foo#bar")
                 .addTrait(TagsTrait.builder().addValue("qux").build())
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
-                .addShapes(stringA, stringB)
-                .build();
         Model model = Model.builder()
-                .shapeIndex(index)
+                .addShapes(stringA, stringB)
                 .build();
         Model result = new ExcludeShapesByTag()
                 .createTransformer(Collections.singletonList("foo"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(stringA.getId()), is(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(stringB.getId()), not(Optional.empty()));
+        assertThat(result.getShape(stringA.getId()), is(Optional.empty()));
+        assertThat(result.getShape(stringB.getId()), not(Optional.empty()));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsTest.java
@@ -48,9 +48,9 @@ public class ExcludeTraitsTest {
                 .createTransformer(Collections.singletonList("documentation"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(ShapeId.from("ns.foo#baz")).get().getTrait(DocumentationTrait.class),
+        assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(DocumentationTrait.class),
                    is(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(ShapeId.from("ns.foo#baz")).get().getTrait(SensitiveTrait.class),
+        assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(SensitiveTrait.class),
                    not(Optional.empty()));
         assertFalse(result.getTraitDefinition("smithy.api#documentation").isPresent());
     }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeAuthTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeAuthTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.AuthTrait;
 import software.amazon.smithy.model.traits.Protocol;
 import software.amazon.smithy.model.traits.ProtocolsTrait;
@@ -51,20 +50,17 @@ public class IncludeAuthTest {
                 .version("1")
                 .addTrait(ProtocolsTrait.builder().addProtocol(Protocol.builder().name("foo").build()).build())
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
-                .addShapes(service1, service2, service3)
-                .build();
         Model model = Model.builder()
-                .shapeIndex(index)
+                .addShapes(service1, service2, service3)
                 .build();
         Model result = new IncludeAuth()
                 .createTransformer(Collections.singletonList("foo"))
                 .apply(ModelTransformer.create(), model);
 
-        Shape updateService1 = result.getShapeIndex().getShape(service1.getId()).get();
+        Shape updateService1 = result.getShape(service1.getId()).get();
         assertThat(updateService1.getTrait(AuthTrait.class).get().getValues(), contains("foo"));
         assertThat(updateService1.getTrait(ProtocolsTrait.class).get().getAllAuthSchemes(), contains("foo"));
-        assertThat(result.getShapeIndex().getShape(service2.getId()).get(), equalTo(service2));
-        assertThat(result.getShapeIndex().getShape(service3.getId()).get(), equalTo(service3));
+        assertThat(result.getShape(service2.getId()).get(), equalTo(service2));
+        assertThat(result.getShape(service3.getId()).get(), equalTo(service3));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeNamespacesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeNamespacesTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
@@ -35,15 +34,14 @@ public class IncludeNamespacesTest {
         StringShape string2 = StringShape.builder().id("ns.foo#qux").build();
         StringShape string3 = StringShape.builder().id("ns.bar#yuck").build();
         StringShape string4 = StringShape.builder().id("ns.qux#yuck").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(string1, string2, string3, string4).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(string1, string2, string3, string4).build();
         Model result = new IncludeNamespaces()
                 .createTransformer(Arrays.asList("ns.foo", "ns.bar"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(string1.getId()), not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(string2.getId()), not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(string3.getId()), not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(string4.getId()), is(Optional.empty()));
+        assertThat(result.getShape(string1.getId()), not(Optional.empty()));
+        assertThat(result.getShape(string2.getId()), not(Optional.empty()));
+        assertThat(result.getShape(string3.getId()), not(Optional.empty()));
+        assertThat(result.getShape(string4.getId()), is(Optional.empty()));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeProtocolsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeProtocolsTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.Protocol;
 import software.amazon.smithy.model.traits.ProtocolsTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
@@ -37,12 +36,11 @@ public class IncludeProtocolsTest {
                         .addProtocol(Protocol.builder().name("qux").build()).build())
                 .id("ns.foo#baz")
                 .build();
-        ShapeIndex index = ShapeIndex.builder().addShape(service).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShape(service).build();
         Model result = new IncludeProtocols()
                 .createTransformer(Collections.singletonList("qux"))
                 .apply(ModelTransformer.create(), model);
-        ServiceShape shape = result.getShapeIndex().getShape(service.getId()).get().asServiceShape().get();
+        ServiceShape shape = result.getShape(service.getId()).get().asServiceShape().get();
 
         Assertions.assertEquals(shape.getTrait(ProtocolsTrait.class).get().getProtocolNames(), ListUtils.of("qux"));
     }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeServicesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeServicesTest.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
@@ -35,14 +34,13 @@ public class IncludeServicesTest {
         ServiceShape serviceA = ServiceShape.builder().id("ns.foo#baz").version("1").build();
         ServiceShape serviceB = ServiceShape.builder().id("ns.foo#bar").version("1").build();
         StringShape string = StringShape.builder().id("ns.foo#yuck").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(serviceA, serviceB, string).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(serviceA, serviceB, string).build();
         Model result = new IncludeServices()
                 .createTransformer(Collections.singletonList("ns.foo#baz"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(serviceA.getId()), not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(string.getId()), not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(serviceB.getId()), is(Optional.empty()));
+        assertThat(result.getShape(serviceA.getId()), not(Optional.empty()));
+        assertThat(result.getShape(string.getId()), not(Optional.empty()));
+        assertThat(result.getShape(serviceB.getId()), is(Optional.empty()));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeShapesByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeShapesByTagTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
@@ -40,17 +39,14 @@ public class IncludeShapesByTagTest {
                 .id("ns.foo#bar")
                 .addTrait(TagsTrait.builder().addValue("qux").build())
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
-                .addShapes(stringA, stringB)
-                .build();
         Model model = Model.builder()
-                .shapeIndex(index)
+                .addShapes(stringA, stringB)
                 .build();
         Model result = new IncludeShapesByTag()
                 .createTransformer(Collections.singletonList("foo"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(stringA.getId()), not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(stringB.getId()), is(Optional.empty()));
+        assertThat(result.getShape(stringA.getId()), not(Optional.empty()));
+        assertThat(result.getShape(stringB.getId()), is(Optional.empty()));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTagsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTagsTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
@@ -41,14 +40,13 @@ public class IncludeTagsTest {
                 .addTrait(TagsTrait.builder().addValue("foo").build())
                 .build();
         Shape shape3 = StringShape.builder().id("ns.foo#shape3").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(shape1, shape2, shape3).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(shape1, shape2, shape3).build();
         Model result = new IncludeTags()
                 .createTransformer(Collections.singletonList("foo"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(shape1.getId()).get().getTags(), contains("foo"));
-        assertThat(result.getShapeIndex().getShape(shape2.getId()).get(), equalTo(shape2));
-        assertThat(result.getShapeIndex().getShape(shape3.getId()).get(), equalTo(shape3));
+        assertThat(result.expectShape(shape1.getId()).getTags(), contains("foo"));
+        assertThat(result.expectShape(shape2.getId()), equalTo(shape2));
+        assertThat(result.expectShape(shape3.getId()), equalTo(shape3));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsTest.java
@@ -50,9 +50,9 @@ public class IncludeTraitsTest {
                 .createTransformer(ListUtils.of("documentation"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(ShapeId.from("ns.foo#baz")).get().getTrait(DocumentationTrait.class),
+        assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(DocumentationTrait.class),
                    not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(ShapeId.from("ns.foo#baz")).get().getTrait(SensitiveTrait.class),
+        assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(SensitiveTrait.class),
                    is(Optional.empty()));
 
         assertTrue(result.getTraitDefinition("smithy.api#documentation").isPresent());
@@ -74,9 +74,9 @@ public class IncludeTraitsTest {
                 .createTransformer(Collections.singletonList("smithy.api"))
                 .apply(ModelTransformer.create(), model);
 
-        assertThat(result.getShapeIndex().getShape(ShapeId.from("ns.foo#baz")).get().getTrait(DocumentationTrait.class),
+        assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(DocumentationTrait.class),
                    not(Optional.empty()));
-        assertThat(result.getShapeIndex().getShape(ShapeId.from("ns.foo#baz")).get().getTrait(SensitiveTrait.class),
+        assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(SensitiveTrait.class),
                    not(Optional.empty()));
         assertTrue(result.getTraitDefinition("smithy.api#documentation").isPresent());
         assertTrue(result.getTraitDefinition("smithy.api#sensitive").isPresent());

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RemoveUnusedShapesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RemoveUnusedShapesTest.java
@@ -43,7 +43,7 @@ public class RemoveUnusedShapesTest {
         Model result = new RemoveUnusedShapes()
                 .createTransformer(Collections.singletonList("export"))
                 .apply(ModelTransformer.create(), model);
-        List<String> ids = result.getShapeIndex().shapes()
+        List<String> ids = result.shapes()
                 .filter(FunctionalUtils.not(Prelude::isPreludeShape))
                 .map(Shape::getId)
                 .map(Object::toString)
@@ -63,8 +63,8 @@ public class RemoveUnusedShapesTest {
                 .apply(ModelTransformer.create(), model);
 
         assertTrue(result.getTraitDefinition("ns.foo#bar").isPresent());
-        assertTrue(result.getShapeIndex().getShape(ShapeId.from("ns.foo#bar")).isPresent());
-        assertTrue(result.getShapeIndex().getShape(ShapeId.from("ns.foo#BarTraitShapeMember")).isPresent());
+        assertTrue(result.getShape(ShapeId.from("ns.foo#bar")).isPresent());
+        assertTrue(result.getShape(ShapeId.from("ns.foo#BarTraitShapeMember")).isPresent());
         assertFalse(result.getTraitDefinition("ns.foo#QuuxTraitShapeMember").isPresent());
     }
 
@@ -79,6 +79,6 @@ public class RemoveUnusedShapesTest {
                 .apply(ModelTransformer.create(), model);
 
         assertFalse(result.getTraitDefinition("ns.foo#quux").isPresent());
-        assertFalse(result.getShapeIndex().getShape(ShapeId.from("ns.foo#QuuxTraitShape")).isPresent());
+        assertFalse(result.getShape(ShapeId.from("ns.foo#QuuxTraitShape")).isPresent());
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -61,7 +61,7 @@ final class Validator {
             System.out.println(String.join("", Collections.nCopies(line.length(), "-")));
             System.out.println(line);
             result.getResult().ifPresent(model -> System.out.println(String.format(
-                    "Validated %d shapes in model", model.getShapeIndex().shapes().count())));
+                    "Validated %d shapes in model", model.shapes().count())));
         }
 
         if (errors + dangers > 0) {

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/Differences.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/Differences.java
@@ -67,8 +67,7 @@ public final class Differences {
      * @return Returns a stream of each added shape.
      */
     public Stream<Shape> addedShapes() {
-        return newModel.getShapeIndex().shapes()
-                .filter(shape -> !oldModel.getShapeIndex().getShape(shape.getId()).isPresent());
+        return newModel.shapes().filter(shape -> !oldModel.getShape(shape.getId()).isPresent());
     }
 
     /**
@@ -102,8 +101,7 @@ public final class Differences {
      * @return Returns a stream of each removed shape.
      */
     public Stream<Shape> removedShapes() {
-        return oldModel.getShapeIndex().shapes()
-                .filter(shape -> !newModel.getShapeIndex().getShape(shape.getId()).isPresent());
+        return oldModel.shapes().filter(shape -> !newModel.getShape(shape.getId()).isPresent());
     }
 
     /**
@@ -164,8 +162,8 @@ public final class Differences {
     }
 
     private static void detectShapeChanges(Model oldModel, Model newModel, Differences differences) {
-        for (Shape oldShape : oldModel.getShapeIndex().toSet()) {
-            newModel.getShapeIndex().getShape(oldShape.getId()).ifPresent(newShape -> {
+        for (Shape oldShape : oldModel.toSet()) {
+            newModel.getShape(oldShape.getId()).ifPresent(newShape -> {
                 if (!oldShape.equals(newShape)) {
                     differences.changedShapes.add(new ChangedShape<>(oldShape, newShape));
                 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationInputOutput.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationInputOutput.java
@@ -64,7 +64,7 @@ public class AddedOperationInputOutput implements DiffEvaluator {
     private Optional<ValidationEvent> validateChange(String rel, Model model, Shape operation, ShapeId target) {
         String eventId = "AddedOperation" + rel;
 
-        return model.getShapeIndex().getShape(target).flatMap(Shape::asStructureShape).map(struct -> {
+        return model.getShape(target).flatMap(Shape::asStructureShape).map(struct -> {
             if (struct.getAllMembers().values().stream().noneMatch(MemberShape::isRequired)) {
                 // This is a backward compatible change.
                 return ValidationEvent.builder()

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberTarget.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberTarget.java
@@ -57,7 +57,7 @@ public class ChangedMemberTarget extends AbstractDiffEvaluator {
     }
 
     private Shape getShapeTarget(Model model, ShapeId id) {
-        return model.getShapeIndex().getShape(id).orElse(null);
+        return model.getShape(id).orElse(null);
     }
 
     private boolean areShapesCompatible(Shape oldShape, Shape newShape) {

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/DifferencesTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/DifferencesTest.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 
@@ -62,7 +61,7 @@ public class DifferencesTest {
     public void detectsAddedShapes() {
         Shape shape = StringShape.builder().id("foo.bar#Baz").build();
         Model previous = Model.builder().build();
-        Model current = Model.builder().shapeIndex(ShapeIndex.builder().addShapes(shape).build()).build();
+        Model current = Model.builder().addShapes(shape).build();
         Differences differences = Differences.detect(previous, current);
 
         assertThat(differences.addedShapes().count(), equalTo(1L));
@@ -72,7 +71,7 @@ public class DifferencesTest {
     @Test
     public void detectsRemovedShapes() {
         Shape shape = StringShape.builder().id("foo.bar#Baz").build();
-        Model previous = Model.builder().shapeIndex(ShapeIndex.builder().addShapes(shape).build()).build();
+        Model previous = Model.builder().addShapes(shape).build();
         Model current = Model.builder().build();
         Differences differences = Differences.detect(previous, current);
 

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConverter.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConverter.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.node.Node;
@@ -170,14 +171,19 @@ public final class JsonSchemaConverter {
         return this;
     }
 
+    @Deprecated
+    public SchemaDocument convert(ShapeIndex shapeIndex) {
+        return doConversion(shapeIndex, null);
+    }
+
     /**
      * Perform the conversion of the entire shape Index.
      *
-     * @param shapeIndex Shape index to convert.
+     * @param model Model to convert.
      * @return Returns the created SchemaDocument.
      */
-    public SchemaDocument convert(ShapeIndex shapeIndex) {
-        return doConversion(shapeIndex, null);
+    public SchemaDocument convert(Model model) {
+        return convert(model.getShapeIndex());
     }
 
     /**
@@ -192,6 +198,20 @@ public final class JsonSchemaConverter {
      */
     public SchemaDocument convert(ShapeIndex shapeIndex, Shape shape) {
         return doConversion(shapeIndex, shape);
+    }
+
+    /**
+     * Perform the conversion of a single shape.
+     *
+     * <p>The root shape of the created document is set to the given shape,
+     * and only shapes connected to the given shape are added as a definition.
+     *
+     * @param model Model to convert.
+     * @param shape Shape to convert.
+     * @return Returns the created SchemaDocument.
+     */
+    public SchemaDocument convert(Model model, Shape shape) {
+        return convert(model.getShapeIndex(), shape);
     }
 
     private SchemaDocument doConversion(ShapeIndex shapeIndex, Shape rootShape) {

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/AbbreviationNameValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/AbbreviationNameValidator.java
@@ -60,7 +60,7 @@ public final class AbbreviationNameValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes()
+        return model.shapes()
                 .flatMap(this::validateShapeName)
                 .collect(Collectors.toList());
     }

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
@@ -68,7 +68,7 @@ public final class CamelCaseValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         // Normal shapes are expected to be upper camel.
-        model.getShapeIndex().shapes()
+        model.shapes()
                 .filter(FunctionalUtils.not(Shape::isMemberShape))
                 .filter(shape -> !shape.hasTrait(TraitDefinition.class))
                 .filter(shape -> !getPattern(UPPER).matcher(shape.getId().getName()).find())
@@ -77,7 +77,7 @@ public final class CamelCaseValidator extends AbstractValidator {
                 .forEach(events::add);
 
         // Trait shapes are expected to be lower camel.
-        model.getShapeIndex().shapes()
+        model.shapes()
                 .filter(shape -> shape.hasTrait(TraitDefinition.class))
                 .filter(shape -> !getPattern(LOWER).matcher(shape.getId().getName()).find())
                 .map(shape -> danger(shape, format("%s trait definition, `%s`, is not lower camel case",
@@ -85,7 +85,7 @@ public final class CamelCaseValidator extends AbstractValidator {
                 .forEach(events::add);
 
         Pattern isValidMemberName = getPattern(memberNames);
-        model.getShapeIndex().shapes(MemberShape.class)
+        model.shapes(MemberShape.class)
                 .filter(shape -> !isValidMemberName.matcher(shape.getMemberName()).find())
                 .map(shape -> danger(shape, format("Member shape member name, `%s`, is not %s camel case",
                                                    shape.getMemberName(), memberNames)))

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/DeprecatedAuthSchemesValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/DeprecatedAuthSchemesValidator.java
@@ -63,7 +63,7 @@ public final class DeprecatedAuthSchemesValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, AuthTrait.class))
                 .flatMap(pair -> validateAuthSchemes(pair.getLeft(), pair.getRight()))
                 .collect(Collectors.toList());

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/DeprecatedProtocolsValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/DeprecatedProtocolsValidator.java
@@ -63,7 +63,7 @@ public final class DeprecatedProtocolsValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, ProtocolsTrait.class))
                 .flatMap(pair -> validateProtocols(pair.getLeft(), pair.getRight()))
                 .collect(Collectors.toList());

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/EmitEachSelectorValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/EmitEachSelectorValidator.java
@@ -55,7 +55,7 @@ public final class EmitEachSelectorValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return selector.select(model.getShapeIndex()).stream()
+        return selector.select(model).stream()
                 .map(shape -> danger(shape, "Selector capture matched selector: " + selector))
                 .collect(Collectors.toList());
     }

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/EmitNoneSelectorValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/EmitNoneSelectorValidator.java
@@ -61,7 +61,7 @@ public final class EmitNoneSelectorValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         // Filter out prelude types.
-        Set<Shape> shapes = selector.select(model.getShapeIndex()).stream()
+        Set<Shape> shapes = selector.select(model).stream()
                 .filter(shape -> !Prelude.isPreludeShape(shape.getId()))
                 .collect(Collectors.toSet());
 

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/InputOutputStructureReuseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/InputOutputStructureReuseValidator.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -51,45 +50,44 @@ public class InputOutputStructureReuseValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        ShapeIndex index = model.getShapeIndex();
-        Map<ShapeId, Set<ShapeId>> inputs = createStructureToOperation(index, OperationShape::getInput);
-        Map<ShapeId, Set<ShapeId>> outputs = createStructureToOperation(index, OperationShape::getOutput);
+        Map<ShapeId, Set<ShapeId>> inputs = createStructureToOperation(model, OperationShape::getInput);
+        Map<ShapeId, Set<ShapeId>> outputs = createStructureToOperation(model, OperationShape::getOutput);
 
         // Look for structures used as both input and output.
         Set<ShapeId> both = new HashSet<>(inputs.keySet());
         both.retainAll(outputs.keySet());
         both.stream().map(id -> emitWhenBothInputAndOutput(
-                index, id, inputs.get(id), outputs.get(id))).forEach(events::add);
+                model, id, inputs.get(id), outputs.get(id))).forEach(events::add);
 
         // Look for shared usage across multiple operations.
-        events.addAll(emitShared(index, inputs, "input"));
-        events.addAll(emitShared(index, outputs, "output"));
+        events.addAll(emitShared(model, inputs, "input"));
+        events.addAll(emitShared(model, outputs, "output"));
         return events;
     }
 
     private List<ValidationEvent> emitShared(
-            ShapeIndex index,
+            Model model,
             Map<ShapeId, Set<ShapeId>> mapping,
             String descriptor
     ) {
         return mapping.entrySet().stream()
                 .filter(entry -> entry.getValue().size() > 1)
-                .map(entry -> emitWhenShared(index, entry.getKey(), entry.getValue(), descriptor))
+                .map(entry -> emitWhenShared(model, entry.getKey(), entry.getValue(), descriptor))
                 .collect(Collectors.toList());
     }
 
     /**
      * Creates a map of structure ShapeId to a list of operations that reference it as input/output.
      *
-     * @param index The shape index used to get all operations.
+     * @param model The model used to get all operations.
      * @param f The mapping function used to retrieve input out output structures.
      * @return Returns the mapping.
      */
     private static Map<ShapeId, Set<ShapeId>> createStructureToOperation(
-            ShapeIndex index,
+            Model model,
             Function<OperationShape, Optional<ShapeId>> f
     ) {
-        return index.shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .flatMap(shape -> Pair.flatMapStream(shape, f))
                 .collect(Collectors.groupingBy(
                         Pair::getRight,
@@ -99,12 +97,12 @@ public class InputOutputStructureReuseValidator extends AbstractValidator {
     }
 
     private ValidationEvent emitWhenBothInputAndOutput(
-            ShapeIndex index,
+            Model model,
             ShapeId structure,
             Set<ShapeId> inputs,
             Set<ShapeId> outputs
     ) {
-        return emit(index, structure, String.format(
+        return emit(model, structure, String.format(
                 "Using the same structure for both input and output can lead to backward-compatibility problems "
                 + "in the future if the members or traits used in input needs to diverge from those used in "
                 + "output. It is always better to use structures that are exclusively used as input or "
@@ -115,12 +113,12 @@ public class InputOutputStructureReuseValidator extends AbstractValidator {
     }
 
     private ValidationEvent emitWhenShared(
-            ShapeIndex index,
+            Model model,
             ShapeId structure,
             Set<ShapeId> operations,
             String descriptor
     ) {
-        return emit(index, structure, String.format(
+        return emit(model, structure, String.format(
                 "Referencing the same %1$s structure from multiple operations can lead to backward-compatibility "
                 + "problems in the future if the %1$ss ever need to diverge. By using the same structure, you "
                 + "are unnecessarily tying the interfaces of these operations together. This structure is"
@@ -128,13 +126,13 @@ public class InputOutputStructureReuseValidator extends AbstractValidator {
                 descriptor, tickedList(operations)));
     }
 
-    private ValidationEvent emit(ShapeIndex index, ShapeId shape, String message) {
+    private ValidationEvent emit(Model model, ShapeId shape, String message) {
         ValidationEvent.Builder builder = ValidationEvent.builder()
                 .eventId(getName())
                 .severity(Severity.DANGER)
                 .message(message)
                 .shapeId(shape);
-        index.getShape(shape).ifPresent(builder::shape);
+        model.getShape(shape).ifPresent(builder::shape);
         return builder.build();
     }
 }

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/ReservedWordsValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/ReservedWordsValidator.java
@@ -32,7 +32,6 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.selector.SelectorSyntaxException;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -82,8 +81,7 @@ public final class ReservedWordsValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex shapeIndex = model.getShapeIndex();
-        return reservations.stream().flatMap(reservation -> reservation.validate(shapeIndex))
+        return reservations.stream().flatMap(reservation -> reservation.validate(model))
                 .collect(Collectors.toList());
     }
 
@@ -135,8 +133,8 @@ public final class ReservedWordsValidator extends AbstractValidator {
             }
         }
 
-        private Stream<ValidationEvent> validate(ShapeIndex shapeIndex) {
-            return selector.select(shapeIndex).stream().flatMap(shape -> OptionalUtils.stream(validateShape(shape)));
+        private Stream<ValidationEvent> validate(Model model) {
+            return selector.select(model).stream().flatMap(shape -> OptionalUtils.stream(validateShape(shape)));
         }
 
         private Optional<ValidationEvent> validateShape(Shape shape) {

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/StandardOperationVerbValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/StandardOperationVerbValidator.java
@@ -87,7 +87,7 @@ public final class StandardOperationVerbValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .flatMap(shape -> OptionalUtils.stream(validateShape(shape, verbs, prefixes, alts)))
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/AuthIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/AuthIndex.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.knowledge;
 import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.AuthTrait;
 import software.amazon.smithy.model.traits.Protocol;
@@ -31,13 +30,13 @@ import software.amazon.smithy.utils.OptionalUtils;
  * for specific protocols.
  */
 public final class AuthIndex implements KnowledgeIndex {
-    private final ShapeIndex index;
+    private final Model model;
 
     /**
      * @param model Model to compute the index from.
      */
     public AuthIndex(Model model) {
-        this.index = model.getShapeIndex();
+        this.model = model;
     }
 
     /**
@@ -49,7 +48,7 @@ public final class AuthIndex implements KnowledgeIndex {
      * @return Returns the list of auth schemes or an empty list if not found.
      */
     public List<String> getDefaultServiceSchemes(ToShapeId service) {
-        return index.getShape(service.toShapeId())
+        return model.getShape(service.toShapeId())
                 .flatMap(serviceShape -> OptionalUtils.or(serviceShape.getTrait(AuthTrait.class)
                         .map(AuthTrait::getValues),
                         () -> serviceShape.getTrait(ProtocolsTrait.class)
@@ -75,7 +74,7 @@ public final class AuthIndex implements KnowledgeIndex {
      * @return Returns the computed authentication schemes.
      */
     public List<String> getOperationSchemes(ToShapeId service, ToShapeId operation) {
-        return index.getShape(operation.toShapeId())
+        return model.getShape(operation.toShapeId())
                 // Get the auth trait from the operation or the service.
                 .map(shape -> shape.getTrait(AuthTrait.class)
                         .map(AuthTrait::getValues)
@@ -98,7 +97,7 @@ public final class AuthIndex implements KnowledgeIndex {
      */
     public List<String> getOperationSchemes(ToShapeId service, ToShapeId operation, String protocolName) {
         // Get the authentication schemes of the protocol.
-        List<String> protocolSchemes = index.getShape(service.toShapeId())
+        List<String> protocolSchemes = model.getShape(service.toShapeId())
                 .flatMap(serviceShape -> serviceShape.getTrait(ProtocolsTrait.class))
                 .flatMap(protocolsTrait -> protocolsTrait.getProtocol(protocolName))
                 .map(Protocol::getAuth)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
@@ -40,7 +40,7 @@ public final class BottomUpIndex implements KnowledgeIndex {
 
     public BottomUpIndex(Model model) {
         PathFinder pathFinder = PathFinder.create(model);
-        model.getShapeIndex().shapes(ServiceShape.class).forEach(service -> {
+        model.shapes(ServiceShape.class).forEach(service -> {
             Map<ShapeId, List<EntityShape>> serviceBindings = new HashMap<>();
             parentBindings.put(service.getId(), serviceBindings);
             for (PathFinder.Path path : pathFinder.search(service, SELECTOR)) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -26,7 +26,6 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.RequiredTrait;
@@ -53,9 +52,8 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
     }
 
     public IdentifierBindingIndex(Model model) {
-        ShapeIndex index = model.getShapeIndex();
         OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
-        index.shapes(ResourceShape.class).forEach(resource -> processResource(resource, operationIndex, index));
+        model.shapes(ResourceShape.class).forEach(resource -> processResource(resource, operationIndex, model));
     }
 
     /**
@@ -91,12 +89,12 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
                 .orElseGet(Collections::emptyMap);
     }
 
-    private void processResource(ResourceShape resource, OperationIndex operationIndex, ShapeIndex index) {
+    private void processResource(ResourceShape resource, OperationIndex operationIndex, Model model) {
         bindings.put(resource.getId(), new HashMap<>());
         bindingTypes.put(resource.getId(), new HashMap<>());
         resource.getAllOperations().forEach(operationId -> {
             // Ignore broken models in this index.
-            Map<String, String> computedBindings = index.getShape(operationId).flatMap(Shape::asOperationShape)
+            Map<String, String> computedBindings = model.getShape(operationId).flatMap(Shape::asOperationShape)
                     .flatMap(operationIndex::getInput)
                     .map(inputShape -> computeBindings(resource, inputShape))
                     .orElseGet(HashMap::new);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/KnowledgeIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/KnowledgeIndex.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.knowledge;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 
 /**
@@ -29,7 +28,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
  * A KnowledgeIndex is often a mapping of {@link ShapeId} to some kind of
  * interesting computed information. For example, in order to resolve the
  * input/output/error structures referenced by an {@link OperationShape},
- * you need a {@link ShapeIndex}, to ensure that the reference from the
+ * you need a {@link Model}, to ensure that the reference from the
  * operation to the structure is resolvable in the shape index, that the
  * shape it references is a structure, and then to cast the shape to a
  * {@link StructureShape}. Because this process is error prone, verbose,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NeighborProviderIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NeighborProviderIndex.java
@@ -26,8 +26,8 @@ public final class NeighborProviderIndex implements KnowledgeIndex {
     private volatile NeighborProvider reversed;
 
     public NeighborProviderIndex(Model model) {
-        provider = NeighborProvider.precomputed(model.getShapeIndex());
-        reversed = NeighborProvider.reverse(model.getShapeIndex(), provider);
+        provider = NeighborProvider.precomputed(model);
+        reversed = NeighborProvider.reverse(model, provider);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -26,7 +26,6 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.PaginatedTrait;
@@ -49,11 +48,10 @@ public final class PaginatedIndex implements KnowledgeIndex {
     private final Map<ShapeId, Map<ShapeId, PaginationInfo>> paginationInfo = new HashMap<>();
 
     public PaginatedIndex(Model model) {
-        ShapeIndex index = model.getShapeIndex();
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
         OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
 
-        index.shapes(ServiceShape.class).forEach(service -> {
+        model.shapes(ServiceShape.class).forEach(service -> {
             PaginatedTrait serviceTrait = service.getTrait(PaginatedTrait.class).orElse(null);
             Map<ShapeId, PaginationInfo> mappings = topDownIndex.getContainedOperations(service).stream()
                     .flatMap(operation -> Trait.flatMapStream(operation, PaginatedTrait.class))

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
@@ -31,7 +31,6 @@ import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.utils.SetUtils;
 
@@ -44,7 +43,6 @@ public final class TopDownIndex implements KnowledgeIndex {
     private final Map<ShapeId, Set<OperationShape>> operations = new HashMap<>();
 
     public TopDownIndex(Model model) {
-        ShapeIndex index = model.getShapeIndex();
         NeighborProvider provider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
         Walker walker = new Walker(provider);
 
@@ -64,9 +62,9 @@ public final class TopDownIndex implements KnowledgeIndex {
             }
         };
 
-        index.shapes(ResourceShape.class).forEach(resource -> findContained(
+        model.shapes(ResourceShape.class).forEach(resource -> findContained(
                 resource.getId(), walker.walkShapes(resource, filter)));
-        index.shapes(ServiceShape.class).forEach(resource -> findContained(
+        model.shapes(ServiceShape.class).forEach(resource -> findContained(
                 resource.getId(), walker.walkShapes(resource, filter)));
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -487,7 +487,7 @@ public final class ModelAssembler {
     private static void mergeModelIntoVisitor(Model model, LoaderVisitor visitor) {
         visitor.onVersion(SourceLocation.NONE, model.getSmithyVersion());
         model.getMetadata().forEach(visitor::onMetadata);
-        model.getShapeIndex().shapes().forEach(visitor::onShape);
+        model.shapes().forEach(visitor::onShape);
     }
 
     private ValidatedResult<Model> validate(Model model, List<ValidationEvent> modelResultEvents) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
@@ -230,23 +230,28 @@ public final class Prelude {
         return PUBLIC_PRELUDE_SHAPE_IDS.contains(toId) || PRELUDE_TRAITS.contains(toId);
     }
 
-    /**
-     * Returns the resolved shape of a shape target by first checking if a
-     * shape in the namespace relative to the target matches the given name,
-     * and then by checking if a public prelude shape matches the given name.
-     *
-     * @param index Shape index to resolve against.
-     * @param fromNamespace Namespace the target was defined in.
-     * @param target The shape target (e.g., "foo", "smithy.api#String", etc.).
-     * @return Returns the optionally resolved shape.
-     * @throws ShapeIdSyntaxException if the target or namespace is invalid.
-     */
+    @Deprecated
     public static Optional<Shape> resolveShapeId(ShapeIndex index, String fromNamespace, String target) {
         // First check shapes in the same namespace.
         return OptionalUtils.or(index.getShape(ShapeId.fromOptionalNamespace(fromNamespace, target)),
                 // Then check shapes in the prelude that are public.
                 () -> index.getShape(ShapeId.fromParts(NAMESPACE, target))
                         .filter(Prelude::isPublicPreludeShape));
+    }
+
+    /**
+     * Returns the resolved shape of a shape target by first checking if a
+     * shape in the namespace relative to the target matches the given name,
+     * and then by checking if a public prelude shape matches the given name.
+     *
+     * @param model Model to resolve against.
+     * @param fromNamespace Namespace the target was defined in.
+     * @param target The shape target (e.g., "foo", "smithy.api#String", etc.).
+     * @return Returns the optionally resolved shape.
+     * @throws ShapeIdSyntaxException if the target or namespace is invalid.
+     */
+    public static Optional<Shape> resolveShapeId(Model model, String fromNamespace, String target) {
+        return resolveShapeId(model.getShapeIndex(), fromNamespace, target);
     }
 
     // Used by the ModelAssembler to load the prelude into another visitor.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
@@ -57,7 +57,7 @@ final class ValidatorDefinition {
         // If there's a selector, create a list of candidate shape IDs that can be emitted.
         if (selector != null) {
             NeighborProvider provider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
-            candidates = selector.select(provider, model.getShapeIndex()).stream()
+            candidates = selector.select(provider, model).stream()
                     .map(Shape::getId)
                     .collect(Collectors.toSet());
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -47,8 +48,13 @@ import software.amazon.smithy.utils.ListUtils;
 final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> implements NeighborProvider {
     private final ShapeIndex shapeIndex;
 
+    @Deprecated
     NeighborVisitor(ShapeIndex shapeIndex) {
         this.shapeIndex = shapeIndex;
+    }
+
+    NeighborVisitor(Model model) {
+        this(model.getShapeIndex());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedShapes.java
@@ -57,18 +57,18 @@ public final class UnreferencedShapes {
         Walker shapeWalker = new Walker(model.getKnowledge(NeighborProviderIndex.class).getProvider());
 
         // Find all shapes connected to any service shape.
-        Set<Shape> connected = model.getShapeIndex().shapes(ServiceShape.class)
+        Set<Shape> connected = model.shapes(ServiceShape.class)
                 .flatMap(service -> shapeWalker.walkShapes(service).stream())
                 .collect(Collectors.toSet());
 
         // Don't remove shapes that are traits or connected to traits.
-        model.getShapeIndex().shapes()
+        model.shapes()
                 .filter(shape -> shape.hasTrait(TraitDefinition.class))
                 .flatMap(shape -> shapeWalker.walkShapes(shape).stream())
                 .forEach(connected::add);
 
         // Any shape that wasn't identified as connected to a service is considered unreferenced.
-        return model.getShapeIndex().shapes()
+        return model.shapes()
                 .filter(FunctionalUtils.not(Shape::isMemberShape))
                 .filter(FunctionalUtils.not(connected::contains))
                 // Retain prelude shapes

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedTraitDefinitions.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.utils.FunctionalUtils;
 import software.amazon.smithy.utils.OptionalUtils;
 
@@ -49,7 +48,6 @@ public final class UnreferencedTraitDefinitions {
 
     public Set<Shape> compute(Model model) {
         Walker walker = new Walker(model.getKnowledge(NeighborProviderIndex.class).getProvider());
-        ShapeIndex index = model.getShapeIndex();
 
         // Begin with a mutable set of all trait definitions contained in the model
         Set<Shape> unused = model.getTraitShapes().stream()
@@ -59,13 +57,13 @@ public final class UnreferencedTraitDefinitions {
 
         // Find all traits used directly or indirectly by a service shape and remove
         // their definitions from the unused set.
-        index.shapes(ServiceShape.class)
+        model.shapes(ServiceShape.class)
                 .flatMap(service -> walker.walkShapes(service).stream())
                 .distinct()
                 .map(Shape::getAllTraits)
                 .flatMap(traits -> traits.keySet().stream())
                 .distinct()
-                .flatMap(traitId -> OptionalUtils.stream(index.getShape(traitId)))
+                .flatMap(traitId -> OptionalUtils.stream(model.getShape(traitId)))
                 .filter(keepFilter)
                 .forEach(unused::remove);
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/Walker.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/Walker.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIndex;
@@ -44,12 +46,17 @@ public final class Walker {
 
     private final NeighborProvider provider;
 
-    public Walker(ShapeIndex shapeIndex) {
-        this(NeighborProvider.of(shapeIndex));
+    public Walker(Model model) {
+        this(model.getKnowledge(NeighborProviderIndex.class).getProvider());
     }
 
     public Walker(NeighborProvider provider) {
         this.provider = provider;
+    }
+
+    @Deprecated
+    public Walker(ShapeIndex shapeIndex) {
+        this(NeighborProvider.of(shapeIndex));
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
@@ -83,13 +83,7 @@ public final class PathFinder {
         return new PathFinder(model.getShapeIndex(), model.getKnowledge(NeighborProviderIndex.class).getProvider());
     }
 
-    /**
-     * Creates a {@code PathFinder} that uses the given {@code ShapeIndex}
-     * and computes the neighbors.
-     *
-     * @param index Shape index to search using a {@code PathFinder}.
-     * @return Returns the crated {@code PathFinder}.
-     */
+    @Deprecated
     public static PathFinder create(ShapeIndex index) {
         return new PathFinder(index, NeighborProvider.of(index));
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.Set;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeIndex;
@@ -37,26 +38,36 @@ public interface Selector {
      */
     Set<Shape> select(NeighborProvider neighborProvider, Set<Shape> shapes);
 
-    /**
-     * Matches a selector against a shape index using a custom
-     * neighbor visitor.
-     *
-     * @param neighborProvider Provides neighbors for shapes
-     * @param index Index to query.
-     * @return Returns the matching shapes.
-     */
+    @Deprecated
     default Set<Shape> select(NeighborProvider neighborProvider, ShapeIndex index) {
         return select(neighborProvider, index.toSet());
     }
 
     /**
-     * Matches a selector against a shape index.
+     * Matches a selector against a shape index using a custom
+     * neighbor visitor.
      *
-     * @param index Index to query.
+     * @param neighborProvider Provides neighbors for shapes
+     * @param model Model to query.
      * @return Returns the matching shapes.
      */
+    default Set<Shape> select(NeighborProvider neighborProvider, Model model) {
+        return select(neighborProvider, model.toSet());
+    }
+
+    @Deprecated
     default Set<Shape> select(ShapeIndex index) {
         return select(NeighborProvider.of(index), index);
+    }
+
+    /**
+     * Matches a selector against a model.
+     *
+     * @param model Model to query.
+     * @return Returns the matching shapes.
+     */
+    default Set<Shape> select(Model model) {
+        return select(NeighborProvider.of(model), model);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.shapes;
 
 import java.util.Optional;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -101,15 +102,27 @@ public final class MemberShape extends Shape implements ToSmithyBuilder<MemberSh
     }
 
     @Override
+    @Deprecated
     public <T extends Trait> Optional<T> getMemberTrait(ShapeIndex index, Class<T> trait) {
         return OptionalUtils.or(getTrait(trait),
                 () -> index.getShape(getTarget()).flatMap(targetedShape -> targetedShape.getTrait(trait)));
     }
 
     @Override
+    @Deprecated
     public Optional<Trait> findMemberTrait(ShapeIndex index, String traitName) {
         return OptionalUtils.or(findTrait(traitName),
                 () -> index.getShape(getTarget()).flatMap(targetedShape -> targetedShape.findTrait(traitName)));
+    }
+
+    @Override
+    public <T extends Trait> Optional<T> getMemberTrait(Model model, Class<T> trait) {
+        return getMemberTrait(model.getShapeIndex(), trait);
+    }
+
+    @Override
+    public Optional<Trait> findMemberTrait(Model model, String traitName) {
+        return findMemberTrait(model.getShapeIndex(), traitName);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -100,7 +100,7 @@ public final class ModelSerializer {
      * @return Returns the grouped namespaces.
      */
     private TreeMap<String, List<Shape>> createNamespaces(Model model) {
-        Map<String, List<Shape>> shapes = model.getShapeIndex().shapes()
+        Map<String, List<Shape>> shapes = model.shapes()
                 .filter(shapeFilter)
                 .collect(Collectors.groupingBy(s -> s.getId().getNamespace()));
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.traits.Trait;
@@ -37,7 +38,7 @@ import software.amazon.smithy.utils.Tagged;
  *
  * <p>Shape does implement {@link Comparable}, but comparisons are based
  * solely on the ShapeId of the shape. This assumes that shapes are being
- * compared in the context of a ShapeIndex that forbids shape ID conflcits.
+ * compared in the context of a Model that forbids shape ID conflicts.
  */
 public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Comparable<Shape> {
     private final ShapeId id;
@@ -215,19 +216,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
         return traits;
     }
 
-    /**
-     * Gets a trait from the member shape or from the shape targeted by the
-     * member.
-     *
-     * <p>If the shape is not a member, then the method functions the same as
-     * {@link #getTrait(Class)}.
-     *
-     * @param index Shape index used to find member targets.
-     * @param trait Trait type to get.
-     * @param <T> Trait type to get.
-     * @return Returns the optionally found trait on the shape or member.
-     * @see MemberShape#getTrait(Class)
-     */
+    @Deprecated
     public <T extends Trait> Optional<T> getMemberTrait(ShapeIndex index, Class<T> trait) {
         return getTrait(trait);
     }
@@ -237,14 +226,36 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
      * member.
      *
      * <p>If the shape is not a member, then the method functions the same as
+     * {@link #getTrait(Class)}.
+     *
+     * @param model Model used to find member targets.
+     * @param trait Trait type to get.
+     * @param <T> Trait type to get.
+     * @return Returns the optionally found trait on the shape or member.
+     * @see MemberShape#getTrait(Class)
+     */
+    public <T extends Trait> Optional<T> getMemberTrait(Model model, Class<T> trait) {
+        return getTrait(trait);
+    }
+
+    @Deprecated
+    public Optional<Trait> findMemberTrait(ShapeIndex index, String traitName) {
+        return findTrait(traitName);
+    }
+
+    /**
+     * Gets a trait from the member shape or from the shape targeted by the
+     * member.
+     *
+     * <p>If the shape is not a member, then the method functions the same as
      * {@link #findTrait(String)}.
      *
-     * @param index Shape index used to find member targets.
+     * @param model Model used to find member targets.
      * @param traitName Trait name to get.
      * @return Returns the optionally found trait on the shape or member.
      * @see MemberShape#findTrait(String)
      */
-    public Optional<Trait> findMemberTrait(ShapeIndex index, String traitName) {
+    public Optional<Trait> findMemberTrait(Model model, String traitName) {
         return findTrait(traitName);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeIndex.java
@@ -44,6 +44,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * invalid state when it is accessed. As such, a {@code ShapeIndex} should be
  * thoroughly validated before it is utilized.
  */
+@Deprecated
 public final class ShapeIndex implements ToSmithyBuilder<ShapeIndex> {
 
     /** A map of shape ID to shapes that backs the shape map. */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EffectiveTraitQuery.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EffectiveTraitQuery.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.model.traits;
 
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeIndex;
@@ -95,15 +96,20 @@ public final class EffectiveTraitQuery implements ToSmithyBuilder<EffectiveTrait
             return new EffectiveTraitQuery(this);
         }
 
-        /**
-         * Sets the required shape index to query.
-         *
-         * @param shapeIndex Shape index to query.
-         * @return Returns the query object builder.
-         */
+        @Deprecated
         public Builder shapeIndex(ShapeIndex shapeIndex) {
             this.shapeIndex = shapeIndex;
             return this;
+        }
+
+        /**
+         * Sets the required model to query.
+         *
+         * @param model Model to query.
+         * @return Returns the query object builder.
+         */
+        public Builder model(Model model) {
+            return shapeIndex(model.getShapeIndex());
         }
 
         /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/FilterShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/FilterShapes.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.utils.FunctionalUtils;
 
 /**
@@ -44,14 +43,14 @@ final class FilterShapes {
     }
 
     Model transform(ModelTransformer transformer, Model model) {
-        return transformer.removeShapes(model, model.getShapeIndex().shapes()
-                .filter(shape -> canFilterShape(model.getShapeIndex(), shape))
+        return transformer.removeShapes(model, model.shapes()
+                .filter(shape -> canFilterShape(model, shape))
                 .filter(FunctionalUtils.not(predicate))
                 .collect(Collectors.toSet()));
     }
 
-    private static boolean canFilterShape(ShapeIndex index, Shape shape) {
-        return !shape.isMemberShape() || index.getShape(shape.asMemberShape().get().getContainer())
+    private static boolean canFilterShape(Model model, Shape shape) {
+        return !shape.isMemberShape() || model.getShape(shape.asMemberShape().get().getContainer())
                 .filter(container -> container.isStructureShape() || container.isUnionShape())
                 .isPresent();
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MapShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MapShapes.java
@@ -39,7 +39,7 @@ final class MapShapes {
     }
 
     Model transform(ModelTransformer transformer, Model model) {
-        return transformer.replaceShapes(model, model.getShapeIndex().shapes()
+        return transformer.replaceShapes(model, model.shapes()
                 .flatMap(shape -> {
                     Shape mapped = Objects.requireNonNull(mapper.apply(shape), "Shape mapper must not return null");
                     if (mapped.equals(shape)) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MarkAndSweep.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MarkAndSweep.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.model.neighbor.NeighborProvider;
 import software.amazon.smithy.model.neighbor.Relationship;
 import software.amazon.smithy.model.neighbor.RelationshipType;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 /**
  * Performs a garbage collection style cleanup of a model by removing
@@ -53,8 +52,7 @@ final class MarkAndSweep {
     }
 
     Set<Shape> markAndSweep(Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        NeighborProvider reverseNeighbors = NeighborProvider.bottomUp(model.getShapeIndex());
+        NeighborProvider reverseNeighbors = NeighborProvider.bottomUp(model);
         MarkerContext context = new MarkerContext(reverseNeighbors, model, sweepFilter);
 
         int currentSize;
@@ -62,7 +60,7 @@ final class MarkAndSweep {
             currentSize = context.getMarkedForRemoval().size();
             marker.accept(context);
             // Find shapes that are only referenced by a shape that has been marked for removal.
-            index.shapes().filter(shape -> !shape.isMemberShape()).forEach(shape -> {
+            model.shapes().filter(shape -> !shape.isMemberShape()).forEach(shape -> {
                 if (!context.getMarkedForRemoval().contains(shape)) {
                     Set<Shape> targetedFrom = context.getTargetedFrom(shape);
                     if (!targetedFrom.isEmpty()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -338,15 +338,9 @@ public final class ModelTransformer {
         return new ScrubTraitDefinitions().transform(this, model);
     }
 
-    /**
-     * Gets all shapes from a model as a {@code ShapeIndex} where shapes that
-     * define traits or shapes that are only used as part of a trait
-     * definition have been removed.
-     *
-     * @param model Model that contains shapes.
-     * @return Returns a ShapeIndex containing matching shapes.
-     */
+    @Deprecated
     public ShapeIndex getNonTraitShapes(Model model) {
+        // TODO: remove once ShapeIndex is removed.
         ShapeIndex currentIndex = model.getShapeIndex();
         ShapeIndex.Builder indexBuilder = ShapeIndex.builder();
 
@@ -356,12 +350,24 @@ public final class ModelTransformer {
         // a ShapeIndex is created by getting all shape IDs from the modified
         // model, grabbing shapes from the original model, and building a new
         // ShapeIndex.
-        scrubTraitDefinitions(model).getShapeIndex().shapes()
+        scrubTraitDefinitions(model).shapes()
                 .map(Shape::getId)
                 .map(currentIndex::getShape)
                 .map(Optional::get)
                 .forEach(indexBuilder::addShape);
 
         return indexBuilder.build();
+    }
+
+    /**
+     * Gets all shapes from a model where shapes that define traits or shapes
+     * that are only used as part of a trait definition have been removed.
+     *
+     * @param model Model that contains shapes.
+     * @return Returns a model that contains matching shapes.
+     */
+    public Model getModelWithoutTraitShapes(Model model) {
+        ShapeIndex updatedIndex = getNonTraitShapes(model);
+        return model.toBuilder().shapeIndex(updatedIndex).build();
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveShapes.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 /**
  * Removes shapes from a model while ensuring that relationships to/from
@@ -45,8 +44,7 @@ final class RemoveShapes {
     }
 
     Model transform(ModelTransformer transformer, Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        ShapeIndex.Builder builder = index.toBuilder();
+        Model.Builder builder = model.toBuilder();
 
         // Iteratively add each shape that needs to be removed from the index using multiple rounds.
         Set<Shape> removed = new HashSet<>(toRemove);
@@ -57,7 +55,7 @@ final class RemoveShapes {
             removed.addAll(removedShape.members());
         }
 
-        Model result = model.toBuilder().shapeIndex(builder.build()).build();
+        Model result = builder.build();
 
         for (ModelTransformerPlugin plugin : plugins) {
             result = plugin.onRemove(transformer, removed, result);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
@@ -44,9 +44,8 @@ final class ScrubTraitDefinitions {
     Model transform(ModelTransformer transformer, Model model) {
         // Find all trait definition shapes and private shapes in the prelude.
         Set<Shape> toMark = Stream.concat(
-                model.getShapeIndex().shapes().filter(shape -> shape.hasTrait(TraitDefinition.class)),
-                model.getShapeIndex().shapes().filter(shape -> Prelude.isPreludeShape(shape)
-                                                               && shape.hasTrait(PrivateTrait.class))
+                model.shapes().filter(shape -> shape.hasTrait(TraitDefinition.class)),
+                model.shapes().filter(shape -> Prelude.isPreludeShape(shape) && shape.hasTrait(PrivateTrait.class))
         ).collect(Collectors.toSet());
 
         MarkAndSweep markAndSweep = new MarkAndSweep(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanBindings.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanBindings.java
@@ -50,7 +50,7 @@ public final class CleanBindings implements ModelTransformerPlugin {
     }
 
     private Set<Shape> getServicesToUpdate(Model model, Set<ShapeId> resources, Set<ShapeId> operations) {
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .filter(service -> containsAny(service.getResources(), resources)
                                    || containsAny(service.getOperations(), operations))
                 .map(service -> {
@@ -63,7 +63,7 @@ public final class CleanBindings implements ModelTransformerPlugin {
     }
 
     private Set<Shape> getResourcesToUpdate(Model model, Set<ShapeId> resources, Set<ShapeId> operations) {
-        return model.getShapeIndex().shapes(ResourceShape.class)
+        return model.shapes(ResourceShape.class)
                 .filter(resource -> containsAny(resource.getAllOperations(), operations)
                                     || containsAny(resource.getResources(), resources))
                 .map(resource -> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanOperationStructures.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanOperationStructures.java
@@ -39,7 +39,7 @@ public final class CleanOperationStructures implements ModelTransformerPlugin {
     }
 
     private Collection<Shape> getModifiedOperations(Model model, Collection<Shape> removed) {
-        return model.getShapeIndex().shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .flatMap(operation -> {
                     OperationShape result = transformErrors(removed, operation);
                     result = transformInput(removed, result);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanResourceReferences.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanResourceReferences.java
@@ -43,7 +43,7 @@ public final class CleanResourceReferences implements ModelTransformerPlugin {
     }
 
     private Set<Shape> getAffectedStructures(Model model, Shape resource) {
-        return model.getShapeIndex().shapes(StructureShape.class)
+        return model.shapes(StructureShape.class)
                 .flatMap(s -> Trait.flatMapStream(s, ReferencesTrait.class))
                 .flatMap(pair -> {
                     // Subject is the structure shape that might be modified.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveTraits.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveTraits.java
@@ -52,7 +52,7 @@ public final class RemoveTraits implements ModelTransformerPlugin {
     }
 
     private List<Shape> determineShapesToUpdate(Model model, Set<ShapeId> removedTraits) {
-        List<Shape> shapes = model.getShapeIndex().shapes()
+        List<Shape> shapes = model.shapes()
                 .filter(shape -> !removedTraits.contains(shape.getId()))
                 .filter(shape -> isShapeInNeedOfUpdate(shape, removedTraits))
                 .map(shape -> removeTraitsFromShape(shape, removedTraits))

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeType;
 import software.amazon.smithy.model.node.StringNode;
@@ -394,16 +395,21 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
         Builder() {}
 
-        /**
-         * Sets the <strong>required</strong> shape index to use when traversing
-         * walking shapes during validation.
-         *
-         * @param index Shape index that contains shapes to validate.
-         * @return Returns the builder.
-         */
+        @Deprecated
         public Builder index(ShapeIndex index) {
             this.index = Objects.requireNonNull(index);
             return this;
+        }
+
+        /**
+         * Sets the <strong>required</strong> model to use when traversing
+         * walking shapes during validation.
+         *
+         * @param model Model that contains shapes to validate.
+         * @return Returns the builder.
+         */
+        public Builder model(Model model) {
+            return index(model.getShapeIndex());
         }
 
         /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.validation.node;
 
 import java.util.List;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeIndex;
@@ -26,13 +27,18 @@ import software.amazon.smithy.model.shapes.ShapeIndex;
  * provided for a trait in the model are valid for the shape of the trait).
  */
 public interface NodeValidatorPlugin {
+    @Deprecated
+    List<String> apply(Shape shape, Node value, ShapeIndex index);
+
     /**
      * Applies the plugin to the given shape, node value, and shape index.
      *
      * @param shape Shape being checked.
      * @param value Value being evaluated.
-     * @param index Shape index used to traverse the model.
+     * @param model Model to traverse.
      * @return Returns any validation messages that were encountered.
      */
-    List<String> apply(Shape shape, Node value, ShapeIndex index);
+    default List<String> apply(Shape shape, Node value, Model model) {
+        return apply(shape, value, model.getShapeIndex());
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthProtocolsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthProtocolsValidator.java
@@ -41,7 +41,7 @@ public final class AuthProtocolsValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(service -> validateOperationAgainstProtocols(topDownIndex, service))
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthValidator.java
@@ -50,7 +50,7 @@ public final class AuthValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(service -> validateService(topDownIndex, service).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EnumTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EnumTraitValidator.java
@@ -39,7 +39,7 @@ public class EnumTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(StringShape.class)
+        return model.shapes(StringShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, EnumTrait.class))
                 .flatMap(pair -> validateEnumTrait(pair.getLeft(), pair.getRight()).stream())
                 .collect(Collectors.toList());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventPayloadTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventPayloadTraitValidator.java
@@ -39,7 +39,7 @@ import software.amazon.smithy.utils.FunctionalUtils;
 public class EventPayloadTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(StructureShape.class)
+        return model.shapes(StructureShape.class)
                 .flatMap(this::validateEvent)
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExclusiveStructureMemberTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExclusiveStructureMemberTraitValidator.java
@@ -38,7 +38,7 @@ public class ExclusiveStructureMemberTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(StructureShape.class)
+        return model.shapes(StructureShape.class)
                 .flatMap(shape -> validateExclusiveTraits(model, shape).stream())
                 .collect(toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.model.pattern.Pattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.HostLabelTrait;
@@ -62,14 +61,14 @@ public class HostLabelTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         // Validate all operation shapes with the `endpoint` trait.
-        return model.getShapeIndex().shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, EndpointTrait.class))
-                .flatMap(pair -> validateStructure(model.getShapeIndex(), pair.getLeft(), pair.getRight()).stream())
+                .flatMap(pair -> validateStructure(model, pair.getLeft(), pair.getRight()).stream())
                 .collect(Collectors.toList());
     }
 
     private List<ValidationEvent> validateStructure(
-            ShapeIndex index,
+            Model model,
             OperationShape operation,
             EndpointTrait endpoint
     ) {
@@ -88,7 +87,7 @@ public class HostLabelTraitValidator extends AbstractValidator {
             // Only validate the bindings if the input is a structure. Typing
             // validation of the input is handled elsewhere.
             operation.getInput()
-                    .flatMap(index::getShape)
+                    .flatMap(model::getShape)
                     .flatMap(Shape::asStructureShape)
                     .ifPresent(input -> events.addAll(validateBindings(operation, endpoint, input)));
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingsMissingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingsMissingValidator.java
@@ -35,7 +35,7 @@ public final class HttpBindingsMissingValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpHeaderTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpHeaderTraitValidator.java
@@ -57,11 +57,11 @@ public final class HttpHeaderTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        List<ValidationEvent> events = model.getShapeIndex().shapes(StructureShape.class)
+        List<ValidationEvent> events = model.shapes(StructureShape.class)
                 .flatMap(shape -> validateStructure(shape).stream())
                 .collect(Collectors.toList());
 
-        events.addAll(model.getShapeIndex().shapes(MemberShape.class)
+        events.addAll(model.shapes(MemberShape.class)
                 .flatMap(member -> Trait.flatMapStream(member, HttpHeaderTrait.class))
                 .filter(pair -> BLACKLIST.contains(pair.getRight().getValue().toLowerCase(Locale.US)))
                 .map(pair -> danger(pair.getLeft(), String.format(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.model.traits.IdempotentTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
@@ -64,9 +63,8 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex index = model.getShapeIndex();
         HttpBindingIndex bindingIndex = model.getKnowledge(HttpBindingIndex.class);
-        return index.shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, HttpTrait.class))
                 .flatMap(pair -> validateOperation(bindingIndex, pair.getLeft(), pair.getRight()).stream())
                 .collect(Collectors.toList());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPayloadValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPayloadValidator.java
@@ -49,11 +49,11 @@ public final class HttpPayloadValidator extends AbstractValidator {
         OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
         HttpBindingIndex bindings = model.getKnowledge(HttpBindingIndex.class);
         List<ValidationEvent> events = new ArrayList<>();
-        events.addAll(model.getShapeIndex().shapes(OperationShape.class)
+        events.addAll(model.shapes(OperationShape.class)
                 .filter(shape -> shape.getTrait(HttpTrait.class).isPresent())
                 .flatMap(shape -> validateOperation(bindings, opIndex, shape).stream())
                 .collect(toList()));
-        events.addAll(model.getShapeIndex().shapes(StructureShape.class)
+        events.addAll(model.shapes(StructureShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, ErrorTrait.class))
                 .flatMap(pair -> validateError(pair.getLeft(), bindings).stream())
                 .collect(toList()));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPrefixHeadersTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPrefixHeadersTraitValidator.java
@@ -37,7 +37,7 @@ public final class HttpPrefixHeadersTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(StructureShape.class)
+        return model.shapes(StructureShape.class)
                 .flatMap(shape -> validateStructure(shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryTraitValidator.java
@@ -35,7 +35,7 @@ public final class HttpQueryTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(StructureShape.class)
+        return model.shapes(StructureShape.class)
                 .flatMap(shape -> validateStructure(shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
@@ -38,7 +38,7 @@ public final class HttpUriConflictValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -39,13 +39,13 @@ public final class PrivateAccessValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        Set<ShapeId> privateShapes = model.getShapeIndex().shapes()
+        Set<ShapeId> privateShapes = model.shapes()
                 .filter(shape -> shape.getTrait(PrivateTrait.class).isPresent())
                 .map(Shape::getId)
                 .collect(Collectors.toSet());
 
         NeighborProvider provider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
-        return model.getShapeIndex().shapes()
+        return model.shapes()
                 .filter(shape -> !(shape instanceof SimpleShape))
                 .flatMap(shape -> validateNeighbors(shape, provider.getNeighbors(shape), privateShapes))
                 .collect(Collectors.toList());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceIdentifierValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceIdentifierValidator.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.utils.OptionalUtils;
@@ -36,14 +35,14 @@ public final class ResourceIdentifierValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(ResourceShape.class)
-                .flatMap(resource -> validateAgainstChildren(resource, model.getShapeIndex()))
+        return model.shapes(ResourceShape.class)
+                .flatMap(resource -> validateAgainstChildren(resource, model))
                 .collect(Collectors.toList());
     }
 
-    private Stream<ValidationEvent> validateAgainstChildren(ResourceShape resource, ShapeIndex index) {
+    private Stream<ValidationEvent> validateAgainstChildren(ResourceShape resource, Model model) {
         return resource.getResources().stream()
-                .flatMap(shape -> OptionalUtils.stream(index.getShape(shape).flatMap(Shape::asResourceShape)))
+                .flatMap(shape -> OptionalUtils.stream(model.getShape(shape).flatMap(Shape::asResourceShape)))
                 .flatMap(child -> Stream.concat(
                         OptionalUtils.stream(checkForMissing(child, resource)),
                         OptionalUtils.stream(checkForMismatches(child, resource))));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceLifecycleValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceLifecycleValidator.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.IdempotentTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -38,39 +37,38 @@ public final class ResourceLifecycleValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        return model.getShapeIndex().shapes(ResourceShape.class)
-                .flatMap(shape -> validateResource(index, shape).stream())
+        return model.shapes(ResourceShape.class)
+                .flatMap(shape -> validateResource(model, shape).stream())
                 .collect(Collectors.toList());
     }
 
-    private List<ValidationEvent> validateResource(ShapeIndex index, ResourceShape resource) {
+    private List<ValidationEvent> validateResource(Model model, ResourceShape resource) {
         List<ValidationEvent> events = new ArrayList<>();
 
         // Note: Whether or not these use a valid bindings is validated in ResourceIdentifierBindingValidator.
-        resource.getPut().flatMap(index::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
+        resource.getPut().flatMap(model::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
             validateReadonly(resource, operation, "put", false).ifPresent(events::add);
             validateIdempotent(resource, operation, "put", "").ifPresent(events::add);
         });
 
-        resource.getCreate().flatMap(index::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
+        resource.getCreate().flatMap(model::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
             validateReadonly(resource, operation, "create", false).ifPresent(events::add);
         });
 
-        resource.getRead().flatMap(index::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
+        resource.getRead().flatMap(model::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
             validateReadonly(resource, operation, "read", true).ifPresent(events::add);
         });
 
-        resource.getUpdate().flatMap(index::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
+        resource.getUpdate().flatMap(model::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
             validateReadonly(resource, operation, "update", false).ifPresent(events::add);
         });
 
-        resource.getDelete().flatMap(index::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
+        resource.getDelete().flatMap(model::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
             validateReadonly(resource, operation, "delete", false).ifPresent(events::add);
             validateIdempotent(resource, operation, "delete", "").ifPresent(events::add);
         });
 
-        resource.getList().flatMap(index::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
+        resource.getList().flatMap(model::getShape).flatMap(Shape::asOperationShape).ifPresent(operation -> {
             validateReadonly(resource, operation, "list", true).ifPresent(events::add);
         });
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceValidator.java
@@ -36,7 +36,7 @@ public class ServiceValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ShapeIdConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ShapeIdConflictValidator.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -34,8 +33,7 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class ShapeIdConflictValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        Map<String, List<Shape>> conflicts = index.shapes()
+        Map<String, List<Shape>> conflicts = model.shapes()
                 .collect(Collectors.groupingBy(shape -> shape.getId().toString().toLowerCase(Locale.US)))
                 .entrySet().stream()
                 .filter(entry -> entry.getValue().size() > 1)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleOperationBindingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleOperationBindingValidator.java
@@ -39,7 +39,7 @@ public class SingleOperationBindingValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleResourceBindingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleResourceBindingValidator.java
@@ -38,7 +38,7 @@ public class SingleResourceBindingValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        return model.getShapeIndex().shapes(ServiceShape.class)
+        return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitConflictValidator.java
@@ -35,7 +35,7 @@ public final class TraitConflictValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes()
+        return model.shapes()
                 .flatMap(shape -> {
                     // Map of trait shape IDs to trait value.
                     Map<ShapeId, Trait> traits = shape.getAllTraits();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
 import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -41,11 +40,10 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class TraitTargetValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex shapeIndex = model.getShapeIndex();
         NeighborProvider neighborProvider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
-        return shapeIndex.shapes()
+        return model.shapes()
                 .flatMap(shape -> getSelectors(shape, model))
-                .filter(check -> !matchesSelector(check, shapeIndex, neighborProvider))
+                .filter(check -> !matchesSelector(check, model, neighborProvider))
                 .map(check -> error(check.shape, String.format(
                         "Trait `%s` cannot be applied to `%s`. This trait may only be applied to shapes "
                         + "that match the following selector: %s",
@@ -77,9 +75,9 @@ public final class TraitTargetValidator extends AbstractValidator {
 
     private boolean matchesSelector(
             SelectorCheck check,
-            ShapeIndex index,
+            Model model,
             NeighborProvider neighborProvider
     ) {
-        return check.selector.select(neighborProvider, index).contains(check.shape);
+        return check.selector.select(neighborProvider, model).contains(check.shape);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnstableFeatureValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnstableFeatureValidator.java
@@ -35,7 +35,7 @@ import software.amazon.smithy.utils.FunctionalUtils;
 public final class UnstableFeatureValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(DocumentShape.class)
+        return model.shapes(DocumentShape.class)
                 .filter(FunctionalUtils.not(Prelude::isPreludeShape))
                 .map(shape -> warning(shape, "The document shape type is currently unstable and subject to "
                                              + "change. It is not generally supported across tooling and should "

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/XmlNamespaceTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/XmlNamespaceTraitValidator.java
@@ -40,7 +40,7 @@ public class XmlNamespaceTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(StructureShape.class)
+        return model.shapes(StructureShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, XmlNamespaceTrait.class))
                 .flatMap(pair -> OptionalUtils.stream(validateTrait(pair.getLeft(), pair.getRight())))
                 .collect(Collectors.toList());

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TraitDefinition;
 
@@ -32,16 +31,12 @@ public class ModelTest {
 
     @Test
     public void buildsModel() {
-        ShapeIndex index = ShapeIndex.builder()
+        Model model = Model.builder()
+                .putMetadataProperty("name.name", Node.objectNode())
                 .addShape(StringShape.builder()
                                   .id("smithy.example#String")
                                   .addTrait(TraitDefinition.builder().build())
                                   .build())
-                .build();
-
-        Model model = Model.builder()
-                .putMetadataProperty("name.name", Node.objectNode())
-                .shapeIndex(index)
                 .smithyVersion(Model.MODEL_VERSION)
                 .build();
 
@@ -54,12 +49,9 @@ public class ModelTest {
     public void modelEquality() {
         Model modelA = Model.builder()
                 .putMetadataProperty("foo", Node.from("baz"))
-                .shapeIndex(ShapeIndex.builder()
-                        .addShape(StringShape.builder().id("ns.foo#baz").build())
-                        .build())
+                .addShape(StringShape.builder().id("ns.foo#baz").build())
                 .build();
         Model modelB = Model.builder()
-                .shapeIndex(ShapeIndex.builder().build())
                 .putMetadataProperty("foo", Node.from("baz"))
                 .build();
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/AuthIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/AuthIndexTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.AuthTrait;
 import software.amazon.smithy.model.traits.Protocol;
 import software.amazon.smithy.model.traits.ProtocolsTrait;
@@ -39,8 +38,7 @@ public class AuthIndexTest {
                                   .addProtocol(Protocol.builder().name("xml").addAuth("qux").addAuth("foo").build())
                                   .build())
                 .build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(service).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShape(service).build();
         AuthIndex authIndex = model.getKnowledge(AuthIndex.class);
 
         assertThat(authIndex.getDefaultServiceSchemes(service), equalTo(ListUtils.of("foo", "baz", "qux")));
@@ -69,8 +67,7 @@ public class AuthIndexTest {
                         .addProtocol(Protocol.builder().name("xml").addAuth("qux").build())
                         .build())
                 .build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(service, operation1, operation2, operation3).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(service, operation1, operation2, operation3).build();
         AuthIndex authIndex = model.getKnowledge(AuthIndex.class);
 
         // Use the schemes defined on the shape itself or the schemes of the service.
@@ -98,8 +95,7 @@ public class AuthIndexTest {
                                   .addProtocol(Protocol.builder().name("json").addAuth("foo").build())
                                   .build())
                 .build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(service, operation1).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(service, operation1).build();
         AuthIndex authIndex = model.getKnowledge(AuthIndex.class);
 
         assertThat(authIndex.getOperationSchemes(service, operation1), equalTo(ListUtils.of("none")));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -270,7 +270,7 @@ public class HttpBindingIndexTest {
 
     private static MemberShape expectMember(Model model, String id) {
         ShapeId shapeId = ShapeId.from(id);
-        return model.getShapeIndex().getShape(shapeId).get().asMemberShape().get();
+        return model.expectShape(shapeId).asMemberShape().get();
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
@@ -57,10 +57,10 @@ public class OperationIndexTest {
     @Test
     public void indexesOperations() {
         OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
-        Shape input = model.getShapeIndex().getShape(ShapeId.from("ns.foo#Input")).get();
-        Shape output = model.getShapeIndex().getShape(ShapeId.from("ns.foo#Output")).get();
-        Shape error1 = model.getShapeIndex().getShape(ShapeId.from("ns.foo#Error1")).get();
-        Shape error2 = model.getShapeIndex().getShape(ShapeId.from("ns.foo#Error2")).get();
+        Shape input = model.getShape(ShapeId.from("ns.foo#Input")).get();
+        Shape output = model.getShape(ShapeId.from("ns.foo#Output")).get();
+        Shape error1 = model.getShape(ShapeId.from("ns.foo#Error1")).get();
+        Shape error2 = model.getShape(ShapeId.from("ns.foo#Error2")).get();
 
         assertThat(opIndex.getInput(ShapeId.from("ns.foo#B")), is(Optional.of(input)));
         assertThat(opIndex.getOutput(ShapeId.from("ns.foo#B")), is(Optional.of(output)));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/TopDownIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/TopDownIndexTest.java
@@ -26,7 +26,6 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 public class TopDownIndexTest {
     @Test
@@ -37,8 +36,7 @@ public class TopDownIndexTest {
                 .addResource("ns.foo#Resource")
                 .build();
         ResourceShape resource = ResourceShape.builder().id("ns.foo#Resource").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(service, resource).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(service, resource).build();
         TopDownIndex childIndex = model.getKnowledge(TopDownIndex.class);
 
         assertThat(childIndex.getContainedOperations(service), empty());
@@ -63,8 +61,7 @@ public class TopDownIndexTest {
         ResourceShape resourceB = ResourceShape.builder().id("ns.foo#B").addOperation("ns.foo#Operation").build();
         OperationShape operation = OperationShape.builder().id("ns.foo#Operation").build();
         OperationShape list = OperationShape.builder().id("ns.foo#List").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(service, resourceA, resourceB, operation, list).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(service, resourceA, resourceB, operation, list).build();
         TopDownIndex childIndex = model.getKnowledge(TopDownIndex.class);
 
         assertThat(childIndex.getContainedResources(service.getId()), containsInAnyOrder(resourceA, resourceB));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/LoaderVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/LoaderVisitorTest.java
@@ -194,7 +194,7 @@ public class LoaderVisitorTest {
         visitor.onTrait(id, "foo.baz#Bar", Node.from(true));
         Model model = visitor.onEnd().unwrap();
 
-        assertThat(model.getShapeIndex().getShape(id).get().findTrait("foo.baz#Bar").get(),
+        assertThat(model.expectShape(id).findTrait("foo.baz#Bar").get(),
                    instanceOf(DynamicTrait.class));
     }
 
@@ -219,7 +219,7 @@ public class LoaderVisitorTest {
                 .assemble()
                 .unwrap();
 
-        Shape shape = model.getShapeIndex().getShape(ShapeId.from("ns.foo#Foo")).get();
+        Shape shape = model.expectShape(ShapeId.from("ns.foo#Foo"));
         assertTrue(shape.getTrait(DeprecatedTrait.class).isPresent());
         assertTrue(shape.getTrait(TagsTrait.class).isPresent());
         assertTrue(shape.getTrait(ReferencesTrait.class).isPresent());
@@ -235,7 +235,7 @@ public class LoaderVisitorTest {
                                                  + "structure foo {}\n")
                 .assemble()
                 .unwrap();
-        Shape shape = model.getShapeIndex().getShape(ShapeId.from("smithy.example#MyString")).get();
+        Shape shape = model.expectShape(ShapeId.from("smithy.example#MyString"));
 
         assertTrue(shape.hasTrait("smithy.example#foo"));
     }
@@ -254,7 +254,7 @@ public class LoaderVisitorTest {
     @Test
     public void coercesListTraitValues() {
         Model model = createCoercionModel("list foo { member: String }");
-        Shape shape = model.getShapeIndex().getShape(ShapeId.from("smithy.example#MyString")).get();
+        Shape shape = model.expectShape(ShapeId.from("smithy.example#MyString"));
 
         assertTrue(shape.hasTrait("smithy.example#foo"));
     }
@@ -262,7 +262,7 @@ public class LoaderVisitorTest {
     @Test
     public void coercesBooleanTraitValuesToStructures() {
         Model model = createCoercionModel("structure foo {}");
-        Shape shape = model.getShapeIndex().getShape(ShapeId.from("smithy.example#MyString")).get();
+        Shape shape = model.expectShape(ShapeId.from("smithy.example#MyString"));
 
         assertTrue(shape.hasTrait("smithy.example#foo"));
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -96,7 +96,7 @@ public class ModelAssemblerTest {
                 .assemble();
 
         assertThat(result.getValidationEvents(), empty());
-        assertThat(result.unwrap().getShapeIndex().getShape(ShapeId.from("ns.foo#Bar")), is(Optional.of(shape)));
+        assertThat(result.unwrap().getShape(ShapeId.from("ns.foo#Bar")), is(Optional.of(shape)));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class ModelAssemblerTest {
         ValidatedResult<Model> result = new ModelAssembler().addDocumentNode(node).assemble();
 
         assertThat(result.getValidationEvents(), empty());
-        assertTrue(result.unwrap().getShapeIndex().getShape(ShapeId.from("ns.foo#String")).isPresent());
+        assertTrue(result.unwrap().getShape(ShapeId.from("ns.foo#String")).isPresent());
     }
 
     @Test
@@ -121,7 +121,7 @@ public class ModelAssemblerTest {
                 .assemble();
 
         assertThat(result.getValidationEvents(), empty());
-        assertTrue(result.unwrap().getShapeIndex().getShape(ShapeId.from("ns.foo#String")).isPresent());
+        assertTrue(result.unwrap().getShape(ShapeId.from("ns.foo#String")).isPresent());
     }
 
     @Test
@@ -159,7 +159,7 @@ public class ModelAssemblerTest {
         assertThat(result.getValidationEvents(), hasSize(1));
         assertThat(result.getValidationEvents().get(0).getMessage(), containsString("Invalid shape `type`: foobaz"));
         assertThat(result.getValidationEvents().get(0).getSeverity(), is(Severity.ERROR));
-        assertTrue(result.getResult().get().getShapeIndex()
+        assertTrue(result.getResult().get()
                            .getShape(ShapeId.from("example.namespace#String")).isPresent());
     }
 
@@ -176,48 +176,48 @@ public class ModelAssemblerTest {
             .assemble();
         assertThat(result.getValidationEvents(), empty());
         Model model = result.unwrap();
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).isPresent());
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String")).isPresent());
+        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String2")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String2")).get().getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String3")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String3")).get().getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Integer")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Integer")).get().getType(),
             is(ShapeType.INTEGER));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Long")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Long")).get().getType(),
             is(ShapeType.LONG));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Float")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Float")).get().getType(),
             is(ShapeType.FLOAT));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#BigDecimal")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#BigDecimal")).get().getType(),
             is(ShapeType.BIG_DECIMAL));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#BigInteger")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#BigInteger")).get().getType(),
             is(ShapeType.BIG_INTEGER));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Blob")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Blob")).get().getType(),
             is(ShapeType.BLOB));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Boolean")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Boolean")).get().getType(),
             is(ShapeType.BOOLEAN));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Timestamp")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Timestamp")).get().getType(),
             is(ShapeType.TIMESTAMP));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#List")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#List")).get().getType(),
             is(ShapeType.LIST));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Map")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Map")).get().getType(),
             is(ShapeType.MAP));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Structure")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Structure")).get().getType(),
             is(ShapeType.STRUCTURE));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#TaggedUnion")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion")).get().getType(),
             is(ShapeType.UNION));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Resource")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Resource")).get().getType(),
             is(ShapeType.RESOURCE));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Operation")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Operation")).get().getType(),
             is(ShapeType.OPERATION));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Service")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Service")).get().getType(),
             is(ShapeType.SERVICE));
 
         ShapeId stringId = ShapeId.from("example.namespace#String");
-        Optional<SensitiveTrait> sensitiveTrait = model.getShapeIndex()
+        Optional<SensitiveTrait> sensitiveTrait = model
             .getShape(stringId).get()
             .getTrait(SensitiveTrait.class);
         assertTrue(sensitiveTrait.isPresent());
@@ -233,7 +233,7 @@ public class ModelAssemblerTest {
             containsInAnyOrder("a", "b", "c"));
 
         // The String shape should have a documentation trait applied.
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String"))
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String"))
             .flatMap(shape -> shape.getTrait(DocumentationTrait.class))
             .isPresent());
     }
@@ -248,7 +248,7 @@ public class ModelAssemblerTest {
         assertThat(result.getValidationEvents(), empty());
         Model model = result.unwrap();
         // The String shape should have a documentation trait applied.
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String"))
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String"))
             .flatMap(shape -> shape.getTrait(DocumentationTrait.class))
             .isPresent());
     }
@@ -270,48 +270,48 @@ public class ModelAssemblerTest {
 
         assertThat(result.getValidationEvents(), empty());
         Model model = result.unwrap();
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).isPresent());
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String")).isPresent());
+        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String2")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String2")).get().getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String3")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String3")).get().getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Integer")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Integer")).get().getType(),
                    is(ShapeType.INTEGER));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Long")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Long")).get().getType(),
                    is(ShapeType.LONG));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Float")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Float")).get().getType(),
                    is(ShapeType.FLOAT));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#BigDecimal")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#BigDecimal")).get().getType(),
                    is(ShapeType.BIG_DECIMAL));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#BigInteger")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#BigInteger")).get().getType(),
                    is(ShapeType.BIG_INTEGER));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Blob")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Blob")).get().getType(),
                    is(ShapeType.BLOB));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Boolean")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Boolean")).get().getType(),
                    is(ShapeType.BOOLEAN));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Timestamp")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Timestamp")).get().getType(),
                    is(ShapeType.TIMESTAMP));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#List")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#List")).get().getType(),
                     is(ShapeType.LIST));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Map")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Map")).get().getType(),
                    is(ShapeType.MAP));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Structure")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Structure")).get().getType(),
                    is(ShapeType.STRUCTURE));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#TaggedUnion")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion")).get().getType(),
                    is(ShapeType.UNION));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Resource")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Resource")).get().getType(),
                    is(ShapeType.RESOURCE));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Operation")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Operation")).get().getType(),
                    is(ShapeType.OPERATION));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#Service")).get().getType(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#Service")).get().getType(),
                    is(ShapeType.SERVICE));
 
         ShapeId stringId = ShapeId.from("example.namespace#String");
-        Optional<SensitiveTrait> sensitiveTrait = model.getShapeIndex()
+        Optional<SensitiveTrait> sensitiveTrait = model
                 .getShape(stringId).get()
                 .getTrait(SensitiveTrait.class);
         assertTrue(sensitiveTrait.isPresent());
@@ -327,7 +327,7 @@ public class ModelAssemblerTest {
                    containsInAnyOrder("a", "b", "c"));
 
         // The String shape should have a documentation trait applied.
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String"))
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String"))
                            .flatMap(shape -> shape.getTrait(DocumentationTrait.class))
                            .isPresent());
     }
@@ -340,9 +340,9 @@ public class ModelAssemblerTest {
                 .assemble()
                 .unwrap();
 
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).get().getSourceLocation(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getSourceLocation(),
                 is(new SourceLocation(getClass().getResource("main.json").toString(), 13, 23)));
-        assertThat(model.getShapeIndex().getShape(ShapeId.from("example.namespace#TaggedUnion$foo")).get().getSourceLocation(),
+        assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion$foo")).get().getSourceLocation(),
                 is(new SourceLocation(getClass().getResource("main.json").toString(), 76, 28)));
     }
 
@@ -355,9 +355,9 @@ public class ModelAssemblerTest {
 
         assertThat(result.getValidationEvents(), empty());
         // Each namespace had a separate name.
-        assertThat(result.unwrap().getShapeIndex().shapes().count(), equalTo(4L));
+        assertThat(result.unwrap().shapes().count(), equalTo(4L));
         // Each shape had a documentation trait in each namespace.
-        assertThat(result.unwrap().getShapeIndex().shapes()
+        assertThat(result.unwrap().shapes()
                            .filter(shape -> shape.findTrait("ns.shared#customTrait").isPresent())
                            .count(), equalTo(3L));
     }
@@ -398,10 +398,10 @@ public class ModelAssemblerTest {
     }
 
     private void assertImportPathsWereLoaded(Model model) {
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String"))
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String"))
                            .flatMap(shape -> shape.getTrait(DocumentationTrait.class))
                            .isPresent());
-        assertTrue(model.getShapeIndex().getShape(ShapeId.from("example.namespace#String"))
+        assertTrue(model.getShape(ShapeId.from("example.namespace#String"))
                            .flatMap(shape -> shape.getTrait(MediaTypeTrait.class))
                            .isPresent());
     }
@@ -415,7 +415,7 @@ public class ModelAssemblerTest {
                 .assemble()
                 .unwrap();
 
-        assertEquals("hi", model2.getShapeIndex().getShape(ShapeId.from("example.namespace#String")).get()
+        assertEquals("hi", model2.expectShape(ShapeId.from("example.namespace#String"))
                 .getTrait(DocumentationTrait.class).get().getValue());
     }
 
@@ -473,8 +473,8 @@ public class ModelAssemblerTest {
 
         for (String id : ListUtils.of("foo.baz#A", "foo.baz#B", "foo.baz#C")) {
             ShapeId shapeId = ShapeId.from(id);
-            assertTrue(model.getShapeIndex().getShape(shapeId).isPresent());
-            assertThat(model.getShapeIndex().getShape(shapeId).get().getSourceLocation().getFilename(),
+            assertTrue(model.getShape(shapeId).isPresent());
+            assertThat(model.getShape(shapeId).get().getSourceLocation().getFilename(),
                        startsWith("jar:file:"));
         }
     }
@@ -486,6 +486,6 @@ public class ModelAssemblerTest {
 
         assertTrue(result.isBroken());
         assertTrue(result.getResult().isPresent());
-        assertTrue(result.getResult().get().getShapeIndex().getShape(ShapeId.from("foo.baz#MyString")).isPresent());
+        assertTrue(result.getResult().get().getShape(ShapeId.from("foo.baz#MyString")).isPresent());
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/NodeModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/NodeModelLoaderTest.java
@@ -70,13 +70,14 @@ public class NodeModelLoaderTest {
                 .assemble()
                 .unwrap();
 
-        MemberShape baz = model.getShapeIndex()
-                .getShape(ShapeId.from("smithy.example#Foo$baz")).get()
+        MemberShape baz = model
+                .expectShape(ShapeId.from("smithy.example#Foo$baz"))
                 .asMemberShape().get();
-        MemberShape bar = model.getShapeIndex()
-                .getShape(ShapeId.from("smithy.example#Foo$bar")).get()
+        MemberShape bar = model
+                .expectShape(ShapeId.from("smithy.example#Foo$bar"))
                 .asMemberShape().get();
-        ResourceShape resource = model.getShapeIndex().getShape(ShapeId.from("smithy.example#MyResource")).get()
+        ResourceShape resource = model
+                .expectShape(ShapeId.from("smithy.example#MyResource"))
                 .asResourceShape().get();
 
         assertThat(baz.getTarget().toString(), equalTo("smithy.api#String"));
@@ -97,6 +98,6 @@ public class NodeModelLoaderTest {
         assertTrue(model.getTraitDefinition("example.namespace#documentation").isPresent());
         assertTrue(model.getTraitDefinition("example.namespace#numeric").isPresent());
         assertThat(model.getTraitShapes(),
-                   hasItem(model.getShapeIndex().getShape(ShapeId.from("example.namespace#numeric")).get()));
+                   hasItem(model.expectShape(ShapeId.from("example.namespace#numeric"))));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/PreludeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/PreludeTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
@@ -56,7 +55,7 @@ public class PreludeTest {
 
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.scrubTraitDefinitions(model);
-        Set<ShapeId> unreferencedPrivateShapes = result.getShapeIndex().shapes()
+        Set<ShapeId> unreferencedPrivateShapes = result.shapes()
                 .filter(shape -> shape.hasTrait(PrivateTrait.class))
                 .map(Shape::getId)
                 .collect(Collectors.toSet());
@@ -67,19 +66,19 @@ public class PreludeTest {
     @Test
     public void resolvesToTargetInNamespace() {
         Shape stringShape = StringShape.builder().id("foo.baz#Bar").build();
-        ShapeIndex index = ShapeIndex.builder().addShape(stringShape).build();
+        Model model = Model.builder().addShape(stringShape).build();
 
-        assertThat(Prelude.resolveShapeId(index, "foo.baz", "Bar"), equalTo(Optional.of(stringShape)));
-        assertThat(Prelude.resolveShapeId(index, "foo.baz", "Bam"), equalTo(Optional.empty()));
+        assertThat(Prelude.resolveShapeId(model, "foo.baz", "Bar"), equalTo(Optional.of(stringShape)));
+        assertThat(Prelude.resolveShapeId(model, "foo.baz", "Bam"), equalTo(Optional.empty()));
     }
 
     @Test
     public void resolvesToTargetInPrelude() {
         Shape customStringShape = StringShape.builder().id("foo.baz#String").build();
         Shape preludeStringShape = StringShape.builder().id("smithy.api#String").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(customStringShape, preludeStringShape).build();
+        Model model = Model.builder().addShapes(customStringShape, preludeStringShape).build();
 
-        assertThat(Prelude.resolveShapeId(index, "foo.baz", "String"), equalTo(Optional.of(customStringShape)));
-        assertThat(Prelude.resolveShapeId(index, "other.ns", "String"), equalTo(Optional.of(preludeStringShape)));
+        assertThat(Prelude.resolveShapeId(model, "foo.baz", "String"), equalTo(Optional.of(customStringShape)));
+        assertThat(Prelude.resolveShapeId(model, "other.ns", "String"), equalTo(Optional.of(preludeStringShape)));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/SmithyModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/SmithyModelLoaderTest.java
@@ -22,9 +22,7 @@ import static org.hamcrest.Matchers.not;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
-import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
@@ -36,7 +34,7 @@ public class SmithyModelLoaderTest {
                 .assemble()
                 .unwrap();
 
-        model.getShapeIndex().shapes().forEach(shape -> {
+        model.shapes().forEach(shape -> {
             if (!Prelude.isPreludeShape(shape.getId())) {
                 assertThat(shape.getSourceLocation(), not(equalTo(SourceLocation.NONE)));
             }
@@ -57,13 +55,11 @@ public class SmithyModelLoaderTest {
                 .assemble()
                 .unwrap();
 
-        MemberShape baz = model.getShapeIndex()
-                .getShape(ShapeId.from("smithy.example#Foo$baz")).get()
+        MemberShape baz = model.expectShape(ShapeId.from("smithy.example#Foo$baz"))
                 .asMemberShape().get();
-        MemberShape bar = model.getShapeIndex()
-                .getShape(ShapeId.from("smithy.example#Foo$bar")).get()
+        MemberShape bar = model.expectShape(ShapeId.from("smithy.example#Foo$bar"))
                 .asMemberShape().get();
-        ResourceShape resource = model.getShapeIndex().getShape(ShapeId.from("smithy.example#MyResource")).get()
+        ResourceShape resource = model.expectShape(ShapeId.from("smithy.example#MyResource"))
                 .asResourceShape().get();
 
         assertThat(baz.getTarget().toString(), equalTo("smithy.api#String"));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
@@ -33,7 +33,7 @@ public class ValidatorDefinitionTest {
                     public Optional<Validator> createValidator(String name, ObjectNode configuration) {
                         return name.equals("hello")
                                ? Optional.of(
-                                       model -> model.getShapeIndex().shapes()
+                                       model -> model.shapes()
                                                .map(shape -> ValidationEvent.builder()
                                                        .eventId(name)
                                                        .shape(shape)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.ListShape;
@@ -30,7 +31,6 @@ import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
@@ -71,10 +71,10 @@ public class BottomUpNeighborVisitorTest {
                 .addMember(structureMemberShape)
                 .build();
 
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(shape, listShape, mapShape, structureShape)
                 .build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(shape), containsInAnyOrder(
                 Relationship.create(listMemberShape, RelationshipType.MEMBER_TARGET, shape),
@@ -109,7 +109,7 @@ public class BottomUpNeighborVisitorTest {
                 .id("ns.foo#union$aMember")
                 .build();
         Shape unionShape = UnionShape.builder().addMember(tuMemberShape).id("ns.foo#union").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(shape)
                 .addShape(listMemberShape)
                 .addShape(listShape)
@@ -121,7 +121,7 @@ public class BottomUpNeighborVisitorTest {
                 .addShape(tuMemberShape)
                 .addShape(unionShape)
                 .build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(listMemberShape), containsInAnyOrder(
                 Relationship.create(listShape, RelationshipType.LIST_MEMBER, listMemberShape)));
@@ -152,8 +152,8 @@ public class BottomUpNeighborVisitorTest {
                 .output(input.getId())
                 .addError(error.getId())
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShapes(fooOperation, barOperation, input, output, error).build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        Model model = Model.builder().addShapes(fooOperation, barOperation, input, output, error).build();
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(input), containsInAnyOrder(
                 Relationship.create(fooOperation, RelationshipType.INPUT, input),
@@ -176,10 +176,10 @@ public class BottomUpNeighborVisitorTest {
                 .build();
         OperationShape operationShape = OperationShape.builder().id("ns.foo#Operation").build();
         ResourceShape resourceShape = ResourceShape.builder().id("ns.foo#Resource").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(service, resourceShape, operationShape)
                 .build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(service), containsInAnyOrder(
                 Relationship.create(resourceShape, RelationshipType.BOUND, service),
@@ -206,11 +206,11 @@ public class BottomUpNeighborVisitorTest {
                 .build();
         ResourceShape child1 = ResourceShape.builder().id("ns.foo#Child1").addResource("ns.foo#Child2").build();
         ResourceShape child2 = ResourceShape.builder().id("ns.foo#Child2").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(parent, resource, child1, child2)
                 .addShape(otherService)
                 .build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(child2), containsInAnyOrder(
                 Relationship.create(child1, RelationshipType.RESOURCE, child2)));
@@ -272,12 +272,12 @@ public class BottomUpNeighborVisitorTest {
         OperationShape putOperation = OperationShape.builder()
                 .id("ns.foo#Put")
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(parent)
                 .addShapes(resource, createOperation, getOperation, updateOperation, deleteOperation, listOperation)
                 .addShapes(otherService, namedOperation, collectionOperation, putOperation)
                 .build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(namedOperation), containsInAnyOrder(
                 Relationship.create(resource, RelationshipType.OPERATION, namedOperation),
@@ -317,10 +317,10 @@ public class BottomUpNeighborVisitorTest {
         StringShape target = StringShape.builder()
                 .id("ns.foo#String")
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(target)
                 .build();
-        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(shapeIndex);
+        NeighborProvider neighborVisitor = NeighborProvider.bottomUp(model);
 
         assertThat(neighborVisitor.getNeighbors(target), empty());
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.empty;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.BooleanShape;
@@ -33,7 +34,6 @@ import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
@@ -46,8 +46,8 @@ public class NeighborVisitorTest {
     @Test
     public void blobShape() {
         Shape shape = BlobShape.builder().id("ns.foo#name").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShape(shape).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShape(shape).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = shape.accept(neighborVisitor);
 
         assertThat(relationships, empty());
@@ -56,8 +56,8 @@ public class NeighborVisitorTest {
     @Test
     public void booleanShape() {
         Shape shape = BooleanShape.builder().id("ns.foo#name").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShape(shape).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShape(shape).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = shape.accept(neighborVisitor);
 
         assertThat(relationships, empty());
@@ -66,8 +66,8 @@ public class NeighborVisitorTest {
     @Test
     public void stringShape() {
         Shape shape = StringShape.builder().id("ns.foo#name").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShape(shape).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShape(shape).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = shape.accept(neighborVisitor);
 
         assertThat(relationships, empty());
@@ -76,8 +76,8 @@ public class NeighborVisitorTest {
     @Test
     public void timestampShape() {
         Shape shape = TimestampShape.builder().id("ns.foo#name").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShape(shape).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShape(shape).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = shape.accept(neighborVisitor);
 
         assertThat(relationships, empty());
@@ -90,8 +90,8 @@ public class NeighborVisitorTest {
                 .id("ns.foo#name")
                 .member(string.getId())
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShape(list).addShape(string).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShape(list).addShape(string).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         MemberShape memberTarget = list.getMember();
         List<Relationship> relationships = list.accept(neighborVisitor);
 
@@ -115,8 +115,8 @@ public class NeighborVisitorTest {
                 .build();
         MemberShape keyTarget = map.getKey();
         MemberShape valueTarget = map.getValue();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShape(map).addShape(key).addShape(value).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShape(map).addShape(key).addShape(value).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = map.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -141,14 +141,14 @@ public class NeighborVisitorTest {
                 .build();
         MemberShape member1Target = struct.getMember("m1").get();
         MemberShape member2Target = struct.getMember("m2").get();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(struct)
                 .addShape(memberShape1)
                 .addShape(memberShape2)
                 .addShape(member1Target)
                 .addShape(member2Target)
                 .build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = struct.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -173,14 +173,14 @@ public class NeighborVisitorTest {
                 .build();
         MemberShape v1Target = union.getMember("tag1").get();
         MemberShape v2Target = union.getMember("tag2").get();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(union)
                 .addShape(variant1Shape)
                 .addShape(variant2Shape)
                 .addShape(v1Target)
                 .addShape(v2Target)
                 .build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = union.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -198,10 +198,10 @@ public class NeighborVisitorTest {
                 .build();
         OperationShape operationShape = OperationShape.builder().id("ns.foo#Operation").build();
         ResourceShape resourceShape = ResourceShape.builder().id("ns.foo#Resource").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(service, resourceShape, operationShape)
                 .build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = service.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -257,12 +257,12 @@ public class NeighborVisitorTest {
                 .build();
         ResourceShape child1 = ResourceShape.builder().id("ns.foo#Child1").addResource("ns.foo#Child2").build();
         ResourceShape child2 = ResourceShape.builder().id("ns.foo#Child2").build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(parent, resource, identifier, child1, child2)
                 .addShapes(createOperation, getOperation, updateOperation, deleteOperation, listOperation)
                 .addShapes(namedOperation, collectionOperation, putOperation)
                 .build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = resource.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -318,8 +318,8 @@ public class NeighborVisitorTest {
                 .output(output.getId())
                 .addError(error.getId())
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder().addShapes(method, input, output, error).build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        Model model = Model.builder().addShapes(method, input, output, error).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = method.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -341,12 +341,12 @@ public class NeighborVisitorTest {
                 .id("ns.foo#List")
                 .member(target)
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(target)
                 .addShape(string)
                 .addShape(list)
                 .build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = target.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(
@@ -360,10 +360,10 @@ public class NeighborVisitorTest {
                 .id("ns.foo#List$member")
                 .target("ns.foo#String")
                 .build();
-        ShapeIndex shapeIndex = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShape(target)
                 .build();
-        NeighborVisitor neighborVisitor = new NeighborVisitor(shapeIndex);
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
         List<Relationship> relationships = target.accept(neighborVisitor);
 
         assertThat(relationships, containsInAnyOrder(

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/UnreferencedTraitDefinitionsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/UnreferencedTraitDefinitionsTest.java
@@ -32,6 +32,6 @@ public class UnreferencedTraitDefinitionsTest {
         UnreferencedTraitDefinitions unreferencedTraitDefinitions = new UnreferencedTraitDefinitions();
 
         assertThat(unreferencedTraitDefinitions.compute(model),
-                contains(model.getShapeIndex().getShape(ShapeId.from("ns.foo#quux")).get()));
+                contains(model.expectShape(ShapeId.from("ns.foo#quux"))));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/WalkerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/WalkerTest.java
@@ -20,11 +20,11 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 
 public class WalkerTest {
@@ -56,7 +56,7 @@ public class WalkerTest {
                 .id("ns.foo#List")
                 .member(listMember)
                 .build();
-        Walker walker = new Walker(ShapeIndex.builder()
+        Walker walker = new Walker(Model.builder()
                 .addShape(list)
                 .addShape(listMember)
                 .addShape(map)
@@ -96,7 +96,7 @@ public class WalkerTest {
                 .id("ns.foo#List")
                 .member(listMember)
                 .build();
-        Walker walker = new Walker(ShapeIndex.builder()
+        Walker walker = new Walker(Model.builder()
                 .addShape(list)
                 .addShape(listMember)
                 .addShape(map)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/AndSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/AndSelectorTest.java
@@ -22,10 +22,10 @@ import static org.hamcrest.Matchers.empty;
 import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.SensitiveTrait;
@@ -38,8 +38,8 @@ public class AndSelectorTest {
                 new AttributeSelector(new TraitAttributeKey("sensitive"))));
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait(SourceLocation.NONE)).build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(a, b).build();
-        Set<Shape> result = selector.select(index);
+        Model model = Model.builder().addShapes(a, b).build();
+        Set<Shape> result = selector.select(model);
 
         assertThat(result, contains(b));
     }
@@ -51,8 +51,8 @@ public class AndSelectorTest {
                 new AttributeSelector(new TraitAttributeKey("sensitive"))));
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait(SourceLocation.NONE)).build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(a, b).build();
-        Set<Shape> result = selector.select(index);
+        Model model = Model.builder().addShapes(a, b).build();
+        Set<Shape> result = selector.select(model);
 
         assertThat(result, empty());
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/EachSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/EachSelectorTest.java
@@ -21,10 +21,10 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.FloatShape;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 
@@ -37,8 +37,8 @@ public class EachSelectorTest {
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").build();
         Shape c = FloatShape.builder().id("foo.baz#Qux").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(a, b, c).build();
-        Set<Shape> result = selector.select(index);
+        Model model = Model.builder().addShapes(a, b, c).build();
+        Set<Shape> result = selector.select(model);
 
         assertThat(result, containsInAnyOrder(a, b));
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/NeighborSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/NeighborSelectorTest.java
@@ -27,28 +27,26 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 public class NeighborSelectorTest {
-    private static ShapeIndex index;
+    private static Model model;
 
     @BeforeAll
     public static void before() {
-        index = Model.assembler()
+        model = Model.assembler()
                 .addImport(NeighborSelectorTest.class.getResource("neighbor-test.smithy"))
                 .assemble()
-                .unwrap()
-                .getShapeIndex();
+                .unwrap();
     }
 
     @AfterAll
     public static void after() {
-        index = null;
+        model = null;
     }
 
     private Set<String> selectIds(String expression) {
         return Selector.parse(expression)
-                .select(index)
+                .select(model)
                 .stream()
                 .map(Shape::getId)
                 .map(ShapeId::toString)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -23,15 +23,12 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
-import software.amazon.smithy.model.node.BooleanNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.DynamicTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.Trait;
@@ -40,12 +37,11 @@ public class SelectorTest {
 
     @Test
     public void selectsCollections() {
-        ShapeIndex index = Model.assembler().addImport(getClass().getResource("model.json"))
+        Model model = Model.assembler().addImport(getClass().getResource("model.json"))
                 .disablePrelude()
                 .assemble()
-                .unwrap()
-                .getShapeIndex();
-        Set<Shape> result = Selector.parse("collection").select(index);
+                .unwrap();
+        Set<Shape> result = Selector.parse("collection").select(model);
 
         assertThat(result, containsInAnyOrder(
                 SetShape.builder()
@@ -60,12 +56,11 @@ public class SelectorTest {
 
     @Test
     public void selectsCustomTraits() {
-        ShapeIndex index = Model.assembler()
+        Model model = Model.assembler()
                 .addImport(getClass().getResource("model-custom-trait.json"))
                 .assemble()
-                .unwrap()
-                .getShapeIndex();
-        Set<Shape> result = Selector.parse("*[trait|'com.example#beta']").select(index);
+                .unwrap();
+        Set<Shape> result = Selector.parse("*[trait|'com.example#beta']").select(model);
 
         Trait betaTrait = new DynamicTrait(ShapeId.from("com.example#beta"), Node.objectNode());
         Trait requiredTrait = new RequiredTrait();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelectorTest.java
@@ -20,10 +20,10 @@ import static org.hamcrest.Matchers.contains;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 
 public class ShapeTypeCategorySelectorTest {
@@ -32,8 +32,8 @@ public class ShapeTypeCategorySelectorTest {
         Selector selector = new ShapeTypeCategorySelector(NumberShape.class);
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(a, b).build();
-        Set<Shape> result = selector.select(index);
+        Model model = Model.builder().addShapes(a, b).build();
+        Set<Shape> result = selector.select(model);
 
         assertThat(result, contains(a));
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeSelectorTest.java
@@ -20,9 +20,9 @@ import static org.hamcrest.Matchers.contains;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 
@@ -32,8 +32,8 @@ public class ShapeTypeSelectorTest {
         Selector selector = new ShapeTypeSelector(ShapeType.STRING);
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(a, b).build();
-        Set<Shape> result = selector.select(index);
+        Model model = Model.builder().addShapes(a, b).build();
+        Set<Shape> result = selector.select(model);
 
         assertThat(result, contains(b));
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/TestSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/TestSelectorTest.java
@@ -21,10 +21,10 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.FloatShape;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 
@@ -37,8 +37,8 @@ public class TestSelectorTest {
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").build();
         Shape c = FloatShape.builder().id("foo.baz#Qux").build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(a, b, c).build();
-        Set<Shape> result = selector.select(index);
+        Model model = Model.builder().addShapes(a, b, c).build();
+        Set<Shape> result = selector.select(model);
 
         assertThat(result, containsInAnyOrder(a, b));
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MemberShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MemberShapeTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 
@@ -93,19 +94,19 @@ public class MemberShapeTest {
                 .target(target)
                 .addTrait(new DocumentationTrait("override"))
                 .build();
-        ShapeIndex index = ShapeIndex.builder().addShapes(member, target).build();
+        Model model = Model.builder().addShapes(member, target).build();
 
         assertThat(
-                member.getMemberTrait(index, DocumentationTrait.class).get().getValue(),
+                member.getMemberTrait(model, DocumentationTrait.class).get().getValue(),
                 equalTo("override"));
         assertThat(
-                member.getMemberTrait(index, ExternalDocumentationTrait.class).get().getValue(),
+                member.getMemberTrait(model, ExternalDocumentationTrait.class).get().getValue(),
                 equalTo("http://example.com"));
         assertThat(
-                member.findMemberTrait(index, "documentation"),
+                member.findMemberTrait(model, "documentation"),
                 equalTo(member.findTrait("documentation")));
         assertThat(
-                member.findMemberTrait(index, "externalDocumentation"),
+                member.findMemberTrait(model, "externalDocumentation"),
                 equalTo(target.findTrait("externalDocumentation")));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -61,7 +61,6 @@ public class ModelSerializerTest {
         Model model = Model.builder()
                 .putMetadataProperty("foo", Node.from("baz"))
                 .putMetadataProperty("bar", Node.from("qux"))
-                .shapeIndex(ShapeIndex.builder().build())
                 .build();
         ObjectNode result = serializer.serialize(model);
 
@@ -77,10 +76,8 @@ public class ModelSerializerTest {
                 .shapeFilter(shape -> shape.getId().getName().equals("foo"))
                 .build();
         Model model = Model.builder()
-                .shapeIndex(ShapeIndex.builder()
-                        .addShape(StringShape.builder().id("ns.foo#foo").build())
-                        .addShape(StringShape.builder().id("ns.foo#baz").build())
-                        .build())
+                .addShape(StringShape.builder().id("ns.foo#foo").build())
+                .addShape(StringShape.builder().id("ns.foo#baz").build())
                 .build();
         ObjectNode result = serializer.serialize(model);
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.traits.DocumentationTrait;
@@ -119,15 +120,15 @@ public class ShapeTest {
                 .addTrait(otherTrait)
                 .addTrait(documentationTrait)
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(shape)
                 .build();
 
         assertTrue(shape.getTrait(MyTrait.class).isPresent());
-        assertTrue(shape.getMemberTrait(index, MyTrait.class).isPresent());
+        assertTrue(shape.getMemberTrait(model, MyTrait.class).isPresent());
 
         assertTrue(shape.findTrait("foo.baz#foo").isPresent());
-        assertTrue(shape.findMemberTrait(index, "foo.baz#foo").isPresent());
+        assertTrue(shape.findMemberTrait(model, "foo.baz#foo").isPresent());
 
         assertTrue(shape.hasTrait("foo.baz#foo"));
         assertTrue(shape.getTrait(OtherTrait.class).isPresent());

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/EffectiveTraitQueryTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/EffectiveTraitQueryTest.java
@@ -4,10 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 
 public class EffectiveTraitQueryTest {
@@ -16,11 +16,11 @@ public class EffectiveTraitQueryTest {
         Shape stringShape = StringShape.builder().id("foo.bar#Baz")
                 .addTrait(new SensitiveTrait())
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(stringShape)
                 .build();
         EffectiveTraitQuery query = EffectiveTraitQuery.builder()
-                .shapeIndex(index)
+                .model(model)
                 .traitClass(SensitiveTrait.class)
                 .build();
 
@@ -33,11 +33,11 @@ public class EffectiveTraitQueryTest {
                 .addTrait(new SensitiveTrait())
                 .build();
         ListShape list = ListShape.builder().id("foo.bar#List").member(stringShape.getId()).build();
-        ShapeIndex index = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(stringShape, list)
                 .build();
         EffectiveTraitQuery query = EffectiveTraitQuery.builder()
-                .shapeIndex(index)
+                .model(model)
                 .traitClass(SensitiveTrait.class)
                 .build();
 
@@ -56,11 +56,11 @@ public class EffectiveTraitQueryTest {
                 .member(member)
                 .addTrait(new SensitiveTrait())
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(stringShape, member, list)
                 .build();
         EffectiveTraitQuery query = EffectiveTraitQuery.builder()
-                .shapeIndex(index)
+                .model(model)
                 .traitClass(SensitiveTrait.class)
                 .build();
 
@@ -79,11 +79,11 @@ public class EffectiveTraitQueryTest {
                 .member(member)
                 .addTrait(new SensitiveTrait())
                 .build();
-        ShapeIndex index = ShapeIndex.builder()
+        Model model = Model.builder()
                 .addShapes(stringShape, member, list)
                 .build();
         EffectiveTraitQuery query = EffectiveTraitQuery.builder()
-                .shapeIndex(index)
+                .model(model)
                 .traitClass(SensitiveTrait.class)
                 .inheritFromContainer(true)
                 .build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterMetadataTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterMetadataTest.java
@@ -21,7 +21,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 public class FilterMetadataTest {
     @Test
@@ -30,7 +29,6 @@ public class FilterMetadataTest {
                 .putMetadataProperty("foo", Node.from("string"))
                 .putMetadataProperty("baz", Node.from(1))
                 .putMetadataProperty("lorem", Node.from(true))
-                .shapeIndex(ShapeIndex.builder().build())
                 .build();
         ModelTransformer transformer = ModelTransformer.create();
         // Remove boolean and number metadata key-value pairs.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
@@ -45,17 +44,16 @@ public class FilterTraitsTest {
                 .addTrait(new SensitiveTrait(SourceLocation.NONE))
                 .addTrait(DeprecatedTrait.builder().build())
                 .build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShapes(a, b).build()).build();
+        Model model = Model.builder().addShapes(a, b).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.filterTraits(
                 model, (shape, trait) -> !trait.toShapeId().equals(ShapeId.from("smithy.api#sensitive")));
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.shapes().count(), Matchers.is(2L));
-        assertThat(index.getShape(aId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(aId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(bId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(bId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.shapes().count(), Matchers.is(2L));
+        assertThat(result.getShape(aId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(aId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(bId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(bId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
     }
 
     @Test
@@ -67,28 +65,26 @@ public class FilterTraitsTest {
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .addTrait(DeprecatedTrait.builder().build())
                 .build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(a).build()).build();
+        Model model = Model.builder().addShape(a).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.filterTraits(
                 model, (shape, trait) -> !trait.toShapeId().equals(ShapeId.from("smithy.api#sensitive"))
                                          && !trait.toShapeId().equals(ShapeId.from("smithy.api#documentation")));
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.shapes().count(), Matchers.is(1L));
-        assertThat(index.getShape(aId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(aId).get().getTrait(DocumentationTrait.class), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(aId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.shapes().count(), Matchers.is(1L));
+        assertThat(result.getShape(aId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(aId).get().getTrait(DocumentationTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(aId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
     }
 
     @Test
     public void leavesShapesAlone() {
         ShapeId aId = ShapeId.from("ns.foo#A");
         StringShape a = StringShape.builder().id(aId).build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(a).build()).build();
+        Model model = Model.builder().addShape(a).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.filterTraits(model, (shape, trait) -> true);
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.shapes().count(), Matchers.is(1L));
+        assertThat(result.shapes().count(), Matchers.is(1L));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/IntegTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/IntegTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 public class IntegTest {
 
@@ -42,26 +41,24 @@ public class IntegTest {
     public void removesResources() {
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.removeShapesIf(model, shape -> shape.getId().toString().equals("ns.foo#MyResource"));
-        ShapeIndex index = result.getShapeIndex();
 
         assertValidModel(result);
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.is(Optional.empty()));
         // The operations bound to the resource remain, now orphaned.
-        assertThat(index.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.not(Optional.empty()));
     }
 
     @Test
     public void removesServices() {
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.removeShapesIf(model, shape -> shape.getId().toString().equals("ns.foo#MyService"));
-        ShapeIndex index = result.getShapeIndex();
 
         assertValidModel(result);
         // Operations and resources bound to the service remain.
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceIdentifier")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyOperation")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceIdentifier")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyOperation")), Matchers.not(Optional.empty()));
     }
 
     @Test
@@ -69,15 +66,14 @@ public class IntegTest {
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.removeShapesIf(model, shape -> shape.getId().toString().equals("ns.foo#MyResource"));
         result = transformer.removeUnreferencedShapes(result);
-        ShapeIndex index = result.getShapeIndex();
 
         assertValidModel(result);
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceIdentifier")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#CreateMyResourceOutput")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceOperationInput")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceOperationInputString")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceIdentifier")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#CreateMyResourceOutput")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceOperationInput")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceOperationInputString")), Matchers.is(Optional.empty()));
     }
 
     @Test
@@ -85,15 +81,14 @@ public class IntegTest {
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.removeShapesIf(model, shape -> shape.getId().toString().equals("ns.foo#MyResource"));
         result = transformer.removeUnreferencedShapes(result, shape -> !shape.getTags().contains("foo"));
-        ShapeIndex index = result.getShapeIndex();
 
         assertValidModel(result);
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceIdentifier")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#CreateMyResourceOutput")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceOperationInput")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#MyResourceOperationInputString")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResource")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceIdentifier")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#CreateMyResource")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#CreateMyResourceOutput")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceOperationInput")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#MyResourceOperationInputString")), Matchers.not(Optional.empty()));
     }
 
     private void assertValidModel(Model model) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapShapesTest.java
@@ -26,7 +26,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
@@ -40,13 +39,12 @@ public class MapShapesTest {
                 .id(shapeId)
                 .addTrait(new SensitiveTrait(SourceLocation.NONE))
                 .build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(shape).build()).build();
+        Model model = Model.builder().addShape(shape).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.mapShapes(model, s -> Shape.shapeToBuilder(s).removeTrait("sensitive").build());
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.getShape(shapeId).get().getId(), Matchers.equalTo(shapeId));
-        assertThat(index.getShape(shapeId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(shapeId).getId(), Matchers.equalTo(shapeId));
+        assertThat(result.expectShape(shapeId).getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
     }
 
     @Test
@@ -54,7 +52,7 @@ public class MapShapesTest {
         Assertions.assertThrows(RuntimeException.class, () -> {
             ShapeId shapeId = ShapeId.from("ns.foo#id1");
             StringShape shape = StringShape.builder().id(shapeId).build();
-            Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(shape).build()).build();
+            Model model = Model.builder().addShape(shape).build();
             ModelTransformer transformer = ModelTransformer.create();
             transformer.mapShapes(model, (s -> Shape.shapeToBuilder(s).id("ns.foo#change").build()));
         });
@@ -68,14 +66,13 @@ public class MapShapesTest {
                 .addTrait(new SensitiveTrait(SourceLocation.NONE))
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(shape).build()).build();
+        Model model = Model.builder().addShape(shape).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.mapShapes(model, Arrays.asList(
                 s -> Shape.shapeToBuilder(s).removeTrait("sensitive").build(),
                 s -> Shape.shapeToBuilder(s).removeTrait("documentation").build()));
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.getShape(shapeId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(shapeId).get().getTrait(DocumentationTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(shapeId).getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(shapeId).getTrait(DocumentationTrait.class), Matchers.is(Optional.empty()));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapTraitsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapTraitsTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
@@ -39,7 +38,7 @@ public class MapTraitsTest {
                 .id(shapeId)
                 .addTrait(new SensitiveTrait(SourceLocation.NONE))
                 .build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(shape).build()).build();
+        Model model = Model.builder().addShape(shape).build();
         ModelTransformer transformer = ModelTransformer.create();
         transformer.mapTraits(model, (s, t) -> t);
     }
@@ -52,7 +51,7 @@ public class MapTraitsTest {
                 .addTrait(DeprecatedTrait.builder().message("foo").build())
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .build();
-        Model model = Model.builder().shapeIndex(ShapeIndex.builder().addShape(shape).build()).build();
+        Model model = Model.builder().addShape(shape).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.mapTraits(model, Arrays.asList(
                 (s, t) -> {
@@ -70,12 +69,11 @@ public class MapTraitsTest {
                     }
                 }
         ));
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.getShape(shapeId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(shapeId).get().getTrait(DeprecatedTrait.class).get().getMessage().get(),
+        assertThat(result.expectShape(shapeId).getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(shapeId).getTrait(DeprecatedTrait.class).get().getMessage().get(),
                           Matchers.equalTo("baz"));
-        assertThat(index.getShape(shapeId).get().getTrait(DocumentationTrait.class).get().getValue(),
+        assertThat(result.expectShape(shapeId).getTrait(DocumentationTrait.class).get().getValue(),
                           Matchers.equalTo("changed"));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
 
@@ -36,15 +35,14 @@ public class ModelTransformerTest {
         ModelTransformer transformer = ModelTransformer.create();
         Model model = createTestModel();
         Model result = transformer.removeShapesIf(model, Shape::isStructureShape);
-        ShapeIndex index = result.getShapeIndex();
         ShapeId operation = ShapeId.from("ns.foo#MyOperation");
 
-        assertThat(index.getShape(operation), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(operation).get().asOperationShape().flatMap(OperationShape::getInput),
+        assertThat(result.expectShape(operation), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(operation).asOperationShape().flatMap(OperationShape::getInput),
                           Matchers.is(Optional.empty()));
-        assertThat(index.getShape(operation).get().asOperationShape().flatMap(OperationShape::getOutput),
+        assertThat(result.expectShape(operation).asOperationShape().flatMap(OperationShape::getOutput),
                           Matchers.is(Optional.empty()));
-        assertThat(index.getShape(operation).get().asOperationShape().map(OperationShape::getErrors),
+        assertThat(result.expectShape(operation).asOperationShape().map(OperationShape::getErrors),
                           Matchers.equalTo(Optional.of(Collections.emptyList())));
     }
 
@@ -52,12 +50,12 @@ public class ModelTransformerTest {
     public void removesTraitShapesButNotTraitUsage() {
         ModelTransformer transformer = ModelTransformer.create();
         Model model = createTestModel();
-        ShapeIndex index = transformer.getNonTraitShapes(model);
+        Model nonTraitShapes = transformer.getModelWithoutTraitShapes(model);
         ShapeId operation = ShapeId.from("ns.foo#MyOperation");
 
-        assertThat(index.getShape(operation), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(operation).get().getTrait(ReadonlyTrait.class), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(EnumTrait.ID), Matchers.equalTo(Optional.empty()));
+        assertThat(nonTraitShapes.getShape(operation), Matchers.not(Optional.empty()));
+        assertThat(nonTraitShapes.getShape(operation).get().getTrait(ReadonlyTrait.class), Matchers.not(Optional.empty()));
+        assertThat(nonTraitShapes.getShape(EnumTrait.ID), Matchers.equalTo(Optional.empty()));
     }
 
     private Model createTestModel() {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
@@ -32,7 +32,6 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
@@ -43,18 +42,17 @@ public class RemoveShapesTest {
     private static final ShapeId STRING_TARGET = ShapeId.from("ns.foo#String");
 
     private void assertContainerMembersAreRemoved(Shape container, List<Shape> members) {
-        ShapeIndex.Builder builder = ShapeIndex.builder()
+        Model.Builder builder = Model.builder()
                 .addShape(container)
                 .addShape(StringShape.builder().id(STRING_TARGET).build());
         members.forEach(builder::addShape);
-        Model model = Model.builder().shapeIndex(builder.build()).build();
+        Model model = builder.build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.removeShapes(model, Collections.singleton(container));
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.shapes().count(), Matchers.equalTo(1L));
-        assertThat(index.getShape(STRING_TARGET), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(container.getId()), Matchers.is(Optional.empty()));
+        assertThat(result.shapes().count(), Matchers.equalTo(1L));
+        assertThat(result.getShape(STRING_TARGET), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(container.getId()), Matchers.is(Optional.empty()));
     }
 
     @Test
@@ -132,16 +130,14 @@ public class RemoveShapesTest {
         OperationShape b = OperationShape.builder().id("ns.foo#B").build();
         OperationShape c = OperationShape.builder().id("ns.foo#C").build();
 
-        ShapeIndex index = ShapeIndex.builder().addShapes(container, a, b, c).build();
-        Model model = Model.builder().shapeIndex(index).build();
+        Model model = Model.builder().addShapes(container, a, b, c).build();
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.removeShapes(model, Arrays.asList(a, b));
-        ShapeIndex resultShapeIndex = result.getShapeIndex();
 
-        assertThat(resultShapeIndex.shapes().count(), Matchers.equalTo(2L));
-        assertThat(resultShapeIndex.getShape(container.getId()), Matchers.not(Optional.empty()));
-        assertThat(resultShapeIndex.getShape(c.getId()), Matchers.not(Optional.empty()));
-        assertThat(resultShapeIndex.getShape(container.getId()).get().asResourceShape().get().getOperations(),
-                          Matchers.contains(c.getId()));
+        assertThat(result.shapes().count(), Matchers.equalTo(2L));
+        assertThat(result.getShape(container.getId()), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(c.getId()), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(container.getId()).asResourceShape().get().getOperations(),
+                   Matchers.contains(c.getId()));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
@@ -22,7 +22,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 
 public class ScrubTraitDefinitionsTest {
 
@@ -35,32 +34,31 @@ public class ScrubTraitDefinitionsTest {
 
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.scrubTraitDefinitions(model);
-        ShapeIndex index = result.getShapeIndex();
 
-        assertThat(index.getShape(ShapeId.from("ns.foo#FooStructure")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#BarString")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#BarStringList")), Matchers.is(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#ComplexRemoved")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#FooStructure")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#BarString")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#BarStringList")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#ComplexRemoved")), Matchers.is(Optional.empty()));
 
-        assertThat(index.getShape(ShapeId.from("ns.foo#IpsumString")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#IpsumList")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("ns.foo#KeepStructure")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#IpsumString")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#IpsumList")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#KeepStructure")), Matchers.not(Optional.empty()));
 
         // Make sure public prelude shapes weren't removed.
-        assertThat(index.getShape(ShapeId.from("smithy.api#String")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Blob")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Boolean")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Byte")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Short")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Integer")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Long")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Float")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Double")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#BigInteger")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#BigDecimal")), Matchers.not(Optional.empty()));
-        assertThat(index.getShape(ShapeId.from("smithy.api#Timestamp")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#String")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Blob")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Boolean")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Byte")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Short")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Integer")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Long")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Float")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Double")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#BigInteger")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#BigDecimal")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Timestamp")), Matchers.not(Optional.empty()));
 
         // Make sure public prelude trait definition shapes were removed.
-        assertThat(index.getShape(ShapeId.from("smithy.api#length")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#length")), Matchers.is(Optional.empty()));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -58,11 +58,9 @@ public class NodeValidationVisitorTest {
         Node nodeValue = FACTORY.createNode("N/A", value);
         NodeValidationVisitor cases = NodeValidationVisitor.builder()
                 .value(nodeValue)
-                .index(MODEL.getShapeIndex())
+                .model(MODEL)
                 .build();
-        List<ValidationEvent> events = MODEL.getShapeIndex().getShape(targetId)
-                .orElseThrow(() -> new IllegalArgumentException("No shape found for " + targetId))
-                .accept(cases);
+        List<ValidationEvent> events = MODEL.expectShape(targetId).accept(cases);
 
         if (errors != null) {
             List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.knowledge.KnowledgeIndex;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.Trait;
@@ -60,11 +59,10 @@ public final class ResolvedTopicIndex implements KnowledgeIndex {
 
     public ResolvedTopicIndex(Model model) {
         // Find all the MQTT topic bindings in the model.
-        ShapeIndex index = model.getShapeIndex();
         EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
         OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
 
-        index.shapes(OperationShape.class).forEach(operation -> {
+        model.shapes(OperationShape.class).forEach(operation -> {
             if (operation.hasTrait(PublishTrait.class)) {
                 PublishTrait trait = operation.getTrait(PublishTrait.class).get();
                 createPublishBindings(operationIndex, operation, trait);

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttPublishInputValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttPublishInputValidator.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.EventStreamTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -34,15 +33,14 @@ import software.amazon.smithy.utils.OptionalUtils;
 public class MqttPublishInputValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        return index.shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .filter(shape -> shape.hasTrait(PublishTrait.class))
-                .flatMap(shape -> validateOperation(index, shape))
+                .flatMap(shape -> validateOperation(model, shape))
                 .collect(Collectors.toList());
     }
 
-    private Stream<ValidationEvent> validateOperation(ShapeIndex index, OperationShape operation) {
-        return OptionalUtils.stream(operation.getInput().flatMap(index::getShape).flatMap(Shape::asStructureShape))
+    private Stream<ValidationEvent> validateOperation(Model model, OperationShape operation) {
+        return OptionalUtils.stream(operation.getInput().flatMap(model::getShape).flatMap(Shape::asStructureShape))
                 .flatMap(input -> input.getAllMembers().values().stream()
                         .filter(member -> member.hasTrait(EventStreamTrait.class))
                         .map(member -> error(member, String.format(

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeInputValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeInputValidator.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.mqtt.traits.SubscribeTrait;
@@ -38,15 +37,14 @@ import software.amazon.smithy.utils.OptionalUtils;
 public final class MqttSubscribeInputValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        return index.shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .filter(shape -> shape.hasTrait(SubscribeTrait.class))
-                .flatMap(shape -> validateOperation(index, shape))
+                .flatMap(shape -> validateOperation(model, shape))
                 .collect(Collectors.toList());
     }
 
-    private Stream<ValidationEvent> validateOperation(ShapeIndex index, OperationShape operation) {
-        return OptionalUtils.stream(operation.getInput().flatMap(index::getShape).flatMap(Shape::asStructureShape))
+    private Stream<ValidationEvent> validateOperation(Model model, OperationShape operation) {
+        return OptionalUtils.stream(operation.getInput().flatMap(model::getShape).flatMap(Shape::asStructureShape))
                 .flatMap(input -> input.getAllMembers().values().stream()
                         .filter(member -> !member.hasTrait(TopicLabelTrait.class))
                         .map(member -> error(member, String.format(

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -49,11 +48,10 @@ import software.amazon.smithy.mqtt.traits.TopicLabelTrait;
 public class MqttTopicLabelValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ShapeIndex index = model.getShapeIndex();
-        return model.getShapeIndex().shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .map(MqttTopicLabelValidator::createTopics)
                 .filter(Objects::nonNull)
-                .flatMap(topics -> validateMqtt(index, topics).stream())
+                .flatMap(topics -> validateMqtt(model, topics).stream())
                 .collect(Collectors.toList());
     }
 
@@ -71,10 +69,10 @@ public class MqttTopicLabelValidator extends AbstractValidator {
         }
     }
 
-    private List<ValidationEvent> validateMqtt(ShapeIndex index, TopicCollection topics) {
+    private List<ValidationEvent> validateMqtt(Model model, TopicCollection topics) {
         Set<String> labels = topics.getLabels();
         StructureShape input = topics.operation.getInput()
-                .flatMap(index::getShape)
+                .flatMap(model::getShape)
                 .flatMap(Shape::asStructureShape)
                 .orElse(null);
 

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttUnsupportedErrorsValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttUnsupportedErrorsValidator.java
@@ -38,7 +38,7 @@ import software.amazon.smithy.utils.OptionalUtils;
 public final class MqttUnsupportedErrorsValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        return model.getShapeIndex().shapes(OperationShape.class)
+        return model.shapes(OperationShape.class)
                 .filter(shape -> !shape.getErrors().isEmpty())
                 .flatMap(shape -> OptionalUtils.stream(validateOperation(shape)))
                 .collect(Collectors.toList());

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -45,7 +45,6 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.model.traits.Protocol;
@@ -237,7 +236,7 @@ public final class OpenApiConverter {
                 .withMember(JsonSchemaConstants.DEFINITION_POINTER, OpenApiConstants.SCHEMA_COMPONENTS_POINTER);
 
         // Find the service shape.
-        ServiceShape service = model.getShapeIndex().getShape(serviceShapeId)
+        ServiceShape service = model.getShape(serviceShapeId)
                 .orElseThrow(() -> new IllegalArgumentException(String.format(
                         "Shape `%s` not found in shape index", serviceShapeId)))
                 .asServiceShape()
@@ -275,7 +274,7 @@ public final class OpenApiConverter {
         // Set a protocol name if one wasn't set but instead derived.
         protocolName = protocolName != null ? protocolName : resolvedProtocol.getName();
         ComponentsObject.Builder components = ComponentsObject.builder();
-        SchemaDocument schemas = addSchemas(components, model.getShapeIndex(), service);
+        SchemaDocument schemas = addSchemas(components, model, service);
 
         // Load security scheme converters.
         List<SecuritySchemeConverter> securitySchemeConverters = loadSecuritySchemes(service, extensions);
@@ -444,10 +443,10 @@ public final class OpenApiConverter {
     // Copies the JSON schema schemas over into the OpenAPI object.
     private SchemaDocument addSchemas(
             ComponentsObject.Builder components,
-            ShapeIndex index,
+            Model model,
             ServiceShape service
     ) {
-        SchemaDocument document = getJsonSchemaConverter().convert(index, service);
+        SchemaDocument document = getJsonSchemaConverter().convert(model, service);
         for (Map.Entry<String, Schema> entry : document.getDefinitions().entrySet()) {
             String key = entry.getKey().replace(OpenApiConstants.SCHEMA_COMPONENTS_POINTER + "/", "");
             components.putSchema(key, entry.getValue());

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForPrefixHeaders.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForPrefixHeaders.java
@@ -48,7 +48,7 @@ public class CheckForPrefixHeaders implements OpenApiMapper {
     @Override
     public void before(Context context, OpenApi.Builder builder) {
         HttpBindingIndex httpBindings = context.getModel().getKnowledge(HttpBindingIndex.class);
-        context.getModel().getShapeIndex().shapes(OperationShape.class).forEach(operation -> {
+        context.getModel().shapes(OperationShape.class).forEach(operation -> {
             check(context, httpBindings.getRequestBindings(operation, HttpBinding.Location.PREFIX_HEADERS));
             checkForResponseHeaders(context, httpBindings, operation);
             operation.getErrors().forEach(error -> checkForResponseHeaders(context, httpBindings, error));

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraits.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraits.java
@@ -44,7 +44,7 @@ public final class UnsupportedTraits implements OpenApiMapper {
 
     @Override
     public void before(Context context, OpenApi.Builder builder) {
-        List<Pair<ShapeId, List<String>>> violations = context.getModel().getShapeIndex().shapes()
+        List<Pair<ShapeId, List<String>>> violations = context.getModel().shapes()
                 .map(shape -> Pair.of(shape.getId(), TRAITS.stream()
                         .filter(trait -> shape.findTrait(trait).isPresent())
                         .collect(Collectors.toList())))

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -127,7 +127,7 @@ abstract class AbstractRestProtocol implements OpenApiProtocol {
                     ParameterObject.Builder paramBuilder = ModelUtils.createParameterMember(
                             context, member).in("path");
                     // Timestamps sent in the URI are serialized as a date-time string by default.
-                    boolean needsInlineSchema = context.getModel().getShapeIndex().getShape(member.getTarget())
+                    boolean needsInlineSchema = context.getModel().getShape(member.getTarget())
                             .filter(Shape::isTimestampShape)
                             .isPresent()
                             && !ModelUtils.getMemberTrait(context, member, TimestampFormatTrait.class).isPresent();
@@ -149,8 +149,7 @@ abstract class AbstractRestProtocol implements OpenApiProtocol {
                     ParameterObject.Builder param = ModelUtils.createParameterMember(context, binding.getMember())
                             .in("query")
                             .name(binding.getLocationName());
-                    Shape target = context.getModel().getShapeIndex()
-                            .getShape(binding.getMember().getTarget()).get();
+                    Shape target = context.getModel().expectShape(binding.getMember().getTarget());
 
                     // List and set shapes in the query string are repeated, so we need to "explode" them.
                     if (target instanceof CollectionShape) {
@@ -184,7 +183,7 @@ abstract class AbstractRestProtocol implements OpenApiProtocol {
                         // Response headers don't use "in" or "name".
                         param.in(null).name(null);
                     }
-                    Shape target = context.getModel().getShapeIndex().getShape(binding.getMember().getTarget()).get();
+                    Shape target = context.getModel().expectShape(binding.getMember().getTarget());
                     Schema refSchema = context.createRef(binding.getMember());
                     param.schema(target.accept(new HeaderSchemaVisitor(context, refSchema, binding.getMember())));
                     return Pair.of(binding.getLocationName(), param.build());
@@ -352,7 +351,7 @@ abstract class AbstractRestProtocol implements OpenApiProtocol {
         }
 
         private Schema collection(CollectionShape collection) {
-            Shape memberTarget = context.getModel().getShapeIndex().getShape(collection.getMember().getTarget()).get();
+            Shape memberTarget = context.getModel().getShape(collection.getMember().getTarget()).get();
             String memberPointer = context.getPointer(collection.getMember());
             Schema currentMemberSchema = context.getSchema(memberPointer);
             Schema newMemberSchema = memberTarget.accept(
@@ -411,7 +410,7 @@ abstract class AbstractRestProtocol implements OpenApiProtocol {
         }
 
         private Schema collection(CollectionShape collection) {
-            Shape memberTarget = context.getModel().getShapeIndex().getShape(collection.getMember().getTarget()).get();
+            Shape memberTarget = context.getModel().expectShape(collection.getMember().getTarget());
             String memberPointer = context.getPointer(collection.getMember());
             Schema currentMemberSchema = context.getSchema(memberPointer);
             Schema newMemberSchema = memberTarget.accept(


### PR DESCRIPTION
ShapeIndex is not adding any value as a separate abstraction from
Model. Separating ShapeIndex from Model made building models much more
verbose, interacting with shapes in a model more verbose, updating
models verbose, and caused an awkward API if you need to access things
like knowledge indexes but only have access to a ShapeIndex (knowledge
indexes are only on models).

This commit first deprecates all ShapeIndex APIs and provides
alternatives that are to be used instead. In some cases, the
alternative, Model based APIs, still call into the deprecated ShapeIndex
APIs. This is because a Model always has a ShapeIndex but a ShapeIndex
is not a model, and it cuts down on code duplication. In the next
version bump (likely 0.10.0), we will remove the ShapeIndex APIs
altogether.

*Issue #, if available:*

*Description of changes:*

Addresses #208

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
