### PR TITLE
Update documentation to improve consistency

### DIFF
--- a/docs/source/spec/amazon-apigateway.rst
+++ b/docs/source/spec/amazon-apigateway.rst
@@ -93,11 +93,11 @@ Trait selector
 
     *A service shape that has the protocols trait*
 Value type
-    Map of arbitrary names to *authorizer* definitions. These authorizer
+    ``map`` of arbitrary names to *authorizer* definitions. These authorizer
     definitions are applied to a service, resource, or operation using the
     :ref:`aws.apigateway#authorizer-trait`.
 
-An *authorizer* definition is an object that supports the following properties:
+An *authorizer* definition is a structure that supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -239,7 +239,7 @@ Trait selector
 
     *A service, resource, or operation*
 Value type
-    String value that MUST reference one of the keys in the
+    ``string`` value that MUST reference one of the keys in the
     :ref:`aws.apigateway#authorizers-trait` of the service that contains
     the shape.
 
@@ -268,11 +268,11 @@ Value type
 
         * - Value
           - Description
-        * - full
+        * - ``full``
           - The parameters and body of a request are validated.
-        * - params-only
+        * - ``params-only``
           - Only the parameters of a request are validated.
-        * - body-only
+        * - ``body-only``
           - Only the body of a request is validated.
 See also
     - `Enable Request Validation in API Gateway`_ for more information
@@ -330,7 +330,7 @@ Summary
 Trait selector
     ``:test(service, operation)``
 Value type
-    ``object`` value.
+    ``structure``
 See also
     - :ref:`apigateway-integrations` for information on how this converts
       to OpenAPI
@@ -338,8 +338,8 @@ See also
     - `x-amazon-apigateway-integration`_ for details on how this looks
       to OpenAPI
 
-The ``aws.apigateway#integration`` trait is an object that supports the
-following properties:
+The ``aws.apigateway#integration`` trait is a structure that supports the
+following members:
 
 .. list-table::
     :header-rows: 1
@@ -403,18 +403,18 @@ following properties:
       - ``string``
       - An API-specific tag group of related cached parameters.
     * - cacheKeyParameters
-      - ``[string]``
+      - ``list<string>``
       - A list of request parameter names whose values are to be cached.
     * - requestParameters
-      - ``Map`` of :ref:`apigateway-requestParameters` to request parameters
+      - ``map`` of :ref:`apigateway-requestParameters` to request parameters
       - Specifies mappings from method request parameters to integration
         request parameters. Supported request parameters are querystring,
         path, header, and body.
     * - requestTemplates
-      - ``Map`` of media types to :ref:`apigateway-requestTemplates`
+      - ``map`` of media types to :ref:`apigateway-requestTemplates`
       - Mapping templates for a request payload of specified media types.
     * - responses
-      - ``Map`` of response codes to :ref:`apigateway-responses`
+      - ``map`` of response codes to :ref:`apigateway-responses`
       - Defines the method's responses and specifies desired parameter
         mappings or payload mappings from integration responses to method
         responses.
@@ -503,7 +503,10 @@ Summary
 Trait selector
     ``:test(service, operation)``
 Value type
-    ``object`` value.
+    ``structure``
+
+The ``aws.apigateway#mockIntegration`` trait is a structure that supports the
+following members:
 
 .. list-table::
     :header-rows: 1
@@ -519,15 +522,15 @@ Value type
         values are ``when_no_templates``, ``when_no_match``, and ``never``.
         For more information, see `Integration.passthroughBehavior`_.
     * - requestParameters
-      - ``Map`` of :ref:`apigateway-requestParameters` to request parameters
+      - ``map`` of :ref:`apigateway-requestParameters` to request parameters
       - Specifies mappings from method request parameters to integration
         request parameters. Supported request parameters are querystring,
         path, header, and body.
     * - requestTemplates
-      - ``Map`` of media types to :ref:`apigateway-requestTemplates`
+      - ``map`` of media types to :ref:`apigateway-requestTemplates`
       - Mapping templates for a request payload of specified media types.
     * - responses
