### PR TITLE
Add log-tests project property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ dist: trusty
 
 install: /bin/true
 
-script: ./gradlew clean build
+script: ./gradlew clean build -Plog-tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,6 +241,21 @@ subprojects {
     }
 
     /*
+     * Tests
+     * ====================================================
+     *
+     * Configure the running of tests.
+     */
+    if (plugins.hasPlugin("java")) {
+        // Log on passed, skipped, and failed test events if the `-Plog-tests` property is set.
+        if (project.hasProperty("log-tests")) {
+            tasks.test {
+                testLogging.events("passed", "skipped", "failed")
+            }
+        }
+    }
+
+    /*
      * Spotbugs
      * ====================================================
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -208,6 +208,7 @@ public final class Model implements ToSmithyBuilder<Model> {
      *
      * @param id Shape to retrieve by ID.
      * @param type Shape type to expect and convert to.
+     * @param <T> Expected shape type.
      * @return Returns the shape.
      * @throws ExpectationNotMetException if the shape is not found or is not the expected type.
      */


### PR DESCRIPTION
This commit adds support for the `-Plog-tests` option. When enabled,
this will generate a log line for each "passed", "skipped", or "failed"
test event.

*Issue #, if available:*
Fixes #156 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
