### PR TITLE
Allow page member to be required

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3979,7 +3979,7 @@ The ``paginated`` trait is an object that contains the following properties:
       - ``string``
       - The name of an operation input member that limits the maximum number
         of results to include in the operation output. This input member
-        MUST NOT be required and MUST target an integer shape.
+        SHOULD NOT be required and MUST target an integer shape.
 
         .. warning::
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -87,7 +87,13 @@ public final class PaginatedTraitValidator extends AbstractValidator {
             events.add(error(operation, trait, "paginated operations require an input"));
         } else {
             events.addAll(validateMember(opIndex, model, null, operation, trait, new InputTokenValidator()));
-            events.addAll(validateMember(opIndex, model, null, operation, trait, new PageSizeValidator()));
+            PageSizeValidator pageSizeValidator = new PageSizeValidator();
+            events.addAll(validateMember(opIndex, model, null, operation, trait, pageSizeValidator));
+            pageSizeValidator.getMember(model, opIndex, operation, trait)
+                    .filter(MemberShape::isRequired)
+                    .ifPresent(member -> events.add(danger(operation, trait, String.format(
+                            "paginated trait `%s` member `%s` should not be required",
+                            pageSizeValidator.propertyName(), member.getMemberName()))));
         }
 
         if (!opIndex.getOutput(operation).isPresent()) {
@@ -283,7 +289,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
 
     private static final class PageSizeValidator extends PropertyValidator {
         boolean mustBeOptional() {
-            return true;
+            return false;
         }
 
         boolean isRequiredToBePresent() {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
@@ -6,7 +6,7 @@
 [ERROR] ns.foo#Invalid3: paginated trait `outputToken` member `OutputNotString` targets a integer shape, but must target one of the following: [`string`] | PaginatedTrait
 [ERROR] ns.foo#Invalid4: paginated trait `inputToken` member `nextToken` must not be required | PaginatedTrait
 [ERROR] ns.foo#Invalid4: paginated trait `outputToken` member `nextToken` must not be required | PaginatedTrait
-[ERROR] ns.foo#Invalid4: paginated trait `pageSize` member `pageSize` must not be required | PaginatedTrait
+[DANGER] ns.foo#Invalid4: paginated trait `pageSize` member `pageSize` should not be required | PaginatedTrait
 [ERROR] ns.foo#Invalid6: paginated trait `pageSize` member `Invalid6Input` targets a string shape, but must target one of the following: [`integer`] | PaginatedTrait
 [ERROR] ns.foo#Invalid7: paginated trait `items` member `Invalid7Input` targets a string shape, but must target one of the following: [`list`, `map`] | PaginatedTrait
 [ERROR] ns.foo#Invalid8: paginated trait `items` targets a member `items` that does not exist | PaginatedTrait


### PR DESCRIPTION
This allows the page size member to be required, but still defaults
it to failing the build when it is.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.