-      - ``Map`` of response codes to :ref:`apigateway-responses`
+      - ``map`` of response codes to :ref:`apigateway-responses`
       - Defines the method's responses and specifies desired parameter
         mappings or payload mappings from integration responses to method
         responses.
@@ -620,8 +623,8 @@ Valid values are:
 
 .. _apigateway-requestParameters:
 
-requestParameters object
-------------------------
+requestParameters structure
+---------------------------
 
 Specifies mappings from named method request parameters to integration
 request parameters. The method request parameters must be defined before
@@ -637,7 +640,7 @@ they are referenced.
       - Type
       - Description
     * - ``integration.request.<param-type>.<param-name>``
-      - string
+      - ``string``
       - The value must be a predefined method request parameter of the
         ``method.request.<param-type>.<param-name>`` format, where
         ``<param-type>`` can be querystring, path, header, or body. For
@@ -662,8 +665,8 @@ header (x-userid), and path parameters (op), respectively.
 
 .. _apigateway-requestTemplates:
 
-requestTemplates object
------------------------
+requestTemplates structure
+--------------------------
 
 Specifies mapping templates for a request payload of the specified media types.
 
@@ -677,7 +680,7 @@ Specifies mapping templates for a request payload of the specified media types.
       - Type
       - Description
     * - ``<Media type>``
-      - string
+      - ``string``
       - A `mapping template <mapping templates>`_.
 
 The following example sets mapping templates for a request payload of the
@@ -695,8 +698,8 @@ The following example sets mapping templates for a request payload of the
 
 .. _apigateway-responses:
 
-responses object
-----------------
+responses structure
+-------------------
 
 Defines the method's responses and specifies parameter mappings or payload
 mappings from integration responses to method responses.
@@ -711,7 +714,7 @@ mappings from integration responses to method responses.
       - Type
       - Description
     * - ``<Response status pattern>``
-      - :ref:`Response object <apigateway-response-object>`
+      - :ref:`Response structure <apigateway-response-structure>`
       - Selection regular expression used to match the integration response
         to the method response. For HTTP integrations, this regex applies to
         the integration response status code. For Lambda invocations, the
@@ -755,10 +758,10 @@ property on the integration response's payload.
     }
 
 
-.. _apigateway-response-object:
+.. _apigateway-response-structure:
 
-response object
----------------
+response structure
+------------------
 
 Defines a response and specifies parameter mappings or payload mappings from
 the integration response to the method response.
@@ -773,16 +776,16 @@ the integration response to the method response.
       - Type
       - Description
     * - statusCode
-      - string
+      - ``string``
       - HTTP status code for the method response; for example, "200". This
         must correspond to a matching response in the OpenAPI Operation
         responses field.
     * - responseTemplates
-      - :ref:`Response templates object <apigateway-response-templates-object>`
+      - :ref:`Response templates structure <apigateway-response-templates-structure>`
       - Specifies media type-specific mapping templates for the response's
         payload.
     * - responseParameters
-      - :ref:`Response parameters object <apigateway-response-parameters-object>`
+      - :ref:`Response parameters structure <apigateway-response-parameters-structure>`
       - Specifies parameter mappings for the response. Only the header and
         body parameters of the integration response can be mapped to the header
         parameters of the method.
@@ -809,10 +812,10 @@ redirect URL from the integration response in the method's Location header.
     }
 
 
-.. _apigateway-response-templates-object:
+.. _apigateway-response-templates-structure:
 
-Response templates object
--------------------------
+Response templates structure
+----------------------------
 
 Specifies mapping templates for a response payload of the specified
 media types.
@@ -827,7 +830,7 @@ media types.
       - Type
       - Description
     * - ``<Media type>``
-      - string
+      - ``string``
       - Specifies a mapping template to transform the integration response
         body to the method response body for a given media type. For
         information about creating a mapping template, see
@@ -847,10 +850,10 @@ The following example sets mapping templates for a request payload of the
     }
 
 
-.. _apigateway-response-parameters-object:
+.. _apigateway-response-parameters-structure:
 
-Response parameters object
---------------------------
+Response parameters structure
+-----------------------------
 
 Specifies mappings from integration method response parameters to method
 response parameters. Only the ``header`` and ``body`` types of the integration
