### PR TITLE
Add AWS protocol tests

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "smithy"
 include(":smithy-aws-traits")
 include(":smithy-aws-apigateway-openapi")
+include(":smithy-aws-protocol-tests")
 include(":smithy-cli")
 include(":smithy-codegen-core")
 include(":smithy-codegen-freemarker")
@@ -13,3 +14,10 @@ include(":smithy-jsonschema")
 include(":smithy-openapi")
 include(":smithy-utils")
 include(":smithy-protocol-test-traits")
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}

--- a/smithy-aws-protocol-tests/build.gradle.kts
+++ b/smithy-aws-protocol-tests/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+description = "Defines protocol tests for AWS HTTP protocols."
+extra["displayName"] = "Smithy :: AWS :: Protocol Tests"
+extra["moduleName"] = "software.amazon.smithy.aws.protocoltests"
+
+plugins {
+    id("software.amazon.smithy").version("0.4.2")
+}
+
+dependencies {
+    api(project(":smithy-protocol-test-traits"))
+    api(project(":smithy-aws-traits"))
+}

--- a/smithy-aws-protocol-tests/model/json-rpc-1-1/json-rpc-1-1.json
+++ b/smithy-aws-protocol-tests/model/json-rpc-1-1/json-rpc-1-1.json
@@ -1,0 +1,1155 @@
+{
+    "smithy": "0.5.0",
+    "shapes": {
+        "aws.protocols.tests.json#JsonProtocol": {
+            "type": "service",
+            "version": "2018-01-01",
+            "operations": [
+                {
+                    "target": "aws.protocols.tests.json#EmptyOperation"
+                },
+                {
+                    "target": "aws.protocols.tests.json#KitchenSinkOperation"
+                },
+                {
+                    "target": "aws.protocols.tests.json#OperationWithOptionalInputOutput"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Json Protocol"
+                },
+                "smithy.api#protocols": [
+                    {
+                        "name": "aws.json-1.1",
+                        "auth": ["aws.v4"]
+                    }
+                ],
+                "smithy.api#auth": ["aws.v4"],
+                "smithy.api#title": "Sample Json 1.1 Protocol Service"
+            }
+        },
+        "aws.protocols.tests.json#Blob": {
+            "type": "blob"
+        },
+        "aws.protocols.tests.json#Boolean": {
+            "type": "boolean"
+        },
+        "aws.protocols.tests.json#Double": {
+            "type": "double"
+        },
+        "aws.protocols.tests.json#EmptyOperation": {
+            "type": "operation",
+            "traits": {
+                "smithy.test#httpRequestTests": [
+                    {
+                        "id": "sends_requests_to_slash",
+                        "description": "Sends requests to /",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {}
+                    },
+                    {
+                        "id": "includes_x_amz_target_and_content_type",
+                        "description": "Includes X-Amz-Target header and Content-Type",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {},
+                        "headers": {
+                            "Content-Type": "application/x-amz-json-1.1",
+                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                        }
+                    }
+                ],
+                "smithy.test#httpResponseTests": [
+                    {
+                        "id": "handles_empty_output_shape",
+                        "description": "Handles empty output shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "headers": {
+                            "Content-Type": "application/x-amz-json-1.1"
+                        },
+                        "requireHeaders": ["Content-Length"],
+                        "bodyMediaType": "application/json",
+                        "body": "{}",
+                        "params": {}
+                    }
+                ]
+            }
+        },
+        "aws.protocols.tests.json#EmptyStruct": {
+            "type": "structure",
+            "members": {}
+        },
+        "aws.protocols.tests.json#ErrorWithMembers": {
+            "type": "structure",
+            "members": {
+                "Code": {
+                    "target": "smithy.api#String"
+                },
+                "ComplexData": {
+                    "target": "aws.protocols.tests.json#KitchenSink"
+                },
+                "IntegerField": {
+                    "target": "smithy.api#Integer"
+                },
+                "ListField": {
+                    "target": "aws.protocols.tests.json#ListOfStrings"
+                },
+                "MapField": {
+                    "target": "aws.protocols.tests.json#MapOfStrings"
+                },
+                "Message": {
+                    "target": "smithy.api#String"
+                },
+                "StringField": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "abc"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client"
+            }
+        },
+        "aws.protocols.tests.json#ErrorWithoutMembers": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#error": "server"
+            }
+        },
+        "aws.protocols.tests.json#Float": {
+            "type": "float"
+        },
+        "aws.protocols.tests.json#Integer": {
+            "type": "integer"
+        },
+        "aws.protocols.tests.json#JsonValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#mediaType": "application/json"
+            }
+        },
+        "aws.protocols.tests.json#KitchenSink": {
+            "type": "structure",
+            "members": {
+                "Blob": {
+                    "target": "smithy.api#Blob"
+                },
+                "Boolean": {
+                    "target": "smithy.api#Boolean"
+                },
+                "Double": {
+                    "target": "smithy.api#Double"
+                },
+                "EmptyStruct": {
+                    "target": "aws.protocols.tests.json#EmptyStruct"
+                },
+                "Float": {
+                    "target": "smithy.api#Float"
+                },
+                "HttpdateTimestamp": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "http-date"
+                    }
+                },
+                "Integer": {
+                    "target": "smithy.api#Integer"
+                },
+                "Iso8601Timestamp": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "JsonValue": {
+                    "target": "aws.protocols.tests.json#JsonValue"
+                },
+                "ListOfLists": {
+                    "target": "aws.protocols.tests.json#ListOfListOfStrings"
+                },
+                "ListOfMapsOfStrings": {
+                    "target": "aws.protocols.tests.json#ListOfMapsOfStrings"
+                },
+                "ListOfStrings": {
+                    "target": "aws.protocols.tests.json#ListOfStrings"
+                },
+                "ListOfStructs": {
+                    "target": "aws.protocols.tests.json#ListOfStructs"
+                },
+                "Long": {
+                    "target": "smithy.api#Long"
+                },
+                "MapOfListsOfStrings": {
+                    "target": "aws.protocols.tests.json#MapOfListsOfStrings"
+                },
+                "MapOfMaps": {
+                    "target": "aws.protocols.tests.json#MapOfMapOfStrings"
+                },
+                "MapOfStrings": {
+                    "target": "aws.protocols.tests.json#MapOfStrings"
+                },
+                "MapOfStructs": {
+                    "target": "aws.protocols.tests.json#MapOfStructs"
+                },
+                "RecursiveList": {
+                    "target": "aws.protocols.tests.json#ListOfKitchenSinks"
+                },
+                "RecursiveMap": {
+                    "target": "aws.protocols.tests.json#MapOfKitchenSinks"
+                },
+                "RecursiveStruct": {
+                    "target": "aws.protocols.tests.json#KitchenSink"
+                },
+                "SimpleStruct": {
+                    "target": "aws.protocols.tests.json#SimpleStruct"
+                },
+                "String": {
+                    "target": "smithy.api#String"
+                },
+                "StructWithLocationName": {
+                    "target": "aws.protocols.tests.json#StructWithLocationName"
+                },
+                "Timestamp": {
+                    "target": "smithy.api#Timestamp"
+                },
+                "UnixTimestamp": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "epoch-seconds"
+                    }
+                }
+            }
+        },
+        "aws.protocols.tests.json#KitchenSinkOperation": {
+            "type": "operation",
+            "input": {
+                "target": "aws.protocols.tests.json#KitchenSink"
+            },
+            "output": {
+                "target": "aws.protocols.tests.json#KitchenSink"
+            },
+            "errors": [
+                {
+                    "target": "aws.protocols.tests.json#ErrorWithMembers"
+                },
+                {
+                    "target": "aws.protocols.tests.json#ErrorWithoutMembers"
+                }
+            ],
+            "traits": {
+                "smithy.test#httpRequestTests": [
+                    {
+                        "id": "serializes_string_shapes",
+                        "documentation": "Serializes string shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "String": "abc xyz"
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"String\":\"abc xyz\"}"
+                    },
+                    {
+                        "id": "serializes_string_shapes_with_jsonvalue_trait",
+                        "documentation": "Serializes string shapes with jsonvalue trait",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "JsonValue": "{\"string\":\"value\",\"number\":1234.5,\"boolTrue\":true,\"boolFalse\":false,\"array\":[1,2,3,4],\"object\":{\"key\":\"value\"},\"null\":null}"
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"JsonValue\":\"{\\\"string\\\":\\\"value\\\",\\\"number\\\":1234.5,\\\"boolTrue\\\":true,\\\"boolFalse\\\":false,\\\"array\\\":[1,2,3,4],\\\"object\\\":{\\\"key\\\":\\\"value\\\"},\\\"null\\\":null}\"}"
+                    },
+                    {
+                        "id": "serializes_integer_shapes",
+                        "documentation": "Serializes integer shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Integer": 1234
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Integer\":1234}"
+                    },
+                    {
+                        "id": "serializes_long_shapes",
+                        "documentation": "Serializes long shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Long": 999999999999
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Long\":999999999999}"
+                    },
+                    {
+                        "id": "serializes_float_shapes",
+                        "documentation": "Serializes float shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Float": 1234.5
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Float\":1234.5}"
+                    },
+                    {
+                        "id": "serializes_double_shapes",
+                        "documentation": "Serializes double shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Double": 1234.5
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Double\":1234.5}"
+                    },
+                    {
+                        "id": "serializes_blob_shapes",
+                        "documentation": "Serializes blob shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Blob": "YmluYXJ5LXZhbHVl"
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}"
+                    },
+                    {
+                        "id": "serializes_boolean_shapes_true",
+                        "documentation": "Serializes boolean shapes (true)",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Boolean": true
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Boolean\":true}"
+                    },
+                    {
+                        "id": "serializes_boolean_shapes_false",
+                        "documentation": "Serializes boolean shapes (false)",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Boolean": false
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Boolean\":false}"
+                    },
+                    {
+                        "id": "serializes_timestamp_shapes",
+                        "documentation": "Serializes timestamp shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Timestamp": 946845296
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Timestamp\":946845296}"
+                    },
+                    {
+                        "id": "serializes_timestamp_shapes_with_iso8601_timestampformat",
+                        "documentation": "Serializes timestamp shapes with iso8601 timestampFormat",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Iso8601Timestamp": 946845296
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Iso8601Timestamp\":\"2000-01-02T20:34:56Z\"}"
+                    },
+                    {
+                        "id": "serializes_timestamp_shapes_with_httpdate_timestampformat",
+                        "documentation": "Serializes timestamp shapes with httpdate timestampFormat",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "HttpdateTimestamp": 946845296
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"HttpdateTimestamp\":\"Sun, 02 Jan 2000 20:34:56 GMT\"}"
+                    },
+                    {
+                        "id": "serializes_timestamp_shapes_with_unixtimestamp_timestampformat",
+                        "documentation": "Serializes timestamp shapes with unixTimestamp timestampFormat",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "UnixTimestamp": 946845296
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"UnixTimestamp\":946845296}"
+                    },
+                    {
+                        "id": "serializes_list_shapes",
+                        "documentation": "Serializes list shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "ListOfStrings": [
+                                "abc",
+                                "mno",
+                                "xyz"
+                            ]
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfStrings\":[\"abc\",\"mno\",\"xyz\"]}"
+                    },
+                    {
+                        "id": "serializes_empty_list_shapes",
+                        "documentation": "Serializes empty list shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "ListOfStrings": []
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfStrings\":[]}"
+                    },
+                    {
+                        "id": "serializes_list_of_map_shapes",
+                        "documentation": "Serializes list of map shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "ListOfMapsOfStrings": [
+                                {
+                                    "foo": "bar"
+                                },
+                                {
+                                    "abc": "xyz"
+                                },
+                                {
+                                    "red": "blue"
+                                }
+                            ]
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfMapsOfStrings\":[{\"foo\":\"bar\"},{\"abc\":\"xyz\"},{\"red\":\"blue\"}]}"
+                    },
+                    {
+                        "id": "serializes_list_of_structure_shapes",
+                        "documentation": "Serializes list of structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "ListOfStructs": [
+                                {
+                                    "Value": "abc"
+                                },
+                                {
+                                    "Value": "mno"
+                                },
+                                {
+                                    "Value": "xyz"
+                                }
+                            ]
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfStructs\":[{\"Value\":\"abc\"},{\"Value\":\"mno\"},{\"Value\":\"xyz\"}]}"
+                    },
+                    {
+                        "id": "serializes_list_of_recursive_structure_shapes",
+                        "documentation": "Serializes list of recursive structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "RecursiveList": [
+                                {
+                                    "RecursiveList": [
+                                        {
+                                            "RecursiveList": [
+                                                {
+                                                    "Integer": 123
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"RecursiveList\":[{\"RecursiveList\":[{\"RecursiveList\":[{\"Integer\":123}]}]}]}"
+                    },
+                    {
+                        "id": "serializes_map_shapes",
+                        "documentation": "Serializes map shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "MapOfStrings": {
+                                "abc": "xyz",
+                                "mno": "hjk"
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfStrings\":{\"abc\":\"xyz\",\"mno\":\"hjk\"}}"
+                    },
+                    {
+                        "id": "serializes_empty_map_shapes",
+                        "documentation": "Serializes empty map shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "MapOfStrings": {}
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfStrings\":[]}"
+                    },
+                    {
+                        "id": "serializes_map_of_list_shapes",
+                        "documentation": "Serializes map of list shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "MapOfListsOfStrings": {
+                                "abc": [
+                                    "abc",
+                                    "xyz"
+                                ],
+                                "mno": [
+                                    "xyz",
+                                    "abc"
+                                ]
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfListsOfStrings\":{\"abc\":[\"abc\",\"xyz\"],\"mno\":[\"xyz\",\"abc\"]}}"
+                    },
+                    {
+                        "id": "serializes_map_of_structure_shapes",
+                        "documentation": "Serializes map of structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "MapOfStructs": {
+                                "key1": {
+                                    "Value": "value-1"
+                                },
+                                "key2": {
+                                    "Value": "value-2"
+                                }
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfStructs\":{\"key1\":{\"Value\":\"value-1\"},\"key2\":{\"Value\":\"value-2\"}}}"
+                    },
+                    {
+                        "id": "serializes_map_of_recursive_structure_shapes",
+                        "documentation": "Serializes map of recursive structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "RecursiveMap": {
+                                "key1": {
+                                    "RecursiveMap": {
+                                        "key2": {
+                                            "RecursiveMap": {
+                                                "key3": {
+                                                    "Boolean": false
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"RecursiveMap\":{\"key1\":{\"RecursiveMap\":{\"key2\":{\"RecursiveMap\":{\"key3\":{\"Boolean\":false}}}}}}}"
+                    },
+                    {
+                        "id": "serializes_structure_shapes",
+                        "documentation": "Serializes structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "SimpleStruct": {
+                                "Value": "abc"
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"SimpleStruct\":{\"Value\":\"abc\"}}"
+                    },
+                    {
+                        "id": "serializes_structure_members_with_locationname_traits",
+                        "documentation": "Serializes structure members with locationName traits",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "StructWithLocationName": {
+                                "Value": "some-value"
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"StructWithLocationName\":{\"RenamedMember\":\"some-value\"}}"
+                    },
+                    {
+                        "id": "serializes_empty_structure_shapes",
+                        "documentation": "Serializes empty structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "SimpleStruct": {}
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"SimpleStruct\":[]}"
+                    },
+                    {
+                        "id": "serializes_structure_which_have_no_members",
+                        "documentation": "Serializes structure which have no members",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "EmptyStruct": {}
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"EmptyStruct\":[]}"
+                    },
+                    {
+                        "id": "serializes_recursive_structure_shapes",
+                        "documentation": "Serializes recursive structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "String": "top-value",
+                            "Boolean": false,
+                            "RecursiveStruct": {
+                                "String": "nested-value",
+                                "Boolean": true,
+                                "RecursiveList": [
+                                    {
+                                        "String": "string-only"
+                                    },
+                                    {
+                                        "RecursiveStruct": {
+                                            "MapOfStrings": {
+                                                "color": "red",
+                                                "size": "large"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{\"String\":\"top-value\",\"Boolean\":false,\"RecursiveStruct\":{\"String\":\"nested-value\",\"Boolean\":true,\"RecursiveList\":[{\"String\":\"string-only\"},{\"RecursiveStruct\":{\"MapOfStrings\":{\"color\":\"red\",\"size\":\"large\"}}}]}}"
+                    }
+                ],
+                "smithy.test#httpResponseTests": [
+                    {
+                        "id": "parses_operations_with_empty_json_bodies",
+                        "documentation": "Parses operations with empty JSON bodies",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{}",
+                        "params": {}
+                    },
+                    {
+                        "id": "parses_string_shapes",
+                        "documentation": "Parses string shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"String\":\"string-value\"}",
+                        "params": {
+                            "String": "string-value"
+                        }
+                    },
+                    {
+                        "id": "parses_integer_shapes",
+                        "documentation": "Parses integer shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Integer\":1234}",
+                        "params": {
+                            "Integer": 1234
+                        }
+                    },
+                    {
+                        "id": "parses_long_shapes",
+                        "documentation": "Parses long shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Long\":1234567890123456789}",
+                        "params": {
+                            "Long": 1234567890123456789
+                        }
+                    },
+                    {
+                        "id": "parses_float_shapes",
+                        "documentation": "Parses float shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Float\":1234.5}",
+                        "params": {
+                            "Float": 1234.5
+                        }
+                    },
+                    {
+                        "id": "parses_double_shapes",
+                        "documentation": "Parses double shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Double\":123456789.12345679}",
+                        "params": {
+                            "Double": 123456789.12345679
+                        }
+                    },
+                    {
+                        "id": "parses_boolean_shapes_true",
+                        "documentation": "Parses boolean shapes (true)",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Boolean\":true}",
+                        "params": {
+                            "Boolean": true
+                        }
+                    },
+                    {
+                        "id": "parses_boolean_false",
+                        "documentation": "Parses boolean (false)",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Boolean\":false}",
+                        "params": {
+                            "Boolean": false
+                        }
+                    },
+                    {
+                        "id": "parses_blob_shapes",
+                        "documentation": "Parses blob shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
+                        "params": {
+                            "Blob": "YmluYXJ5LXZhbHVl"
+                        }
+                    },
+                    {
+                        "id": "parses_timestamp_shapes",
+                        "documentation": "Parses timestamp shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Timestamp\":946845296}",
+                        "params": {
+                            "Timestamp": 946845296
+                        }
+                    },
+                    {
+                        "id": "parses_iso8601_timestamps",
+                        "documentation": "Parses iso8601 timestamps",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Timestamp\":\"2000-01-02T20:34:56.000Z\"}",
+                        "params": {
+                            "Timestamp": 946845296
+                        }
+                    },
+                    {
+                        "id": "parses_httpdate_timestamps",
+                        "documentation": "Parses httpdate timestamps",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Timestamp\":\"Sun, 02 Jan 2000 20:34:56.000 GMT\"}",
+                        "params": {
+                            "Timestamp": 946845296
+                        }
+                    },
+                    {
+                        "id": "parses_list_shapes",
+                        "documentation": "Parses list shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfStrings\":[\"abc\",\"mno\",\"xyz\"]}",
+                        "params": {
+                            "ListOfStrings": [
+                                "abc",
+                                "mno",
+                                "xyz"
+                            ]
+                        }
+                    },
+                    {
+                        "id": "parses_list_of_map_shapes",
+                        "documentation": "Parses list of map shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfMapsOfStrings\":[{\"size\":\"large\"},{\"color\":\"red\"}]}",
+                        "params": {
+                            "ListOfMapsOfStrings": [
+                                {
+                                    "size": "large"
+                                },
+                                {
+                                    "color": "red"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "parses_list_of_list_shapes",
+                        "documentation": "Parses list of list shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfLists\":[[\"abc\",\"mno\",\"xyz\"],[\"hjk\",\"qrs\",\"tuv\"]]}",
+                        "params": {
+                            "ListOfLists": [
+                                [
+                                    "abc",
+                                    "mno",
+                                    "xyz"
+                                ],
+                                [
+                                    "hjk",
+                                    "qrs",
+                                    "tuv"
+                                ]
+                            ]
+                        }
+                    },
+                    {
+                        "id": "parses_list_of_structure_shapes",
+                        "documentation": "Parses list of structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"ListOfStructs\":[{\"Value\":\"value-1\"},{\"Value\":\"value-2\"}]}",
+                        "params": {
+                            "ListOfStructs": [
+                                {
+                                    "Value": "value-1"
+                                },
+                                {
+                                    "Value": "value-2"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "parses_list_of_recursive_structure_shapes",
+                        "documentation": "Parses list of recursive structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"RecursiveList\":[{\"RecursiveList\":[{\"RecursiveList\":[{\"String\":\"value\"}]}]}]}",
+                        "params": {
+                            "RecursiveList": [
+                                {
+                                    "RecursiveList": [
+                                        {
+                                            "RecursiveList": [
+                                                {
+                                                    "String": "value"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "parses_map_shapes",
+                        "documentation": "Parses map shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfStrings\":{\"size\":\"large\",\"color\":\"red\"}}",
+                        "params": {
+                            "MapOfStrings": {
+                                "size": "large",
+                                "color": "red"
+                            }
+                        }
+                    },
+                    {
+                        "id": "parses_map_of_list_shapes",
+                        "documentation": "Parses map of list shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfListsOfStrings\":{\"sizes\":[\"large\",\"small\"],\"colors\":[\"red\",\"green\"]}}",
+                        "params": {
+                            "MapOfListsOfStrings": {
+                                "sizes": [
+                                    "large",
+                                    "small"
+                                ],
+                                "colors": [
+                                    "red",
+                                    "green"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "id": "parses_map_of_map_shapes",
+                        "documentation": "Parses map of map shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfMaps\":{\"sizes\":{\"large\":\"L\",\"medium\":\"M\"},\"colors\":{\"red\":\"R\",\"blue\":\"B\"}}}",
+                        "params": {
+                            "MapOfMaps": {
+                                "sizes": {
+                                    "large": "L",
+                                    "medium": "M"
+                                },
+                                "colors": {
+                                    "red": "R",
+                                    "blue": "B"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "id": "parses_map_of_structure_shapes",
+                        "documentation": "Parses map of structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"MapOfStructs\":{\"size\":{\"Value\":\"small\"},\"color\":{\"Value\":\"red\"}}}",
+                        "params": {
+                            "MapOfStructs": {
+                                "size": {
+                                    "Value": "small"
+                                },
+                                "color": {
+                                    "Value": "red"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "id": "parses_map_of_recursive_structure_shapes",
+                        "documentation": "Parses map of recursive structure shapes",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "bodyMediaType": "application/json",
+                        "body": "{\"RecursiveMap\":{\"key-1\":{\"RecursiveMap\":{\"key-2\":{\"RecursiveMap\":{\"key-3\":{\"String\":\"value\"}}}}}}}",
+                        "params": {
+                            "RecursiveMap": {
+                                "key-1": {
+                                    "RecursiveMap": {
+                                        "key-2": {
+                                            "RecursiveMap": {
+                                                "key-3": {
+                                                    "String": "value"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "id": "parses_the_request_id_from_the_response",
+                        "documentation": "Parses the request id from the response",
+                        "protocol": "aws.json-1.1",
+                        "code": 200,
+                        "headers": {
+                            "X-Amzn-Requestid": "amazon-uniq-request-id"
+                        }
+                    }
+                ]
+            }
+        },
+        "aws.protocols.tests.json#ListOfKitchenSinks": {
+            "type": "list",
+            "member": {
+                "target": "aws.protocols.tests.json#KitchenSink"
+            }
+        },
+        "aws.protocols.tests.json#ListOfListOfStrings": {
+            "type": "list",
+            "member": {
+                "target": "aws.protocols.tests.json#ListOfStrings"
+            }
+        },
+        "aws.protocols.tests.json#ListOfMapsOfStrings": {
+            "type": "list",
+            "member": {
+                "target": "aws.protocols.tests.json#MapOfStrings"
+            }
+        },
+        "aws.protocols.tests.json#ListOfStrings": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String"
+            }
+        },
+        "aws.protocols.tests.json#ListOfStructs": {
+            "type": "list",
+            "member": {
+                "target": "aws.protocols.tests.json#SimpleStruct"
+            }
+        },
+        "aws.protocols.tests.json#Long": {
+            "type": "long"
+        },
+        "aws.protocols.tests.json#MapOfKitchenSinks": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "aws.protocols.tests.json#KitchenSink"
+            }
+        },
+        "aws.protocols.tests.json#MapOfListsOfStrings": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "aws.protocols.tests.json#ListOfStrings"
+            }
+        },
+        "aws.protocols.tests.json#MapOfMapOfStrings": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "aws.protocols.tests.json#MapOfStrings"
+            }
+        },
+        "aws.protocols.tests.json#MapOfStrings": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
+            }
+        },
+        "aws.protocols.tests.json#MapOfStructs": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "aws.protocols.tests.json#SimpleStruct"
+            }
+        },
+        "aws.protocols.tests.json#OperationWithOptionalInputOutput": {
+            "type": "operation",
+            "input": {
+                "target": "aws.protocols.tests.json#SimpleStruct"
+            },
+            "output": {
+                "target": "aws.protocols.tests.json#SimpleStruct"
+            },
+            "traits": {
+                "smithy.test#httpRequestTests": [
+                    {
+                        "id": "can_call_operation_with_no_input_or_output",
+                        "description": "Can call operations with no input or output",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "headers": {
+                            "Content-Type": "application/x-amz-json-1.1",
+                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{}"
+                    },
+                    {
+                        "id": "can_call_operation_with_optional_input",
+                        "description": "Can invoke operations with optional input",
+                        "protocol": "aws.json-1.1",
+                        "method": "POST",
+                        "uri": "/",
+                        "params": {
+                            "Value": "Hi"
+                        },
+                        "headers": {
+                            "Content-Type": "application/x-amz-json-1.1",
+                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                        },
+                        "requireHeaders": ["Content-Length"],
+                        "bodyMediaType": "application/json",
+                        "body": "{\"Value\":\"Hi\"}"
+                    }
+                ]
+            }
+        },
+        "aws.protocols.tests.json#SimpleStruct": {
+            "type": "structure",
+            "members": {
+                "Value": {
+                    "target": "smithy.api#String"
+                }
+            }
+        },
+        "aws.protocols.tests.json#String": {
+            "type": "string"
+        },
+        "aws.protocols.tests.json#StructWithLocationName": {
+            "type": "structure",
+            "members": {
+                "Value": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#jsonName": "RenamedMember"
+                    }
+                }
+            }
+        },
+        "aws.protocols.tests.json#Timestamp": {
+            "type": "timestamp"
+        }
+    }
+}

--- a/smithy-aws-protocol-tests/model/rest-json/rest-json.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/rest-json.smithy
@@ -1,0 +1,6 @@
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restjson
+
+// TODO: Copy the tests that are the same from restxml
+// TODO: Write JSON-specific test cases.

--- a/smithy-aws-protocol-tests/model/rest-xml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-lists.smithy
@@ -1,0 +1,255 @@
+// This file defines test cases that serialize lists in XML documents.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This test case serializes XML lists for the following cases for both
+/// input and output:
+///
+/// 1. Normal XML lists.
+/// 2. Normal XML sets.
+/// 3. XML lists of lists.
+/// 4. XML lists with @xmlName on its members
+/// 5. Flattened XML lists.
+/// 6. Flattened XML lists with @xmlName.
+/// 7. Lists of structures.
+@idempotent
+@http(uri: "/XmlLists", method: "PUT")
+operation XmlLists(XmlListsInputOutput) -> XmlListsInputOutput
+
+apply XmlLists @httpRequestTests([
+    {
+        id: "XmlLists",
+        description: "Serializes XML lists",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/XmlLists",
+        body: """
+              <XmlListsInputOutput>
+                  <stringList>
+                      <member>foo</member>
+                      <member>bar</member>
+                  </stringList>
+                  <stringSet>
+                      <member>foo</member>
+                      <member>bar</member>
+                  </stringSet>
+                  <integerList>
+                      <member>1</member>
+                      <member>2</member>
+                  </integerList>
+                  <booleanList>
+                      <member>true</member>
+                      <member>false</member>
+                  </booleanList>
+                  <timestampList>
+                      <member>2014-04-29T18:30:38Z</member>
+                      <member>2014-04-29T18:30:38Z</member>
+                  </timestampList>
+                  <enumList>
+                      <member>Foo</member>
+                      <member>0</member>
+                  </enumList>
+                  <nestedStringList>
+                      <member>
+                          <member>foo</member>
+                          <member>bar</member>
+                      </member>
+                      <member>
+                          <member>baz</member>
+                          <member>qux</member>
+                      </member>
+                  <nestedStringList>
+                  <renamed>
+                      <item>foo</item>
+                      <item>bar</item>
+                  </renamed>
+                  <flattenedList>hi</fuck>
+                  <flattenedList>bye</flattenedList>
+                  <customName>yep</customName>
+                  <customName>nope</customName>
+                  <myStructureList>
+                      <item>
+                          <value>1</value>
+                          <other>2</other>
+                      </item>
+                      <item>
+                          <value>3</value>
+                          <other>4</other>
+                      </item>
+                  </myStructureList>
+              </XmlListsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            stringList: ["foo", "bar"],
+            stringSet: ["foo", "bar"],
+            integerList: [1, 2],
+            booleanList: [true, false],
+            timestampList: [1398796238, 1398796238],
+            enumList: ["Foo", "0"],
+            nestedStringList: [["foo", "bar"], ["baz", "qux"]],
+            renamedListMembers: ["foo", "bar"],
+            flattenedList: ["hi", "bye"],
+            flattenedList2: ["yep", "nope"],
+            structureList: [
+                {
+                    a: "1",
+                    b: "2",
+                },
+                {
+                    a: "3",
+                    b: "4",
+                }
+            ]
+        }
+    }
+])
+
+apply XmlLists @httpResponseTests([
+    {
+        id: "XmlLists",
+        description: "Serializes XML lists",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlListsInputOutput>
+                  <stringList>
+                      <member>foo</member>
+                      <member>bar</member>
+                  </stringList>
+                  <stringSet>
+                      <member>foo</member>
+                      <member>bar</member>
+                  </stringSet>
+                  <integerList>
+                      <member>1</member>
+                      <member>2</member>
+                  </integerList>
+                  <booleanList>
+                      <member>true</member>
+                      <member>false</member>
+                  </booleanList>
+                  <timestampList>
+                      <member>2014-04-29T18:30:38Z</member>
+                      <member>2014-04-29T18:30:38Z</member>
+                  </timestampList>
+                  <enumList>
+                      <member>Foo</member>
+                      <member>0</member>
+                  </enumList>
+                  <nestedStringList>
+                      <member>
+                          <member>foo</member>
+                          <member>bar</member>
+                      </member>
+                      <member>
+                          <member>baz</member>
+                          <member>qux</member>
+                      </member>
+                  <nestedStringList>
+                  <renamed>
+                      <item>foo</item>
+                      <item>bar</item>
+                  </renamed>
+                  <flattenedList>hi</fuck>
+                  <flattenedList>bye</flattenedList>
+                  <customName>yep</customName>
+                  <customName>nope</customName>
+                  <myStructureList>
+                      <item>
+                          <value>1</value>
+                          <other>2</other>
+                      </item>
+                      <item>
+                          <value>3</value>
+                          <other>4</other>
+                      </item>
+                  </myStructureList>
+              </XmlListsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            stringList: ["foo", "bar"],
+            stringSet: ["foo", "bar"],
+            integerList: [1, 2],
+            booleanList: [true, false],
+            timestampList: [1398796238, 1398796238],
+            enumList: ["Foo", "0"],
+            nestedStringList: [["foo", "bar"], ["baz", "qux"]],
+            renamedListMembers: ["foo", "bar"],
+            flattenedList: ["hi", "bye"],
+            flattenedList2: ["yep", "nope"],
+            structureList: [
+                {
+                    a: "1",
+                    b: "2",
+                },
+                {
+                    a: "3",
+                    b: "4",
+                }
+            ]
+        }
+    }
+])
+
+structure XmlListsInputOutput {
+    stringList: StringList,
+
+    stringSet: StringSet,
+
+    integerList: IntegerList,
+
+    booleanList: BooleanList,
+
+    timestampList: TimestampList,
+
+    enumList: FooEnumList,
+
+    nestedStringList: NestedStringList,
+
+    @xmlName("renamed")
+    renamedListMembers: RenamedListMembers,
+
+    @xmlFlattened
+    // The xmlname on the targeted list is ignored, and the member name is used.
+    flattenedList: RenamedListMembers,
+
+    @xmlName("customName")
+    @xmlFlattened
+    // the xmlName trait on the targeted list's member is ignored when
+    // serializing flattened lists in structures.
+    flattenedList2: RenamedListMembers,
+
+    @xmlName("myStructureList")
+    structureList: StructureList
+}
+
+list RenamedListMembers {
+    @xmlName("item")
+    member: String,
+}
+
+list StructureList {
+    @xmlName("item")
+    member: StructureListMember,
+}
+
+structure StructureListMember {
+    @xmlName("value")
+    a: String,
+
+    @xmlName("other")
+    b: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-maps.smithy
@@ -1,0 +1,356 @@
+// This file defines test cases that serialize maps in XML payloads.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// The example tests basic map serialization.
+@http(uri: "/XmlMaps", method: "POST")
+operation XmlMaps(XmlMapsInputOutput) -> XmlMapsInputOutput
+
+apply XmlMaps @httpRequestTests([
+    {
+        id: "XmlMaps",
+        description: "Serializes XML maps",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlMaps",
+        body: """
+              <XmlMapsInputOutput>
+                  <myMap>
+                      <entry>
+                          <key>foo</key>
+                          <value>
+                              <hi>there</hi>
+                          </value>
+                      </entry>
+                      <entry>
+                          <key>baz</key>
+                          <value>
+                              <hi>bye</hi>
+                          </value>
+                      </entry>
+                  </myMap>
+              </XmlMapsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                foo: {
+                    hi: "there"
+                },
+                baz: {
+                    hi: "bye"
+                }
+            }
+        }
+    }
+])
+
+apply XmlMaps @httpResponseTests([
+    {
+        id: "XmlMaps",
+        description: "Serializes XML maps",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlMapsInputOutput>
+                  <myMap>
+                      <entry>
+                          <key>foo</key>
+                          <value>
+                              <hi>there</hi>
+                          </value>
+                      </entry>
+                      <entry>
+                          <key>baz</key>
+                          <value>
+                              <hi>bye</hi>
+                          </value>
+                      </entry>
+                  </myMap>
+              </XmlMapsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                foo: {
+                    hi: "there"
+                },
+                baz: {
+                    hi: "bye"
+                }
+            }
+        }
+    }
+])
+
+structure XmlMapsInputOutput {
+    myMap: XmlMapsInputOutputMap,
+}
+
+map XmlMapsInputOutputMap {
+    key: String,
+    value: GreetingStruct
+}
+
+structure GreetingStruct {
+    hi: String
+}
+
+// This example tests maps with @xmlName on members.
+@http(uri: "/XmlMapsXmlName", method: "POST")
+operation XmlMapsXmlName(XmlMapsXmlNameInputOutput) -> XmlMapsXmlNameInputOutput
+
+apply XmlMapsXmlName @httpRequestTests([
+    {
+        id: "XmlMapsXmlName",
+        description: "Serializes XML maps that have xmlName on members",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlMapsXmlName",
+        body: """
+              <XmlMapsXmlNameInputOutput>
+                  <myMap>
+                      <entry>
+                          <Name>foo</Name>
+                          <Setting>
+                              <hi>there</hi>
+                          </Setting>
+                      </entry>
+                      <entry>
+                          <Name>baz</Name>
+                          <Setting>
+                              <hi>bye</hi>
+                          </Setting>
+                      </entry>
+                  </myMap>
+              </XmlMapsXmlNameInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                foo: {
+                    hi: "there"
+                },
+                baz: {
+                    hi: "bye"
+                }
+            }
+        }
+    }
+])
+
+apply XmlMapsXmlName @httpResponseTests([
+    {
+        id: "XmlMapsXmlName",
+        description: "Serializes XML lists",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlMapsXmlNameInputOutput>
+                  <myMap>
+                      <entry>
+                          <Name>foo</Name>
+                          <Setting>
+                              <hi>there</hi>
+                          </Setting>
+                      </entry>
+                      <entry>
+                          <Name>baz</Name>
+                          <Setting>
+                              <hi>bye</hi>
+                          </Setting>
+                      </entry>
+                  </myMap>
+              </XmlMapsXmlNameInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                foo: {
+                    hi: "there"
+                },
+                baz: {
+                    hi: "bye"
+                }
+            }
+        }
+    }
+])
+
+structure XmlMapsXmlNameInputOutput {
+    myMap: XmlMapsXmlNameInputOutputMap,
+}
+
+map XmlMapsXmlNameInputOutputMap {
+    @xmlName("Attribute")
+    key: String,
+
+    @xmlName("Setting")
+    value: GreetingStruct
+}
+
+/// Flattened maps
+@http(uri: "/FlattenedXmlMap", method: "POST")
+operation FlattenedXmlMap(FlattenedXmlMapInputOutput) -> FlattenedXmlMapInputOutput
+
+apply FlattenedXmlMap @httpRequestTests([
+    {
+        id: "FlattenedXmlMap",
+        description: "Serializes flattened XML maps in requests",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/FlattenedXmlMap",
+        body: """
+              <FlattenedXmlMapInputOutput>
+                  <myMap>
+                      <key>foo</key>
+                      <value>Foo</value>
+                  </myMap>
+                  <myMap>
+                      <key>baz</key>
+                      <value>Baz</value>
+                  </myMap>
+              </FlattenedXmlMapInputOutput>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                foo: "Foo",
+                baz: "Baz"
+            }
+        }
+    }
+])
+
+apply FlattenedXmlMap @httpResponseTests([
+    {
+        id: "FlattenedXmlMap",
+        description: "Serializes flattened XML maps in responses",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <FlattenedXmlMapInputOutput>
+                  <myMap>
+                      <key>foo</key>
+                      <value>Foo</value>
+                  </myMap>
+                  <myMap>
+                      <key>baz</key>
+                      <value>Baz</value>
+                  </myMap>
+              </FlattenedXmlMapInputOutput>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                foo: "Foo",
+                baz: "Baz"
+            }
+        }
+    }
+])
+
+structure FlattenedXmlMapInputOutput {
+    @xmlFlattened
+    myMap: FooEnumMap,
+}
+
+/// Flattened maps with @xmlName
+@http(uri: "/FlattenedXmlMapWithXmlName", method: "POST")
+operation FlattenedXmlMapWithXmlName(FlattenedXmlMapWithXmlNameInputOutput) -> FlattenedXmlMapWithXmlNameInputOutput
+
+apply FlattenedXmlMapWithXmlName @httpRequestTests([
+    {
+        id: "FlattenedXmlMapWithXmlName",
+        description: "Serializes flattened XML maps in requests that have xmlName on members",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/FlattenedXmlMapWithXmlName",
+        body: """
+              <FlattenedXmlMapWithXmlNameInputOutput>
+                  <KVP>
+                      <K>a</K>
+                      <V>A</V>
+                  </myMap>
+                  <KVP>
+                      <K>b</K>
+                      <V>B</V>
+                  </myMap>
+              </FlattenedXmlMapWithXmlNameInputOutput>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                a: "A",
+                b: "B",
+            }
+        }
+    }
+])
+
+apply FlattenedXmlMapWithXmlName @httpResponseTests([
+    {
+        id: "FlattenedXmlMapWithXmlName",
+        description: "Serializes flattened XML maps in responses that have xmlName on members",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <FlattenedXmlMapWithXmlNameInputOutput>
+                  <KVP>
+                      <K>a</K>
+                      <V>A</V>
+                  </myMap>
+                  <KVP>
+                      <K>b</K>
+                      <V>B</V>
+                  </myMap>
+              </FlattenedXmlMapWithXmlNameInputOutput>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            myMap: {
+                a: "A",
+                b: "B",
+            }
+        }
+    }
+])
+
+structure FlattenedXmlMapWithXmlNameInputOutput {
+    @xmlFlattened
+    @xmlName("KVP")
+    myMap: FlattenedXmlMapWithXmlNameInputOutputMap,
+}
+
+map FlattenedXmlMapWithXmlNameInputOutputMap {
+    @xmlName("K")
+    key: String,
+
+    @xmlName("V")
+    value: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-structs.smithy
@@ -1,0 +1,645 @@
+// This file defines test cases that serialize synthesized XML documents
+// in the payload of HTTP requests and responses.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+// This example serializes simple scalar types in the top level XML document.
+// Note that headers are not serialized in the payload.
+@idempotent
+@http(uri: "/SimpleScalarProperties", method: "PUT")
+operation SimpleScalarProperties(SimpleScalarPropertiesInputOutput) -> SimpleScalarPropertiesInputOutput
+
+apply SimpleScalarProperties @httpRequestTests([
+    {
+        id: "SimpleScalarProperties",
+        description: "Serializes simple scalar properties",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>string</stringValue>
+                  <trueBooleanValue>true</trueBooleanValue>
+                  <falseBooleanValue>false</falseBooleanValue>
+                  <byteValue>1</byteValue>
+                  <shortValue>2</shortValue>
+                  <integerValue>3</integerValue>
+                  <longValue>4</longValue>
+                  <floatValue>5.5</floatValue>
+                  <DoubleDribble>6.5</DoubleDribble>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "string",
+            trueBooleanValue: true,
+            falseBooleanValue: false,
+            byteValue: 1,
+            shortValue: 2,
+            integerValue: 3,
+            longValue: 4,
+            floatValue: 5.5,
+            doubleValue: 6.5,
+        }
+    }
+])
+
+apply SimpleScalarProperties @httpResponseTests([
+    {
+        id: "SimpleScalarProperties",
+        description: "Serializes simple scalar properties",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>string</stringValue>
+                  <trueBooleanValue>true</trueBooleanValue>
+                  <falseBooleanValue>false</falseBooleanValue>
+                  <byteValue>1</byteValue>
+                  <shortValue>2</shortValue>
+                  <integerValue>3</integerValue>
+                  <longValue>4</longValue>
+                  <floatValue>5.5</floatValue>
+                  <DoubleDribble>6.5</DoubleDribble>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "string",
+            trueBooleanValue: true,
+            falseBooleanValue: false,
+            byteValue: 1,
+            shortValue: 2,
+            integerValue: 3,
+            longValue: 4,
+            floatValue: 5.5,
+            doubleValue: 6.5,
+        }
+    }
+])
+
+structure SimpleScalarPropertiesInputOutput {
+    @httpHeader("X-Foo")
+    foo: String,
+
+    stringValue: String,
+    trueBooleanValue: Boolean,
+    falseBooleanValue: Boolean,
+    byteValue: Byte,
+    shortValue: Short,
+    integerValue: Integer,
+    longValue: Long,
+    floatValue: Float,
+
+    @xmlName("DoubleDribble")
+    doubleValue: Double,
+}
+
+/// Blobs are base64 encoded
+@http(uri: "/XmlBlobs", method: "POST")
+operation XmlBlobs(XmlBlobsInputOutput) -> XmlBlobsInputOutput
+
+apply XmlBlobs @httpRequestTests([
+    {
+        id: "XmlBlobs",
+        description: "Blobs are base64 encoded",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlBlobs",
+        body: """
+              <XmlBlobsInputOutput>
+                  <data>dmFsdWU=</data>
+              </XmlBlobsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            data: "value"
+        }
+    }
+])
+
+apply XmlBlobs @httpResponseTests([
+    {
+        id: "XmlBlobs",
+        description: "Blobs are base64 encoded",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlBlobsInputOutput>
+                  <data>dmFsdWU=</data>
+              </XmlBlobsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            data: "value"
+        }
+    }
+])
+
+structure XmlBlobsInputOutput {
+    data: Blob
+}
+
+/// This tests how timestamps are serialized, including using the
+/// default format of date-time and various @timestampFormat trait
+/// values.
+@http(uri: "/XmlTimestamps", method: "POST")
+operation XmlTimestamps(XmlTimestampsInputOutput) -> XmlTimestampsInputOutput
+
+apply XmlTimestamps @httpRequestTests([
+    {
+        id: "XmlTimestamps",
+        description: "Tests how normal timestamps are serialized",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <normal>2014-04-29T18:30:38Z</normal>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            normal: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithDateTimeFormat",
+        description: "Ensures that the timestampFormat of date-time works like normal timestamps",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <dateTime>2014-04-29T18:30:38Z</dateTime>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            dateTime: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithEpochSecondsFormat",
+        description: "Ensures that the timestampFormat of epoch-seconds works",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <epochSeconds>1398796238</epochSeconds>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            epochSeconds: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithHttpDateFormat",
+        description: "Ensures that the timestampFormat of http-date works",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            httpDate: 1398796238
+        }
+    },
+])
+
+apply XmlTimestamps @httpResponseTests([
+    {
+        id: "XmlTimestamps",
+        description: "Tests how normal timestamps are serialized",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <normal>2014-04-29T18:30:38Z</normal>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            normal: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithDateTimeFormat",
+        description: "Ensures that the timestampFormat of date-time works like normal timestamps",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <dateTime>2014-04-29T18:30:38Z</dateTime>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            dateTime: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithEpochSecondsFormat",
+        description: "Ensures that the timestampFormat of epoch-seconds works",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <epochSeconds>1398796238</epochSeconds>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            epochSeconds: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithHttpDateFormat",
+        description: "Ensures that the timestampFormat of http-date works",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            httpDate: 1398796238
+        }
+    },
+])
+
+structure XmlTimestampsInputOutput {
+    normal: Timestamp,
+
+    @timestampFormat("date-time")
+    dateTime: Timestamp,
+
+    @timestampFormat("epoch-seconds")
+    epochSeconds: Timestamp,
+
+    @timestampFormat("http-date")
+    httpDate: Timestamp,
+}
+
+/// This example serializes enums as top level properties, in lists, sets, and maps.
+@idempotent
+@http(uri: "/XmlEnums", method: "PUT")
+operation XmlEnums(XmlEnumsInputOutput) -> XmlEnumsInputOutput
+
+apply XmlEnums @httpRequestTests([
+    {
+        id: "XmlEnums",
+        description: "Serializes simple scalar properties",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/XmlEnums",
+        body: """
+              <XmlEnumsInputOutput>
+                  <fooEnum1>Foo</fooEnum1>
+                  <fooEnum2>0</fooEnum2>
+                  <fooEnum3>1</fooEnum3>
+                  <fooEnumList>
+                      <member>Foo</member>
+                      <member>0</member>
+                  </fooEnumList>
+                  <fooEnumSet>
+                      <member>Foo</member>
+                      <member>0</member>
+                  </fooEnumSet>
+                  <fooEnumMap>
+                      <entry>
+                          <key>hi</key>
+                          <value>Foo</value>
+                      </entry>
+                      <entry>
+                          <key>zero</key>
+                          <value>0</value>
+                      </entry>
+                  </fooEnumMap>
+              </XmlEnumsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            fooEnum1: "Foo",
+            fooEnum2: "0",
+            fooEnum3: "1",
+            fooEnumList: ["Foo", "0"],
+            fooEnumSet: ["Foo", "0"],
+            fooEnumMap: {
+                "hi": "Foo",
+                "zero": "0"
+            }
+        }
+    }
+])
+
+apply XmlEnums @httpResponseTests([
+    {
+        id: "XmlEnums",
+        description: "Serializes simple scalar properties",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlEnumsInputOutput>
+                  <fooEnum1>Foo</fooEnum1>
+                  <fooEnum2>0</fooEnum2>
+                  <fooEnum3>1</fooEnum3>
+                  <fooEnumList>
+                      <member>Foo</member>
+                      <member>0</member>
+                  </fooEnumList>
+                  <fooEnumSet>
+                      <member>Foo</member>
+                      <member>0</member>
+                  </fooEnumSet>
+                  <fooEnumMap>
+                      <entry>
+                          <key>hi</key>
+                          <value>Foo</value>
+                      </entry>
+                      <entry>
+                          <key>zero</key>
+                          <value>0</value>
+                      </entry>
+                  </fooEnumMap>
+              </XmlEnumsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            fooEnum1: "Foo",
+            fooEnum2: "0",
+            fooEnum3: "1",
+            fooEnumList: ["Foo", "0"],
+            fooEnumSet: ["Foo", "0"],
+            fooEnumMap: {
+                "hi": "Foo",
+                "zero": "0"
+            }
+        }
+    }
+])
+
+structure XmlEnumsInputOutput {
+    fooEnum1: FooEnum,
+    fooEnum2: FooEnum,
+    fooEnum3: FooEnum,
+    fooEnumList: FooEnumList,
+    fooEnumSet: FooEnumSet,
+    fooEnumMap: FooEnumMap,
+}
+
+/// Recursive shapes
+@idempotent
+@http(uri: "/RecursiveShapes", method: "PUT")
+operation RecursiveShapes(RecursiveShapesInputOutput) -> RecursiveShapesInputOutput
+
+apply RecursiveShapes @httpRequestTests([
+    {
+        id: "RecursiveShapes",
+        description: "Serializes recursive structures",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/XmlEnums",
+        body: """
+              <RecursiveShapesInputOutput>
+                  <nested>
+                      <foo>Foo1</foo>
+                      <nested>
+                          <bar>Bar1</bar>
+                          <recursiveMember>
+                              <foo>Foo2</foo>
+                              <nested>
+                                  <bar>Bar2</bar>
+                              </nested>
+                          </recursiveMember>
+                      </nested>
+                  </nested>
+              </RecursiveShapesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                foo: "Foo1",
+                nested: {
+                    bar: "Bar1",
+                    recursiveMember: {
+                        foo: "Foo2",
+                        nested: {
+                            bar: "Bar2"
+                        }
+                    }
+                }
+            }
+        }
+    }
+])
+
+apply RecursiveShapes @httpResponseTests([
+    {
+        id: "RecursiveShapes",
+        description: "Serializes recursive structures",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <RecursiveShapesInputOutput>
+                  <nested>
+                      <foo>Foo1</foo>
+                      <nested>
+                          <bar>Bar1</bar>
+                          <recursiveMember>
+                              <foo>Foo2</foo>
+                              <nested>
+                                  <bar>Bar2</bar>
+                              </nested>
+                          </recursiveMember>
+                      </nested>
+                  </nested>
+              </RecursiveShapesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                foo: "Foo1",
+                nested: {
+                    bar: "Bar1",
+                    recursiveMember: {
+                        foo: "Foo2",
+                        nested: {
+                            bar: "Bar2"
+                        }
+                    }
+                }
+            }
+        }
+    }
+])
+
+structure RecursiveShapesInputOutput {
+    nested: RecursiveShapesInputOutputNested1
+}
+
+structure RecursiveShapesInputOutputNested1 {
+    foo: String,
+    nested: RecursiveShapesInputOutputNested2
+}
+
+structure RecursiveShapesInputOutputNested2 {
+    bar: String,
+    recursiveMember: RecursiveShapesInputOutputNested1,
+}
+
+// XML namespace
+@http(uri: "/XmlNamespaces", method: "POST")
+operation XmlNamespaces(XmlNamespacesInputOutput) -> XmlNamespacesInputOutput
+
+apply XmlNamespaces @httpRequestTests([
+    {
+        id: "XmlNamespaces",
+        description: "Serializes XML namespaces",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/XmlNamespaces",
+        body: """
+              <RecursiveShapesInputOutput xmlns="http://foo.com">
+                  <nested>
+                      <foo xmlns:baz="http://baz.com">Foo</foo>
+                      <values xmlns="http://qux.com">
+                          <member xmlns="http://bux.com">Bar</member>
+                          <member xmlns="http://bux.com">Baz</member>
+                      </values>
+                  </nested>
+              </RecursiveShapesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                foo: "Foo",
+                values: [
+                    "Bar",
+                    "Baz"
+                ]
+            }
+        }
+    }
+])
+
+apply XmlNamespaces @httpResponseTests([
+    {
+        id: "XmlNamespaces",
+        description: "Serializes XML namespaces",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <RecursiveShapesInputOutput xmlns="http://foo.com">
+                  <nested>
+                      <foo xmlns:baz="http://baz.com">Foo</foo>
+                      <values xmlns="http://qux.com">
+                          <member xmlns="http://bux.com">Bar</member>
+                          <member xmlns="http://bux.com">Baz</member>
+                      </values>
+                  </nested>
+              </RecursiveShapesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                foo: "Foo",
+                values: [
+                    "Bar",
+                    "Baz"
+                ]
+            }
+        }
+    }
+])
+
+@xmlNamespace(uri: "http://foo.com")
+structure XmlNamespacesInputOutput {
+    nested: XmlNamespaceNested
+}
+
+// Ingored since it's not at the top-level
+@xmlNamespace(uri: "http://foo.com")
+structure XmlNamespaceNested {
+    @xmlNamespace(uri: "http://baz.com", prefix: "baz")
+    foo: String,
+
+    @xmlNamespace(uri: "http://qux.com")
+    values: XmlNamespacedList
+}
+
+list XmlNamespacedList {
+    @xmlNamespace(uri: "http://bux.com")
+    member: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/document-xml-attributes.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-xml-attributes.smithy
@@ -1,0 +1,125 @@
+// This file defines test cases that serialize XML attributes.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This example serializes an XML attributes on synthesized document.
+@idempotent
+@http(uri: "/XmlAttributes", method: "PUT")
+operation XmlAttributes(XmlAttributesInputOutput) -> XmlAttributesInputOutput
+
+apply XmlAttributes @httpRequestTests([
+    {
+        id: "XmlAttributes",
+        description: "Serializes XML attributes on the synthesized document",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/XmlAttributes",
+        body: """
+              <XmlAttributesInputOutput attr="test">
+                  <foo>hi</foo>
+              </XmlAttributesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            foo: "hi",
+            attr: "test"
+        }
+    }
+])
+
+apply XmlAttributes @httpResponseTests([
+    {
+        id: "XmlAttributes",
+        description: "Serializes simple scalar properties",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlAttributesInputOutput attr="test">
+                  <foo>hi</foo>
+              </XmlAttributesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            foo: "hi",
+            attr: "test"
+        }
+    }
+])
+
+structure XmlAttributesInputOutput {
+    foo: String,
+
+    @xmlAttribute
+    @xmlName("test")
+    attr: String,
+}
+
+/// This example serializes an XML attributes on a document targeted by httpPayload.
+@idempotent
+@http(uri: "/XmlAttributesOnPayload", method: "PUT")
+operation XmlAttributesOnPayload(XmlAttributesOnPayloadInputOutput) -> XmlAttributesOnPayloadInputOutput
+
+apply XmlAttributesOnPayload @httpRequestTests([
+    {
+        id: "XmlAttributesOnPayload",
+        description: "Serializes XML attributes on the synthesized document",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/XmlAttributesOnPayload",
+        body: """
+              <XmlAttributesInputOutput attr="test">
+                  <foo>hi</foo>
+              </XmlAttributesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            payload: {
+                foo: "hi",
+                attr: "test"
+            }
+        }
+    }
+])
+
+apply XmlAttributesOnPayload @httpResponseTests([
+    {
+        id: "XmlAttributesOnPayload",
+        description: "Serializes simple scalar properties",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <XmlAttributesInputOutput attr="test">
+                  <foo>hi</foo>
+              </XmlAttributesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            payload: {
+                foo: "hi",
+                attr: "test"
+            }
+        }
+    }
+])
+
+structure XmlAttributesOnPayloadInputOutput {
+    @httpPayload
+    payload: XmlAttributesInputOutput
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/empty-input-output.smithy
@@ -1,0 +1,97 @@
+// This file defines test cases that test the basics of empty input and
+// output shape serialization.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// The example tests how requests and responses are serialized when there's
+/// no request or response payload because the operation has no input or output.
+/// While this should be rare, code generators must support this.
+@http(uri: "/NoInputAndNoOutput", method: "POST")
+operation NoInputAndNoOutput()
+
+apply NoInputAndNoOutput @httpRequestTests([
+    {
+        id: "NoInputAndNoOutput",
+        description: "No input serializes no payload",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/NoInputAndOutput",
+        body: ""
+    }
+])
+
+apply NoInputAndNoOutput @httpResponseTests([
+   {
+       id: "NoInputAndNoOutput",
+       description: "No output serializes no payload",
+       protocol: "aws.rest-xml",
+       code: 200,
+       body: ""
+   }
+])
+
+/// The example tests how requests and responses are serialized when there's
+/// no request or response payload because the operation has no input and the
+/// output is empty. While this should be rare, code generators must support
+/// this.
+@http(uri: "/NoInputAndOutputOutput", method: "POST")
+operation NoInputAndOutput() -> NoInputAndOutputOutput
+
+apply NoInputAndOutput @httpRequestTests([
+    {
+        id: "NoInputAndOutput",
+        description: "No input serializes no payload",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/NoInputAndOutput",
+        body: ""
+    }
+])
+
+apply NoInputAndOutput @httpResponseTests([
+    {
+        id: "NoInputAndOutput",
+        description: "Empty output serializes no payload",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: ""
+    }
+])
+
+structure NoInputAndOutputOutput {}
+
+/// The example tests how requests and responses are serialized when there's
+/// no request or response payload because the operation has an empty input
+/// and empty output structure that reuses the same shape. While this should
+/// be rare, code generators must support this.
+@http(uri: "/EmptyInputAndEmptyOutput", method: "POST")
+operation EmptyInputAndEmptyOutput(EmptyInputAndEmptyOutputInput) -> EmptyInputAndEmptyOutputOutput
+
+apply EmptyInputAndEmptyOutput @httpRequestTests([
+    {
+        id: "EmptyInputAndEmptyOutput",
+        description: "Empty input serializes no payload",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/EmptyInputAndEmptyOutput",
+        body: ""
+    },
+])
+
+apply EmptyInputAndEmptyOutput @httpResponseTests([
+    {
+        id: "EmptyInputAndEmptyOutput",
+        description: "Empty output serializes no payload",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: ""
+    },
+])
+
+structure EmptyInputAndEmptyOutputInput {}
+structure EmptyInputAndEmptyOutputOutput {}

--- a/smithy-aws-protocol-tests/model/rest-xml/endpoint-host-trait.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/endpoint-host-trait.smithy
@@ -1,0 +1,11 @@
+// This file defines test cases that change the endpoint based on the endpoint trait.
+// See: https://awslabs.github.io/smithy/spec/core.html#endpoint-trait
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+// TODO: Write endpoint tests

--- a/smithy-aws-protocol-tests/model/rest-xml/errors.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/errors.smithy
@@ -1,0 +1,127 @@
+// This file defines test cases that test error serialization.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This operation has three possible return values:
+///
+/// 1. A successful response in the form of GreetingWithErrorsOutput
+/// 2. An InvalidGreeting error.
+/// 3. A BadRequest error.
+///
+/// Implementations must be able to successfully take a response and
+/// properly (de)serialize successful and error responses based on the
+/// the presence of the
+@idempotent
+@http(uri: "/GreetingWithErrors", method: "PUT")
+operation GreetingWithErrors() -> GreetingWithErrorsOutput errors [InvalidGreeting, ComplexError]
+
+apply GreetingWithErrors @httpResponseTests([
+    {
+        id: "GreetingWithErrors",
+        description: "Ensures that operations with errors successfully know how to deserialize the successful response",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "",
+        headers: {
+            "X-Greeting": "Hello"
+        },
+        params: {
+            greeting: "Hello"
+        }
+    }
+])
+
+structure GreetingWithErrorsOutput {
+    @httpHeader("X-Greeting")
+    greeting: String,
+}
+
+/// This error is thrown when an invalid greeting value is provided.
+@error("client")
+@httpError(400)
+structure InvalidGreeting {
+    Message: String,
+}
+
+apply InvalidGreeting @httpResponseTests([
+    {
+        id: "InvalidGreetingError",
+        description: "Parses simple XML errors",
+        protocol: "aws.rest-xml",
+        params: {
+            Message: "Hi"
+        },
+        code: 400,
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        body: """
+              <ErrorResponse>
+                 <Error>
+                    <Type>Sender</Type>
+                    <Code>InvalidGreeting</Code>
+                    <Message>Hi</Message>
+                    <AnotherSetting>setting</Message>
+                 </Error>
+                 <RequestId>foo-id</RequestId>
+              </ErrorResponse>
+              """,
+        bodyMediaType: "application/xml",
+    }
+])
+
+/// This error is thrown when a request is invalid.
+@error("client")
+@httpError(403)
+structure ComplexError {
+    // Errors support HTTP bindings!
+    @httpHeader("X-Header")
+    Header: String,
+
+    TopLevel: String,
+
+    Nested: ComplexNestedErrorData,
+}
+
+apply ComplexError @httpResponseTests([
+    {
+        id: "ComplexError",
+        protocol: "aws.rest-xml",
+        params: {
+            Header: "Header",
+            TopLevel: "Top level",
+            Nested: {
+                Foo: "bar"
+            }
+        },
+        code: 400,
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Header": "Header",
+        },
+        body: """
+              <ErrorResponse>
+                 <Error>
+                    <Type>Sender</Type>
+                    <Code>ComplexError</Code>
+                    <Message>Hi</Message>
+                    <TopLevel>Top level</TopLevel>
+                    <Nested>
+                        <Foo>bar</Foo>
+                    </Nested>
+                 </Error>
+                 <RequestId>foo-id</RequestId>
+              </ErrorResponse>
+              """,
+        bodyMediaType: "application/xml",
+    }
+])
+
+structure ComplexNestedErrorData {
+    Foo: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
@@ -1,0 +1,385 @@
+// This file defines test cases that test HTTP header bindings.
+// See: https://awslabs.github.io/smithy/spec/http.html#httpheader-trait
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// The example tests how requests and responses are serialized when there is
+/// no input or output payload but there are HTTP header bindings.
+@http(uri: "/InputAndOutputWithHeaders", method: "POST")
+operation InputAndOutputWithHeaders(InputAndOutputWithHeadersIO) -> InputAndOutputWithHeadersIO
+
+apply InputAndOutputWithHeaders @httpRequestTests([
+    {
+        id: "InputAndOutputWithStringHeaders",
+        description: "Tests requests with string header bindings",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-String": "Hello",
+            "X-StringList": "a, b, c",
+            "X-StringSet": "a, b, c"
+        },
+        body: "",
+        params: {
+            headerString: "Hello",
+            headerStringList: ["a", "b", "c"],
+            headerStringSet: ["a", "b", "c"],
+        }
+    },
+    {
+        id: "InputAndOutputWithNumericHeaders",
+        description: "Tests requests with numeric header bindings",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-Byte": "1",
+            "X-Short": "123",
+            "X-Integer": "123",
+            "X-Long": "123",
+            "X-Float": "1.0",
+            "X-Double": "1.0",
+            "X-HeaderIntegerList": "1, 2, 3",
+        },
+        body: "",
+        params: {
+            headerByte: 1,
+            headerShort: 123,
+            headerInteger: 123,
+            headerLong: 123,
+            headerFloat: 1.0,
+            headerDouble: 1.0,
+            headerIntegerList: [1, 2, 3],
+        }
+    },
+    {
+        id: "InputAndOutputWithBooleanHeaders",
+        description: "Tests requests with boolean header bindings",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-Boolean1": "true",
+            "X-Boolean2": "false",
+            "X-HeaderBooleanList": "true, false, true"
+        },
+        body: "",
+        params: {
+            headerTrueBool: true,
+            headerFalseBool: true,
+            headerBooleanList: [true, false, true]
+        }
+    },
+    {
+        id: "InputAndOutputWithTimestampHeaders",
+        description: "Tests requests with timestamp header bindings",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+        },
+        body: "",
+        params: {
+            headerTimestampList: [1576540098, 1576540098]
+        }
+    },
+    {
+        id: "InputAndOutputWithEnumHeaders",
+        description: "Tests requests with enum header bindings",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-Enum": "Foo",
+            "X-EnumList": "Foo, Baz, Bar"
+        },
+        body: "",
+        params: {
+            headerEnum: "Foo",
+            headerEnumList: ["Foo", "Bar", "Baz"],
+        }
+    },
+])
+
+apply InputAndOutputWithHeaders @httpResponseTests([
+    {
+        id: "InputAndOutputWithStringHeaders",
+        description: "Tests responses with string header bindings",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "X-String": "Hello",
+            "X-StringList": "a, b, c",
+            "X-StringSet": "a, b, c"
+        },
+        body: "",
+        params: {
+            headerString: "Hello",
+            headerStringList: ["a", "b", "c"],
+            headerStringSet: ["a", "b", "c"],
+        }
+    },
+    {
+        id: "InputAndOutputWithNumericHeaders",
+        description: "Tests responses with numeric header bindings",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "X-Byte": "1",
+            "X-Short": "123",
+            "X-Integer": "123",
+            "X-Long": "123",
+            "X-Float": "1.0",
+            "X-Double": "1.0",
+            "X-HeaderIntegerList": "1, 2, 3",
+        },
+        body: "",
+        params: {
+            headerByte: 1,
+            headerShort: 123,
+            headerInteger: 123,
+            headerLong: 123,
+            headerFloat: 1.0,
+            headerDouble: 1.0,
+            headerIntegerList: [1, 2, 3],
+        }
+    },
+    {
+        id: "InputAndOutputWithBooleanHeaders",
+        description: "Tests responses with boolean header bindings",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "X-Boolean1": "true",
+            "X-Boolean2": "false",
+            "X-HeaderBooleanList": "true, false, true"
+        },
+        body: "",
+        params: {
+            headerTrueBool: true,
+            headerFalseBool: true,
+            headerBooleanList: [true, false, true]
+        }
+    },
+    {
+        id: "InputAndOutputWithTimestampHeaders",
+        description: "Tests responses with timestamp header bindings",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+        },
+        body: "",
+        params: {
+            headerTimestampList: [1576540098, 1576540098]
+        }
+    },
+    {
+        id: "InputAndOutputWithEnumHeaders",
+        description: "Tests responses with enum header bindings",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "X-Enum": "Foo",
+            "X-EnumList": "Foo, Baz, Bar"
+        },
+        body: "",
+        params: {
+            headerEnum: "Foo",
+            headerEnumList: ["Foo", "Bar", "Baz"],
+        }
+    },
+])
+
+structure InputAndOutputWithHeadersIO {
+    @httpHeader("X-String")
+    headerString: String,
+
+    @httpHeader("X-Byte")
+    headerByte: Byte,
+
+    @httpHeader("X-Short")
+    headerShort: Short,
+
+    @httpHeader("X-Integer")
+    headerInteger: Integer,
+
+    @httpHeader("X-Long")
+    headerLong: Long,
+
+    @httpHeader("X-Float")
+    headerFloat: Float,
+
+    @httpHeader("X-Double")
+    headerDouble: Double,
+
+    @httpHeader("X-Boolean1")
+    headerTrueBool: Boolean,
+
+    @httpHeader("X-Boolean2")
+    headerFalseBool: Boolean,
+
+    @httpHeader("X-StringList")
+    headerStringList: StringList,
+
+    @httpHeader("X-StringSet")
+    headerStringSet: StringSet,
+
+    @httpHeader("X-IntegerList")
+    headerIntegerList: IntegerList,
+
+    @httpHeader("X-BooleanList")
+    headerBooleanList: BooleanList,
+
+    @httpHeader("X-TimestampList")
+    headerTimestampList: TimestampList,
+
+    @httpHeader("X-Enum")
+    headerEnum: FooEnum,
+
+    @httpHeader("X-EnumList")
+    headerEnumList: FooEnumList,
+}
+
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeaders", method: "GET")
+operation NullAndEmptyHeaders(NullAndEmptyHeadersIO) -> NullAndEmptyHeadersIO
+
+apply NullAndEmptyHeaders @httpRequestTests([
+    {
+        id: "NullAndEmptyHeaders",
+        description: "Do not send null values, empty strings, or empty lists over the wire in headers",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/NullAndEmptyHeaders",
+        forbidHeaders: ["X-A", "X-B", "X-C"],
+        body: "",
+        params: {
+            a: null,
+            b: "",
+            c: [],
+        }
+    },
+])
+
+apply NullAndEmptyHeaders @httpResponseTests([
+    {
+        id: "NullAndEmptyHeaders",
+        description: "Do not send null or empty headers",
+        protocol: "aws.rest-xml",
+        code: 200,
+        forbidHeaders: ["X-A", "X-B", "X-C"],
+        body: "",
+        params: {
+            a: null,
+            b: "",
+            c: [],
+        }
+    },
+])
+
+structure NullAndEmptyHeadersIO {
+    @httpHeader("X-A")
+    a: String,
+
+    @httpHeader("X-B")
+    b: String,
+
+    @httpHeader("X-C")
+    c: StringList,
+}
+
+/// The example tests how timestamp request and response headers are serialized.
+@http(uri: "/TimestampFormatHeaders", method: "POST")
+operation TimestampFormatHeaders(TimestampFormatHeadersIO) -> TimestampFormatHeadersIO
+
+apply TimestampFormatHeaders @httpRequestTests([
+    {
+        id: "TimestampFormatHeaders",
+        description: "Tests how timestamp request headers are serialized",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/TimestampFormatHeaders",
+        headers: {
+            "X-memberEpochSeconds": "1576540098",
+            "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-memberDateTime": "2019-12-16T23:48:18Z",
+            "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetEpochSeconds": "1576540098",
+            "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetDateTime": "2019-12-16T23:48:18Z",
+        },
+        body: "",
+        params: {
+            memberEpochSeconds: 1576540098,
+            memberHttpDate: 1576540098,
+            memberDateTime: 1576540098,
+            defaultFormat: 1576540098,
+            targetEpochSeconds: 1576540098,
+            targetHttpDate: 1576540098,
+            targetDateTime: 1576540098,
+        }
+    },
+])
+
+apply TimestampFormatHeaders @httpResponseTests([
+    {
+        id: "TimestampFormatHeaders",
+        description: "Tests how timestamp response headers are serialized",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "X-memberEpochSeconds": "1576540098",
+            "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-memberDateTime": "2019-12-16T23:48:18Z",
+            "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetEpochSeconds": "1576540098",
+            "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetDateTime": "2019-12-16T23:48:18Z",
+        },
+        body: "",
+        params: {
+            memberEpochSeconds: 1576540098,
+            memberHttpDate: 1576540098,
+            memberDateTime: 1576540098,
+            defaultFormat: 1576540098,
+            targetEpochSeconds: 1576540098,
+            targetHttpDate: 1576540098,
+            targetDateTime: 1576540098,
+        }
+    },
+])
+
+structure TimestampFormatHeadersIO {
+    @httpHeader("X-memberEpochSeconds")
+    @timestampFormat("epoch-seconds")
+    memberEpochSeconds: Timestamp,
+
+    @httpHeader("X-memberHttpDate")
+    @timestampFormat("http-date")
+    memberHttpDate: Timestamp,
+
+    @httpHeader("X-memberDateTime")
+    @timestampFormat("date-time")
+    memberDateTime: Timestamp,
+
+    @httpHeader("X-defaultFormat")
+    defaultFormat: Timestamp,
+
+    @httpHeader("X-targetEpochSeconds")
+    targetEpochSeconds: EpochSeconds,
+
+    @httpHeader("X-targetHttpDate")
+    targetHttpDate: HttpDate,
+
+    @httpHeader("X-targetDateTime")
+    targetDateTime: HttpDate,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
@@ -1,0 +1,169 @@
+// This file defines test cases that test HTTP URI label bindings.
+// See: https://awslabs.github.io/smithy/spec/http.html#httplabel-trait
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// The example tests how requests are serialized when there's no input
+/// payload but there are HTTP labels.
+@readonly
+@http(method: "GET", uri: "/HttpRequestWithLabels/{string}/{short}/{integer}/{long}/{float}/{double}/{boolean}/{timestamp}")
+operation HttpRequestWithLabels(HttpRequestWithLabelsInput)
+
+apply HttpRequestWithLabels @httpRequestTests([
+    {
+        id: "InputWithHeadersAndAllParams",
+        description: "Sends a GET request that uses URI label bindings",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/HttpRequestWithLabels/string/1/2/3/4.0/5.0/true/2019-12-16T23%3A48%3A18Z",
+        body: "",
+        params: {
+            string: "string",
+            short: 1,
+            integer: 2,
+            long: 3,
+            float: 4.0,
+            double: 5.0,
+            boolean: true,
+            timestamp: 1576540098
+        }
+    },
+])
+
+structure HttpRequestWithLabelsInput {
+    @httpLabel
+    @required
+    string: String,
+
+    @httpLabel
+    @required
+    short: Short,
+
+    @httpLabel
+    @required
+    integer: Integer,
+
+    @httpLabel
+    @required
+    long: Long,
+
+    @httpLabel
+    @required
+    float: Float,
+
+    @httpLabel
+    @required
+    double: Double,
+
+    /// Serialized in the path as true or false.
+    @httpLabel
+    @required
+    boolean: Boolean,
+
+    /// Note that this member has no format, so it's serialized as an RFC 3399 date-time.
+    @httpLabel
+    @required
+    timestamp: Timestamp,
+}
+
+/// The example tests how requests serialize different timestamp formats in the
+/// URI path.
+@readonly
+@http(method: "GET", uri: "/HttpRequestWithLabelsAndTimestampFormat/{memberEpochSeconds}/{memberHttpDate}/{memberDateTime}/{defaultFormat}/{targetEpochSeconds}/{targetHttpDate}/{targetDateTime}")
+operation HttpRequestWithLabelsAndTimestampFormat(HttpRequestWithLabelsAndTimestampFormatInput)
+
+apply HttpRequestWithLabelsAndTimestampFormat @httpRequestTests([
+    {
+        id: "HttpRequestWithLabelsAndTimestampFormat",
+        description: "Serializes different timestamp formats in URI labels",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: """
+             /HttpRequestWithLabelsAndTimestampFormat\
+             /1576540098\
+             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /2019-12-16T23%3A48%3A18Z\
+             /2019-12-16T23%3A48%3A18Z\
+             /1576540098\
+             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /2019-12-16T23%3A48%3A18Z""",
+        body: "",
+        params: {
+            memberEpochSeconds: 1576540098,
+            memberHttpDate: 1576540098,
+            memberDateTime: 1576540098,
+            defaultFormat: 1576540098,
+            targetEpochSeconds: 1576540098,
+            targetHttpDate: 1576540098,
+            targetDateTime: 1576540098,
+        }
+    },
+])
+
+structure HttpRequestWithLabelsAndTimestampFormatInput {
+    @httpLabel
+    @required
+    @timestampFormat("epoch-seconds")
+    memberEpochSeconds: Timestamp,
+
+    @httpLabel
+    @required
+    @timestampFormat("http-date")
+    memberHttpDate: Timestamp,
+
+    @httpLabel
+    @required
+    @timestampFormat("date-time")
+    memberDateTime: Timestamp,
+
+    @httpLabel
+    @required
+    defaultFormat: Timestamp,
+
+    @httpLabel
+    @required
+    targetEpochSeconds: EpochSeconds,
+
+    @httpLabel
+    @required
+    targetHttpDate: HttpDate,
+
+    @httpLabel
+    @required
+    targetDateTime: HttpDate,
+}
+
+// This example uses a greedy label and a normal label.
+@readonly
+@http(method: "GET", uri: "/HttpRequestWithGreedyLabelInPath/foo/{foo}/baz/{baz+}")
+operation HttpRequestWithGreedyLabelInPath(HttpRequestWithGreedyLabelInPathInput)
+
+apply HttpRequestWithGreedyLabelInPath @httpRequestTests([
+    {
+        id: "HttpRequestWithGreedyLabelInPath",
+        description: "Serializes greedy labels and normal labels",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/HttpRequestWithGreedyLabelInPath/foo/hello/baz/there/guy",
+        body: "",
+        params: {
+            foo: "hello",
+            baz: "there/guy",
+        }
+    },
+])
+
+structure HttpRequestWithGreedyLabelInPathInput {
+    @httpLabel
+    @required
+    foo: String,
+
+    @httpLabel
+    @required
+    baz: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-payload.smithy
@@ -1,0 +1,381 @@
+// This file defines test cases that test HTTP payload bindings.
+// See: https://awslabs.github.io/smithy/spec/http.html#httppayload-trait
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This examples serializes a blob shape in the payload.
+///
+/// In this example, no XML document is synthesized because the payload is
+/// not a structure or a union type.
+@http(uri: "/HttpPayloadTraits", method: "POST")
+operation HttpPayloadTraits(HttpPayloadTraitsInputOutput) -> HttpPayloadTraitsInputOutput
+
+apply HttpPayloadTraits @httpRequestTests([
+    {
+        id: "HttpPayloadTraitsWithBlob",
+        description: "Serializes a blob in the HTTP payload",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/HttpPayloadTraits",
+        body: "blobby blob blob",
+        headers: {
+            "X-Foo": "Foo"
+        },
+        params: {
+            foo: "Foo",
+            blob: "blobby blob blob"
+        }
+    },
+    {
+        id: "HttpPayloadTraitsWithNoBlobBody",
+        description: "Serializes an empty blob in the HTTP payload",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/HttpPayloadTraits",
+        body: "",
+        headers: {
+            "X-Foo": "Foo"
+        },
+        params: {
+            foo: "Foo"
+        }
+    },
+])
+
+apply HttpPayloadTraits @httpResponseTests([
+    {
+        id: "HttpPayloadTraitsWithBlob",
+        description: "Serializes a blob in the HTTP payload",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "blobby blob blob",
+        headers: {
+            "X-Foo": "Foo"
+        },
+        params: {
+            foo: "Foo",
+            blob: "blobby blob blob"
+        }
+    },
+    {
+        id: "HttpPayloadTraitsWithNoBlobBody",
+        description: "Serializes an empty blob in the HTTP payload",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "",
+        headers: {
+            "X-Foo": "Foo"
+        },
+        params: {
+            foo: "Foo"
+        }
+    }
+])
+
+structure HttpPayloadTraitsInputOutput {
+    @httpHeader("X-Foo")
+    foo: String,
+
+    @httpPayload
+    blob: Blob,
+}
+
+/// This examples uses a `@mediaType` trait on the payload to force a custom
+/// content-type to be serialized.
+@http(uri: "/HttpPayloadTraitsWithMediaType", method: "POST")
+operation HttpPayloadTraitsWithMediaType(HttpPayloadTraitsWithMediaTypeInputOutput) -> HttpPayloadTraitsWithMediaTypeInputOutput
+
+apply HttpPayloadTraitsWithMediaType @httpRequestTests([
+    {
+        id: "HttpPayloadTraitsWithMediaTypeWithBlob",
+        description: "Serializes a blob in the HTTP payload with a content-type",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/HttpPayloadTraitsWithMediaType",
+        body: "blobby blob blob",
+        headers: {
+            "X-Foo": "Foo",
+            "Content-Type": "text/plain"
+        },
+        params: {
+            foo: "Foo",
+            blob: "blobby blob blob"
+        }
+    }
+])
+
+apply HttpPayloadTraitsWithMediaType @httpResponseTests([
+    {
+        id: "HttpPayloadTraitsWithMediaTypeWithBlob",
+        description: "Serializes a blob in the HTTP payload with a content-type",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "blobby blob blob",
+        headers: {
+            "X-Foo": "Foo",
+            "Content-Type": "text/plain"
+        },
+        params: {
+            foo: "Foo",
+            blob: "blobby blob blob"
+        }
+    }
+])
+
+structure HttpPayloadTraitsWithMediaTypeInputOutput {
+    @httpHeader("X-Foo")
+    foo: String,
+
+    @httpPayload
+    blob: TextPlainBlob,
+}
+
+/// This examples serializes a structure in the payload.
+///
+/// Note that serializing a structure changes the wrapper element name
+/// to match the targeted structure.
+@idempotent
+@http(uri: "/HttpPayloadWithStructure", method: "PUT")
+operation HttpPayloadWithStructure(HttpPayloadWithStructureInputOutput) -> HttpPayloadWithStructureInputOutput
+
+apply HttpPayloadWithStructure @httpRequestTests([
+    {
+        id: "HttpPayloadWithStructure",
+        description: "Serializes a structure in the payload",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/HttpPayloadWithStructure",
+        body: """
+              <NestedPayload>
+                  <greeting>hello</greeting>
+                  <name>Phreddy</name>
+              </NestedPayload>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                greeting: "hello",
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+apply HttpPayloadWithStructure @httpResponseTests([
+    {
+        id: "HttpPayloadWithStructure",
+        description: "Serializes a structure in the payload",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+            <NestedPayload>
+                <greeting>hello</greeting>
+                <name>Phreddy</name>
+            </NestedPayload>
+            """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                greeting: "hello",
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+structure HttpPayloadWithStructureInputOutput {
+    @httpPayload
+    nested: NestedPayload,
+}
+
+structure NestedPayload {
+    greeting: String,
+    name: String,
+}
+
+/// The following example serializes a payload that uses an XML name,
+/// changing the wrapper name.
+@idempotent
+@http(uri: "/HttpPayloadWithXmlName", method: "PUT")
+operation HttpPayloadWithXmlName(HttpPayloadWithXmlNameInputOutput) -> HttpPayloadWithXmlNameInputOutput
+
+apply HttpPayloadWithXmlName @httpRequestTests([
+    {
+        id: "HttpPayloadWithXmlName",
+        description: "Serializes a structure in the payload using a wrapper name based on xmlName",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/HttpPayloadWithStructure",
+        body: "<Hello><name>Phreddy</name></Hello>",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+apply HttpPayloadWithXmlName @httpResponseTests([
+    {
+        id: "HttpPayloadWithXmlName",
+        description: "Serializes a structure in the payload using a wrapper name based on xmlName",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "<Hello><name>Phreddy</name></Hello>",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+structure HttpPayloadWithXmlNameInputOutput {
+    @httpPayload
+    nested: PayloadWithXmlName,
+}
+
+@xmlName("Hello")
+structure PayloadWithXmlName {
+    name: String
+}
+
+/// The following example serializes a payload that uses an XML namespace.
+@idempotent
+@http(uri: "/HttpPayloadWithXmlNamespace", method: "PUT")
+operation HttpPayloadWithXmlNamespace(HttpPayloadWithXmlNamespaceInputOutput) -> HttpPayloadWithXmlNamespaceInputOutput
+
+apply HttpPayloadWithXmlNamespace @httpRequestTests([
+    {
+        id: "HttpPayloadWithXmlNamespace",
+        description: "Serializes a structure in the payload using a wrapper with an XML namespace",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/HttpPayloadWithXmlNamespace",
+        body: """
+              <PayloadWithXmlNamespace xmlns="http//foo.com">
+                  <name>Phreddy</name>
+              </PayloadWithXmlNamespace>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+apply HttpPayloadWithXmlNamespace @httpResponseTests([
+    {
+        id: "HttpPayloadWithXmlNamespace",
+        description: "Serializes a structure in the payload using a wrapper with an XML namespace",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <PayloadWithXmlNamespace xmlns="http//foo.com">
+                  <name>Phreddy</name>
+              </PayloadWithXmlNamespace>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+structure HttpPayloadWithXmlNamespaceInputOutput {
+    @httpPayload
+    nested: PayloadWithXmlNamespace,
+}
+
+@xmlNamespace(uri: "http://foo.com")
+structure PayloadWithXmlNamespace {
+    name: String
+}
+
+/// The following example serializes a payload that uses an XML namespace.
+@idempotent
+@http(uri: "/HttpPayloadWithXmlNamespaceAndPrefix", method: "PUT")
+operation HttpPayloadWithXmlNamespaceAndPrefix(HttpPayloadWithXmlNamespaceAndPrefixInputOutput)
+    -> HttpPayloadWithXmlNamespaceAndPrefixInputOutput
+
+apply HttpPayloadWithXmlNamespaceAndPrefix @httpRequestTests([
+    {
+        id: "HttpPayloadWithXmlNamespaceAndPrefix",
+        description: "Serializes a structure in the payload using a wrapper with an XML namespace",
+        protocol: "aws.rest-xml",
+        method: "PUT",
+        uri: "/HttpPayloadWithXmlNamespaceAndPrefix",
+        body: """
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+                  <name>Phreddy</name>
+              </PayloadWithXmlNamespaceAndPrefix>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+apply HttpPayloadWithXmlNamespaceAndPrefix @httpResponseTests([
+    {
+        id: "HttpPayloadWithXmlNamespaceAndPrefix",
+        description: "Serializes a structure in the payload using a wrapper with an XML namespace",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: """
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+                  <name>Phreddy</name>
+              </PayloadWithXmlNamespaceAndPrefix>""",
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            nested: {
+                name: "Phreddy"
+            }
+        }
+    }
+])
+
+structure HttpPayloadWithXmlNamespaceAndPrefixInputOutput {
+    @httpPayload
+    nested: PayloadWithXmlNamespaceAndPrefix,
+}
+
+@xmlNamespace(uri: "http://foo.com", prefix: "baz")
+structure PayloadWithXmlNamespaceAndPrefix {
+    name: String
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-prefix-headers.smithy
@@ -1,0 +1,102 @@
+// This file defines test cases that test httpPrefix headers.
+// See: https://awslabs.github.io/smithy/spec/http.html#httpprefixheaders-trait
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This examples adds headers to the input of a request and response by prefix.
+@readonly
+@http(uri: "/HttpPrefixHeaders", method: "GET")
+@externalDocumentation("https://awslabs.github.io/smithy/spec/http.html#httpprefixheaders-trait")
+operation HttpPrefixHeaders(HttpPrefixHeadersInputOutput) -> HttpPrefixHeadersInputOutput
+
+apply HttpPrefixHeaders @httpRequestTests([
+    {
+        id: "HttpPrefixHeadersArePresent",
+        description: "Adds headers by prefix",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/HttpPrefixHeaders",
+        body: "",
+        headers: {
+            "X-Foo": "Foo",
+            "X-Foo-Abc": "Abc value",
+            "X-Foo-Def": "Def value",
+        },
+        params: {
+            foo: "Foo",
+            fooMap: {
+                Abc: "Abc value",
+                Def: "Def value",
+            }
+        }
+    },
+    {
+        id: "HttpPrefixHeadersAreNotPresent",
+        description: "No prefix headers are serialized because the value is empty",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/HttpPrefixHeaders",
+        body: "",
+        headers: {
+            "X-Foo": "Foo"
+        },
+        params: {
+            foo: "Foo",
+            fooMap: {}
+        }
+    },
+])
+
+apply HttpPrefixHeaders @httpResponseTests([
+    {
+        id: "HttpPrefixHeadersArePresent",
+        description: "Adds headers by prefix",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "",
+        headers: {
+            "X-Foo": "Foo",
+            "X-Foo-Abc": "Abc value",
+            "X-Foo-Def": "Def value",
+        },
+        params: {
+            foo: "Foo",
+            fooMap: {
+                Abc: "Abc value",
+                Def: "Def value",
+            }
+        }
+    },
+    {
+        id: "HttpPrefixHeadersAreNotPresent",
+        description: "No prefix headers are serialized because the value is empty",
+        protocol: "aws.rest-xml",
+        code: 200,
+        body: "",
+        headers: {
+            "X-Foo": "Foo"
+        },
+        params: {
+            foo: "Foo",
+            fooMap: {}
+        }
+    },
+])
+
+structure HttpPrefixHeadersInputOutput {
+    @httpHeader("X-Foo")
+    foo: String,
+
+    @httpPrefixHeaders("X-Foo-")
+    fooMap: FooPrefixHeaders,
+}
+
+map FooPrefixHeaders {
+    key: String,
+    value: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-query.smithy
@@ -1,0 +1,318 @@
+// This file defines test cases that test HTTP query string bindings.
+// See: https://awslabs.github.io/smithy/spec/http.html#httpquery-trait
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This example uses all query string types.
+@readonly
+@http(uri: "/AllQueryStringTypesInput", method: "GET")
+operation AllQueryStringTypes(AllQueryStringTypesInput)
+
+apply AllQueryStringTypes @httpRequestTests([
+    {
+        id: "AllQueryStringTypes",
+        description: "Serializes query string parameters with all supported types",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/AllQueryStringTypes",
+        body: "",
+        queryParams: [
+            "String=Hello%20there",
+            "StringList=a",
+            "StringList=b",
+            "StringList=c",
+            "StringSet=a",
+            "StringSet=b",
+            "StringSet=c",
+            "Byte=1",
+            "Short=2",
+            "Integer=3",
+            "IntegerList=1",
+            "IntegerList=2",
+            "IntegerList=3",
+            "IntegerSet=1",
+            "IntegerSet=2",
+            "IntegerSet=3",
+            "Long=4",
+            "Float=1",
+            "Double=1",
+            "DoubleList=1.0",
+            "DoubleList=2.0",
+            "DoubleList=3.0",
+            "Boolean=true",
+            "BooleanList=true",
+            "BooleanList=false",
+            "BooleanList=true",
+            "Timestamp=1",
+            "TimestampList=1",
+            "TimestampList=2",
+            "TimestampList=3",
+            "Enum=Foo",
+            "EnumList=Foo",
+            "EnumList=Baz",
+            "EnumList=Bar",
+        ],
+        params: {
+            queryString: "Hello there",
+            queryStringList: ["a", "b", "c"],
+            queryStringSet: ["a", "b", "c"],
+            queryByte: 1,
+            queryShort: 2,
+            queryInteger: 3,
+            queryIntegerList: [1, 2, 3],
+            queryIntegerSet: [1, 2, 3],
+            queryLong: 4,
+            queryFloat: 1,
+            queryDouble: 1,
+            queryDoubleList: [1.0, 2.0, 3.0],
+            queryBoolean: true,
+            queryBooleanList: [true, false, true],
+            queryTimestamp: 1,
+            queryTimestampList: [1, 2, 3],
+            queryEnum: "Foo",
+            queryEnumList: ["Foo", "Baz", "Bar"],
+        }
+    }
+])
+
+structure AllQueryStringTypesInput {
+    @httpQuery("String")
+    queryString: String,
+
+    @httpQuery("StringList")
+    queryStringList: StringList,
+
+    @httpQuery("StringSet")
+    queryStringSet: StringSet,
+
+    @httpQuery("Byte")
+    queryByte: Byte,
+
+    @httpQuery("Short")
+    queryShort: Short,
+
+    @httpQuery("Integer")
+    queryInteger: Integer,
+
+    @httpQuery("IntegerList")
+    queryIntegerList: IntegerList,
+
+    @httpQuery("IntegerSet")
+    queryIntegerSet: IntegerSet,
+
+    @httpQuery("Long")
+    queryLong: Long,
+
+    @httpQuery("Float")
+    queryFloat: Float,
+
+    @httpQuery("Double")
+    queryDouble: Double,
+
+    @httpQuery("DoubleList")
+    queryDoubleList: DoubleList,
+
+    @httpQuery("Boolean")
+    queryBoolean: Boolean,
+
+    @httpQuery("BooleanList")
+    queryBooleanList: BooleanList,
+
+    @httpQuery("Timestamp")
+    queryTimestamp: Timestamp,
+
+    @httpQuery("TimestampList")
+    queryTimestampList: TimestampList,
+
+    @httpQuery("Enum")
+    queryEnum: FooEnum,
+
+    @httpQuery("EnumList")
+    queryEnumList: FooEnumList,
+}
+
+/// This example uses a constant query string parameters and a label.
+/// This simply tests that labels and query string parameters are
+/// compatible. The fixed query string parameter named "hello" should
+/// in no way conflict with the label, `{hello}`.
+@readonly
+@http(uri: "/ConstantQueryString/{hello}?foo=bar&hello", method: "GET")
+@httpRequestTests([
+    {
+        id: "ConstantQueryString",
+        description: "Includes constant query string parameters",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/ConstantQueryString/hi",
+        queryParams: [
+            "foo=bar",
+            "hello",
+        ],
+        body: "",
+        params: {
+            hello: "hi"
+        }
+    },
+])
+operation ConstantQueryString(ConstantQueryStringInput)
+
+structure ConstantQueryStringInput {
+    @httpLabel
+    @required
+    hello: String,
+}
+
+/// This example uses fixed query string params and variable query string params.
+/// The fixed query string parameters and variable parameters must both be
+/// serialized (implementations may need to merge them together).
+@readonly
+@http(uri: "/ConstantAndVariableQueryString?foo=bar", method: "GET")
+operation ConstantAndVariableQueryString(ConstantAndVariableQueryStringInput)
+
+apply ConstantAndVariableQueryString @httpRequestTests([
+    {
+        id: "ConstantAndVariableQueryStringMissingOneValue",
+        description: "Mixes constant and variable query string parameters",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/ConstantAndVariableQueryString",
+        queryParams: [
+            "foo=bar",
+            "baz=bam",
+        ],
+        forbidQueryParams: ["maybeSet"],
+        body: "",
+        params: {
+            baz: "bam"
+        }
+    },
+    {
+        id: "ConstantAndVariableQueryStringAllValues",
+        description: "Mixes constant and variable query string parameters",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/ConstantAndVariableQueryString",
+        queryParams: [
+            "foo=bar",
+            "baz=bam",
+            "maybeSet=yes"
+        ],
+        body: "",
+        params: {
+            baz: "bam",
+            maybeSet: "yes"
+        }
+    },
+])
+
+structure ConstantAndVariableQueryStringInput {
+    @httpQuery("baz")
+    baz: String,
+
+    @httpQuery("maybeSet")
+    maybeSet: String,
+}
+
+/// This example ensures that query string bound request parameters are
+/// serialized in the body of responses if the structure is used in both
+/// the request and response.
+@readonly
+@http(uri: "/IgnoreQueryParamsInResponse", method: "GET")
+operation IgnoreQueryParamsInResponse() -> IgnoreQueryParamsInResponseOutput
+
+apply IgnoreQueryParamsInResponse @httpResponseTests([
+    {
+        id: "IgnoreQueryParamsInResponse",
+        description: "Query parameters must be ignored when serializing the output of an operation",
+        protocol: "aws.rest-xml",
+        code: 200,
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        body: "<IgnoreQueryParamsInResponseInputOutput><baz>bam</baz></IgnoreQueryParamsInResponseInputOutput>",
+        bodyMediaType: "xml",
+        params: {
+            baz: "bam"
+        }
+    }
+])
+
+structure IgnoreQueryParamsInResponseOutput {
+    @httpQuery("baz")
+    baz: String
+}
+
+/// Omits null, but serializes empty string value.
+@readonly
+@http(uri: "/OmitsNullSerializesEmptyString", method: "GET")
+operation OmitsNullSerializesEmptyString(OmitsNullSerializesEmptyStringInput)
+
+apply OmitsNullSerializesEmptyString @httpRequestTests([
+    {
+        id: "OmitsNullSerializesEmptyString",
+        description: "Serializes empty query strings but omits null",
+        protocol: "aws.rest-xml",
+        method: "GET",
+        uri: "/OmitsNullSerializesEmptyString",
+        body: "",
+        queryParams: [
+            "Empty=",
+        ],
+        params: {
+            nullValue: null,
+            emptyString: "",
+        }
+    }
+])
+
+structure OmitsNullSerializesEmptyStringInput {
+    @httpQuery("Null")
+    nullValue: String,
+
+    @httpQuery("Empty")
+    emptyString: String,
+}
+
+/// Automatically adds idempotency tokens.
+@http(uri: "/QueryIdempotencyTokenAutoFill", method: "POST")
+@tags(["client-only"])
+operation QueryIdempotencyTokenAutoFill(QueryIdempotencyTokenAutoFillInput)
+
+apply QueryIdempotencyTokenAutoFill @httpRequestTests([
+    {
+        id: "QueryIdempotencyTokenAutoFill",
+        description: "Automatically adds idempotency token when not set",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/QueryIdempotencyTokenAutoFill",
+        body: "",
+        queryParams: [
+            "token=00000000-0000-4000-8000-000000000000",
+        ]
+    },
+    {
+        id: "QueryIdempotencyTokenAutoFillIsSet",
+        description: "Uses the given idempotency token as-is",
+        protocol: "aws.rest-xml",
+        method: "POST",
+        uri: "/QueryIdempotencyTokenAutoFill",
+        body: "",
+        queryParams: [
+            "token=00000000-0000-4000-8000-000000000123",
+        ],
+        params: {
+            token: "00000000-0000-4000-8000-000000000123"
+        }
+    }
+])
+
+structure QueryIdempotencyTokenAutoFillInput {
+    @httpQuery("token")
+    @idempotencyToken
+    token: String,
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/main.smithy
@@ -1,0 +1,68 @@
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// A REST XML service that sends XML requests and responses.
+@protocols([{"name": "aws.rest-xml"}])
+service RestXml {
+    version: "2019-12-16",
+    operations: [
+        // Basic input and output tests
+        NoInputAndNoOutput,
+        NoInputAndOutput,
+        EmptyInputAndEmptyOutput,
+
+        // @httpHeader tests
+        InputAndOutputWithHeaders,
+        NullAndEmptyHeaders,
+        TimestampFormatHeaders,
+
+        // @httpLabel tests
+        HttpRequestWithLabels,
+        HttpRequestWithLabelsAndTimestampFormat,
+        HttpRequestWithGreedyLabelInPath,
+
+        // @httpQuery tests
+        AllQueryStringTypes,
+        ConstantQueryString,
+        ConstantAndVariableQueryString,
+        IgnoreQueryParamsInResponse,
+        OmitsNullSerializesEmptyString,
+        QueryIdempotencyTokenAutoFill,
+
+        // @httpPrefixHeaders tests
+        HttpPrefixHeaders,
+
+        // @httpPayload tests
+        HttpPayloadTraits,
+        HttpPayloadTraitsWithMediaType,
+        HttpPayloadWithStructure,
+        HttpPayloadWithXmlName,
+        HttpPayloadWithXmlNamespace,
+        HttpPayloadWithXmlNamespaceAndPrefix,
+
+        // Errors
+        GreetingWithErrors,
+
+        // Synthesized XML document body tests
+        SimpleScalarProperties,
+        XmlTimestamps,
+        XmlEnums,
+        RecursiveShapes,
+        XmlLists,
+        XmlMaps,
+        XmlMapsXmlName,
+        FlattenedXmlMap,
+        FlattenedXmlMapWithXmlName,
+
+        // @xmlAttribute tests
+        XmlAttributes,
+        XmlAttributesOnPayload,
+
+        // @xmlNamespace trait tests
+        XmlNamespaces,
+    ]
+}

--- a/smithy-aws-protocol-tests/model/rest-xml/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/shared-types.smithy
@@ -1,0 +1,76 @@
+// This file contains shared types that are used throughout the rest-xml
+// test cases. Anything that is generic enough that it could potentially
+// be reused should be defined in this file. However, things like input
+// or output structures or other test-case specific shapes should be
+// defined closer to the test case and in its same file.
+
+$version: "0.5.0"
+
+namespace aws.protocols.tests.restxml
+
+list StringList {
+    member: String,
+}
+
+set StringSet {
+    member: String,
+}
+
+/// A list of lists of strings.
+list NestedStringList {
+    member: StringList,
+}
+
+list IntegerList {
+    member: Integer,
+}
+
+set IntegerSet {
+    member: Integer,
+}
+
+list DoubleList {
+    member: Double,
+}
+
+list BooleanList {
+    member: PrimitiveBoolean,
+}
+
+list TimestampList {
+    member: Timestamp,
+}
+
+@enum(
+    Foo: {},
+    Baz: {},
+    Bar: {},
+    "1": {},
+    "0": {},
+)
+string FooEnum
+
+list FooEnumList {
+    member: FooEnum,
+}
+
+set FooEnumSet {
+    member: FooEnum,
+}
+
+map FooEnumMap {
+    key: String,
+    value: FooEnum,
+}
+
+@timestampFormat("date-time")
+timestamp DateTime
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSeconds
+
+@timestampFormat("http-date")
+timestamp HttpDate
+
+@mediaType("text/plain")
+blob TextPlainBlob


### PR DESCRIPTION
This commit adds the start of AWS protocol tests for REST XML and JSON
RPC 1.1. More protocol tests to follow.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
