### PR TITLE
[0.10] Simplify unsignedPayload trait to be an annotation

### DIFF
--- a/docs/source/spec/aws-core.rst
+++ b/docs/source/spec/aws-core.rst
@@ -840,15 +840,10 @@ plane unless an operation or resource is marked with the
 Summary
     Indicates that the payload of an operation is not to be part of the
     signature computed for the request of an operation.
-
-    Providing a list of strings will limit the effect of this trait to
-    only specific authentication schemes by name. An empty list of strings
-    causes this trait to apply to all authentication schemes used with the
-    the operation.
 Trait selector
     ``operation``
 Value type
-    List of authentication scheme strings
+    Annotation trait
 
 Most requests sent to AWS services require that the payload of the request is
 signed. However, in some cases, a service that streams large amounts of data
@@ -884,48 +879,12 @@ operation MUST NOT be used as part of the request signature calculation:
                         "target": "smithy.example#PutThingsOutput"
                     },
                     "traits": {
-                        "aws.api#unsignedPayload": []
+                        "aws.api#unsignedPayload": true
                     }
                 }
             }
         }
 
-The following example defines an operation that requires an unsigned payload
-only when using the "aws.v4" authentication scheme:
-
-.. tabs::
-
-    .. code-tab:: smithy
-
-        use aws.api#unsignedPayload
-
-        @unsignedPayload(["aws.v4"])
-        operation PutThings {
-            input: PutThingsInput,
-            output: PutThingsOutput
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "0.5.0",
-            "shapes": {
-                "smithy.example#PutThings": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#PutThingsInput"
-                    },
-                    "output": {
-                        "target": "smithy.example#PutThingsOutput"
-                    },
-                    "traits": {
-                        "aws.api#unsignedPayload": [
-                            "aws.v4"
-                        ]
-                    }
-                }
-            }
-        }
 
 Unsigned Payloads and signature version 4
 =========================================

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/UnsignedPayloadTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/UnsignedPayloadTrait.java
@@ -15,56 +15,28 @@
 
 package software.amazon.smithy.aws.traits;
 
-import java.util.List;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.StringListTrait;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.ToSmithyBuilder;
+import software.amazon.smithy.model.traits.BooleanTrait;
 
 /**
  * Indicates that the payload of an operation is not to be signed.
- *
- * <p>Providing a list of strings will limit the effect of this trait to
- * only specific authentication schemes by name.
  */
-public final class UnsignedPayloadTrait extends StringListTrait implements ToSmithyBuilder<UnsignedPayloadTrait> {
+public final class UnsignedPayloadTrait extends BooleanTrait {
     public static final ShapeId ID = ShapeId.from("aws.api#unsignedPayload");
 
-    public UnsignedPayloadTrait(List<String> values, FromSourceLocation sourceLocation) {
-        super(ID, values, sourceLocation);
-    }
-
     public UnsignedPayloadTrait(FromSourceLocation sourceLocation) {
-        this(ListUtils.of(), sourceLocation);
+        super(ID, sourceLocation.getSourceLocation());
     }
 
     public UnsignedPayloadTrait() {
-        this(ListUtils.of(), SourceLocation.NONE);
+        this(SourceLocation.NONE);
     }
 
-    public static final class Provider extends StringListTrait.Provider<UnsignedPayloadTrait> {
+    public static final class Provider extends BooleanTrait.Provider<UnsignedPayloadTrait> {
         public Provider() {
             super(ID, UnsignedPayloadTrait::new);
-        }
-    }
-
-    @Override
-    public Builder toBuilder() {
-        return builder().values(getValues());
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static final class Builder extends StringListTrait.Builder<UnsignedPayloadTrait, Builder> {
-        private Builder() {}
-
-        @Override
-        public UnsignedPayloadTrait build() {
-            return new UnsignedPayloadTrait(getValues(), getSourceLocation());
         }
     }
 }

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
@@ -74,15 +74,12 @@
             }
         },
         "aws.api#unsignedPayload": {
-            "type": "list",
-            "member": {
-                "target": "smithy.api#String"
-            },
+            "type": "structure",
             "traits": {
                 "smithy.api#trait": {
                     "selector": "operation"
                 },
-                "smithy.api#documentation": "Indicates that the request payload of a signed request is not to be used as part of the signature. Providing a list of strings will limit the effect of this trait to only specific authentication schemes by name."
+                "smithy.api#documentation": "Indicates that the request payload of a signed request is not to be used as part of the signature."
             }
         },
         "aws.api#data": {

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/UnsignedPayloadTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/UnsignedPayloadTraitTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.ListUtils;
 
 public class UnsignedPayloadTraitTest {
     @Test
@@ -34,12 +33,6 @@ public class UnsignedPayloadTraitTest {
         assertTrue(result
                 .getShape(ShapeId.from("ns.foo#Unsigned1"))
                 .flatMap(shape -> shape.getTrait(UnsignedPayloadTrait.class))
-                .isPresent());
-
-        assertTrue(result
-                .getShape(ShapeId.from("ns.foo#Unsigned2"))
-                .flatMap(shape -> shape.getTrait(UnsignedPayloadTrait.class))
-                .filter(trait -> trait.getValues().equals(ListUtils.of("aws.v4")))
                 .isPresent());
     }
 }

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/unsigned-request-payload.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/unsigned-request-payload.json
@@ -4,15 +4,7 @@
         "ns.foo#Unsigned1": {
             "type": "operation",
             "traits": {
-                "aws.api#unsignedPayload": []
-            }
-        },
-        "ns.foo#Unsigned2": {
-            "type": "operation",
-            "traits": {
-                "aws.api#unsignedPayload": [
-                    "aws.v4"
-                ]
+                "aws.api#unsignedPayload": true
             }
         }
     }


### PR DESCRIPTION
The aws.api#unsignedPayload trait currently takes a set of signing names to
enable unsigned payloads on. However, I don't think we will ever need this
level of granularity and it makes it more difficult to implement codegen.

Closes #232

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
