### PR TITLE
Sort keys alphebetically and cleanup

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeSerializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeSerializers.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -247,7 +248,7 @@ final class DefaultNodeSerializers {
         private static final ConcurrentMap<Class, ClassInfo> CACHE = new ConcurrentHashMap<>();
 
         // Methods aren't returned normally in any particular order, so give them an order.
-        final Map<String, Method> getters = new TreeMap<>(String::compareToIgnoreCase);
+        final Map<String, Method> getters = new HashMap<>();
 
         static ClassInfo fromClass(Class<?> type) {
             return CACHE.computeIfAbsent(type, klass -> {
@@ -327,7 +328,7 @@ final class DefaultNodeSerializers {
 
             // Add the current value to the set.
             serializedObjects.add(value);
-            Map<StringNode, Node> mappings = new HashMap<>();
+            Map<StringNode, Node> mappings = new TreeMap<>(Comparator.comparing(StringNode::getValue));
             ClassInfo info = ClassInfo.fromClass(value.getClass());
 
             for (Map.Entry<String, Method> entry : info.getters.entrySet()) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
@@ -61,6 +61,15 @@ public class NodeMapperTest {
     }
 
     @Test
+    public void serializesAlphabetically() {
+        NodeMapper mapper = new NodeMapper();
+        ObjectNode result = mapper.serialize(new Foo()).expectObjectNode();
+        Collection<String> keys = result.getStringMap().keySet();
+
+        assertThat(keys, contains("bar", "baz"));
+    }
+
+    @Test
     public void serializesCollectionsAndArrays() {
         NodeMapper mapper = new NodeMapper();
         List<String> foos = ListUtils.of("a", "b", "c");


### PR DESCRIPTION
This commit sorts keys in NodeMapper serializer's output. Methods are
returned in an arbitrary order by default, so using sorted order is
friendlier. Further, this commit cleans up how deserialization finds
methods (it's a non-functional change, just cleanup)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
