### PR TITLE
Disable URLConnection cache

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -304,7 +304,11 @@ public final class ModelAssembler {
         Objects.requireNonNull(url, "The provided url to ModelAssembler#addImport was null");
         inputStreamModels.put(url.toExternalForm(), () -> {
             try {
-                return url.openStream();
+                URLConnection connection = url.openConnection();
+                if (properties.containsKey(ModelAssembler.DISABLE_JAR_CACHE)) {
+                    connection.setUseCaches(false);
+                }
+                return connection.getInputStream();
             } catch (IOException | UncheckedIOException e) {
                 throw new ModelImportException("Unable to open Smithy model import URL: " + url.toExternalForm(), e);
             }


### PR DESCRIPTION
This commit further implements the ability to disable JAR file caching
when loading Smithy models. This is necessary to make loading models
from JARs when using build tools like Gradle more reliable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
