### PR TITLE
Allow min to equal max in range

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/RangeTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/RangeTraitValidator.java
@@ -57,9 +57,9 @@ public class RangeTraitValidator extends AbstractValidator {
         // Makes sure that `min` is less than `max`
         trait.getMin()
                 .flatMap(min -> trait.getMax().map(max -> Pair.of(min, max)))
-                .filter(pair -> pair.getLeft().compareTo(pair.getRight()) >= 0)
+                .filter(pair -> pair.getLeft().compareTo(pair.getRight()) > 0)
                 .map(pair -> error(shape, trait, "A range trait is applied with a `min` value greater than "
-                        + "or equal to its `max` value."))
+                        + "its `max` value."))
                 .map(events::add);
 
         return events;

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/range-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/range-trait.errors
@@ -8,7 +8,7 @@
 [ERROR] ns.foo#Invalid4: Shape `ns.foo#Invalid4` is marked with the `range` trait, but its `min` property is a decimal (0.5) when its shape (`long`) does not support decimals. | RangeTrait
 [ERROR] ns.foo#Invalid5: Shape `ns.foo#Invalid5` is marked with the `range` trait, but its `max` property is a decimal (10.5) when its shape (`bigInteger`) does not support decimals. | RangeTrait
 [ERROR] ns.foo#Invalid5: Shape `ns.foo#Invalid5` is marked with the `range` trait, but its `min` property is a decimal (0.5) when its shape (`bigInteger`) does not support decimals. | RangeTrait
-[ERROR] ns.foo#Invalid6: A range trait is applied with a `min` value greater than or equal to its `max` value. | RangeTrait
+[ERROR] ns.foo#Invalid6: A range trait is applied with a `min` value greater than its `max` value. | RangeTrait
 [ERROR] ns.foo#Structure$InvalidMember1: Member `ns.foo#Structure$InvalidMember1` is marked with the `range` trait, but its `max` property is a decimal (10.5) when its target (`smithy.api#Byte`) does not support decimals. | RangeTrait
 [ERROR] ns.foo#Structure$InvalidMember1: Member `ns.foo#Structure$InvalidMember1` is marked with the `range` trait, but its `min` property is a decimal (0.5) when its target (`smithy.api#Byte`) does not support decimals. | RangeTrait
 [ERROR] ns.foo#Structure$InvalidMember2: Member `ns.foo#Structure$InvalidMember2` is marked with the `range` trait, but its `max` property is a decimal (10.5) when its target (`smithy.api#Short`) does not support decimals. | RangeTrait
@@ -19,4 +19,4 @@
 [ERROR] ns.foo#Structure$InvalidMember4: Member `ns.foo#Structure$InvalidMember4` is marked with the `range` trait, but its `min` property is a decimal (0.5) when its target (`smithy.api#Long`) does not support decimals. | RangeTrait
 [ERROR] ns.foo#Structure$InvalidMember5: Member `ns.foo#Structure$InvalidMember5` is marked with the `range` trait, but its `max` property is a decimal (10.5) when its target (`smithy.api#BigInteger`) does not support decimals. | RangeTrait
 [ERROR] ns.foo#Structure$InvalidMember5: Member `ns.foo#Structure$InvalidMember5` is marked with the `range` trait, but its `min` property is a decimal (0.5) when its target (`smithy.api#BigInteger`) does not support decimals. | RangeTrait
-[ERROR] ns.foo#Structure$InvalidMember6: A range trait is applied with a `min` value greater than or equal to its `max` value. | RangeTrait
+[ERROR] ns.foo#Structure$InvalidMember6: A range trait is applied with a `min` value greater than its `max` value. | RangeTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/range-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/range-trait.json
@@ -89,6 +89,13 @@
               "max": 10.5e4
             }
           },
+          "ValidMember13": {
+            "target": "smithy.api#Integer",
+            "range": {
+              "min": 5,
+              "max": 5
+            }
+          },
           "InvalidMember1": {
             "target": "smithy.api#Byte",
             "range": {
@@ -208,6 +215,13 @@
         "range": {
           "min": 0.5,
           "max": 10.5
+        }
+      },
+      "Valid12": {
+        "type": "integer",
+        "range": {
+          "min": 5,
+          "max": 5
         }
       },
       "Invalid1": {


### PR DESCRIPTION
This is still a valid configuration, it just only allows a single
value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.