### PR TITLE
[0.10] Add JSON pointer, patch, and OpenAPI mapper

### DIFF
--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -261,18 +261,21 @@ openapi.substitutions (``Map<String, any>``)
     Defines a map of strings to any JSON value to find and replace in the
     generated OpenAPI model.
 
-    This allows for placeholders to appear in the value of Smithy traits that
-    can be converted at build-time to an appropriate value.
-
     String values are replaced if the string in its entirety matches
     one of the keys provided in the ``openapi.substitutions`` map. The
-    corresponding value is then substituted for the string-- this could even
-    result in a string changing into an object, array, etc.
+    corresponding value is then substituted for the string; this could
+    even result in a string changing into an object, array, etc.
 
     The following example will find all strings with a value of "REPLACE_ME"
     and replace the string with an array value of
     ``["this is a", " replacement"]`` and replace all strings with a value
     of ``ANOTHER_REPLACEMENT`` with ``Hello!!!``:
+
+    .. warning::
+
+        When possible, prefer ``openapi.jsonAdd`` instead because the update
+        performed on the generated document is more explicit and resilient to
+        change.
 
     .. code-block:: json
 
@@ -284,6 +287,36 @@ openapi.substitutions (``Map<String, any>``)
                     "openapi.substitutions": {
                         "REPLACE_ME": ["this is a", " replacement"],
                         "ANOTHER_REPLACEMENT": "Hello!!!"
+                    }
+                }
+            }
+        }
+
+openapi.jsonAdd (``Map<String, Node>``)
+    Adds or replaces the JSON value in the generated OpenAPI document at the
+    given JSON pointer locations with a different JSON value. The value must
+    be a map where each key is a valid JSON pointer string as defined in
+    :rfc:`6901`. Each value in the map is the JSON value to add or replace
+    at the given target.
+
+    Values are added using similar semantics of the "add" operation of
+    JSON Patch, as specified in :rfc:`6902`, with the exception that adding
+    properties to an undefined object will create nested objects in the
+    result as needed.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "openapi.jsonAdd": {
+                        "/info/title": "Replaced title value",
+                        "/info/nested/foo": {
+                            "hi": "Adding this object created intermediate objects too!"
+                        },
+                        "/info/nested/foo/baz": true
                     }
                 }
             }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/JsonSubstitutions.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/JsonSubstitutions.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.build;
 
 import java.util.Map;
-import java.util.regex.Pattern;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeVisitor;
@@ -32,10 +31,7 @@ import software.amazon.smithy.utils.Pair;
  * <p>Each key represents a string to search for, and each value represents
  * what to replace the string with. A value can be any type of Node, allowing
  * for strings to be changed to objects, arrays, etc. Partial string matches
- * are not currently supported. Each replacement string must match the
- * following regular expression: {@code ^[A-Za-z_][A-Za-z_0-9-]+$} (this
- * constraint could potentially be relaxed in the future to allow for
- * substring replacements from string to string).
+ * are not currently supported.
  *
  * <p>For example, given the following values to replace:
  *
