### PR TITLE
Properly allow omitting endpoint operation inputs

### DIFF
--- a/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/clientendpointdiscovery/errorfiles/no-input.json
+++ b/aws/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/clientendpointdiscovery/errorfiles/no-input.json
@@ -1,0 +1,111 @@
+{
+    "smithy": "0.4.0",
+    "ns.foo": {
+        "shapes": {
+            "FooService": {
+                "type": "service",
+                "version": "2019-09-10",
+                "aws.api#clientEndpointDiscovery": {
+                    "operation": "ns.foo#DescribeEndpoints",
+                    "error": "ns.foo#InvalidEndpointError"
+                },
+                "operations": [
+                    "DescribeEndpoints",
+                    "GetObject",
+                    "PutObject"
+                ]
+            },
+            "BarService": {
+                "type": "service",
+                "version": "2019-09-10",
+                "operations": [
+                    "DescribeEndpoints"
+                ]
+            },
+            "DescribeEndpoints": {
+                "type": "operation",
+                "input": "DescribeEndpointsInput",
+                "output": "DescribeEndpointsOutput"
+            },
+            "DescribeEndpointsInput": {
+                "type": "structure"
+            },
+            "DescribeEndpointsOutput": {
+                "type": "structure",
+                "members": {
+                    "Endpoints": {
+                        "target": "Endpoints"
+                    }
+                }
+            },
+            "Endpoints": {
+                "type": "list",
+                "member": {
+                    "target": "Endpoint"
+                }
+            },
+            "Endpoint": {
+                "type": "structure",
+                "members": {
+                    "Address": {
+                        "target": "smithy.api#String"
+                    },
+                    "CachePeriodInMinutes": {
+                        "target": "smithy.api#Long"
+                    }
+                }
+            },
+            "GetObject": {
+                "type": "operation",
+                "input": "GetObjectInput",
+                "output": "GetObjectOutput",
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "errors": ["InvalidEndpointError"]
+            },
+            "GetObjectInput": {
+                "type": "structure",
+                "members": {
+                    "Id": {
+                        "target": "smithy.api#String",
+                        "required": true
+                    }
+                }
+            },
+            "GetObjectOutput": {
+                "type": "structure",
+                "members": {
+                    "Object": {
+                        "target": "smithy.api#Blob"
+                    }
+                }
+            },
+            "PutObject": {
+                "type": "operation",
+                "input": "PutObjectInput",
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": false
+                },
+                "errors": ["InvalidEndpointError"]
+            },
+            "PutObjectInput": {
+                "type": "structure",
+                "members": {
+                    "Id": {
+                        "target": "smithy.api#String",
+                        "required": true
+                    },
+                    "Object": {
+                        "target": "smithy.api#Blob"
+                    }
+                }
+            },
+            "InvalidEndpointError": {
+                "type": "structure",
+                "error": "client",
+                "httpError": 421
+            }
+        }
+    }
+}


### PR DESCRIPTION
The validation for endpoint discovery previously did not allow for
the endpoint operation to have a subset of the allowed inputs, this
change fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.