@@ -867,7 +870,7 @@ response.
       - Type
       - Description
     * - ``method.response.header.<param-name>``
-      - string
+      - ``string``
       - The named parameter value can be derived from the header and body
         types of the integration response parameters only.
 

--- a/docs/source/spec/aws-core.rst
+++ b/docs/source/spec/aws-core.rst
@@ -24,7 +24,7 @@ Summary
 Trait selector
     ``service``
 Value type
-    ``object`` that contains the following properties:
+    ``structure`` that contains the following members:
 
     * :ref:`service-sdk-id` (required)
     * :ref:`service-cloudformation-name`
@@ -255,10 +255,10 @@ Trait summary
 Trait selector
     ``resource``
 Trait value
-    ``object``
+    ``structure``
 
-The ``aws.api#arn`` trait is an object that supports the following
-properties:
+The ``aws.api#arn`` trait is a structure that supports the following
+members:
 
 .. list-table::
     :header-rows: 1
@@ -491,15 +491,15 @@ Trait summary
 Trait selector
     ``string``
 Trait value
-    ``object``
+    ``structure``
 
 Smithy models can refer to AWS resources using ARNs. The
 ``aws.api#arnReference`` can be applied to a string shape to indicate
 that the string contains an ARN and what resource is targeted by the
 ARN.
 
-The ``aws.api#arnReference`` trait is an object that supports the following
-optional properties:
+The ``aws.api#arnReference`` trait is a structure that supports the following
+optional members:
 
 .. list-table::
     :header-rows: 1
@@ -848,7 +848,7 @@ Summary
 Trait selector
     ``operation``
 Value type
-    List of authentication scheme strings
+    ``list<string>`` of authentication schemes
 
 Most requests sent to AWS services require that the payload of the request is
 signed. However, in some cases, a service that streams large amounts of data
@@ -1018,10 +1018,10 @@ Trait summary
 Trait selector
     ``service``
 Trait value
-    ``object``
+    ``structure``
 
-The ``aws.api#clientEndpointDiscovery`` trait is an object that supports the
-following properties:
+The ``aws.api#clientEndpointDiscovery`` trait is a structure that supports the
+following members:
 
 .. list-table::
     :header-rows: 1
@@ -1065,10 +1065,10 @@ Trait summary
 Trait selector
     ``operation``
 Trait value
-    ``object``
+    ``structure``
 
-The ``aws.api#clientDiscoveredEndpoint`` trait is an object that supports the
-following properties:
+The ``aws.api#clientDiscoveredEndpoint`` trait is a structure that supports the
+following members:
 
 .. list-table::
     :header-rows: 1

--- a/docs/source/spec/aws-iam.rst
+++ b/docs/source/spec/aws-iam.rst
@@ -73,7 +73,7 @@ Summary
 Trait selector
     ``:test(resource, operation)``
 Value type
-    ``array`` of ``string`` values
+    ``list<string>``
 
 Condition keys derived automatically can be applied to a resource or operation
 explicitly. Condition keys applied this way MUST be either inferred or
@@ -181,13 +181,13 @@ Summary
 Trait selector
     ``service``
 Value type
-    ``map`` of IAM identifiers to condition key ``object``
+    ``map`` of IAM identifiers to condition key ``structure``
 
 The ``aws.iam#defineConditionKeys`` trait defines additional condition keys
 that appear within a service. Keys in the map must be valid IAM identifiers,
 meaning they must adhere to the following regular expression:
 ``"^([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:[^:]+)$"``.
-Each condition key object supports the following key-value pairs:
+Each condition key structure supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -205,10 +205,10 @@ Each condition key object supports the following key-value pairs:
         ``ArrayOfNumeric``, ``ArrayOfString``. See :ref:`condition-key-types`
         for more information.
     * - documentation
-      - string
+      - ``string``
       - Defines documentation about the condition key.
     * - externalDocumentation
-      - string
+      - ``string``
       - A valid URL that defines more information about the condition key.
 
 .. tabs::
@@ -404,8 +404,8 @@ Summary
 Trait selector
     ``operation``
 Value type
