### PR TITLE
Clean up and rewrite spec for XML bindings

### DIFF
--- a/docs/source/spec/xml.rst
+++ b/docs/source/spec/xml.rst
@@ -25,10 +25,10 @@ if necessary.
 Structure and union serialization
 =================================
 
-All XML serialization starts with a structure. The shape name of a structure
-is used as the outermost XML element name. Members of a structure or union
-shape are serialized as nested XML elements where the name of the element is
-the same as the name of the member.
+All XML serialization starts with a structure or union. The shape name of a
+structure/union is used as the outermost XML element name. Members of a
+structure/union are serialized as nested XML elements where the name of the
+element is the same as the name of the member.
 
 For example, given the following:
 
@@ -61,11 +61,11 @@ The :ref:`xmlattribute-trait` is used to serialize a structure
 member as an XML attribute.
 
 
-``xmlName`` on structures
--------------------------
+``xmlName`` on structures and unions
+------------------------------------
 
-An ``xmlName`` trait applied to a structure changes the element name of the
-serialized structure; however, it does not influence the serialization of
+An ``xmlName`` trait applied to a structure or union changes the element name
+of the serialized shape; however, it does not influence the serialization of
 members that target it. Given the following:
 
 .. tabs::
@@ -849,11 +849,12 @@ The XML serialization is:
 -----------------
 
 Summary
-    Changes the serialized element or attribute name of a structure or member.
+    Changes the serialized element or attribute name of a structure, union,
+    or member.
 Trait selector
-    ``:test(structure, member)``
+    ``:test(structure, union, member)``
 
-    *A structure or member*
+    *A structure, union, or member*
 Value type
     ``string`` value that MUST adhere to the :token:`xml_name` ABNF production:
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -140,21 +140,19 @@ structure idempotencyToken {}
 @tags(["diff.error.const"])
 string jsonName
 
-/// Moves a serialized object property to an attribute of the enclosing structure.
+/// Serializes an object property as an XML attribute rather than a nested XML element.
 @trait(selector: ":test(member:of(structure) > :test(boolean, number, string, timestamp))",
        conflicts: ["xmlNamespace"])
 @tags(["diff.error.const"])
 structure xmlAttribute {}
 
-/// Moves serialized collection members from their collection element to that of
-/// the collection's container.
-@trait(selector: ":test(map, collection, member:of(structure) > :test(map, collection))")
+/// Unwraps the values of a list, set, or map into the containing structure/union.
+@trait(selector: ":test(member:of(structure, union) > :each(collection, map))")
 @tags(["diff.error.const"])
 structure xmlFlattened {}
 
-/// Allows a serialized object property name to differ from a structure member name
-/// used in the model.
-@trait
+/// Changes the serialized element or attribute name of a structure or member.
+@trait(selector: ":test(structure, member)")
 @tags(["diff.error.const"])
 @pattern("^[a-zA-Z_][a-zA-Z_0-9-]*(:[a-zA-Z_][a-zA-Z_0-9-]*)?$")
 string xmlName

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -151,8 +151,8 @@ structure xmlAttribute {}
 @tags(["diff.error.const"])
 structure xmlFlattened {}
 
-/// Changes the serialized element or attribute name of a structure or member.
-@trait(selector: ":test(structure, member)")
+/// Changes the serialized element or attribute name of a structure, union, or member.
+@trait(selector: ":test(structure, union, member)")
 @tags(["diff.error.const"])
 @pattern("^[a-zA-Z_][a-zA-Z_0-9-]*(:[a-zA-Z_][a-zA-Z_0-9-]*)?$")
 string xmlName

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-flattened.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-flattened.errors
@@ -1,0 +1,2 @@
+[ERROR] ns.foo#InvalidStringList: Trait `xmlFlattened` cannot be applied to `ns.foo#InvalidStringList`. | TraitTarget
+[ERROR] ns.foo#InvalidStringMap: Trait `xmlFlattened` cannot be applied to `ns.foo#InvalidStringMap`. | TraitTarget

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-flattened.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/xml-flattened.json
@@ -1,7 +1,22 @@
 {
     "smithy": "0.5.0",
     "shapes": {
-        "ns.foo#FlatCollection": {
+        "ns.foo#StringList": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String"
+            }
+        },
+        "ns.foo#StringMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
+            }
+        },
+        "ns.foo#InvalidStringList": {
             "type": "list",
             "member": {
                 "target": "smithy.api#String"
@@ -10,13 +25,7 @@
                 "smithy.api#xmlFlattened": true
             }
         },
-        "ns.foo#NotFlatCollection": {
-            "type": "list",
-            "member": {
-                "target": "smithy.api#String"
-            }
-        },
-        "ns.foo#FlatMap": {
+        "ns.foo#InvalidStringMap": {
             "type": "map",
             "key": {
                 "target": "smithy.api#String"
@@ -28,39 +37,17 @@
                 "smithy.api#xmlFlattened": true
             }
         },
-        "ns.foo#NotFlatMap": {
-            "type": "map",
-            "key": {
-                "target": "smithy.api#String"
-            },
-            "value": {
-                "target": "smithy.api#String"
-            }
-        },
-        "ns.foo#ValidStructure1": {
+        "ns.foo#ValidStructure": {
             "type": "structure",
             "members": {
                 "flatList": {
-                    "target": "ns.foo#FlatCollection"
-                }
-            }
-        },
-        "ns.foo#ValidStructure2": {
-            "type": "structure",
-            "members": {
-                "flatList": {
-                    "target": "ns.foo#NotFlatCollection",
+                    "target": "ns.foo#StringList",
                     "traits": {
                         "smithy.api#xmlFlattened": true
                     }
-                }
-            }
-        },
-        "ns.foo#ValidStructure3": {
-            "type": "structure",
-            "members": {
-                "flatmap": {
-                    "target": "ns.foo#NotFlatMap",
+                },
+                "flatMap": {
+                    "target": "ns.foo#StringMap",
                     "traits": {
                         "smithy.api#xmlFlattened": true
                     }


### PR DESCRIPTION
This commit updates the XML traits spec to be made more generic and
framed in terms of binding to XML. XML traits have been restricted to
only apply to shapes in which they are actually supported. Many more
examples have been added to the XML spec (note that I selectively did
not include a JSON equivalent example when a JSON example adds no
expository value).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
