### PR TITLE
Fail model builds early when syntax errors occur

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
@@ -68,6 +68,11 @@ final class ModelLoader {
             } else {
                 return false;
             }
+        } catch (ModelSyntaxException e) {
+            // A syntax error in any model is going to really mess up the loading
+            // process. While we *could* tolerate syntax errors and move on, to the
+            // next model, doing so would likely emit many unintelligible errors.
+            throw e;
         } catch (SourceException e) {
             visitor.onError(ValidationEvent.fromSourceException(e));
             return true;

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/LoaderVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/LoaderVisitorTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -61,12 +62,10 @@ public class LoaderVisitorTest {
     }
 
     @Test
-    public void cannotCallOnEndTwice() {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            LoaderVisitor visitor = new LoaderVisitor(FACTORY);
-            visitor.onEnd();
-            visitor.onEnd();
-        });
+    public void callingOnEndTwiceIsIdempotent() {
+        LoaderVisitor visitor = new LoaderVisitor(FACTORY);
+
+        assertThat(visitor.onEnd(), is(visitor.onEnd()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -483,10 +483,14 @@ public class ModelAssemblerTest {
 
     @Test
     public void gracefullyParsesPartialDocuments() {
-        String document = "namespace foo.baz\nstring MyString\nstr";
+        String document = "namespace foo.baz\n"
+                          + "@required\n" // < this trait is invalid, but that's not validated due to the syntax error
+                          + "string MyString\n"
+                          + "str"; // < syntax error here
         ValidatedResult<Model> result = new ModelAssembler().addUnparsedModel("foo.smithy", document).assemble();
 
         assertTrue(result.isBroken());
+        assertThat(result.getValidationEvents(Severity.ERROR), hasSize(1));
         assertTrue(result.getResult().isPresent());
         assertTrue(result.getResult().get().getShape(ShapeId.from("foo.baz#MyString")).isPresent());
     }


### PR DESCRIPTION
Continuing to parse models after a syntax error will result in many
unintelligible validation events that obscure the actual syntax error.

Fixes #262

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