-    This trait contains an unordered list of string values that reference
-    condition keys defined in the closure of the service.
+    ``list<string>`` where each string value references condition keys
+    defined in the closure of the service.
 
 Defines the actions, in addition to the targeted operation, that a user must
 be authorized to execute in order invoke an operation. The following example

--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -2799,7 +2799,7 @@ a :ref:`list` shape:
     @tags(["foo", "baz", "bar"])
     string MyString
 
-    // This is a valid trait collision on an array trait, tags.
+    // This is a valid trait collision on a list trait, tags.
     // tags becomes ["foo", "baz", "bar", "bar", "qux"]
     apply MyString @tags(["bar", "qux"])
 
@@ -2894,7 +2894,8 @@ automatically available in every Smithy model through relative shape IDs.
 Trait definition properties
 ---------------------------
 
-The trait definition trait is an object that supports the following properties:
+The trait definition trait is a structure that supports the following
+members:
 
 .. list-table::
     :header-rows: 1
@@ -3184,9 +3185,9 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``object``
+    ``structure``
 
-The ``deprecated`` trait is an object that supports the following properties:
+The ``deprecated`` trait is a structure that supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -3322,18 +3323,18 @@ Summary
 Trait selector
     ``string``
 Value type
-    ``map`` of enum constant values to objects optionally containing a name,
+    ``map`` of enum constant values to structures optionally containing a name,
     documentation, tags, and/or a deprecation flag.
 
 Smithy models SHOULD apply the enum trait when string shapes have a fixed
 set of allowable values.
 
 The enum trait is a map of allowed string values to enum constant definition
-objects. Enum values do not allow aliasing; all enum constant values MUST be
+structures. Enum values do not allow aliasing; all enum constant values MUST be
 unique across the entire set.
 
-An enum definition is an object that supports the following optional
-properties:
+An enum definition is a structure that supports the following optional
+members:
 
 .. list-table::
     :header-rows: 1
@@ -3362,7 +3363,7 @@ properties:
       - string
       - Defines documentation about the enum value in the CommonMark_ format.
     * - tags
-      - ``List<string>``
+      - ``list<string>``
       - Attaches a list of tags that allow the enum value to be categorized and
         grouped.
     * - deprecated
@@ -3463,10 +3464,10 @@ Trait selector
 
     *A string shape or a member that targets a string shape*
 Value type
-    ``object``
+    ``structure``
 
-The ``idRef`` trait is an object that supports the following optional
-properties:
+The ``idRef`` trait is a structure that supports the following optional
+members:
 
 .. list-table::
     :header-rows: 1
@@ -3613,9 +3614,9 @@ Trait selector
 
     *Any list, map, string, or blob; or a member that targets one of these shapes*
 Value type
-    ``object`` value
+    ``structure``
 
-The length trait is an object that contains the following key value pairs:
+The length trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1
@@ -3681,7 +3682,7 @@ Trait selector
 
     *A string or a member that targets a string*
 Value type
-    ``string`` value
+    ``string``
 
 Smithy regular expressions MUST be valid regular expressions according to the
 `ECMA 262 regular expression dialect`_. Patterns SHOULD avoid the use of
@@ -3743,9 +3744,9 @@ Trait selector
 
     *A number or a member that targets a number*
 Value type
-    ``object`` value
+    ``structure``
 
-The length trait is an object that contains the following key value pairs:
+The length trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1
@@ -3755,10 +3756,10 @@ The length trait is an object that contains the following key value pairs:
       - Type
       - Description
     * - min
-      - ``number``
+      - ``bigDecimal``
       - Specifies the allowed inclusive minimum value.
     * - max
-      - ``number``
+      - ``bigDecimal``
       - Specifies the allowed inclusive maximum value.
 
 At least one of ``min`` or ``max`` is required. ``min`` and ``max`` accept both
@@ -3999,9 +4000,9 @@ Trait selector
 
     *A structure shape with the error trait*
 Value type
-    ``object``
+    ``structure``
 
-The retryable trait is an object that contains the following key value pairs:
+The retryable trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1
@@ -4045,13 +4046,13 @@ Trait selector
 
     *An operation or service*
 Value type
