### PR TITLE
Update smithy-build to be streaming

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildResult.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildResult.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.build;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -123,7 +124,7 @@ public final class SmithyBuildResult {
      * Creates a SmithyBuildResult.
      */
     public static final class Builder implements SmithyBuilder<SmithyBuildResult> {
-        private final List<ProjectionResult> results = new ArrayList<>();
+        private final List<ProjectionResult> results = Collections.synchronizedList(new ArrayList<>());
 
         private Builder() {}
 
@@ -134,6 +135,9 @@ public final class SmithyBuildResult {
 
         /**
          * Adds a projection result to the builder.
+         *
+         * <p>This method is thread-safe as a synchronized list is updated each
+         * time this is called.
          *
          * @param result Result to add.
          * @return Returns the builder.

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/trigger-plugin-error.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/trigger-plugin-error.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "projections": {
+    "exampleProjection": {
+      "plugins": {
+        "foo": {}
+      }
+    }
+  }
+}

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/projection-build-failure.json
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/projection-build-failure.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "projections": {
+    "exampleProjection": {
+      "transforms": [
+        {"name": "excludeTraits", "args": ["readonly"]}
+      ]
+    }
+  }
+}

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/valid-model.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/valid-model.smithy
@@ -1,0 +1,18 @@
+namespace smithy.example
+
+resource Foo {
+    identifier: {id: FooId},
+    read: GetFoo,
+}
+
+string FooId
+
+@readonly
+operation GetFoo(GetFooInput) -> GetFooOutput
+
+structure GetFooInput {
+    @required
+    id: FooId,
+}
+
+structure GetFooOutput {}


### PR DESCRIPTION
smithy-build used to load every model from every projection into memory
at once. This was not ideal since some use cases utilize hundreds of
projections. For example, in AWS SDKs, we create a projection for every
AWS service, which is hundreds of them with tens-of-thousands of shapes
and operations.

This commit updates smithy-build to support two modes: in-memory and
streaming. The in-memory mode is useful for testing or one-off
integrations. The streaming mode is useful for actually executing
smithy-build from the CLI so that results are outputted to stdout as
they happen and not all models are loaded into memory.

The CLI was updated to significantly change its output to show more
information about things that go wrong and print more statistics. Every
projection and plugin is attempted to be executed -- the CLI previously
failed on the first exception.

Finally, executing tasks is now done with an ExecutorService rather than
parallel streams to have more control over task execution.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
