### PR TITLE
Use list of string for queryParams

### DIFF
--- a/docs/source/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/spec/http-protocol-compliance-tests.rst
@@ -108,19 +108,30 @@ that support the following properties:
         It's possible that specific authentication schemes might influence
         the serialization logic of an HTTP request.
     * - queryParams
-      - ``Map<String, String>``
-      - A map of expected query string parameters.
+      - ``[string]``
+      - A list of the expected serialized query string parameters.
+
+        Each element in the list is a query string key value pair
+        that starts with the query string parameter name optionally
+        followed by "=", optionally followed by the query string
+        parameter value. For example, "foo=bar", "foo=", and "foo"
+        are all valid values.
+
+        .. note::
+
+            This kind of list is used instead of a map so that query string
+            parameter values for lists can be represented using repeated
+            key-value pairs.
+
+        The query string parameter name and the value MUST appear in the
+        format in which it is expected to be sent over the wire; if a key or
+        value needs to be percent-encoded, then it MUST appear
+        percent-encoded in this list.
 
         A serialized HTTP request is not in compliance with the protocol
         if any query string parameter defined in ``queryParams`` is not
         defined in the request or if the value of a query string parameter
         in the request differs from the expected value.
-
-        Each key represents the query string parameter name, and each
-        value represents the query string parameter value. Both keys and
-        values MUST appear in the format in which it is expected to be
-        sent over the wire; if a key or value needs to be percent-encoded,
-        then it MUST appear percent-encoded in this map.
 
         ``queryParams`` applies no constraints on additional query parameters.
     * - forbidQueryParams
@@ -204,10 +215,14 @@ that uses :ref:`HTTP binding traits <http-traits>`.
                 protocol: "example",
                 params: {
                     "greeting": "Hi",
-                    "name": "Teddy"
+                    "name": "Teddy",
+                    "query": "Hello there"
                 },
                 method: "POST",
                 uri: "/",
+                queryParams: [
+                    "Hi=Hello%20there"
+                ],
                 headers: {
                     "X-Greeting": "Hi",
                 },
@@ -220,6 +235,9 @@ that uses :ref:`HTTP binding traits <http-traits>`.
         structure SayHelloInput {
             @httpHeader("X-Greeting")
             greeting: String,
+
+            @httpQuery("Hi")
+            query: String,
 
             name: String
         }
@@ -244,17 +262,21 @@ that uses :ref:`HTTP binding traits <http-traits>`.
                             {
                                 "id": "say_hello",
                                 "protocol": "example",
+                                "method": "POST",
+                                "uri": "/",
                                 "headers": {
                                     "X-Greeting": "Hi"
                                 },
+                                "queryParams": [
+                                    "Hi=Hello%20there"
+                                ],
                                 "body": "{\"name\": \"Teddy\"}",
                                 "bodyMediaType": "application/json"
                                 "params": {
                                     "greeting": "Hi",
-                                    "name": "Teddy"
-                                },
-                                "method": "POST",
-                                "uri": "/"
+                                    "name": "Teddy",
+                                    "query": "Hello there"
+                                }
                             }
                         ]
                     }

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -41,21 +41,24 @@ structure HttpRequestTestCase {
     /// logic of an HTTP request.
     authScheme: String,
 
-    /// A map of expected query string parameters.
+    /// A list of the expected serialized query string parameters.
+    ///
+    /// Each element in the list is a query string key value pair
+    /// that starts with the query string parameter name optionally
+    /// followed by "=", optionally followed by the query string
+    /// parameter value. For example, "foo=bar", "foo=", and "foo"
+    /// are all valid values. The query string parameter name and
+    /// the value MUST appear in the format in which it is expected
+    /// to be sent over the wire; if a key or value needs to be
+    /// percent-encoded, then it MUST appear percent-encoded in this list.
     ///
     /// A serialized HTTP request is not in compliance with the protocol
     /// if any query string parameter defined in `queryParams` is not
     /// defined in the request or if the value of a query string parameter
     /// in the request differs from the expected value.
     ///
-    /// Each key represents the query string parameter name, and each
-    /// value represents the query string parameter value. Both keys and
-    /// values MUST appear in the format in which it is expected to be
-    /// sent over the wire; if a key or value needs to be percent-encoded,
-    /// then it MUST appear percent-encoded in this map.
-    ///
     /// `queryParams` applies no constraints on additional query parameters.
-    queryParams: StringMap,
+    queryParams: StringList,
 
     /// A list of query string parameter names that must not appear in the
     /// serialized HTTP request.

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-request-features.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-request-features.smithy
@@ -11,7 +11,7 @@ use smithy.test#httpRequestTests
         authScheme: "test",
         method: "POST",
         uri: "/",
-        queryParams: {"foo": "baz"},
+        queryParams: ["foo=baz"],
         forbidQueryParams: ["Nope"],
         requireQueryParams: ["Yap"],
         headers: {"X-Foo": "baz"},


### PR DESCRIPTION
queryParams in protocol compliance tests previously used a map of query
string parameter names to values. However, this approach makes it
impossible to define test cases for query string parameter lists where
the serialized query string keys are repeated (which is the default
serialization format used in Smithy HTTP protocol bindings).

Now queryParams is a list of the query string parameter key value pairs
(e.g., `queryParams: ["foo=bar", "foo=baz%20bam"]`. This allows for testing
any kind of query string serialization format, including repeated key
parameters.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