-    ``object`` value
+    ``structure``
 
 Pagination is the process of dividing large result sets into discrete
 pages. Smithy provides a built-in pagination mechanism that utilizes a
 cursor.
 
-The ``paginated`` trait is an object that contains the following properties:
+The ``paginated`` trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1
@@ -4503,10 +4504,10 @@ Trait selector
 
     *Any structure or string*
 Value type
-    ``array``
+    ``list`` of ``Reference`` structures
 
-The ``references`` trait is an array of ``Reference`` objects that contain the
-following properties:
+The ``references`` trait is a list of ``Reference`` structures that contain
+the following members:
 
 .. list-table::
     :header-rows: 1
@@ -4530,7 +4531,7 @@ following properties:
         The reference will not be resolvable at build time but MAY be resolvable
         at runtime if the tool has loaded more than one model.
     * - ids
-      - Map<String, String>
+      - ``map<string, string>``
       - Defines a mapping of each resource identifier name to a structure
         member name that provides its value. Each key in the map MUST refer
         to one of the identifier names in the identifiers property of the
@@ -4542,7 +4543,7 @@ following properties:
         - This property MAY be omitted if the identifiers of the resource
           can be :ref:`mapped implicitly <implicit-ids>`.
     * - rel
-      - String
+      - ``string``
       - Defines the semantics of the relationship. The ``rel`` property SHOULD
         contain a link relation as defined in :rfc:`5988#section-4` (i.e.,
         this value SHOULD contain either a `standard link relation`_ or URI).
@@ -4616,7 +4617,7 @@ Trait selector
 
     *Any required member of a structure that targets a string*
 Value type
-    ``string`` value
+    ``string``
 
 The ``resourceIdentifier`` trait may only be used on members of structures that
 serve as input shapes for operations bound to resources. The string value
@@ -4672,7 +4673,7 @@ Summary
 Trait selector
     ``service``
 Value type
-    ``array`` of protocol ``object``
+    ``list`` of protocol ``structure``
 
 Smithy is protocol agnostic, which means it focuses on the interfaces and
 abstractions that are provided to end-users rather than how the data is sent
@@ -4688,8 +4689,8 @@ protocols supported by the service and the authentication schemes that each
 protocol supports. A client MUST understand at least one of the protocols in
 order to successfully communicate with the service.
 
-The value of the ``protocols`` trait is an array of protocol objects. Each
-protocol object supports the following key-value pairs:
+The value of the ``protocols`` trait is a list of protocol structures. Each
+protocol structure supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -4704,12 +4705,12 @@ protocol object supports the following key-value pairs:
         the entire list and MUST match the following regular expression:
         ``^[a-z][a-z0-9\-.+]*$``.
     * - auth
-      - ``List<string>``
+      - ``list<string>``
       - A priority ordered list of authentication schemes supported by this
         protocol. Each value MUST match the following regular expression:
         ``^[a-z][a-z0-9\-.+]*$``.
     * - tags
-      - ``List<string>``
+      - ``list<string>``
       - Attaches a list of tags that allow the protocol to be categorized and
         grouped.
 
@@ -4810,7 +4811,7 @@ Trait selector
 
     *Service or operation shapes*
 Value type
-    This trait contains a priority ordered list of string values that
+    ``list<string>`` which represents a priority ordered list of values that
     reference authentication schemes defined on a service shape.
 
 The ``auth`` trait is used to explicitly define which authentication schemes
@@ -5007,7 +5008,7 @@ Trait selector
 
     *Any structure member*
 Value type
-    ``string`` value
+    ``string``
 
 Given the following structure definition,
 
@@ -5075,7 +5076,7 @@ Trait selector
 
     *Any blob or string*
 Value type
-    ``string`` value
+    ``string``
 
 The ``mediaType`` can be used in tools for documentation, validation,
 automated conversion or encoding in code, automatically determining an
@@ -5103,7 +5104,7 @@ Trait selector
 
     *timestamp or member that targets a timestamp*
 Value type
-    ``string`` value
+    ``string``
 
 The serialization format of a timestamp shape is normally dictated by the
 :ref:`protocol <protocols-trait>` of a service. In order to interoperate with
