### PR TITLE
Fix dependency of protocol test traits

### DIFF
--- a/smithy-aws-protocol-tests/build.gradle.kts
+++ b/smithy-aws-protocol-tests/build.gradle.kts
@@ -21,6 +21,13 @@ plugins {
     id("software.amazon.smithy").version("0.4.2")
 }
 
+buildscript {
+    dependencies {
+        classpath("software.amazon.smithy:smithy-protocol-test-traits:0.9.6")
+        classpath("software.amazon.smithy:smithy-protocol-test-traits:0.9.6")
+    }
+}
+
 dependencies {
     api(project(":smithy-protocol-test-traits"))
     api(project(":smithy-aws-traits"))


### PR DESCRIPTION
For some reason (TBD), using `api` doesn't work, but `implementation`
does.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
