### PR TITLE
[0.10] Clean up LoaderVisitor and IDL loading

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -87,7 +87,6 @@ enum AstModelLoader {
 
     void load(ObjectNode model, LoaderVisitor visitor) {
         model.expectNoAdditionalProperties(TOP_LEVEL_PROPERTIES);
-        visitor.onOpenFile(model.getSourceLocation().getFilename());
         loadMetadata(model, visitor);
         loadShapes(model, visitor);
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -84,7 +84,7 @@ public final class ModelAssembler {
     private ValidatorFactory validatorFactory;
 
     /**
-     * A map of files ot parse and load into the Model.
+     * A map of files to parse and load into the Model.
      *
      * <p>A {@code TreeMap} is used to ensure that JSON models are loaded
      * before IDL models. This is mostly a performance optimization. JSON

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -19,11 +19,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class IdlModelLoaderTest {
@@ -76,5 +78,20 @@ public class IdlModelLoaderTest {
                 .addImport(getClass().getResource("second-namespace.smithy"))
                 .assemble()
                 .unwrap();
+    }
+
+    @Test
+    public void defersApplyTargetAndTrait() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("apply-use-1.smithy"))
+                .addImport(getClass().getResource("apply-use-2.smithy"))
+                .addImport(getClass().getResource("apply-use-3.smithy"))
+                .assemble()
+                .unwrap();
+
+        Shape shape = model.expectShape(ShapeId.from("smithy.example#Foo"));
+
+        assertThat(shape.findTrait(ShapeId.from("smithy.example#bar")), not(Optional.empty()));
+        assertThat(shape.findTrait(ShapeId.from("smithy.example.b#baz")), not(Optional.empty()));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-1.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-1.smithy
@@ -1,0 +1,9 @@
+namespace smithy.example
+
+use smithy.example.b#baz
+
+// This applies smithy.example#bar to smithy.example#Foo
+apply Foo @bar("hi")
+
+// This applies smithy.example.b#baz to smithy.example#Foo
+apply Foo @baz("hi")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-2.smithy
@@ -1,0 +1,6 @@
+namespace smithy.example
+
+string Foo
+
+@trait
+string bar

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-3.smithy
@@ -1,0 +1,4 @@
+namespace smithy.example.b
+
+@trait
+string baz


### PR DESCRIPTION
* Ensures that JSON IDL models are loaded before IDL models to reduce forward reference lookups when loading IDL models.
* Move IDL specific loading logic to IDL

  This commit moves all IDL-specific model loading logic into the IDL loader and out of the LoaderVisitor. This cleans up the LoaderVisitor and also fixes a bug in how the `apply` statement wasn't properly resolving the targeted shape ID (it always assumed that the target was in the current namespace).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
