### PR TITLE
Add ec2QueryNameTrait

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -30,9 +30,9 @@
     </module>
 
     <!-- Files must contain a copyright header. -->
-    <module name="Header">
+    <module name="RegexpHeader">
         <property name="header"
-                  value="/*\n * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.\n"/>
+                  value="/\*\n \* Copyright 20(19|20) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/docs/source/spec/aws-core.rst
+++ b/docs/source/spec/aws-core.rst
@@ -923,6 +923,64 @@ literal string ``UNSIGNED-PAYLOAD`` is used when constructing a
 `canonical request`_, and the same value is sent in the
 `x-amz-content-sha256`_ header when sending an HTTP request.
 
+.. _aws.api#ec2QueryName-trait:
+
+---------------------------------
+``aws.api#ec2QueryName`` trait
+---------------------------------
+
+Summary
+    Indicates the serialized name of a structure member when that structure is
+    serialized for the input of an EC2 operation.
+Trait selector
+    ``member:of(structure)``
+Value type
+    ``string``
+
+It is very important to note that the ``aws.api#ec2QueryName`` ONLY applies
+when serializing an INPUT. For example, given the following Smithy model:
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        structure MyStruct {
+            @ec2QueryName("foo")
+            bar: String
+        }
+
+    .. code-tabe:: json
+
+        {
+            "smithy": "0.5.0",
+            "shapes": {
+                "smithy.example#MyStruct": {
+                    "type": "structure",
+                    "members": {
+                        "bar": {
+                            "target": "smithy.api#String",
+                            "traits": {
+                                "aws.api#ec2QueryName": "foo"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+The serialization of this structure as an input is:
+
+.. code-block::
+
+    MyStruct.bar=baz
+
+The serialization of the structure as an (XML) output is:
+
+.. code-block:: xml
+
+    <MyStruct>
+        <foo>baz</foo>
+    </MyStruct>
 
 .. _endpoint-discovery:
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/Ec2QueryNameTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/Ec2QueryNameTrait.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.StringTrait;
+
+/**
+ * Indicates the serialized name of a structure member when that structure is
+ * serialized for the input of an EC2 operation.
+ */
+public class Ec2QueryNameTrait extends StringTrait {
+    public static final ShapeId ID = ShapeId.from("aws.api#ec2QueryName");
+
+    public Ec2QueryNameTrait(String value, SourceLocation sourceLocation) {
+        super(ID, value, sourceLocation);
+    }
+
+    public Ec2QueryNameTrait(String value) {
+        this(value, SourceLocation.NONE);
+    }
+
+    public static final class Provider extends StringTrait.Provider<Ec2QueryNameTrait> {
+        public Provider() {
+            super(ID, Ec2QueryNameTrait::new);
+        }
+    }
+}

--- a/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -20,3 +20,4 @@ software.amazon.smithy.aws.traits.apigateway.MockIntegrationTrait$Provider
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryTrait$Provider
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryIdTrait$Provider
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientDiscoveredEndpointTrait$Provider
+software.amazon.smithy.aws.traits.Ec2QueryNameTrait$Provider

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
@@ -238,6 +238,16 @@
                 },
                 "smithy.api#documentation": "Configures endpoint discovery for the service."
             }
+        },
+        "aws.api#ec2QueryName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "member:of(structure)"
+                },
+                "smithy.api#documentation": "Indicates the serialized name of a structure member when that structure is serialized for the input of an EC2 operation.",
+                "smithy.api#pattern": "^[a-zA-Z_][a-zA-Z_0-9-]*$"
+            }
         }
     }
 }

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/ec2-query-name.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/ec2-query-name.json
@@ -1,0 +1,17 @@
+{
+    "smithy": "0.5.0",
+    "shapes": {
+        "com.example#Input": {
+            "type": "structure",
+            "members": {
+                "Ipv6AddressSet": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#xmlName": "ipv6AddressSet",
+                        "aws.api#ec2QueryName": "Ipv6Addresses"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a trait to specify the name of an EC2 structure member when
it is used as an input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.