### PR TITLE
[0.10] Suppress deprecation warnings in protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -7,6 +7,15 @@
 
 $version: "0.5.0"
 
+metadata suppressions = [{
+    ids: ["DeprecatedTrait"],
+    reason: """
+        Some of the AWS protocols make use of deprecated traits, and some are
+        themselves deprecated traits. As this package is intended to test those
+        protocols, the warnings should be suppressed.
+        """
+}]
+
 namespace aws.protocoltests.shared
 
 list StringList {


### PR DESCRIPTION
Some of the protocols traits are marked as deprecated. One of the changes picked up from master was a validator that emits warnings for deprecated traits. Since we know those traits are deprecated, this suppresses the warnings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
