### PR TITLE
Add ability to configure timestamp validation

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.node;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeIndex;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Defines how timestamps are validated.
+ */
+public enum TimestampValidationStrategy implements NodeValidatorPlugin {
+    /**
+     * Validates timestamps by requiring that the value uses matches the
+     * resolved timestamp format, or is a unix timestamp or integer in the
+     * case that a member or shape does not have a {@code timestampFormat}
+     * trait.
+     */
+    FORMAT {
+        @Override
+        public List<String> apply(Shape shape, Node value, ShapeIndex index) {
+            return new TimestampFormatPlugin().apply(shape, value, index);
+        }
+    },
+
+    /**
+     * Requires that the value provided for all timestamp shapes is a
+     * unix timestamp.
+     */
+    EPOCH_SECONDS {
+        @Override
+        public List<String> apply(Shape shape, Node value, ShapeIndex index) {
+            if (isTimestampMember(index, shape) && !value.isNumberNode()) {
+                return ListUtils.of("Invalid " + value.getType() + " value provided for timestamp, `"
+                                    + shape.getId() + "`. Expected a number that contains epoch seconds "
+                                    + "with optional millisecond precision");
+            } else {
+                return Collections.emptyList();
+            }
+        }
+    };
+
+    private static boolean isTimestampMember(ShapeIndex model, Shape shape) {
+        return shape.asMemberShape()
+                .map(MemberShape::getTarget)
+                .flatMap(model::getShape)
+                .filter(Shape::isTimestampShape)
+                .isPresent();
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.NodeValidationVisitor;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.node.TimestampValidationStrategy;
 
 abstract class ProtocolTestCaseValidator<T extends Trait> extends AbstractValidator {
 
@@ -94,6 +95,7 @@ abstract class ProtocolTestCaseValidator<T extends Trait> extends AbstractValida
                 .value(value)
                 .startingContext(traitId + "." + position + ".params")
                 .eventId(getName())
+                .timestampValidationStrategy(TimestampValidationStrategy.EPOCH_SECONDS)
                 .build();
     }
 }

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/timestamp-validation.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/timestamp-validation.smithy
@@ -1,0 +1,21 @@
+namespace smithy.example
+
+use smithy.test#httpRequestTests
+
+@http(method: "POST", uri: "/")
+@httpRequestTests([
+    {
+        id: "foo3",
+        protocol: "example",
+        method: "POST",
+        uri: "/",
+        params: {
+            time: 946845296
+        }
+    }
+])
+operation HasTime(HasTimeInput)
+
+structure HasTimeInput {
+    time: Timestamp,
+}


### PR DESCRIPTION
This commit updates the Node validation visitor to allow for a
configurable strategy for validating timestamps. This is needed in order
to validate that the timestamps provided for protocol tests are always
in epoch seconds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
