### PR TITLE
[0.10] Support Smithy IDL Serialization

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
@@ -258,7 +258,12 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
 
     @Override
     public int compareTo(ShapeId other) {
-        return toString().compareTo(other.toString());
+        int outcome = toString().compareToIgnoreCase(other.toString());
+        if (outcome == 0) {
+            // If they're case-insensitively equal, use a case-sensitive comparison as a tie-breaker.
+            return toString().compareTo(other.toString());
+        }
+        return outcome;
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -165,7 +165,7 @@ public final class SmithyIdlModelSerializer {
     /**
      * Comparator used to sort shapes.
      */
-    public static final class ShapeComparator implements Comparator<Shape>, Serializable {
+    private static final class ShapeComparator implements Comparator<Shape>, Serializable {
         private static final List<ShapeType> PRIORITY = ListUtils.of(
                 ShapeType.SERVICE,
                 ShapeType.RESOURCE,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -111,7 +111,7 @@ public final class SmithyIdlModelSerializer {
         // Write the full metadata into every output. When loaded back together the conflicts will be ignored,
         // but if they're separated out then each file will still have all the context.
         fullModel.getMetadata().entrySet().stream()
-                .sorted(Map.Entry.comparingByKey(String.CASE_INSENSITIVE_ORDER))
+                .sorted(Map.Entry.comparingByKey())
                 .filter(entry -> metadataFilter.test(entry.getKey()))
                 .forEach(entry -> {
                     codeWriter.trimTrailingSpaces(false)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -170,8 +170,8 @@ public final class SmithyIdlModelSerializer {
                 ShapeType.SERVICE,
                 ShapeType.RESOURCE,
                 ShapeType.OPERATION,
-                ShapeType.UNION,
                 ShapeType.STRUCTURE,
+                ShapeType.UNION,
                 ShapeType.LIST,
                 ShapeType.SET,
                 ShapeType.MAP

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -229,6 +229,7 @@ public final class SmithyIdlModelSerializer {
 
         /**
          * Predicate that determines if a metadata is serialized.
+         *
          * @param metadataFilter Predicate that accepts a metadata key.
          * @return Returns the builder.
          */
@@ -239,6 +240,7 @@ public final class SmithyIdlModelSerializer {
 
         /**
          * Predicate that determines if a shape and its traits are serialized.
+         *
          * @param shapeFilter Predicate that accepts a shape.
          * @return Returns the builder.
          */
@@ -268,6 +270,7 @@ public final class SmithyIdlModelSerializer {
          * <p>The returned paths may be absolute or relative.
          *
          * <p>NOTE: the Smithy IDL only supports one namespace per file.
+         *
          * @param shapePlacer Function that accepts a shape and returns file path.
          * @return Returns the builder.
          */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -1,0 +1,723 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.shapes;
+
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.BooleanNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NumberNode;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.traits.BooleanTrait;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.IdRefTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.traits.TraitDefinition;
+import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.FunctionalUtils;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Serializes a {@link Model} into a set of Smithy IDL files.
+ */
+public final class SmithyIdlModelSerializer {
+    private final Function<Shape, Path> shapePlacer;
+
+    private SmithyIdlModelSerializer(Builder builder) {
+        shapePlacer = builder.shapePlacer;
+    }
+
+    /**
+     * Serializes a {@link Model} into a set of Smithy IDL files.
+     *
+     * <p>This does not write the models to disk.
+     * @param model The model to serialize.
+     * @return A map of (possibly relative) file paths to Smithy IDL strings.
+     */
+    public Map<Path, String> serialize(Model model) {
+        return model.shapes()
+                .filter(FunctionalUtils.not(Prelude::isPreludeShape))
+                .collect(Collectors.groupingBy(shapePlacer)).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> serialize(model, entry.getValue())));
+    }
+
+    private String serialize(Model fullModel, Collection<Shape> shapes) {
+        Set<String> namespaces = shapes.stream()
+                .map(shape -> shape.getId().getNamespace())
+                .collect(Collectors.toSet());
+        if (namespaces.size() != 1) {
+            throw new RuntimeException("All shapes in a single file must share a namespace.");
+        }
+
+        // There should only be one namespace at this point, so grab it.
+        String namespace = namespaces.iterator().next();
+        SmithyCodeWriter codeWriter = new SmithyCodeWriter(namespace, fullModel);
+        NodeSerializer nodeSerializer = new NodeSerializer(codeWriter, fullModel);
+
+        ShapeSerializer shapeSerializer = new ShapeSerializer(codeWriter, nodeSerializer, fullModel);
+        shapes.stream()
+                .filter(FunctionalUtils.not(Shape::isMemberShape))
+                .sorted(new ShapeComparator())
+                .forEach(shape -> shape.accept(shapeSerializer));
+
+        return serializeHeader(namespace, fullModel) + codeWriter.toString();
+    }
+
+    private String serializeHeader(String namespace, Model fullModel) {
+        SmithyCodeWriter codeWriter = new SmithyCodeWriter(namespace, fullModel);
+        NodeSerializer nodeSerializer = new NodeSerializer(codeWriter, fullModel);
+
+        codeWriter.write("$$version: \"$L\"", Model.MODEL_VERSION).write("");
+
+        // Write the full metadata into every output. When loaded back together the conflicts will be ignored,
+        // but if they're separated out then each file will still have all the context.
+        fullModel.getMetadata().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(String.CASE_INSENSITIVE_ORDER))
+                .forEach(entry -> {
+                    codeWriter.trimTrailingSpaces(false)
+                            .writeInline("metadata $M = ", entry.getKey())
+                            .trimTrailingSpaces();
+                    nodeSerializer.serialize(entry.getValue());
+                    codeWriter.write("");
+                });
+        if (!fullModel.getMetadata().isEmpty()) {
+            codeWriter.write("");
+        }
+
+        codeWriter.write("namespace " + namespace)
+                .trimBlankLines(-1)
+                .write("");
+        return codeWriter.toString();
+    }
+
+    /**
+     * @return Returns a builder used to create a {@link SmithyIdlModelSerializer}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Path placeShapesByNamespace(Shape shape) {
+        return Paths.get(shape.getId().getNamespace() + ".smithy");
+    }
+
+    /**
+     * Comparator used to sort shapes.
+     */
+    public static final class ShapeComparator implements Comparator<Shape>, Serializable {
+        private static final List<ShapeType> PRIORITY = ListUtils.of(
+                ShapeType.SERVICE,
+                ShapeType.RESOURCE,
+                ShapeType.OPERATION,
+                ShapeType.UNION,
+                ShapeType.STRUCTURE,
+                ShapeType.LIST,
+                ShapeType.SET,
+                ShapeType.MAP
+        );
+
+        @Override
+        public int compare(Shape s1, Shape s2) {
+            // Traits go first
+            if (s1.hasTrait(TraitDefinition.class) || s2.hasTrait(TraitDefinition.class)) {
+                if (!s1.hasTrait(TraitDefinition.class)) {
+                    return 1;
+                }
+                if (!s2.hasTrait(TraitDefinition.class)) {
+                    return -1;
+                }
+                // The other sorting rules don't matter for traits.
+                return compareCaseInsensitive(s1, s2);
+            }
+            // If the shapes are the same type, just compare their shape ids.
+            if (s1.getType().equals(s2.getType())) {
+                return compareCaseInsensitive(s1, s2);
+            }
+            // If one shape is prioritized, compare by priority.
+            if (PRIORITY.contains(s1.getType()) || PRIORITY.contains(s2.getType())) {
+                // If only one shape is prioritized, that shape is "greater".
+                if (!PRIORITY.contains(s1.getType())) {
+                    return 1;
+                }
+                if (!PRIORITY.contains(s2.getType())) {
+                    return -1;
+                }
+                return PRIORITY.indexOf(s1.getType()) - PRIORITY.indexOf(s2.getType());
+            }
+            return compareCaseInsensitive(s1, s2);
+        }
+
+        /**
+         * Compare two shapes by id case-insensitively.
+         */
+        private int compareCaseInsensitive(Shape s1, Shape s2) {
+            return s1.toShapeId().toString().toLowerCase().compareTo(s2.toShapeId().toString().toLowerCase());
+        }
+    }
+
+    /**
+     * Builder used to create {@link SmithyIdlModelSerializer}.
+     */
+    public static final class Builder implements SmithyBuilder<SmithyIdlModelSerializer> {
+        private Function<Shape, Path> shapePlacer = SmithyIdlModelSerializer::placeShapesByNamespace;
+
+        public Builder() {}
+
+        /**
+         * Function that determines what output file a shape should go in.
+         *
+         * <p>NOTE: the Smithy IDL only supports one namespace per file.
+         * @param shapePlacer Function that accepts a shape and returns file path.
+         * @return Returns the builder.
+         */
+        Builder shapePlacer(Function<Shape, Path> shapePlacer) {
+            this.shapePlacer = Objects.requireNonNull(shapePlacer);
+            return this;
+        }
+
+        @Override
+        public SmithyIdlModelSerializer build() {
+            return new SmithyIdlModelSerializer(this);
+        }
+    }
+
+    /**
+     * Serializes shapes in the IDL format.
+     */
+    private static final class ShapeSerializer extends ShapeVisitor.Default<Void> {
+        private final SmithyCodeWriter codeWriter;
+        private final NodeSerializer nodeSerializer;
+        private final Model model;
+
+        ShapeSerializer(SmithyCodeWriter codeWriter, NodeSerializer nodeSerializer, Model model) {
+            this.codeWriter = codeWriter;
+            this.nodeSerializer = nodeSerializer;
+            this.model = model;
+        }
+
+        @Override
+        protected Void getDefault(Shape shape) {
+            serializeTraits(shape);
+            codeWriter.write("$L $L", shape.getType(), shape.getId().getName()).write("");
+            return null;
+        }
+
+        private void shapeWithMembers(Shape shape, List<MemberShape> members) {
+            serializeTraits(shape);
+            if (members.isEmpty()) {
+                // If there are no members then we don't want to introduce an unnecessary newline by opening a block.
+                codeWriter.write("$L $L {}", shape.getType(), shape.getId().getName()).write("");
+                return;
+            }
+
+            codeWriter.openBlock("$L $L {", shape.getType(), shape.getId().getName());
+            for (MemberShape member : members) {
+                serializeTraits(member);
+                codeWriter.write("$L: $I,", member.getMemberName(), member.getTarget());
+            }
+            codeWriter.closeBlock("}").write("");
+        }
+
+        private void serializeTraits(Shape shape) {
+            // The documentation trait always needs to be serialized first since it uses special syntax.
+            shape.getTrait(DocumentationTrait.class).ifPresent(this::serializeDocumentationTrait);
+            shape.getAllTraits().values().stream()
+                    .filter(trait -> !(trait instanceof DocumentationTrait))
+                    .sorted(Comparator.comparing(trait -> trait.toShapeId().toString(), String.CASE_INSENSITIVE_ORDER))
+                    .forEach(this::serializeTrait);
+        }
+
+        private void serializeDocumentationTrait(DocumentationTrait trait) {
+            // The documentation trait has a special syntax, which we always want to use.
+            codeWriter.setNewlinePrefix("/// ")
+                    .write(trait.getValue().replace("$", "$$"))
+                    .setNewlinePrefix("");
+        }
+
+        private void serializeTrait(Trait trait) {
+            Node node = trait.toNode();
+            Shape shape = model.expectShape(trait.toShapeId());
+
+            if (trait instanceof BooleanTrait || isEmptyStructure(node, shape)) {
+                // Traits that inherit from BooleanTrait specifically can omit a value.
+                // Traits that are simply boolean shapes which don't implement BooleanTrait cannot.
+                // Additionally, empty structure traits can omit a value.
+                codeWriter.write("@$I", trait.toShapeId());
+            } else if (node.isObjectNode()) {
+                codeWriter.writeIndent().openBlockInline("@$I(", trait.toShapeId());
+                nodeSerializer.serializeKeyValuePairs(node.expectObjectNode(), shape);
+                codeWriter.closeBlock(")");
+            } else {
+                codeWriter.writeIndent().writeInline("@$I(", trait.toShapeId());
+                nodeSerializer.serialize(node, shape);
+                codeWriter.write(")");
+            }
+        }
+
+        private boolean isEmptyStructure(Node node, Shape shape) {
+            return !shape.isDocumentShape() && node.asObjectNode().map(ObjectNode::isEmpty).orElse(false);
+        }
+
+        @Override
+        public Void listShape(ListShape shape) {
+            shapeWithMembers(shape, Collections.singletonList(shape.getMember()));
+            return null;
+        }
+
+        @Override
+        public Void setShape(SetShape shape) {
+            shapeWithMembers(shape, Collections.singletonList(shape.getMember()));
+            return null;
+        }
+
+        @Override
+        public Void mapShape(MapShape shape) {
+            shapeWithMembers(shape, ListUtils.of(shape.getKey(), shape.getValue()));
+            return null;
+        }
+
+        @Override
+        public Void structureShape(StructureShape shape) {
+            shapeWithMembers(shape, sortMembers(shape.getAllMembers().values()));
+            return null;
+        }
+
+        @Override
+        public Void unionShape(UnionShape shape) {
+            shapeWithMembers(shape, sortMembers(shape.getAllMembers().values()));
+            return null;
+        }
+
+        private List<MemberShape> sortMembers(Collection<MemberShape> members) {
+            return members.stream()
+                    .sorted(Comparator.comparing(MemberShape::getMemberName, String.CASE_INSENSITIVE_ORDER))
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public Void serviceShape(ServiceShape shape) {
+            serializeTraits(shape);
+            codeWriter.openBlock("service $L {", shape.getId().getName())
+                    .write("version: $S,", shape.getVersion());
+            codeWriter.writeOptionalIdList("operations", shape.getOperations());
+            codeWriter.writeOptionalIdList("resources", shape.getResources());
+            codeWriter.closeBlock("}").write("");
+            return null;
+        }
+
+        @Override
+        public Void resourceShape(ResourceShape shape) {
+            serializeTraits(shape);
+            if (isEmptyResource(shape)) {
+                codeWriter.write("resource $L {}", shape.getId().getName()).write("");
+                return null;
+            }
+
+            codeWriter.openBlock("resource $L {", shape.getId().getName());
+            if (!shape.getIdentifiers().isEmpty()) {
+                codeWriter.openBlock("identifiers: {");
+                shape.getIdentifiers().entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey(String.CASE_INSENSITIVE_ORDER))
+                        .forEach(entry -> codeWriter.write(
+                                "$L: $I,", entry.getKey(), entry.getValue()));
+                codeWriter.closeBlock("},");
+            }
+
+            shape.getPut().ifPresent(shapeId -> codeWriter.write("put: $I,", shapeId));
+            shape.getCreate().ifPresent(shapeId -> codeWriter.write("create: $I,", shapeId));
+            shape.getRead().ifPresent(shapeId -> codeWriter.write("read: $I,", shapeId));
+            shape.getUpdate().ifPresent(shapeId -> codeWriter.write("update: $I,", shapeId));
+            shape.getDelete().ifPresent(shapeId -> codeWriter.write("delete: $I,", shapeId));
+            shape.getList().ifPresent(shapeId -> codeWriter.write("list: $I,", shapeId));
+            codeWriter.writeOptionalIdList("operations", shape.getOperations());
+            codeWriter.writeOptionalIdList("collectionOperations", shape.getCollectionOperations());
+            codeWriter.writeOptionalIdList("resources", shape.getResources());
+
+            codeWriter.closeBlock("}");
+            codeWriter.write("");
+            return null;
+        }
+
+        private boolean isEmptyResource(ResourceShape shape) {
+            return !(!shape.getIdentifiers().isEmpty()
+                    || !shape.getOperations().isEmpty()
+                    || !shape.getCollectionOperations().isEmpty()
+                    || !shape.getResources().isEmpty()
+                    || shape.getPut().isPresent()
+                    || shape.getCreate().isPresent()
+                    || shape.getRead().isPresent()
+                    || shape.getUpdate().isPresent()
+                    || shape.getDelete().isPresent()
+                    || shape.getList().isPresent());
+        }
+
+        @Override
+        public Void operationShape(OperationShape shape) {
+            serializeTraits(shape);
+            if (isEmptyOperation(shape)) {
+                codeWriter.write("operation $L {}", shape.getId().getName()).write("");
+                return null;
+            }
+
+            codeWriter.openBlock("operation $L {", shape.getId().getName());
+            shape.getInput().ifPresent(shapeId -> codeWriter.write("input: $I,", shapeId));
+            shape.getOutput().ifPresent(shapeId -> codeWriter.write("output: $I,", shapeId));
+            codeWriter.writeOptionalIdList("errors", shape.getErrors());
+            codeWriter.closeBlock("}");
+            codeWriter.write("");
+            return null;
+        }
+
+        private boolean isEmptyOperation(OperationShape shape) {
+            return !(shape.getInput().isPresent() || shape.getOutput().isPresent() || !shape.getErrors().isEmpty());
+        }
+    }
+
+    /**
+     * Serializes nodes into the Smithy IDL format.
+     */
+    private static final class NodeSerializer {
+        private final SmithyCodeWriter codeWriter;
+        private final Model model;
+
+        NodeSerializer(SmithyCodeWriter codeWriter, Model model) {
+            this.codeWriter = codeWriter;
+            this.model = model;
+        }
+
+        /**
+         * Serialize a node into the Smithy IDL format.
+         *
+         * @param node The node to serialize.
+         */
+        public void serialize(Node node) {
+            serialize(node, null);
+        }
+
+        /**
+         * Serialize a node into the Smithy IDL format.
+         *
+         * <p>This uses the given shape to influence serialization. For example, a string shape marked with the idRef
+         * trait will be serialized as a shape id rather than a string.
+         *
+         * @param node The node to serialize.
+         * @param shape The shape of the node.
+         */
+        public void serialize(Node node, Shape shape) {
+            // ShapeIds are represented differently than strings, so if a shape looks like it's
+            // representing a shapeId we need to serialize it without quotes.
+            if (isShapeId(shape)) {
+                serializeShapeId(node.expectStringNode());
+                return;
+            }
+
+            if (shape != null && shape.isMemberShape()) {
+                shape = model.expectShape(shape.asMemberShape().get().getTarget());
+            }
+
+            if (node.isStringNode()) {
+                serializeString(node.expectStringNode());
+            } else if (node.isNumberNode()) {
+                serializeNumber(node.expectNumberNode());
+            } else if (node.isBooleanNode()) {
+                serializeBoolean(node.expectBooleanNode());
+            } else if (node.isNullNode()) {
+                serializeNull();
+            } else if (node.isArrayNode()) {
+                serializeArray(node.expectArrayNode(), shape);
+            } else if (node.isObjectNode()) {
+                serializeObject(node.expectObjectNode(), shape);
+            }
+        }
+
+        private boolean isShapeId(Shape shape) {
+            if (shape == null) {
+                return false;
+            }
+            if (shape.isMemberShape()) {
+                return shape.asMemberShape()
+                        .flatMap(member -> member.getMemberTrait(model, IdRefTrait.class)).isPresent();
+            }
+            return shape.hasTrait(IdRefTrait.class);
+        }
+
+        private void serializeString(StringNode node) {
+            codeWriter.writeInline("$S", node.getValue());
+        }
+
+        private void serializeShapeId(StringNode node) {
+            codeWriter.writeInline("$I", node.getValue());
+        }
+
+        private void serializeNumber(NumberNode node) {
+            codeWriter.writeInline("$L", node.getValue());
+        }
+
+        private void serializeBoolean(BooleanNode node) {
+            codeWriter.writeInline(String.valueOf(node.getValue()));
+        }
+
+        private void serializeNull() {
+            codeWriter.writeInline("null");
+        }
+
+        private void serializeArray(ArrayNode node, Shape shape) {
+            if (node.isEmpty()) {
+                codeWriter.writeInline("[]");
+                return;
+            }
+
+            codeWriter.openBlockInline("[");
+
+            // If it's not a collection shape, it'll be a document shape or null
+            Shape member = shape;
+            if (shape instanceof CollectionShape) {
+                member = ((CollectionShape) shape).getMember();
+            }
+
+            for (Node element : node.getElements()) {
+                // Elements will be written inline to enable them being written as values.
+                // So here we need to ensure that they're written on a new line that's properly indented.
+                codeWriter.write("");
+                codeWriter.writeIndent();
+                serialize(element, member);
+                codeWriter.writeInline(",");
+            }
+            codeWriter.write("");
+
+            // We want to make sure to close without inserting a newline, as this could itself be a list element
+            //or an object value.
+            codeWriter.closeBlockWithoutNewline("]");
+        }
+
+        private void serializeObject(ObjectNode node, Shape shape) {
+            if (node.isEmpty()) {
+                codeWriter.writeInline("{}");
+                return;
+            }
+
+            codeWriter.openBlockInline("{");
+            serializeKeyValuePairs(node, shape);
+            codeWriter.closeBlockWithoutNewline("}");
+        }
+
+        /**
+         * Serialize an object node without the surrounding brackets.
+         *
+         * <p>This is mainly useful for serializing trait value nodes.
+         *
+         * @param node The node to serialize.
+         * @param shape The shape of the node.
+         */
+        public void serializeKeyValuePairs(ObjectNode node, Shape shape) {
+            if (node.isEmpty()) {
+                return;
+            }
+
+            // If we're looking at a structure or union shape, we'll need to get the member shape based on the
+            // node key. Here we pre-compute a mapping so we don't have to traverse the member list every time.
+            Map<String, MemberShape> members;
+            if (shape == null) {
+                members = Collections.emptyMap();
+            } else {
+                members = shape.members().stream().distinct()
+                        .collect(Collectors.toMap(MemberShape::getMemberName, Function.identity()));
+            }
+
+            node.getMembers().forEach((name, value) -> {
+                // Try to find the member shape.
+                Shape member;
+                if (shape != null && shape.isMapShape()) {
+                    // For maps the value member will always be the same.
+                    member = shape.asMapShape().get().getValue();
+                } else if (shape instanceof NamedMembersShape) {
+                    member = members.get(name.getValue());
+                } else {
+                    // At this point the shape is either null or a document shape.
+                    member = shape;
+                }
+
+                codeWriter.writeInline("\n$M: ", name.getValue());
+                serialize(value, member);
+                codeWriter.writeInline(",");
+            });
+            codeWriter.write("");
+        }
+    }
+
+    /**
+     * Extension of {@link CodeWriter} that provides additional convenience methods.
+     *
+     * <p>Provides a built in $I formatter that formats shape ids, automatically trimming namespace where possible.
+     */
+    private static final class SmithyCodeWriter extends CodeWriter {
+        private static final Pattern UNQUOTED_STRING = Pattern.compile("[a-zA-Z_][\\w$.#]*");
+        private final String namespace;
+        private final Model model;
+        private final Set<ShapeId> imports;
+
+        SmithyCodeWriter(String namespace, Model model) {
+            super();
+            this.namespace = namespace;
+            this.model = model;
+            this.imports = new HashSet<>();
+            trimTrailingSpaces();
+            trimBlankLines();
+            putFormatter('I', (s, i) -> formatShapeId(s));
+            putFormatter('M', this::optionallyQuoteString);
+        }
+
+        /**
+         * Opens a block without writing indentation whitespace or inserting a newline.
+         */
+        public SmithyCodeWriter openBlockInline(String content, Object... args) {
+            writeInline(content, args).indent();
+            return this;
+        }
+
+        /**
+         * Closes a block without inserting a newline.
+         */
+        public SmithyCodeWriter closeBlockWithoutNewline(String content, Object... args) {
+            setNewline("");
+            closeBlock(content, args);
+            setNewline("\n");
+            return this;
+        }
+
+        /**
+         * Writes an empty line that contains only indentation appropriate to the current indentation level.
+         *
+         * <p> This does not insert a trailing newline.
+         */
+        public SmithyCodeWriter writeIndent() {
+            setNewline("");
+            // We explicitly want the trailing spaces, so disable trimming for this call.
+            trimTrailingSpaces(false);
+            write("");
+            trimTrailingSpaces();
+            setNewline("\n");
+            return this;
+        }
+
+        private String formatShapeId(Object value) {
+            if (value == null) {
+                return "";
+            }
+            ShapeId shapeId = ShapeId.from(String.valueOf(value));
+            if (!shouldWriteNamespace(shapeId)) {
+                return shapeId.asRelativeReference();
+            }
+            return shapeId.toString();
+        }
+
+        private boolean shouldWriteNamespace(ShapeId shapeId) {
+            if (shapeId.getNamespace().equals(namespace)) {
+                return false;
+            }
+            if (Prelude.isPublicPreludeShape(shapeId)) {
+                return conflictsWithLocalNamespace(shapeId);
+            }
+            if (shouldImport(shapeId)) {
+                imports.add(shapeId.withoutMember());
+            }
+            return !imports.contains(shapeId);
+        }
+
+        private boolean conflictsWithLocalNamespace(ShapeId shapeId) {
+            return model.getShape(ShapeId.fromParts(namespace, shapeId.getName())).isPresent();
+        }
+
+        private boolean shouldImport(ShapeId shapeId) {
+            return !conflictsWithLocalNamespace(shapeId)
+                    // It's easier to simply never import something that conflicts with the prelude, because
+                    // if we did then we'd have to somehow handle rewriting all existing references to the
+                    // prelude shape that it conflicts with.
+                    && !conflictsWithPreludeNamespace(shapeId)
+                    && !conflictsWithImports(shapeId);
+
+        }
+
+        private boolean conflictsWithPreludeNamespace(ShapeId shapeId) {
+            return Prelude.isPublicPreludeShape(ShapeId.fromParts(Prelude.NAMESPACE, shapeId.getName()));
+        }
+
+        private boolean conflictsWithImports(ShapeId shapeId) {
+            return imports.stream().anyMatch(importId -> importId.getName().equals(shapeId.getName()));
+        }
+
+        /**
+         * Writes a possibly-empty list where each element is a shape id.
+         *
+         * <p>If the list is empty, nothing is written.
+         */
+        public SmithyCodeWriter writeOptionalIdList(String textBeforeList, Collection<ShapeId> shapeIds) {
+            if (shapeIds.isEmpty()) {
+                return this;
+            }
+
+            openBlock("$L: [", textBeforeList);
+            shapeIds.stream()
+                    .sorted(Comparator.comparing(ShapeId::toString, String.CASE_INSENSITIVE_ORDER))
+                    .forEach(shapeId -> write("$I,", shapeId));
+            closeBlock("],");
+
+            return this;
+        }
+
+        /**
+         * Formatter that quotes (and escapes) a string unless it's a valid unquoted string.
+         */
+        private String optionallyQuoteString(Object key, String indent) {
+            String formatted = CodeWriter.formatLiteral(key);
+            if (UNQUOTED_STRING.matcher(formatted).matches()) {
+                return formatted;
+            }
+            return StringUtils.escapeJavaString(formatted, indent);
+        }
+
+        @Override
+        public String toString() {
+            String contents = StringUtils.stripStart(super.toString(), null);
+            if (imports.isEmpty()) {
+                return contents;
+            }
+            String importString = imports.stream()
+                    .sorted(Comparator.comparing(ShapeId::toString, String.CASE_INSENSITIVE_ORDER))
+                    .map(shapeId -> String.format("use %s", shapeId.toString()))
+                    .collect(Collectors.joining("\n"));
+            return importString + "\n\n" + contents;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -274,7 +274,7 @@ public final class SmithyIdlModelSerializer {
          * @param shapePlacer Function that accepts a shape and returns file path.
          * @return Returns the builder.
          */
-        Builder shapePlacer(Function<Shape, Path> shapePlacer) {
+        public Builder shapePlacer(Function<Shape, Path> shapePlacer) {
             this.shapePlacer = Objects.requireNonNull(shapePlacer);
             return this;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -502,7 +502,7 @@ public final class SmithyIdlModelSerializer {
          *
          * @param node The node to serialize.
          */
-        public void serialize(Node node) {
+        private void serialize(Node node) {
             serialize(node, null);
         }
 
@@ -515,7 +515,7 @@ public final class SmithyIdlModelSerializer {
          * @param node The node to serialize.
          * @param shape The shape of the node.
          */
-        public void serialize(Node node, Shape shape) {
+        private void serialize(Node node, Shape shape) {
             // ShapeIds are represented differently than strings, so if a shape looks like it's
             // representing a shapeId we need to serialize it without quotes.
             if (isShapeId(shape)) {
@@ -621,7 +621,7 @@ public final class SmithyIdlModelSerializer {
          * @param node The node to serialize.
          * @param shape The shape of the node.
          */
-        public void serializeKeyValuePairs(ObjectNode node, Shape shape) {
+        private void serializeKeyValuePairs(ObjectNode node, Shape shape) {
             if (node.isEmpty()) {
                 return;
             }
@@ -682,7 +682,7 @@ public final class SmithyIdlModelSerializer {
         /**
          * Opens a block without writing indentation whitespace or inserting a newline.
          */
-        public SmithyCodeWriter openBlockInline(String content, Object... args) {
+        private SmithyCodeWriter openBlockInline(String content, Object... args) {
             writeInline(content, args).indent();
             return this;
         }
@@ -690,7 +690,7 @@ public final class SmithyIdlModelSerializer {
         /**
          * Closes a block without inserting a newline.
          */
-        public SmithyCodeWriter closeBlockWithoutNewline(String content, Object... args) {
+        private SmithyCodeWriter closeBlockWithoutNewline(String content, Object... args) {
             setNewline("");
             closeBlock(content, args);
             setNewline("\n");
@@ -702,7 +702,7 @@ public final class SmithyIdlModelSerializer {
          *
          * <p> This does not insert a trailing newline.
          */
-        public SmithyCodeWriter writeIndent() {
+        private SmithyCodeWriter writeIndent() {
             setNewline("");
             // We explicitly want the trailing spaces, so disable trimming for this call.
             trimTrailingSpaces(false);
@@ -763,7 +763,7 @@ public final class SmithyIdlModelSerializer {
          *
          * <p>If the list is empty, nothing is written.
          */
-        public SmithyCodeWriter writeOptionalIdList(String textBeforeList, Collection<ShapeId> shapeIds) {
+        private SmithyCodeWriter writeOptionalIdList(String textBeforeList, Collection<ShapeId> shapeIds) {
             if (shapeIds.isEmpty()) {
                 return this;
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -68,7 +68,15 @@ public final class SmithyIdlModelSerializer {
     /**
      * Serializes a {@link Model} into a set of Smithy IDL files.
      *
-     * <p>This does not write the models to disk.
+     * <p>The output is a mapping
+     *
+     * <p>By default the paths are relative paths where each namespace is given its own file in the form
+     * "namespace.smithy". This is configurable via the shape placer, which can place shapes into absolute
+     * paths.
+     *
+     * <p>If the model contains no shapes, or all shapes are filtered out, then a single path "metadata.smithy"
+     * will be present. This will contain only any defined metadata.
+     *
      * @param model The model to serialize.
      * @return A map of (possibly relative) file paths to Smithy IDL strings.
      */
@@ -147,6 +155,9 @@ public final class SmithyIdlModelSerializer {
         return new Builder();
     }
 
+    /**
+     * Sorts shapes into files based on their namespace, where each file is named {namespace}.smithy.
+     */
     public static Path placeShapesByNamespace(Shape shape) {
         return Paths.get(shape.getId().getNamespace() + ".smithy");
     }
@@ -253,6 +264,8 @@ public final class SmithyIdlModelSerializer {
 
         /**
          * Function that determines what output file a shape should go in.
+         *
+         * <p>The returned paths may be absolute or relative.
          *
          * <p>NOTE: the Smithy IDL only supports one namespace per file.
          * @param shapePlacer Function that accepts a shape and returns file path.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeIdTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeIdTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -236,6 +237,34 @@ public class ShapeIdTest {
                 {"name.space", "Name", null, "name.space#Name"},
                 {"name.space", "Name", "member", "name.space#Name$member"},
         });
+    }
+
+    @Test
+    public void compareToTest() {
+        List<ShapeId> given = Arrays.asList(
+                ShapeId.fromParts("ns.foo", "foo"),
+                ShapeId.fromParts("ns.foo", "Foo"),
+                ShapeId.fromParts("ns.foo", "bar"),
+                ShapeId.fromParts("ns.foo", "bar", "member"),
+                ShapeId.fromParts("ns.foo", "bar", "Member"),
+                ShapeId.fromParts("ns.foo", "bar", "AMember"),
+                ShapeId.fromParts("ns.Foo", "foo"),
+                ShapeId.fromParts("ns.baz", "foo")
+        );
+        given.sort(ShapeId::compareTo);
+
+        List<ShapeId> expected = Arrays.asList(
+                ShapeId.fromParts("ns.baz", "foo"),
+                ShapeId.fromParts("ns.foo", "bar"),
+                ShapeId.fromParts("ns.foo", "bar", "AMember"),
+                ShapeId.fromParts("ns.foo", "bar", "Member"),
+                ShapeId.fromParts("ns.foo", "bar", "member"),
+                ShapeId.fromParts("ns.Foo", "foo"),
+                ShapeId.fromParts("ns.foo", "Foo"),
+                ShapeId.fromParts("ns.foo", "foo")
+        );
+
+        assertEquals(expected, given);
     }
 
     @ParameterizedTest

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -1,0 +1,54 @@
+package software.amazon.smithy.model.shapes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.IoUtils;
+
+public class SmithyIdlModelSerializerTest {
+    @TestFactory
+    public Stream<DynamicTest> generateTests() throws IOException {
+        return Files.list(Paths.get(
+                SmithyIdlModelSerializer.class.getResource("idl-serialization/cases").getPath()))
+                .map(path -> DynamicTest.dynamicTest(path.getFileName().toString(), () -> testConversion(path)));
+    }
+
+    public void testConversion(Path path) {
+        Model model = Model.assembler().addImport(path).assemble().unwrap();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder().build();
+        Map<Path, String> serialized = serializer.serialize(model);
+
+        if (serialized.size() != 1) {
+            throw new RuntimeException("Exactly one smithy file should be output for generated tests.");
+        }
+
+        String serializedString = serialized.entrySet().iterator().next().getValue();
+        assertThat(serializedString, equalTo(IoUtils.readUtf8File(path)));
+    }
+
+    @Test
+    public void multipleNamespacesGenerateMultipleFiles() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("idl-serialization/multiple-namespaces/input.json"))
+                .assemble()
+                .unwrap();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder().build();
+        Map<Path, String> serialized = serializer.serialize(model);
+
+        Path outputDir = Paths.get(getClass().getResource("idl-serialization/multiple-namespaces/output").getFile());
+        serialized.forEach((path, generated) -> {
+            Path expectedPath = outputDir.resolve(path);
+            assertThat(generated, equalTo(IoUtils.readUtf8File(expectedPath)));
+        });
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -1,7 +1,11 @@
 package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,6 +17,8 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.utils.IoUtils;
 
 public class SmithyIdlModelSerializerTest {
@@ -50,5 +56,67 @@ public class SmithyIdlModelSerializerTest {
             Path expectedPath = outputDir.resolve(path);
             assertThat(generated, equalTo(IoUtils.readUtf8File(expectedPath)));
         });
+    }
+
+    @Test
+    public void filtersShapes() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("idl-serialization/test-model.json"))
+                .assemble()
+                .unwrap();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder()
+                .shapeFilter(shape -> shape.getId().getNamespace().equals("ns.structures"))
+                .build();
+        Map<Path, String> serialized = serializer.serialize(model);
+
+        assertThat(serialized, aMapWithSize(1));
+        assertThat(serialized, hasKey(Paths.get("ns.structures.smithy")));
+        assertThat(serialized.get(Paths.get("ns.structures.smithy")),
+                containsString("namespace ns.structures"));
+    }
+
+    @Test
+    public void filtersMetadata() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("idl-serialization/test-model.json"))
+                .assemble()
+                .unwrap();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder()
+                .metadataFilter(key -> false)
+                .build();
+        Map<Path, String> serialized = serializer.serialize(model);
+        for (String output : serialized.values()) {
+            assertThat(output, not(containsString("metadata")));
+        }
+    }
+
+    @Test
+    public void filtersTraits() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("idl-serialization/test-model.json"))
+                .assemble()
+                .unwrap();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder()
+                .traitFilter(trait -> !(trait instanceof RequiredTrait))
+                .build();
+        Map<Path, String> serialized = serializer.serialize(model);
+        for (String output : serialized.values()) {
+            assertThat(output, not(containsString("@required")));
+        }
+    }
+
+    @Test
+    public void filtersDocumentationTrait() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("idl-serialization/test-model.json"))
+                .assemble()
+                .unwrap();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder()
+                .traitFilter(trait -> !(trait instanceof DocumentationTrait))
+                .build();
+        Map<Path, String> serialized = serializer.serialize(model);
+        for (String output : serialized.values()) {
+            assertThat(output, not(containsString("/// ")));
+        }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/boolean-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/boolean-traits.smithy
@@ -1,0 +1,11 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+/// This trait isn't an annotation trait since it doesn't extend BooleanTrait
+@trait
+boolean FalseBooleanTrait
+
+@FalseBooleanTrait(true)
+@private
+string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/collection-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/collection-traits.smithy
@@ -1,0 +1,27 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+@trait
+list ListTrait {
+    member: String,
+}
+
+@trait
+set SetTrait {
+    member: String,
+}
+
+@ListTrait([])
+@SetTrait([])
+string Bar
+
+@ListTrait([
+    "first",
+    "second",
+])
+@SetTrait([
+    "first",
+    "second",
+])
+string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/document-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/document-traits.smithy
@@ -1,0 +1,28 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+@trait
+document DocumentTrait
+
+@DocumentTrait(false)
+string Boolean
+
+@DocumentTrait([
+    "foo",
+])
+string List
+
+@DocumentTrait(
+    foo: "bar",
+)
+string Map
+
+@DocumentTrait(null)
+string Null
+
+@DocumentTrait(123)
+string Number
+
+@DocumentTrait("foo")
+string String

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
@@ -4,4 +4,5 @@ namespace ns.foo
 
 /// Documentation comments are used.
 /// $ is escaped
+/// /// doesn't need to be escaped
 string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
@@ -1,0 +1,7 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+/// Documentation comments are used.
+/// $ is escaped
+string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
@@ -16,7 +16,3 @@ metadata example.object = {
 }
 metadata example.string = "hello there"
 metadata "key must be quoted" = true
-
-namespace ns.foo
-
-string Placeholder

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
@@ -1,0 +1,20 @@
+$version: "0.5.0"
+
+metadata example.array = [
+    10,
+    true,
+    "hello",
+]
+metadata example.bool1 = true
+metadata example.bool2 = false
+metadata example.null = null
+metadata example.number = 10
+metadata example.object = {
+    foo: "baz",
+}
+metadata example.string = "hello there"
+metadata "key must be quoted" = true
+
+namespace ns.foo
+
+string Placeholder

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
@@ -1,5 +1,7 @@
 $version: "0.5.0"
 
+metadata CaseSensitive = true
+metadata caseSensitive = true
 metadata example.array = [
     10,
     true,

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/number-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/number-traits.smithy
@@ -1,0 +1,37 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+@trait
+bigDecimal BigDecimalTrait
+
+@trait
+bigInteger BigIntegerTrait
+
+@trait
+byte ByteTrait
+
+@trait
+double DoubleTrait
+
+@trait
+float FloatTrait
+
+@trait
+integer IntegerTrait
+
+@trait
+long LongTrait
+
+@trait
+short ShortTrait
+
+@BigDecimalTrait(3.14)
+@BigIntegerTrait(123)
+@ByteTrait(123)
+@DoubleTrait(1.234)
+@FloatTrait(-1.234)
+@IntegerTrait(-123)
+@LongTrait(321)
+@ShortTrait(12321)
+string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/object-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/object-traits.smithy
@@ -1,0 +1,66 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+@trait
+map MapTrait {
+    key: String,
+    value: String,
+}
+
+@trait
+structure StructureTrait {
+    collectionMember: StringList,
+    nestedMember: NestedMember,
+    shapeIdMember: ShapeId,
+    staticMember: String,
+}
+
+@trait
+union UnionTrait {
+    boolean: Boolean,
+    string: String,
+}
+
+structure NestedMember {
+    shapeIds: ShapeIdList,
+}
+
+list ShapeIdList {
+    member: ShapeId,
+}
+
+list StringList {
+    member: String,
+}
+
+@MapTrait
+@StructureTrait
+string EmptyBody
+
+@MapTrait(
+    bar: "baz",
+    foo: "bar",
+    "must be quoted": "bam",
+)
+@StructureTrait(
+    collectionMember: [
+        "foo",
+        "bar",
+    ],
+    nestedMember: {
+        shapeIds: [
+            String,
+            EmptyBody,
+        ],
+    },
+    shapeIdMember: UnionTrait,
+    staticMember: "Foo",
+)
+@UnionTrait(
+    boolean: false,
+)
+string NonEmptyBody
+
+@idRef
+string ShapeId

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/optional-namespaces-are-stripped.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/optional-namespaces-are-stripped.smithy
@@ -1,0 +1,11 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+structure Structure {
+    localWithConflict: String,
+    prelude: Blob,
+    preludeWithConflict: smithy.api#String,
+}
+
+string String

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
@@ -16,7 +16,8 @@ service MyService {
     ],
 }
 
-resource EmptyResource {}
+resource EmptyResource {
+}
 
 resource MyResource {
     identifiers: {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
@@ -1,0 +1,75 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+service EmptyService {
+    version: "2020-02-18",
+}
+
+service MyService {
+    version: "2020-02-18",
+    operations: [
+        MyOperation,
+    ],
+    resources: [
+        MyResource,
+    ],
+}
+
+resource EmptyResource {}
+
+resource MyResource {
+    identifiers: {
+        id: String,
+    },
+    put: ResourceOperation,
+    create: ResourceOperation,
+    read: ReadonlyResourceOperation,
+    update: ResourceOperation,
+    delete: ResourceOperation,
+    list: ReadonlyResourceOperation,
+    operations: [
+        ResourceOperation,
+    ],
+    collectionOperations: [
+        ResourceOperation,
+    ],
+    resources: [
+        SubResource,
+    ],
+}
+
+resource SubResource {
+    identifiers: {
+        id: String,
+    },
+}
+
+operation EmptyOperation {}
+
+operation MyOperation {
+    input: InputOutput,
+    output: InputOutput,
+    errors: [
+        Error,
+    ],
+}
+
+@readonly
+operation ReadonlyResourceOperation {
+    input: ResourceOperationInput,
+}
+
+@idempotent
+operation ResourceOperation {
+    input: ResourceOperationInput,
+}
+
+@error("client")
+structure Error {}
+
+structure InputOutput {}
+
+structure ResourceOperationInput {
+    id: String,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
@@ -2,17 +2,17 @@ $version: "0.5.0"
 
 namespace ns.foo
 
-union Union {
-    byte: Byte,
-    double: Double,
-}
-
 structure StructureWithMembers {
     a: String,
     b: String,
 }
 
 structure StructureWithoutMembers {}
+
+union Union {
+    byte: Byte,
+    double: Double,
+}
 
 list List {
     member: String,

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
@@ -1,0 +1,52 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+union Union {
+    byte: Byte,
+    double: Double,
+}
+
+structure StructureWithMembers {
+    a: String,
+    b: String,
+}
+
+structure StructureWithoutMembers {}
+
+list List {
+    member: String,
+}
+
+set Set {
+    member: String,
+}
+
+map Map {
+    key: String,
+    value: String,
+}
+
+bigDecimal BigDecimal
+
+bigInteger BigInteger
+
+blob Blob
+
+boolean Boolean
+
+byte Byte
+
+document Document
+
+double Double
+
+float Float
+
+integer Integer
+
+long Long
+
+short Short
+
+string String

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/string-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/string-traits.smithy
@@ -1,0 +1,9 @@
+$version: "0.5.0"
+
+namespace ns.foo
+
+@trait
+string StringTrait
+
+@StringTrait("foo")
+string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/input.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/input.json
@@ -1,0 +1,28 @@
+{
+    "smithy": "0.5.0",
+    "metadata": {
+        "shared": true
+    },
+    "shapes": {
+        "ns.structures#Structure": {
+            "type": "structure",
+            "members": {
+                "listMember": {
+                    "target": "ns.primitives#StringList"
+                },
+                "stringMember": {
+                    "target": "ns.primitives#String"
+                }
+            }
+        },
+        "ns.primitives#String": {
+            "type": "string"
+        },
+        "ns.primitives#StringList": {
+            "type": "list",
+            "member": {
+                "target": "ns.primitives#String"
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
@@ -1,0 +1,11 @@
+$version: "0.5.0"
+
+metadata shared = true
+
+namespace ns.primitives
+
+list StringList {
+    member: String,
+}
+
+string String

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
@@ -1,0 +1,12 @@
+$version: "0.5.0"
+
+metadata shared = true
+
+namespace ns.structures
+
+use ns.primitives#StringList
+
+structure Structure {
+    listMember: StringList,
+    stringMember: ns.primitives#String,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/test-model.json
@@ -1,0 +1,44 @@
+{
+    "smithy": "0.5.0",
+    "metadata": {
+        "shared": true
+    },
+    "shapes": {
+        "ns.structures#Structure": {
+            "type": "structure",
+            "members": {
+                "listMember": {
+                    "target": "ns.primitives#StringList",
+                    "traits": {
+                        "smithy.api#documentation": "A list member"
+                    }
+                },
+                "stringMember": {
+                    "target": "ns.primitives#String",
+                    "traits": {
+                        "smithy.api#required": true,
+                        "smithy.api#documentation": "A string member"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "A structure shape"
+            }
+        },
+        "ns.primitives#String": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "A string shape"
+            }
+        },
+        "ns.primitives#StringList": {
+            "type": "list",
+            "member": {
+                "target": "ns.primitives#String"
+            },
+            "traits": {
+                "smithy.api#documentation": "A list shape"
+            }
+        }
+    }
+}

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.utils;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -956,29 +956,26 @@ public class CodeWriter {
      */
     public final CodeWriter writeInline(Object content, Object... args) {
         String value = formatter.format(content, currentState.indentText, this, args);
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(value.split(newlineRegexQuoted, -1)));
+        String[] lines = value.split(newlineRegexQuoted, -1);
 
         // The first line is written directly, with no added indentation or newline
-        currentState.write(lines.remove(0));
+        currentState.write(lines[0]);
 
         // If there aren't any additional lines, return.
-        if (lines.isEmpty()) {
+        if (lines.length == 1) {
             return this;
         }
 
         // If there are additional lines, they need to be handled properly. So insert a newline.
         currentState.write(newline);
 
-        // We don't want to append a newline, so remove the last line for handling later.
-        String lastLine = lines.remove(lines.size() - 1);
-
         // Write all the intermediate lines as normal.
-        for (String line : lines) {
-            currentState.writeLine(line + newline);
+        for (int i = 1; i <= lines.length - 2; i++) {
+            currentState.writeLine(lines[i] + newline);
         }
 
         // Write the final line with proper indentation, but without an appended newline.
-        currentState.writeLine(lastLine);
+        currentState.writeLine(lines[lines.length - 1]);
         return this;
     }
 

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -505,4 +505,46 @@ public class CodeWriterTest {
 
         assertThat(result, equalTo("$Hello\n"));
     }
+
+    @Test
+    public void canWriteInline() {
+        String result = CodeWriter.createDefault()
+                .writeInline("foo")
+                .writeInline(", bar")
+                .toString();
+
+        assertThat(result, equalTo("foo, bar"));
+    }
+
+    @Test
+    public void writeInlineHandlesSingleNewline() {
+        String result = CodeWriter.createDefault()
+                .writeInline("foo").indent()
+                .writeInline(":\nbar")
+                .toString();
+
+        assertThat(result, equalTo("foo:\n    bar"));
+    }
+
+    @Test
+    public void writeInlineHandlesMultipleNewlines() {
+        String result = CodeWriter.createDefault()
+                .writeInline("foo:")
+                .writeInline(" [").indent()
+                .writeInline("\nbar,\nbaz,\nbam,")
+                .dedent().writeInline("\n]")
+                .toString();
+
+        assertThat(result, equalTo("foo: [\n    bar,\n    baz,\n    bam,\n]"));
+    }
+
+    @Test
+    public void writeInlineStripsSpaces() {
+        String result = CodeWriter.createDefault()
+                .trimTrailingSpaces()
+                .writeInline("foo ")
+                .toString();
+
+        assertThat(result, equalTo("foo"));
+    }
 }


### PR DESCRIPTION
This adds the ability to take an in-memory model and serialize it into the Smithy IDL format.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
