### PR TITLE
Expand sensitive applicability

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -5135,9 +5135,9 @@ Summary
     Indicates that the data stored in the shape or member is sensitive
     and MUST be handled with care.
 Trait selector
-    ``:test(blob, string, member > :test(blob, string))``
+    ``:not(:test(service, operation, resource))``
 
-    *Any blob or string; or a member that targets a blob/string*
+    *Any shape that is not a service, operation, or resource.*
 Value type
     Annotation trait
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -230,7 +230,7 @@ string resourceIdentifier
 structure private {}
 
 /// Indicates that the data stored in the shape or member is sensitive and MUST be handled with care.
-@trait(selector: ":test(blob, string, member > :each(blob, string))")
+@trait(selector: ":not(:test(service, operation, resource))")
 structure sensitive {}
 
 /// Defines the version or date in which a shape or member was added to the model.

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/sensitive-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/sensitive-trait.errors
@@ -1,0 +1,1 @@
+[ERROR] ns.foo#Operation: Trait `sensitive` cannot be applied to `ns.foo#Operation`. This trait may only be applied to shapes that match the following selector: :not(:test(service, operation, resource)) | TraitTarget

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/sensitive-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/sensitive-trait.json
@@ -1,0 +1,31 @@
+{
+    "smithy": "0.4.0",
+    "ns.foo": {
+        "shapes": {
+            "Operation": {
+                "type": "operation",
+                "smithy.api#sensitive": true
+            },
+            "Structure": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "target": "String"
+                    }
+                },
+                "smithy.api#sensitive": true
+            },
+            "Blob": {
+                "type": "blob",
+                "smithy.api#sensitive": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "SensitiveString": {
+                "type": "string",
+                "smithy.api#sensitive": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allow anything but operations, services, and resources to have the
sensitive trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.