@@ -5156,7 +5157,7 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``string`` value
+    ``string``
 
 .. tabs::
 
@@ -5240,15 +5241,15 @@ Summary
 Trait selector
     ``operation``
 Value type
-    ``array`` of :ref:`example objects <example-object>`
+    ``list`` of :ref:`example structures <example-structure>`
 
 
-.. _example-object:
+.. _example-structure:
 
-Example object
-``````````````
+Example structure
+`````````````````
 
-Each ``example`` trait value is an object with the following properties:
+Each ``example`` trait value is a structure with the following members:
 
 .. list-table::
     :header-rows: 1
@@ -5264,17 +5265,17 @@ Each ``example`` trait value is an object with the following properties:
       - ``string``
       - A longer description of the example in the CommonMark_ format.
     * - input
-      - ``object``
+      - ``document``
       - Provides example input parameters for the operation. Each key is
         the name of a top-level input structure member, and each value is the
         value of the member.
     * - output
-      - ``object``
+      - ``document``
       - Provides example output parameters for the operation. Each key is
         the name of a top-level output structure member, and each value is the
         value of the member.
 
-The values provided for the ``input`` and ``output`` properties MUST be
+The values provided for the ``input`` and ``output`` members MUST be
 compatible with the shapes and constraints of the corresponding structure.
 These values use the same semantics and format as
 :ref:`custom trait values <trait-definition-values>`.
@@ -5321,7 +5322,7 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``string`` value containing a valid URL.
+    ``string`` containing a valid URL.
 
 .. tabs::
 
@@ -5371,7 +5372,7 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``string`` value representing the date it was added.
+    ``string`` representing the date it was added.
 
 
 .. _tags-trait:
@@ -5385,7 +5386,7 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``array`` of ``string`` values
+    ``list<string>``
 
 Tools can use these tags to filter shapes that should not be visible for a
 particular consumer of a model. The string values that can be provided to the
@@ -5451,9 +5452,9 @@ Summary
 Trait selector
     ``operation``
 Value type
-    ``object``
+    ``structure``
 
-The ``endpoint`` trait is an object that contains the following properties:
+The ``endpoint`` trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1

--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -1748,7 +1748,7 @@ Given the following model,
             identifiers: {
                 forecastId: ForecastId,
             },
-            operations: [BatchPutForecasts],
+            collectionOperations: [BatchPutForecasts],
         }
 
         operation BatchPutForecasts {
@@ -1773,7 +1773,7 @@ Given the following model,
                             "target": "smithy.example#ForecastId"
                         }
                     },
-                    "operations": [
+                    "collectionOperations": [
                         {
                             "target": "smithy.example#BatchPutForecasts"
                         }

--- a/docs/source/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/spec/http-protocol-compliance-tests.rst
@@ -71,10 +71,10 @@ Trait selector
 
         operation
 Value type
-    [``HttpRequestTestCase``]
+    ``list`` of ``HttpRequestTestCase`` structures
 
-The ``httpRequestTests`` trait is a list of ``HttpRequestTestCase`` objects
-that support the following properties:
+The ``httpRequestTests`` trait is a list of ``HttpRequestTestCase`` structures
+that support the following members:
 
 .. list-table::
     :header-rows: 1
@@ -108,7 +108,7 @@ that support the following properties:
         It's possible that specific authentication schemes might influence
         the serialization logic of an HTTP request.
     * - queryParams
-      - ``[string]``
+      - ``list<string>``
       - A list of the expected serialized query string parameters.
 
         Each element in the list is a query string key value pair
@@ -135,7 +135,7 @@ that support the following properties:
 
         ``queryParams`` applies no constraints on additional query parameters.
     * - forbidQueryParams
-      - [``string``]
+      - ``list<string>``
       - A list of query string parameter names that must not appear in the
         serialized HTTP request.
 
@@ -143,7 +143,7 @@ that support the following properties:
         wire; if a key needs to be percent-encoded, then it MUST appear
         percent-encoded in this list.
     * - requireQueryParams
-      - [``string``]
+      - ``list<string>``
       - A list of query string parameter names that MUST appear in the
         serialized request URI, but no assertion is made on the value.
 
@@ -151,7 +151,7 @@ that support the following properties:
         wire; if a key needs to be percent-encoded, then it MUST appear
         percent-encoded in this list.
     * - headers
-      - ``Map<String, String>``
+      - ``map<string, string>``
       - A map of expected HTTP headers. Each key represents a header field
         name and each value represents the expected header value. An HTTP
         request is not in compliance with the protocol if any listed header
@@ -316,10 +316,10 @@ Trait selector
 
         :each(operation, structure[trait|error])
 Value type
-    [``HttpResponseTestCase``]
+    ``list`` of ``HttpResponseTestCase`` structures
 
-The ``httpResponseTests`` trait is a list of ``HttpResponseTestCase`` objects
-that support the following properties:
+The ``httpResponseTests`` trait is a list of ``HttpResponseTestCase``
+structures that support the following members:
 
 .. list-table::
     :header-rows: 1
@@ -349,7 +349,7 @@ that support the following properties:
         It's possible that specific authentication schemes might influence
         the serialization logic of an HTTP response.
     * - headers
-      - ``Map<String, String>``
+      - ``map<string, string>``
       - A map of expected HTTP headers. Each key represents a header field
         name and each value represents the expected header value. An HTTP
         response is not in compliance with the protocol if any listed header
@@ -358,11 +358,11 @@ that support the following properties:
 
         ``headers`` applies no constraints on additional headers.
     * - forbidHeaders
-      - [``string``]
+      - ``list<string>``
       - A list of header field names that must not appear in the serialized
         HTTP response.
     * - requireHeaders
-      - [``string``]
+      - ``list<string>``
       - A list of header field names that must appear in the serialized
         HTTP response, but no assertion is made on the value. Headers listed
         in ``headers`` do not need to appear in this list.

--- a/docs/source/spec/http.rst
+++ b/docs/source/spec/http.rst
@@ -28,9 +28,9 @@ Summary
 Trait selector
     ``operation``
 Value type
-    ``object``
+    ``structure``
 
-The ``http`` trait is an object that supports the following properties:
+The ``http`` trait is a structure that supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -830,9 +830,9 @@ Summary
 Trait selector
     ``service``
 Value type
-    ``object``
+    ``structure``
 
-The ``cors`` trait is an object that supports the following properties:
+The ``cors`` trait is a structure that supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -852,7 +852,7 @@ The ``cors`` trait is an object that supports the following properties:
         maximum age permitted by several browsers. Set to ``-1`` to disable
         caching entirely.
     * - additionalAllowedHeaders
-      - ``List<String>``
+      - ``list<string>``
       - The names of headers that should be included in the
         ``Access-Control-Allow-Headers`` header in responses to preflight
         ``OPTIONS`` requests. This list will be used in addition to the names of
@@ -860,7 +860,7 @@ The ``cors`` trait is an object that supports the following properties:
         :ref:`httpHeader-trait`, as well as any headers required by the protocol
         or authentication scheme.
     * - additionalExposedHeaders
-      - ``List<String>``
+      - ``list<string>``
       - The names of headers that should be included in the
         ``Access-Control-Expose-Headers`` header in all responses sent by the
         service. This list will be used in addition to the names of all request

--- a/docs/source/spec/xml.rst
+++ b/docs/source/spec/xml.rst
@@ -937,11 +937,11 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``object`` value
+    ``structure``
 Conflicts with
     :ref:`xmlAttribute-trait`
 
-The ``xmlNamespace`` trait is an object that contains the following properties:
+The ``xmlNamespace`` trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1


### PR DESCRIPTION
*Issue #, if available:*

Fixes #296
Fixes #295

*Description of changes:*

This updates an example in the docs showcasing the interaction of
collection operations and implicit identifier bindings that had not been
updated when the `collectionOperations` member was added to resource
shapes.

This also improves the consistency of trait value documentation. Primarily it
does this by using Smithy terminology everywhere it references shapes,
where previously there was a lot of JSON terminology usage. In addtion the
following smaller consistency improvements were made:

* Shape types are always given backtick markup
* Parametric shape types now always use java-style carrots in
  in shorthand. Previously there were a mix of ways defining them
  in shorthand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.