@@ -53,18 +49,9 @@ import software.amazon.smithy.utils.Pair;
  * string did not literally match the string "FOO".
  */
 public final class JsonSubstitutions {
-    private static final Pattern SUBSTITUTIONS_KEY_PATTERN = Pattern.compile("^[A-Za-z_][A-Za-z_0-9-]+$");
     private final Map<String, Node> findAndReplace;
 
     private JsonSubstitutions(Map<String, Node> findAndReplace) {
-        for (String key : findAndReplace.keySet()) {
-            if (!SUBSTITUTIONS_KEY_PATTERN.matcher(key).find()) {
-                throw new SmithyBuildException(String.format(
-                        "JSON substitution key found named `%s`, but each key must match the following regular "
-                        + "expression: %s", key, SUBSTITUTIONS_KEY_PATTERN.pattern()));
-            }
-        }
-
         this.findAndReplace = MapUtils.copyOf(findAndReplace);
     }
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/JsonSubstitutionsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/JsonSubstitutionsTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -36,13 +35,5 @@ public class JsonSubstitutionsTest {
 
         assertThat(result.expectMember("a").expectStringNode().getValue(), equalTo("Hi!"));
         assertThat(result.expectMember("b").expectStringNode().getValue(), equalTo("FOO_BAR baz"));
-    }
-
-    @Test
-    public void validatesKeysAdhereToPattern() {
-        Map<String, Node> mappings = new HashMap<>();
-        mappings.put("!FOO_BAR", Node.from("Hi!"));
-
-        Assertions.assertThrows(SmithyBuildException.class, () -> JsonSubstitutions.create(mappings));
     }
 }

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/Schema.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/Schema.java
@@ -460,7 +460,7 @@ public final class Schema implements ToNode, ToSmithyBuilder<Schema> {
         }
 
         try {
-            int position = Integer.parseInt(segments[1]);
+            int position = segments[1].equals("-") ? schemaArray.size() - 1 : Integer.parseInt(segments[1]);
             return position > -1 && position < schemaArray.size()
                    ? getRecursiveSchema(Optional.of(schemaArray.get(position)), segments, 2)
                    : Optional.empty();

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/SchemaDocumentTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/SchemaDocumentTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -105,28 +104,6 @@ public class SchemaDocumentTest {
     }
 
     @Test
-    public void requiresSegmentsWithMultipleSlashes() {
-        Assertions.assertThrows(RuntimeException.class, () -> {
-            SchemaDocument document = SchemaDocument.builder()
-                    .putDefinition("#/definitions", Schema.builder().type("string").build())
-                    .build();
-            document.toNode().expectObjectNode();
-        });
-
-    }
-
-    @Test
-    public void detectsConflictingPointers() {
-        Assertions.assertThrows(RuntimeException.class, () -> {
-            SchemaDocument document = SchemaDocument.builder()
-                    .putDefinition("#/definitions/foo", Schema.builder().type("string").build())
-                    .putDefinition("#/definitions/foo/bar", Schema.builder().type("string").build())
-                    .build();
-            document.toNode().expectObjectNode();
-        });
-    }
-
-    @Test
     public void unescapesJsonPointers() {
         Schema schema = Schema.builder().type("string").build();
         SchemaDocument document = SchemaDocument.builder()
@@ -159,6 +136,5 @@ public class SchemaDocumentTest {
 
         assertThat(document.getDefinition(""), equalTo(Optional.of(string)));
         assertThat(document.getDefinition("#"), equalTo(Optional.of(string)));
-        assertThat(document.getDefinition("#/"), equalTo(Optional.of(string)));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
@@ -99,7 +99,9 @@ public final class ArrayNode extends Node implements Iterable<Node> {
      * @return Returns an optional node at the given index.
      */
     public Optional<Node> get(int index) {
-        return elements.size() > index ? Optional.of(elements.get(index)) : Optional.empty();
+        return elements.size() > index && index > -1
+               ? Optional.of(elements.get(index))
+               : Optional.empty();
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodePointer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodePointer.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.node;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * JSON Pointer abstraction over Smithy {@link Node} values.
+ *
+ * <p>A parsed JSON pointer can get a value from a Node by pointer and
+ * perform JSON-patch like operations like adding a value to a specific
+ * pointer target.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902</a>
+ */
+public final class NodePointer {
+
+    private static final Logger LOGGER = Logger.getLogger(NodePointer.class.getName());
+
+    private String originalString;
+    private List<String> parts;
+
+    private NodePointer(String originalString, List<String> parts) {
+        this.originalString = originalString;
+        this.parts = parts;
+    }
+
+    /**
+     * Unescapes special JSON pointer cases.
+     *
+     * @param pointerPart Pointer to unescape.
+     * @return Returns the unescaped pointer.
+     */
+    public static String unescape(String pointerPart) {
+        if (!pointerPart.contains("~")) {
+            return pointerPart;
+        } else {
+            return pointerPart.replace("~1", "/").replace("~0", "~");
+        }
+    }
+
+    /**
+     * Parses a JSON pointer.
+     *
+     * <p>A JSON pointer that starts with "#/" is treated as "/". JSON
+     * pointers must start with "#/" or "/" to be parsed correctly.
+     *
+     * @param pointer JSON pointer to parse.
+     * @return Returns the parsed pointer.
+     * @throws IllegalArgumentException if the pointer does not start with slash (/).
+     */
+    public static NodePointer parse(String pointer) {
+        return new NodePointer(pointer, parseJsonPointer(pointer));
+    }
+
+    private static List<String> parseJsonPointer(String pointer) {
+        if (pointer.isEmpty()) {
+            return Collections.emptyList();
+        } else if (pointer.startsWith("#")) {
+            // Strip a leading "#" if present.
+            return parseJsonPointer(pointer.substring(1));
+        } else if (!pointer.startsWith("/")) {
+            throw new IllegalArgumentException("JSON pointer must start with '/': " + pointer);
+        }
+
+        List<String> parts = new ArrayList<>();
+        int start = 0;
+
+        for (int i = 0; i < pointer.length(); i++) {
+            if (pointer.charAt(i) == '/') {
+                if (start > 0) {
+                    String part = pointer.substring(start, i);
+                    parts.add(unescape(part));
+                }
+                start = i + 1;
+            }
+        }
+
+        parts.add(unescape(pointer.substring(start)));
+        return parts;
+    }
+
+    /**
+     * Gets the parsed parts of the pointer.
+     *
+     * @return Returns the immutable pointer parts.
+     */
+    public List<String> getParts() {
+        return Collections.unmodifiableList(parts);
+    }
+
+    @Override
+    public String toString() {
+        return originalString;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof NodePointer && other.toString().equals(toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return originalString.hashCode();
+    }
+
+    /**
+     * Gets a value from a container shape at the pointer location.
+     *
+     * <p>When the pointer is "", then provided value is returned. When
+     * the pointer is "/", a root object key value of "" is returned. When
+     * an invalid property or array index is accessed, a {@link NullNode}
+     * is returned. "-" can be used to access the last element of an array.
+     * Any error like accessing an object key from an array or attempting
+     * to access an invalid array index will return a {@code NullNode}.
+     *
+     * @param container Node value container to extract a value from.
+     * @return Returns the extracted value or a {@link NullNode} if not found.
+     */
+    public Node getValue(Node container) {
+        Node result = container;
+
+        for (String part : parts) {
+            if (result.asObjectNode().isPresent()) {
+                result = result.expectObjectNode().getMember(part).orElse(Node.nullNode());
+            } else if (result.asArrayNode().isPresent()) {
+                ArrayNode array = result.expectArrayNode();
+                if (part.equals("-")) {
+                    return array.get(array.size() - 1).orElse(Node.nullNode());
+                } else {
+                    result = array.get(parseIntPart(part)).orElse(Node.nullNode());
+                }
+            } else {
+                return Node.nullNode();
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Adds or replaces a {@code value} in {@code container} at the
+     * JSON pointer location.
+     *
+     * <p>When the JSON pointer is "", the entire document is replaced with the
+     * given {@code value}. "-" can be used to access the last element of an array
+     * or to add an element to the end of an array. Any error like adding
+     * an object key to an array or attempting to access an invalid array
+     * segment will log a warning and return the given value as-is.
+     *
+     * @param container Node to update.
+     * @param value Value to update or replace.
+     * @return Returns a representation of {@code container} with the updated value.
+     */
+    public Node addValue(Node container, Node value) {
+        return addWithFlag(container, value, false);
+    }
+
+    /**
+     * Adds or replaces a {@code value} in {@code container} at the
+     * JSON pointer location.
+     *
+     * <p>When the JSON pointer is "", the entire document is replaced with the
+     * given {@code value}. "-" can be used to access the last element of an array
+     * or to add an element to the end of an array. Unlike {@link #addValue(Node, Node)},
+     * attempting to add a property to a non-existent object will create a
+     * new object and continue adding to the created result.
+     *
+     * @param container Node to update.
+     * @param value Value to update or replace.
+     * @return Returns a representation of {@code container} with the updated value.
+     */
+    public Node addWithIntermediateValues(Node container, Node value) {
+        return addWithFlag(container, value, true);
+    }
+
+    private Node addWithFlag(Node container, Node value, boolean intermediate) {
+        // Special case for replacing the entire document.
+        if (parts.isEmpty()) {
+            return value;
+        } else {
+            return addValue(container, value, 0, intermediate);
+        }
+    }
+
+    private Node addValue(Node container, Node value, int partPosition, boolean intermediate) {
+        String part = parts.get(partPosition);
+        boolean isLast = partPosition == parts.size() - 1;
+
+        if (container.isObjectNode()) {
+            return addObjectMember(part, isLast, container.expectObjectNode(), value, partPosition, intermediate);
+        } else if (container.isArrayNode()) {
+            return addArrayMember(part, isLast, container.expectArrayNode(), value, partPosition, intermediate);
+        } else {
+            LOGGER.warning(() -> String.format(
+                    "Attempted to add a value through JSON pointer `%s`, but segment %d targets %s",
+                    toString(), partPosition, Node.printJson(container)));
+            return container;
+        }
+    }
+
+    private Node addObjectMember(
+            String part, boolean isLast, ObjectNode container, Node value, int partPosition, boolean intermediate) {
+        if (isLast) {
+            return container.withMember(part, value);
+        } else if (container.getMember(part).isPresent()) {
+            // Found the member, grab it, traverse into it, and update it.
+            Node member = container.expectMember(part);
+            Node updatedMember = addValue(member, value, partPosition + 1, intermediate);
+            return container.withMember(part, updatedMember);
+        } else if (intermediate) {
+            // When creating intermediate values, generate a new object and
+            // continue to traverse into it.
+            Node synthesized = addValue(Node.objectNode(), value, partPosition + 1, intermediate);
+            return container.withMember(part, synthesized);
+        } else {
+            LOGGER.warning(() -> String.format(
+                    "Attempted to add a value through JSON pointer `%s`, but `%s` could not be found in %s",
+                    toString(), part, Node.printJson(container)));
+            return container;
+        }
+    }
+
+    private Node addArrayMember(
+            String part, boolean isLast, ArrayNode container, Node value, int partPosition, boolean intermediate) {
+        if (!isLast) {
+            // "-" is a special case for the last element.
+            int partInt = part.equals("-") ? container.size() - 1 : parseIntPart(part);
+            if (container.get(partInt).isPresent()) {
+                // Can only traverse into actual array elements.
+                Node item = container.get(partInt).get();
+                List<Node> list = new ArrayList<>(container.getElements());
+                list.set(partInt, addValue(item, value, partPosition + 1, intermediate));
+                return new ArrayNode(list, container.getSourceLocation());
+            } else {
+                logInvalidArrayIndex(container, partInt);
+                return container;
+            }
+        } else if (part.equals("-")) {
+            // Special case pushing to the end of the array.
+            return container.withValue(value);
+        } else {
+            // Add the value before the given index.
+            int partInt = parseIntPart(part);
+            if (partInt > -1 && container.size() >= partInt) {
+                List<Node> list = new ArrayList<>(container.getElements());
+                list.add(partInt, value);
+                return new ArrayNode(list, container.getSourceLocation());
+            } else {
+                // The index must exist!
+                logInvalidArrayIndex(container, partInt);
+                return container;
+            }
+        }
+    }
+
+    private void logInvalidArrayIndex(Node container, int partInt) {
+        LOGGER.warning(() -> String.format(
+                "Attempted to add a value through JSON pointer `%s`, but index %d could not be set in %s",
+                toString(), partInt, Node.printJson(container)));
+    }
+
+    private int parseIntPart(String part) {
+        try {
+            return Integer.parseInt(part);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/ArrayNodeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/ArrayNodeTest.java
@@ -202,4 +202,12 @@ public class ArrayNodeTest {
             Node.fromStrings("a", "b", "c").getElementsAs(BooleanNode::getValue);
         });
     }
+
+    @Test
+    public void checksBoundaries() {
+        ArrayNode array = Node.arrayNode();
+
+        assertFalse(array.get(-1).isPresent());
+        assertFalse(array.get(10).isPresent());
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodePointerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodePointerTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.node;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+// See https://github.com/json-patch/json-patch-tests/blob/master/tests.json
+public class NodePointerTest {
+    @Test
+    public void mustStartWithSlash() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> NodePointer.parse("foo"));
+    }
+
+    @Test
+    public void persistsOriginalValue() {
+        NodePointer pointer = NodePointer.parse("/~1/foo");
+
+        assertThat(pointer.toString(), equalTo("/~1/foo"));
+        assertThat(pointer.hashCode(), equalTo("/~1/foo".hashCode()));
+        assertThat(pointer, equalTo(NodePointer.parse("/~1/foo")));
+    }
+
+    @Test
+    public void persistsOriginalValueWithPound() {
+        NodePointer pointer = NodePointer.parse("#/~1/foo");
+
+        assertThat(pointer.toString(), equalTo("#/~1/foo"));
+        assertThat(pointer.hashCode(), equalTo("#/~1/foo".hashCode()));
+        assertThat(pointer, equalTo(NodePointer.parse("#/~1/foo")));
+    }
+
+    @Test
+    public void unescapesTildes() {
+        NodePointer pointer = NodePointer.parse("/~0/~~11");
+
+        assertThat(pointer.toString(), equalTo("/~0/~~11"));
+        assertThat(pointer.getParts(), contains("~", "~/1"));
+    }
+
+    @Test
+    public void getsNestedPointerValue() {
+        NodePointer pointer = NodePointer.parse("/a/b/1/c");
+        Node node = Node.parse("{\"a\":{\"b\":[0, {\"c\":true}]}}");
+
+        assertThat(pointer.getValue(node), equalTo(Node.from(true)));
+    }
+
+    @Test
+    public void getLastArrayElement() {
+        NodePointer pointer = NodePointer.parse("/-");
+        Node node = Node.parse("[0, 1]");
+
+        assertThat(pointer.getValue(node), equalTo(Node.from(1)));
+    }
+
+    @Test
+    public void getsRoot() {
+        NodePointer pointer = NodePointer.parse("");
+        Node node = Node.parse("[0, 1]");
+
+        assertThat(pointer.getValue(node), equalTo(node));
+    }
+
+    @Test
+    public void getsRootWithPound() {
+        NodePointer pointer = NodePointer.parse("#");
+        Node node = Node.parse("[0, 1]");
+
+        assertThat(pointer.getValue(node), equalTo(node));
+    }
+
+    @Test
+    public void slashIsNotRoot() {
+        NodePointer pointer = NodePointer.parse("/");
+        Node node = Node.parse("{\"\":true}");
+
+        assertThat(pointer.getValue(node), equalTo(Node.from(true)));
+    }
+
+    @Test
+    public void slashWithPoundIsNotRoot() {
+        NodePointer pointer = NodePointer.parse("#/");
+        Node node = Node.parse("{\"\":true}");
+
+        assertThat(pointer.getValue(node), equalTo(Node.from(true)));
+    }
+
+    @Test
+    public void getNullNodeForInvalidGetType() {
+        NodePointer pointer = NodePointer.parse("/a");
+        Node node = Node.parse("[1]");
+
+        assertThat(pointer.getValue(node), equalTo(Node.nullNode()));
+    }
+
+    @Test
+    public void getNullNodeForInvalidArrayIndex() {
+        NodePointer pointer = NodePointer.parse("/1");
+        Node node = Node.parse("[1]");
+
+        assertThat(pointer.getValue(node), equalTo(Node.nullNode()));
+    }
+
+    @Test
+    public void getNullNodeForInvalidObjectKey() {
+        NodePointer pointer = NodePointer.parse("/a");
+        Node node = Node.parse("{\"b\":true}");
+
+        assertThat(pointer.getValue(node), equalTo(Node.nullNode()));
+    }
+
+    @Test
+    public void getNullNodeForInvalidType() {
+        NodePointer pointer = NodePointer.parse("/a");
+        Node node = Node.from(true);
+
+        assertThat(pointer.getValue(node), equalTo(Node.nullNode()));
+    }
+
+    @Test
+    public void addsNestedValue() {
+        NodePointer pointer = NodePointer.parse("/a/b/1/c");
+        Node node = Node.parse("{\"a\":{\"b\":[0, {\"c\":true}]}}");
+        Node result = pointer.addValue(node, Node.from(false));
+
+        assertThat(result, equalTo(Node.parse("{\"a\":{\"b\":[0, {\"c\":false}]}}")));
+    }
+
+    @Test
+    public void addReplacesAnExistingField() {
+        NodePointer pointer = NodePointer.parse("/a");
+        Node node = Node.objectNode().withMember("a", true);
+        Node result = pointer.addValue(node, Node.from(false));
+
+        assertThat(result, equalTo(Node.objectNode().withMember("a", false)));
+    }
+
+    @Test
+    public void addsTo0InEmptyArray() {
+        NodePointer pointer = NodePointer.parse("/0");
+        Node node = Node.parse("[]");
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.parse("[true]")));
+    }
+
+    @Test
+    public void addsToEmptyObject() {
+        NodePointer pointer = NodePointer.parse("/foo");
+        Node node = Node.objectNode();
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.objectNode().withMember("foo", true)));
+    }
+
+    @Test
+    public void addReplacesObjectDocumentWithArrayDocument() {
+        NodePointer pointer = NodePointer.parse("");
+        Node node = Node.arrayNode();
+        Node result = pointer.addValue(node, Node.objectNode());
+
+        assertThat(result, equalTo(Node.objectNode()));
+    }
+
+    @Test
+    public void addReplacesArrayDocumentWithObjectDocument() {
+        NodePointer pointer = NodePointer.parse("");
+        Node node = Node.objectNode();
+        Node result = pointer.addValue(node, Node.arrayNode());
+
+        assertThat(result, equalTo(Node.arrayNode()));
+    }
+
+    @Test
+    public void addAppendsToEmptyRootArray() {
+        NodePointer pointer = NodePointer.parse("/-");
+        Node node = Node.arrayNode();
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.arrayNode(Node.from(true))));
+    }
+
+    @Test
+    public void addAppendsToExistingArray() {
+        NodePointer pointer = NodePointer.parse("/-");
+        Node node = Node.arrayNode().withValue(Node.from(true));
+        Node result = pointer.addValue(node, Node.from(false));
+
+        assertThat(result, equalTo(Node.arrayNode(Node.from(true), Node.from(false))));
+    }
+
+    @Test
+    public void addAppendsToExistingArrayByIndex() {
+        NodePointer pointer = NodePointer.parse("/1");
+        Node node = Node.arrayNode(Node.from(1), Node.from(2));
+        Node result = pointer.addValue(node, Node.from(3));
+
+        assertThat(result, equalTo(Node.arrayNode(Node.from(1), Node.from(3), Node.from(2))));
+    }
+
+    @Test
+    public void addAppendsToEndOfExistingArrayByIndexPlusOne() {
+        NodePointer pointer = NodePointer.parse("/2");
+        Node node = Node.arrayNode(Node.from(1), Node.from(2));
+        Node result = pointer.addValue(node, Node.from(3));
+
+        assertThat(result, equalTo(Node.arrayNode(Node.from(1), Node.from(2), Node.from(3))));
+    }
+
+    @Test
+    public void addIgnoresAppendingToIndexPlus2orMore() {
+        NodePointer pointer = NodePointer.parse("/3");
+        Node node = Node.arrayNode(Node.from(1), Node.from(2));
+        Node result = pointer.addValue(node, Node.from(3));
+
+        assertThat(result, equalTo(node));
+    }
+
+    @Test
+    public void addIgnoresAppendingToNegativeIndex() {
+        NodePointer pointer = NodePointer.parse("/-1");
+        Node node = Node.arrayNode(Node.from(1));
+        Node result = pointer.addValue(node, Node.from(2));
+
+        assertThat(result, equalTo(node));
+    }
+
+    @Test
+    public void addIgnoresAppendingThroughMissingIndex() {
+        NodePointer pointer = NodePointer.parse("/2/-1");
+        Node node = Node.arrayNode(Node.from(1));
+        Node result = pointer.addValue(node, Node.from(2));
+
+        assertThat(result, equalTo(node));
+    }
+
+    @Test
+    public void addIgnoresAppendingToInvalidType() {
+        NodePointer pointer = NodePointer.parse("/foo");
+        Node node = Node.from(true);
+        Node result = pointer.addValue(node, Node.from("hi"));
+
+        assertThat(result, equalTo(node));
+    }
+
+    @Test
+    public void addIgnoresAppendingToMissingObject() {
+        NodePointer pointer = NodePointer.parse("/foo/bar/baz");
+        Node node = Node.parse("{\"foo\": {}}");
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(node));
+    }
+
+    @Test
+    public void addAppendsToNestedArray() {
+        NodePointer pointer = NodePointer.parse("/2/1/-");
+        Node node = Node.parse("[ 1, 2, [ 3, [ 4, 5 ] ] ]");
+        Node result = pointer.addValue(node, Node.parse("{ \"foo\": [ \"bar\", \"baz\" ] }"));
+
+        assertThat(result, equalTo(Node.parse("[ 1, 2, [ 3, [ 4, 5, { \"foo\": [ \"bar\", \"baz\" ] } ] ] ]}")));
+    }
+
+    @Test
+    public void addCanCreateEntryForSlashTarget() {
+        NodePointer pointer = NodePointer.parse("/");
+        Node node = Node.objectNode();
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.objectNode().withMember("", true)));
+    }
+
+    @Test
+    public void addFooWithTrailingSlash() {
+        NodePointer pointer = NodePointer.parse("/foo/");
+        Node node = Node.objectNode().withMember("foo", Node.objectNode());
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.parse("{\"foo\": {\"\": true}}")));
+    }
+
+    @Test
+    public void addsCompositeValueAtTopLevel() {
+        NodePointer pointer = NodePointer.parse("/bar");
+        Node node = Node.objectNode().withMember("foo", 1);
+        Node result = pointer.addValue(node, Node.arrayNode(Node.from(1), Node.from(2)));
+
+        assertThat(result, equalTo(Node.parse("{\"foo\": 1, \"bar\": [1, 2]}")));
+    }
+
+    @Test
+    public void addObjectOperationOnArrayTargetReturnsValueAsIs() {
+        NodePointer pointer = NodePointer.parse("/foo");
+        Node node = Node.arrayNode().withValue(Node.from(true));
+        Node result = pointer.addValue(node, Node.from(false));
+
+        assertThat(result, equalTo(node));
+    }
+
+    @Test
+    public void addCanUseZeroAsObjectMember() {
+        NodePointer pointer = NodePointer.parse("/0");
+        Node node = Node.objectNode();
+        Node result = pointer.addValue(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.objectNode().withMember("0", true)));
+    }
+
+    @Test
+    public void addsIntermediateValues() {
+        NodePointer pointer = NodePointer.parse("/a/b/c");
+        Node node = Node.objectNode();
+        Node result = pointer.addWithIntermediateValues(node, Node.from(true));
+
+        assertThat(result, equalTo(Node.parse("{\"a\": {\"b\": {\"c\": true } } }")));
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConstants.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConstants.java
@@ -112,5 +112,18 @@ public final class OpenApiConstants {
      */
     public static final String SUBSTITUTIONS = "openapi.substitutions";
 
+    /**
+     * Adds or replaces the JSON value at the given JSON pointer locations with a
+     * different JSON value.
+     *
+     * <p>The value must be a Map of String to Node where each key is a JSON
+     * Pointer, and each value is the value to replace at that location. The
+     * mutation of the model follows the same semantics as the "add" operation
+     * of JSON Patch as specified in RFC 6902, with the exception that missing
+     * intermediate objects are created as necessary. Attempting to modifyproperties
+     * of objects that do not exist will log a warning.
+     */
+    public static final String JSON_ADD = "openapi.jsonAdd";
+
     private OpenApiConstants() {}
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/CoreExtension.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/CoreExtension.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.jsonschema.JsonSchemaMapper;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.mappers.CheckForGreedyLabels;
 import software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders;
+import software.amazon.smithy.openapi.fromsmithy.mappers.OpenApiJsonAdd;
 import software.amazon.smithy.openapi.fromsmithy.mappers.OpenApiJsonSubstitutions;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveEmptyComponents;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveUnusedComponents;
@@ -58,6 +59,7 @@ public final class CoreExtension implements Smithy2OpenApiExtension {
                 new CheckForGreedyLabels(),
                 new CheckForPrefixHeaders(),
                 new OpenApiJsonSubstitutions(),
+                new OpenApiJsonAdd(),
                 new RemoveUnusedComponents(),
                 new UnsupportedTraits(),
                 new RemoveEmptyComponents()

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAdd.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAdd.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.openapi.fromsmithy.mappers;
+
+import java.util.Map;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodePointer;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.openapi.OpenApiConstants;
+import software.amazon.smithy.openapi.OpenApiException;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.model.OpenApi;
+
+/**
+ * Adds JSON values into the generated OpenAPI model using a JSON Patch
+ * like "add" operation that also generated intermediate objects as needed.
+ * Any existing property is overwritten.
+ *
+ * <p>This mapper is applied using the contents of {@code openapi.jsonAdd}.
+ * This is run after substitutions so it is unaffected by them.
+ */
+public final class OpenApiJsonAdd implements OpenApiMapper {
+    @Override
+    public byte getOrder() {
+        // This is run after substitutions.
+        return 122;
+    }
+
+    @Override
+    public ObjectNode updateNode(Context<? extends Trait> context, OpenApi openapi, ObjectNode node) {
+        return context.getConfig().getObjectMember(OpenApiConstants.JSON_ADD)
+                .map(add -> {
+                    ObjectNode result = node;
+                    for (Map.Entry<String, Node> entry : add.getStringMap().entrySet()) {
+                        try {
+                            result = NodePointer.parse(entry.getKey())
+                                    .addWithIntermediateValues(result, entry.getValue().toNode())
+                                    .expectObjectNode();
+                        } catch (IllegalArgumentException e) {
+                            throw new OpenApiException(e.getMessage(), e);
+                        }
+                    }
+                    return result;
+                })
+                .orElse(node);
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonSubstitutions.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonSubstitutions.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.openapi.fromsmithy.mappers;
 
+import java.util.logging.Logger;
 import software.amazon.smithy.build.JsonSubstitutions;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.traits.Trait;
@@ -28,6 +29,8 @@ import software.amazon.smithy.openapi.model.OpenApi;
  * {@code openapi.substitutions}.
  */
 public final class OpenApiJsonSubstitutions implements OpenApiMapper {
+    private static final Logger LOGGER = Logger.getLogger(OpenApiJsonSubstitutions.class.getName());
+
     @Override
     public byte getOrder() {
         return 120;
@@ -36,7 +39,14 @@ public final class OpenApiJsonSubstitutions implements OpenApiMapper {
     @Override
     public ObjectNode updateNode(Context<? extends Trait> context, OpenApi openapi, ObjectNode node) {
         return context.getConfig().getObjectMember(OpenApiConstants.SUBSTITUTIONS)
-                .map(substitutions -> JsonSubstitutions.create(substitutions).apply(node).expectObjectNode())
+                .map(substitutions -> {
+                    LOGGER.warning("Using " + OpenApiConstants.SUBSTITUTIONS + " is discouraged. DO NOT use "
+                                   + "placeholders in your Smithy model for properties that are used by other tools "
+                                   + "like SDKs or service frameworks; placeholders should only ever be used in "
+                                   + "models for metadata that is specific to generating OpenAPI artifacts.\n\n"
+                                   + "Prefer safer alternatives like " + OpenApiConstants.JSON_ADD);
+                    return JsonSubstitutions.create(substitutions).apply(node).expectObjectNode();
+                })
                 .orElse(node);
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAddTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAddTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.openapi.fromsmithy.mappers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodePointer;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConstants;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+
+public class OpenApiJsonAddTest {
+    @Test
+    public void addsWithPointers() {
+        Model model = Model.assembler()
+                // Reusing another test cases's model, but that doesn't matter for the
+                // purpose of this test.
+                .addImport(RemoveUnusedComponentsTest.class.getResource("substitutions.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        ObjectNode addNode = Node.objectNodeBuilder()
+                .withMember("/info/description", "hello")
+                .withMember("/info/foo", "bar")
+                .withMember("/info/nested/abc", "nested")
+                .withMember("/info/title", "custom")
+                .build();
+
+        ObjectNode openApi = OpenApiConverter.create()
+                .putSetting(OpenApiConstants.JSON_ADD, addNode)
+                .convertToNode(model, ShapeId.from("smithy.example#Service"));
+
+        String description = NodePointer.parse("/info/description").getValue(openApi).expectStringNode().getValue();
+        String infoFoo = NodePointer.parse("/info/foo").getValue(openApi).expectStringNode().getValue();
+        String infoNested = NodePointer.parse("/info/nested/abc").getValue(openApi).expectStringNode().getValue();
+        String infoTitle = NodePointer.parse("/info/title").getValue(openApi).expectStringNode().getValue();
+
+        Assertions.assertEquals("hello", description);
+        Assertions.assertEquals("bar", infoFoo);
+        Assertions.assertEquals("nested", infoNested);
+        Assertions.assertEquals("custom", infoTitle);
+    }
+}


### PR DESCRIPTION
This commit adds a new mapper to OpenAPI that allows changing specific
parts of the generated schema using JSON pointers that inject values
using semantics similar to JSON Patch. This approach is preferred over
string substitutions because it is more explicit and does not encourage
modelers to include placeholders in their models.

The JSON substitutions mapper now allows for any string to be replaced.
This is still basically just as safe since it only replaces exact string
matches (it doesn't replace inside of larger strings). Most importantly,
the use of placeholder like strings encouraged modelers to include
placeholders in their models. By opening up the string to any value, you
can now replace whatever was generated from real model values.

To achieve this, I implemented a JSON Pointer parser and abstraction
over Node values that also include methods for getting a value from a
node by a pointer, and adding/replacing a value in a node using a
pointer (with immutable return values, of course). I was able to
integrate this abstraction into SchemaDocument and Schema too. The JSON
Patch "add" operation has been implemented in two ways: 1) we do it just
like JSON patch, where attempting to traverse through missing objects
and arrays causes the change to be ignored 2) we have a mode that
creates intermediate objects when needed, allowing this to be used in
the JSON Schema SchemaDocument code for generating JSON from an
in-memory document.

Implementing this change revealed an omission in ArrayNode where bounds
were not being checked. For example, attempting to access index -1 would
raise an exception. This is now fixed and covered in a test case.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
