### PR TITLE
Mark NodeFactory and DefaultNodeFactory Deprecated

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeFactory.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeFactory.java
@@ -39,7 +39,11 @@ import software.amazon.smithy.utils.MapUtils;
  *
  * <p>Uses Jackson internally, but that is free to change in the
  * future if needed.
+ *
+ * <p>Using this class directly is deprecated and it will be made
+ * package-private in 0.10.0. Use {@link Node#parse} instead.
  */
+@Deprecated
 public final class DefaultNodeFactory implements NodeFactory {
     private final JsonFactory jsonFactory;
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeFactory.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeFactory.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.model.loader.ModelSyntaxException;
  * from strings.
  */
 @FunctionalInterface
+@Deprecated
 public interface NodeFactory {
     /**
      * Creates a {@link Node} from a document {@code String}.


### PR DESCRIPTION
Node#parse should be used instead. NodeFactory and DefaultNodeFactory
will be removed in 0.10.0.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
