### PR TITLE
Update smithy-build to use NodeMapper

### DIFF
--- a/docs/source/guides/building-models/build-config.rst
+++ b/docs/source/guides/building-models/build-config.rst
@@ -67,8 +67,18 @@ The following is an example ``smithy-build.json`` configuration:
                 "projection-name": {
                     "imports": ["projection-specific-imports/"],
                     "transforms": [
-                        {"name": "excludeShapesByTag", "args": ["internal", "beta", "..."]},
-                        {"name": "excludeTraitsByTag", "args": ["internal"]}
+                        {
+                            "name": "excludeShapesByTag",
+                            "args": {
+                                "tags": ["internal", "beta", "..."]
+                            }
+                        },
+                        {
+                            "name": "excludeTraitsByTag",
+                            "args": {
+                                "tags": ["internal"]
+                            }
+                        }
                     ],
                     "plugins": {
                         "plugin-name": {
@@ -167,7 +177,6 @@ Transforms are applied to the model, in order.
 
 A transform accepts the following configuration:
 
-
 .. list-table::
     :header-rows: 1
     :widths: 10 20 70
@@ -179,8 +188,8 @@ A transform accepts the following configuration:
       - ``string``
       - The required name of the transform.
     * - args
-      - ``string[]``
-      - Provides a list of arguments to pass to the transform.
+      - ``structure``
+      - A structure that contains configuration key-value pairs.
 
 
 .. _apply-transform:
@@ -188,10 +197,21 @@ A transform accepts the following configuration:
 apply
 -----
 
-Applies the transforms defined in the given projection names. Each provided
-name must be a valid projection name. The transforms of the referenced
-projections are applied in the order provided. No cycles are allowed in
-``apply``.
+Applies the transforms defined in the given projection names.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - projections
+      - ``[string]``
+      - The ordered list of projection names to apply. Each provided
+        name must be a valid projection name. The transforms of the
+        referenced projections are applied in the order provided.
+        No cycles are allowed in ``apply``.
 
 .. tabs::
 
@@ -210,7 +230,12 @@ projections are applied in the order provided. No cycles are allowed in
                     "imports": ["projection-specific-imports/"],
                     "transforms": [
                         {"name": "baz"},
-                        {"name": "apply", "args": ["my-abstract-projection"]},
+                        {
+                            "name": "apply",
+                            "args": {
+                                "projections": ["my-abstract-projection"]
+                            }
+                        },
                         {"name": "bar"}
                     ]
                 }
@@ -225,8 +250,19 @@ excludeShapesByTag
 
 Aliases: ``excludeByTag`` (deprecated)
 
-Removes shapes if they are tagged with one or more of the given arguments via
+Removes shapes if they are tagged with one or more of the given ``tags`` via
 the :ref:`tags trait <tags-trait>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - tags
+      - ``[string]``
+      - The set of tags that causes shapes to be removed.
 
 .. tabs::
 
@@ -237,7 +273,12 @@ the :ref:`tags trait <tags-trait>`.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "excludeByTag", "args": ["foo", "baz"]}
+                        {
+                            "name": "excludeByTag",
+                            "args": {
+                                "tags": ["foo", "baz"]
+                            }
+                        }
                     ]
                 }
             }
@@ -255,8 +296,19 @@ includeShapesByTag
 
 Aliases: ``includeByTag`` (deprecated)
 
-Removes shapes that are not tagged with at least one of the given arguments
+Removes shapes that are not tagged with at least one of the given ``tags``
 via the :ref:`tags trait <tags-trait>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - tags
+      - ``[string]``
+      - The set of tags that causes shapes to be retained in the model.
 
 .. tabs::
 
@@ -267,7 +319,12 @@ via the :ref:`tags trait <tags-trait>`.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeByTag", "args": ["foo", "baz"]}
+                        {
+                            "name": "includeByTag",
+                            "args": {
+                                "tags": ["foo", "baz"]
+                            }
+                        }
                     ]
                 }
             }
@@ -286,6 +343,17 @@ includeNamespaces
 Filters out shapes that are not part of one of the given :ref:`namespaces <namespaces>`.
 Note that this does not filter out traits based on namespaces.
 
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - namespaces
+      - ``[string]``
+      - The namespaces to include in the model.
+
 .. tabs::
 
     .. code-tab:: json
@@ -295,7 +363,12 @@ Note that this does not filter out traits based on namespaces.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeNamespaces", "args": ["com.foo.bar", "my.api"]}
+                        {
+                            "name": "includeNamespaces",
+                            "args": {
+                                "namespaces": ["com.foo.bar", "my.api"]
+                            }
+                        }
                     ]
                 }
             }
@@ -311,8 +384,20 @@ Note that this does not filter out traits based on namespaces.
 includeServices
 ---------------
 
-Filters out service shapes that are not included in the arguments list of
-service shape IDs.
+Filters out service shapes that are not included in the ``services`` list of
+shape IDs.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - services
+      - ``[string]``
+      - The service shape IDs to include in the model. Each entry MUST be
+        a valid service shape ID.
 
 .. tabs::
 
@@ -323,7 +408,12 @@ service shape IDs.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeServices", "args": ["my.api#MyService"]}
+                        {
+                            "name": "includeServices",
+                            "args": {
+                                "services": ["my.api#MyService"]
+                            }
+                        }
                     ]
                 }
             }
@@ -336,8 +426,18 @@ excludeTags
 -----------
 
 Removes tags from shapes and trait definitions that match any of the
-provided arguments (a list of allowed tags).
+provided ``tags``.
 
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - tags
+      - ``[string]``
+      - The set of tags that are removed from the model.
 
 .. tabs::
 
@@ -348,7 +448,12 @@ provided arguments (a list of allowed tags).
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "excludeTags", "args": ["tagA", "tagB"]}
+                        {
+                            "name": "excludeTags",
+                            "args": {
+                                "tags": ["tagA", "tagB"]
+                            }
+                        }
                     ]
                 }
             }
@@ -361,12 +466,26 @@ excludeTraits
 -------------
 
 Removes trait definitions from a model if the trait name is present in the
-provided list of arguments. Any instance of a removed trait is also removed
+provided list of ``traits``. Any instance of a removed trait is also removed
 from shapes in the model.
 
 The shapes that make up trait definitions that are removed *are not*
 automatically removed from the model. Use ``removeUnusedShapes`` to remove
 orphaned shapes.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - traits
+      - ``[string]``
+      - The set of traits that are removed from the model. Arguments that
+        end with "#" exclude the traits of an entire namespace. Trait
+        shape IDs that are relative are assumed to be part of the
+        ``smithy.api`` prelude namespace.
 
 .. tabs::
 
@@ -377,7 +496,12 @@ orphaned shapes.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "excludeTraits", "args": ["since", "com.foo#customTrait"]}
+                        {
+                            "name": "excludeTraits",
+                            "args": {
+                                "traits": ["since", "com.foo#customTrait"]
+                            }
+                        }
                     ]
                 }
             }
@@ -397,7 +521,12 @@ all traits in the "example.foo" namespace:
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "excludeTraits", "args": ["example.foo#"]}
+                        {
+                            "name": "excludeTraits",
+                            "args": {
+                                "traits": ["example.foo#"]
+                            }
+                        }
                     ]
                 }
             }
@@ -417,6 +546,17 @@ The shapes that make up trait definitions that are removed *are not*
 automatically removed from the model. Use ``removeUnusedShapes`` to remove
 orphaned shapes.
 
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - tags
+      - ``[string]``
+      - The list of tags that, if present, cause a trait to be removed.
+
 .. tabs::
 
     .. code-tab:: json
@@ -426,7 +566,12 @@ orphaned shapes.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "excludeTraitsByTag", "args": ["internal"]}
+                        {
+                            "name": "excludeTraitsByTag",
+                            "args": {
+                                "tags": ["internal"]
+                            }
+                        }
                     ]
                 }
             }
@@ -442,8 +587,19 @@ orphaned shapes.
 includeTags
 -----------
 
-Removes tags from shapes and trait definitions that are not in the
-argument list (a list of allowed tags).
+Removes tags from shapes and trait definitions that are not in the ``tags``
+list.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - tags
+      - ``[string]``
+      - The set of tags that are retained in the model.
 
 .. tabs::
 
@@ -454,7 +610,12 @@ argument list (a list of allowed tags).
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeTags", "args": ["foo", "baz"]}
+                        {
+                            "name": "includeTags",
+                            "args": {
+                                "tags": ["foo", "baz"]
+                            }
+                        }
                     ]
                 }
             }
@@ -467,12 +628,26 @@ includeTraits
 -------------
 
 Removes trait definitions from a model if the trait name is not present in the
-provided list of arguments. Any instance of a removed trait is also removed
+provided list of ``traits``. Any instance of a removed trait is also removed
 from shapes in the model.
 
 The shapes that make up trait definitions that are removed *are not*
 automatically removed from the model. Use ``removeUnusedShapes`` to remove
 orphaned shapes.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - traits
+      - ``[string]``
+      - The list of trait shape IDs to include. A trait ID that ends with "#"
+        will include all traits from a namespace. Trait shape IDs that are
+        relative are assumed to be part of the ``smithy.api``
+        prelude namespace.
 
 .. tabs::
 
@@ -483,7 +658,12 @@ orphaned shapes.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeTraits", "args": ["sensitive", "com.foo.baz#customTrait"]}
+                        {
+                            "name": "includeTraits",
+                            "args": {
+                                "traits": ["sensitive", "com.foo.baz#customTrait"]
+                            }
+                        }
                     ]
                 }
             }
@@ -503,7 +683,12 @@ all traits in the "smithy.api" namespace:
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeTraits", "args": ["smithy.api#"]}
+                        {
+                            "name": "includeTraits",
+                            "args": {
+                                "traits": ["smithy.api#"]
+                            }
+                        }
                     ]
                 }
             }
@@ -523,6 +708,18 @@ The shapes that make up trait definitions that are removed *are not*
 automatically removed from the model. Use ``removeUnusedShapes`` to remove
 orphaned shapes.
 
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - tags
+      - ``[string]``
+      - The list of tags that must be present for a trait to be included
+        in the filtered model.
+
 .. tabs::
 
     .. code-tab:: json
@@ -532,7 +729,12 @@ orphaned shapes.
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "includeTraitsByTag", "args": ["public"]}
+                        {
+                            "name": "includeTraitsByTag",
+                            "args": {
+                                "tags": ["public"]
+                            }
+                        }
                     ]
                 }
             }
@@ -554,8 +756,21 @@ Removes shapes from the model that are not connected to any service shape
 or to a shape definition.
 
 You can *export* shapes that are not connected to any service shape by
-applying specific tags to the shape and adding the list of export tags as
-arguments to the transform.
+applying specific tags to the shape and adding the list of export tags in
+the ``exportTagged`` argument.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - exportTagged
+      - ``[string]``
+      - The set of tags that, if found on a shape, forces the shape to be
+        present in the transformed model regardless of if it was connected
+        to a service.
 
 The following example removes shapes that are not connected to any service,
 but keeps the shape if it has any of the provided tags:
@@ -569,7 +784,15 @@ but keeps the shape if it has any of the provided tags:
             "projections": {
                 "exampleProjection": {
                     "transforms": [
-                        {"name": "removeUnusedShapes", "args": ["export-tag1", "another-export-tag"]}
+                        {
+                            "name": "removeUnusedShapes",
+                            "args": {
+                                "exportTagged": [
+                                    "export-tag1",
+                                    "another-export-tag"
+                                ]
+                            }
+                        }
                     ]
                 }
             }
@@ -600,7 +823,12 @@ Consider the following ``smithy-build.json`` file:
         "projections": {
             "a": {
                 "transforms": [
-                    {"${NAME_KEY}": "includeByTag", "args": ["${FOO}", "\\${BAZ}"]}
+                    {
+                        "${NAME_KEY}": "includeByTag",
+                        "args": {
+                            "tags": ["${FOO}", "\\${BAZ}"]
+                        }
+                    }
                 ]
             }
         }
@@ -616,7 +844,12 @@ environment variable set to "hi", this file is equivalent to:
         "projections": {
             "a": {
                 "transforms": [
-                    {"name": "includeByTag", "args": ["Hi", "${BAZ}"]}
+                    {
+                        "name": "includeByTag",
+                        "args": {
+                            "tags": ["Hi", "${BAZ}"]
+                        }
+                     }
                 ]
             }
         }

--- a/docs/source/guides/building-models/gradle-plugin.rst
+++ b/docs/source/guides/building-models/gradle-plugin.rst
@@ -239,10 +239,27 @@ projection. For example:
             "projections": {
                 "external": {
                     "transforms": [
-                        {"name": "excludeShapesByTag", "args": ["internal"]},
-                        {"name": "excludeTraitsByTag", "args": ["internal"]},
-                        {"name": "excludeMetadata", "args": ["suppressions", "validators"]},
-                        {"name": "removeUnusedShapes", "args": []}
+                        {
+                            "name": "excludeShapesByTag",
+                            "args": {
+                                "tags": ["internal"]
+                            }
+                        },
+                        {
+                            "name": "excludeTraitsByTag",
+                            "args": {
+                                "tags": ["internal"]
+                            }
+                        },
+                        {
+                            "name": "excludeMetadata",
+                            "args": {
+                                "keys": ["suppressions", "validators"]
+                            }
+                        },
+                        {
+                            "name": "removeUnusedShapes"
+                        }
                     ]
                 }
             }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionTransformer.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionTransformer.java
@@ -17,14 +17,11 @@ package software.amazon.smithy.build;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.ListUtils;
 
 /**
@@ -48,14 +45,13 @@ public interface ProjectionTransformer {
     }
 
     /**
-     * Creates a function that transforms a model using the provided
-     * {@link ModelTransformer}.
+     * Transforms the given model using the provided {@link TransformContext}.
      *
-     * @param arguments Arguments used to create the ModelTransformer.
+     * @param context Transformation context.
      * @return Returns the created transformer.
      * @throws IllegalArgumentException if the arguments are invalid.
      */
-    BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments);
+    Model transform(TransformContext context);
 
     /**
      * Creates a {@code ProjectionTransformer} factory function using SPI

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -39,6 +39,9 @@ import software.amazon.smithy.model.transform.ModelTransformer;
  * and writes the artifacts to a {@link FileManifest}.
  */
 public final class SmithyBuild {
+    /** The version of Smithy build. */
+    public static final String VERSION = "1.0";
+
     SmithyBuildConfig config;
     Path importBasePath;
     Path outputDirectory;

--- a/smithy-build/src/main/java/software/amazon/smithy/build/TransformContext.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/TransformContext.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Context object used when applying a {@link ProjectionTransformer}.
+ *
+ * <p>Implementer's note: A context object is used to allow contextual
+ * information provided to projection transforms to evolve over time.
+ */
+public final class TransformContext implements ToSmithyBuilder<TransformContext> {
+
+    private final ObjectNode settings;
+    private final Model model;
+    private final Model originalModel;
+    private final Set<Path> sources;
+    private final String projectionName;
+    private final ModelTransformer transformer;
+    private final Set<String> visited;
+
+    private TransformContext(Builder builder) {
+        model = SmithyBuilder.requiredState("model", builder.model);
+        transformer = builder.transformer != null ? builder.transformer : ModelTransformer.create();
+        settings = builder.settings;
+        originalModel = builder.originalModel;
+        sources = SetUtils.copyOf(builder.sources);
+        projectionName = builder.projectionName;
+        visited = new LinkedHashSet<>(builder.visited);
+    }
+
+    /**
+     * @return Returns a TransformContext builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder()
+                .settings(settings)
+                .model(model)
+                .originalModel(originalModel)
+                .sources(sources)
+                .projectionName(projectionName)
+                .transformer(transformer)
+                .visited(visited);
+    }
+
+    /**
+     * Gets the arguments object of the transform.
+     *
+     * @return Returns the transformer arguments.
+     */
+    public ObjectNode getSettings() {
+        return settings;
+    }
+
+    /**
+     * Gets the model to transform.
+     *
+     * @return Returns the model to transform.
+     */
+    public Model getModel() {
+        return model;
+    }
+
+    /**
+     * Get the original model before applying the projection.
+     *
+     * @return The optionally provided original model.
+     */
+    public Optional<Model> getOriginalModel() {
+        return Optional.ofNullable(originalModel);
+    }
+
+    /**
+     * Gets the source models, or models that are considered the subject
+     * of the build.
+     *
+     * <p>This does not return an exhaustive set of model paths! There are
+     * typically two kinds of models that are added to a build: source
+     * models and discovered models. Discovered models are someone else's
+     * models. Source models are the models owned by the package being built.
+     *
+     * @return Returns the source models.
+     */
+    public Set<Path> getSources() {
+        return sources;
+    }
+
+    /**
+     * Gets the name of the projection being applied.
+     *
+     * <p>If no projection could be found, "source" is assumed.
+     *
+     * @return Returns the explicit or assumed projection name.
+     */
+    public String getProjectionName() {
+        return projectionName;
+    }
+
+    /**
+     * Gets the {@code ModelTransformer} that has been configured to aid
+     * in the transformation.
+     *
+     * @return Returns the model transformer.
+     */
+    public ModelTransformer getTransformer() {
+        return transformer;
+    }
+
+    /**
+     * Gets the set of previously visited transforms.
+     *
+     * <p>This method is used as bookkeeping for the {@code apply}
+     * plugin to detect cycles.
+     *
+     * @return Returns the ordered set of visited projections.
+     */
+    public Set<String> getVisited() {
+        return visited;
+    }
+
+    /**
+     * Builds a {@link TransformContext}.
+     */
+    public static final class Builder implements SmithyBuilder<TransformContext> {
+
+        private ObjectNode settings = Node.objectNode();
+        private Model model;
+        private Model originalModel;
+        private Set<Path> sources = Collections.emptySet();
+        private String projectionName = "source";
+        private ModelTransformer transformer;
+        private Set<String> visited = Collections.emptySet();
+
+        private Builder() {}
+
+        @Override
+        public TransformContext build() {
+            return new TransformContext(this);
+        }
+
+        public Builder settings(ObjectNode settings) {
+            this.settings = Objects.requireNonNull(settings);
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = Objects.requireNonNull(model);
+            return this;
+        }
+
+        public Builder originalModel(Model originalModel) {
+            this.originalModel = originalModel;
+            return this;
+        }
+
+        public Builder sources(Set<Path> sources) {
+            this.sources = Objects.requireNonNull(sources);
+            return this;
+        }
+
+        public Builder projectionName(String projectionName) {
+            this.projectionName = Objects.requireNonNull(projectionName);
+            return this;
+        }
+
+        public Builder transformer(ModelTransformer transformer) {
+            this.transformer = transformer;
+            return this;
+        }
+
+        public Builder visited(Set<String> visited) {
+            this.visited = visited;
+            return this;
+        }
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
@@ -16,19 +16,15 @@
 package software.amazon.smithy.build.model;
 
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import software.amazon.smithy.build.SmithyBuildException;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelSyntaxException;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.node.NodeVisitor;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
@@ -39,24 +35,6 @@ import software.amazon.smithy.utils.Pair;
  * Loads a {@link SmithyBuildConfig} from disk.
  */
 final class ConfigLoader {
-    private static final String VERSION = "1.0";
-    private static final String VERSION_KEY = "version";
-    private static final String IMPORTS_KEY = "imports";
-    private static final String OUTPUT_DIRECTORY_KEY = "outputDirectory";
-    private static final String PROJECTIONS_KEY = "projections";
-    private static final String PLUGINS_KEY = "plugins";
-    private static final String ABSTRACT_KEY = "abstract";
-    private static final String FILTERS_KEY = "filters";
-    private static final String MAPPERS_KEY = "mappers";
-    private static final String TRANSFORMS_KEY = "transforms";
-    private static final String NAME_KEY = "name";
-    private static final String ARGS_KEY = "args";
-
-    private static final List<String> ROOT_KEYS = Arrays.asList(
-            VERSION_KEY, IMPORTS_KEY, OUTPUT_DIRECTORY_KEY, PROJECTIONS_KEY, PLUGINS_KEY);
-    private static final List<String> PROJECTION_KEYS = Arrays.asList(
-            ABSTRACT_KEY, FILTERS_KEY, MAPPERS_KEY, TRANSFORMS_KEY, IMPORTS_KEY, PLUGINS_KEY);
-    private static final List<String> TRANSFORM_KEYS = Arrays.asList(NAME_KEY, ARGS_KEY);
 
     private ConfigLoader() {}
 
@@ -74,63 +52,8 @@ final class ConfigLoader {
     }
 
     private static SmithyBuildConfig load(ObjectNode node) {
-        SmithyBuildConfig.Builder builder = SmithyBuildConfig.builder();
-        node.warnIfAdditionalProperties(ROOT_KEYS);
-
-        node.expectStringMember(VERSION_KEY).expectOneOf(VERSION);
-        builder.imports(node.getArrayMember(IMPORTS_KEY)
-                .map(imports -> Node.loadArrayOfString(IMPORTS_KEY, imports))
-                .orElse(Collections.emptyList()));
-        node.getStringMember(OUTPUT_DIRECTORY_KEY).map(StringNode::getValue).ifPresent(builder::outputDirectory);
-        builder.projections(node.getObjectMember(PROJECTIONS_KEY)
-                .map(ConfigLoader::loadProjections)
-                .orElse(Collections.emptyMap()));
-        builder.plugins(node.getObjectMember(PLUGINS_KEY)
-                .map(ConfigLoader::loadPlugins)
-                .orElse(Collections.emptyMap()));
-        return builder.build();
-    }
-
-    private static Map<String, ProjectionConfig> loadProjections(ObjectNode container) {
-        return container.getMembers().entrySet().stream()
-                .map(entry -> Pair.of(entry.getKey().getValue(), loadProjection(entry.getValue().expectObjectNode())))
-                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-    }
-
-    private static ProjectionConfig loadProjection(ObjectNode members) {
-        members.warnIfAdditionalProperties(PROJECTION_KEYS);
-        ProjectionConfig.Builder builder = ProjectionConfig.builder()
-                .isAbstract(members.getBooleanMemberOrDefault(ABSTRACT_KEY));
-        builder.transforms(members.getArrayMember(TRANSFORMS_KEY)
-                .map(ConfigLoader::loadTransforms)
-                .orElse(Collections.emptyList()));
-        builder.imports(members.getArrayMember(IMPORTS_KEY)
-                .map(imports -> Node.loadArrayOfString(IMPORTS_KEY, imports))
-                .orElse(Collections.emptyList()));
-        builder.plugins(members.getObjectMember(PLUGINS_KEY)
-                .map(ConfigLoader::loadPlugins)
-                .orElse(Collections.emptyMap()));
-        return builder.build();
-    }
-
-    private static List<TransformConfig> loadTransforms(ArrayNode node) {
-        return node.getElements().stream()
-                .map(element -> {
-                    ObjectNode objectNode = element.expectObjectNode();
-                    objectNode.warnIfAdditionalProperties(TRANSFORM_KEYS);
-                    String name = objectNode.expectStringMember(NAME_KEY).getValue();
-                    List<String> args = objectNode.getArrayMember(ARGS_KEY)
-                            .map(argsNode -> argsNode.getElementsAs(StringNode::getValue))
-                            .orElseGet(Collections::emptyList);
-                    return TransformConfig.builder().name(name).args(args).build();
-                })
-                .collect(Collectors.toList());
-    }
-
-    private static Map<String, ObjectNode> loadPlugins(ObjectNode container) {
-        return container.getMembers().entrySet().stream()
-                .map(entry -> Pair.of(entry.getKey().getValue(), entry.getValue().expectObjectNode()))
-                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+        NodeMapper mapper = new NodeMapper();
+        return mapper.deserialize(node, SmithyBuildConfig.class);
     }
 
     /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
@@ -21,10 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.build.SmithyBuildException;
-import software.amazon.smithy.model.node.ArrayNode;
-import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -32,7 +29,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 /**
  * ProjectionConfig stored in a {@link SmithyBuildConfig}.
  */
-public final class ProjectionConfig implements ToNode {
+public final class ProjectionConfig {
     private final boolean isAbstract;
     private final List<String> imports;
     private final List<TransformConfig> transforms;
@@ -83,28 +80,6 @@ public final class ProjectionConfig implements ToNode {
         return imports;
     }
 
-    @Override
-    public Node toNode() {
-        ObjectNode.Builder result = Node.objectNodeBuilder();
-        if (isAbstract) {
-            result.withMember("abstract", Node.from(true));
-        }
-
-        if (!imports.isEmpty()) {
-            result.withMember("imports", imports.stream().map(Node::from).collect(ArrayNode.collect()));
-        }
-
-        return result
-                .withMember("transforms", createTransformerNode(getTransforms()))
-                .withMember("plugins", getPlugins().entrySet().stream()
-                        .collect(ObjectNode.collectStringKeys(Map.Entry::getKey, Map.Entry::getValue)))
-                .build();
-    }
-
-    private static Node createTransformerNode(List<TransformConfig> values) {
-        return values.stream().map(TransformConfig::toNode).collect(ArrayNode.collect());
-    }
-
     /**
      * Builds a {@link ProjectionConfig}.
      */
@@ -133,7 +108,7 @@ public final class ProjectionConfig implements ToNode {
          * @param isAbstract Set to true to mark as abstract.
          * @return Returns the builder.
          */
-        public Builder isAbstract(boolean isAbstract) {
+        public Builder setAbstract(boolean isAbstract) {
             this.isAbstract = isAbstract;
             return this;
         }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -40,6 +40,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfig> {
     private static final Set<String> BUILTIN_PLUGINS = SetUtils.of("build-info", "model", "sources");
 
+    private final String version;
     private final List<String> imports;
     private final String outputDirectory;
     private final Map<String, ProjectionConfig> projections;
@@ -47,6 +48,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     private final Path importBasePath;
 
     private SmithyBuildConfig(Builder builder) {
+        SmithyBuilder.requiredState("version", builder.version);
+        version = builder.version;
         importBasePath = builder.importBasePath;
         outputDirectory = builder.outputDirectory;
         imports = ListUtils.copyOf(builder.imports);
@@ -108,12 +111,22 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     @Override
     public Builder toBuilder() {
         Builder builder = builder()
+                .version(version)
                 .outputDirectory(outputDirectory)
                 .imports(imports)
                 .projections(projections)
                 .plugins(plugins);
         builder.importBasePath = importBasePath;
         return builder;
+    }
+
+    /**
+     * Gets the version of Smithy-Build.
+     *
+     * @return Returns the version.
+     */
+    public String getVersion() {
+        return version;
     }
 
     /**
@@ -170,6 +183,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         private final List<String> imports = new ArrayList<>();
         private final Map<String, ProjectionConfig> projections = new LinkedHashMap<>();
         private final Map<String, ObjectNode> plugins = new LinkedHashMap<>();
+        private String version;
         private String outputDirectory;
         private Path importBasePath;
 
@@ -178,6 +192,17 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         @Override
         public SmithyBuildConfig build() {
             return new SmithyBuildConfig(this);
+        }
+
+        /**
+         * Sets the builder config file version.
+         *
+         * @param version Version to set.
+         * @return Returns the builder.
+         */
+        public Builder version(String version) {
+            this.version = version;
+            return this;
         }
 
         /**
@@ -199,6 +224,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
          */
         public Builder merge(SmithyBuildConfig config) {
             config.getOutputDirectory().ifPresent(this::outputDirectory);
+            version(config.getVersion());
             imports.addAll(config.getImports());
             projections.putAll(config.getProjections());
             plugins.putAll(config.getPlugins());

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/TransformConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/TransformConfig.java
@@ -17,15 +17,13 @@ package software.amazon.smithy.build.model;
 
 import java.util.Collections;
 import java.util.List;
-import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
  * Transform configuration found in a projection.
  */
-public final class TransformConfig implements ToNode {
+public final class TransformConfig {
     private final String name;
     private final List<String> args;
 
@@ -50,14 +48,6 @@ public final class TransformConfig implements ToNode {
      */
     public List<String> getArgs() {
         return args;
-    }
-
-    @Override
-    public Node toNode() {
-        return Node.objectNodeBuilder()
-                .withMember("name", Node.from(getName()))
-                .withMember("args", Node.fromStrings(args))
-                .build();
     }
 
     public static final class Builder implements SmithyBuilder<TransformConfig> {

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/TransformConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/TransformConfig.java
@@ -15,9 +15,8 @@
 
 package software.amazon.smithy.build.model;
 
-import java.util.Collections;
-import java.util.List;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -25,11 +24,11 @@ import software.amazon.smithy.utils.SmithyBuilder;
  */
 public final class TransformConfig {
     private final String name;
-    private final List<String> args;
+    private final ObjectNode args;
 
     private TransformConfig(Builder builder) {
         name = SmithyBuilder.requiredState("name", builder.name);
-        args = ListUtils.copyOf(builder.args);
+        args = builder.args;
     }
 
     public static Builder builder() {
@@ -46,13 +45,13 @@ public final class TransformConfig {
     /**
      * @return Gets the args.
      */
-    public List<String> getArgs() {
+    public ObjectNode getArgs() {
         return args;
     }
 
     public static final class Builder implements SmithyBuilder<TransformConfig> {
         private String name;
-        private List<String> args = Collections.emptyList();
+        private ObjectNode args = Node.objectNode();
 
         private Builder() {}
 
@@ -75,11 +74,22 @@ public final class TransformConfig {
         /**
          * Sets the args of the transform.
          *
+         * <p>If an array is provided, the array is automatically converted
+         * to an object with a key named "__args" that contains the array.
+         * This is a backward compatibility shim for older versions of
+         * Smithy Builder that only accepts a list of strings for
+         * projection transforms.
+         *
          * @param args Arguments to set.
          * @return Returns the builder.
          */
-        public Builder args(List<String> args) {
-            this.args = args;
+        public Builder args(Node args) {
+            if (args.isArrayNode()) {
+                this.args = Node.objectNode().withMember("__args", args);
+            } else {
+                this.args = args.expectObjectNode();
+            }
+
             return this;
         }
     }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/plugins/BuildInfo.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/plugins/BuildInfo.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.plugins;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.ProjectionConfig;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * POJO to represents a smithy-build-info.json file.
+ */
+public final class BuildInfo {
+    private String version = SmithyBuild.VERSION;
+    private String projectionName = "source";
+    private ProjectionConfig projection;
+    private List<ValidationEvent> validationEvents = Collections.emptyList();
+    private List<ShapeId> traitNames = Collections.emptyList();
+    private List<ShapeId> traitDefNames = Collections.emptyList();
+    private List<ShapeId> serviceShapeIds = Collections.emptyList();
+    private List<ShapeId> operationShapeIds = Collections.emptyList();
+    private List<ShapeId> resourceShapeIds = Collections.emptyList();
+    private Map<String, Node> metadata = Collections.emptyMap();
+
+    /**
+     * @return Gets the version of the build-info file format.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * @return Gets the name of the projection used in this build.
+     */
+    public String getProjectionName() {
+        return projectionName;
+    }
+
+    public void setProjectionName(String projectionName) {
+        this.projectionName = projectionName;
+    }
+
+    /**
+     * @return Gets the projection configuration.
+     */
+    public ProjectionConfig getProjection() {
+        return projection;
+    }
+
+    public void setProjection(ProjectionConfig projection) {
+        this.projection = projection;
+    }
+
+    /**
+     * @return Gets the validation events encountered by the projection.
+     */
+    public List<ValidationEvent> getValidationEvents() {
+        return validationEvents;
+    }
+
+    public void setValidationEvents(List<ValidationEvent> validationEvents) {
+        this.validationEvents = validationEvents;
+    }
+
+    /**
+     * @return Gets the shape ID of every trait used in the projected model.
+     */
+    public List<ShapeId> getTraitNames() {
+        return traitNames;
+    }
+
+    public void setTraitNames(List<ShapeId> traitNames) {
+        this.traitNames = traitNames;
+    }
+
+    /**
+     * @return Gets the shape ID of every trait shape defined in the projection.
+     */
+    public List<ShapeId> getTraitDefNames() {
+        return traitDefNames;
+    }
+
+    public void setTraitDefNames(List<ShapeId> traitDefNames) {
+        this.traitDefNames = traitDefNames;
+    }
+
+    /**
+     * @return Gets the shape ID of every service in the projection.
+     */
+    public List<ShapeId> getServiceShapeIds() {
+        return serviceShapeIds;
+    }
+
+    public void setServiceShapeIds(List<ShapeId> serviceShapeIds) {
+        this.serviceShapeIds = serviceShapeIds;
+    }
+
+    /**
+     * @return Gets the shape ID of every operation in the projection.
+     */
+    public List<ShapeId> getOperationShapeIds() {
+        return operationShapeIds;
+    }
+
+    public void setOperationShapeIds(List<ShapeId> operationShapeIds) {
+        this.operationShapeIds = operationShapeIds;
+    }
+
+    /**
+     * @return Gets the shape ID of every resource in the projection.
+     */
+    public List<ShapeId> getResourceShapeIds() {
+        return resourceShapeIds;
+    }
+
+    public void setResourceShapeIds(List<ShapeId> resourceShapeIds) {
+        this.resourceShapeIds = resourceShapeIds;
+    }
+
+    /**
+     * @return Gets the model metadata in the projection.
+     */
+    public Map<String, Node> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Node> metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof BuildInfo)) {
+            return false;
+        }
+
+        BuildInfo buildInfo = (BuildInfo) o;
+        return Objects.equals(getVersion(), buildInfo.getVersion())
+               && Objects.equals(getProjectionName(), buildInfo.getProjectionName())
+               && Objects.equals(getProjection(), buildInfo.getProjection())
+               && Objects.equals(getValidationEvents(), buildInfo.getValidationEvents())
+               && Objects.equals(getTraitNames(), buildInfo.getTraitNames())
+               && Objects.equals(getTraitDefNames(), buildInfo.getTraitDefNames())
+               && Objects.equals(getServiceShapeIds(), buildInfo.getServiceShapeIds())
+               && Objects.equals(getOperationShapeIds(), buildInfo.getOperationShapeIds())
+               && Objects.equals(getResourceShapeIds(), buildInfo.getResourceShapeIds())
+               && Objects.equals(getMetadata(), buildInfo.getMetadata());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVersion(), getProjectionName(), getProjection(), getValidationEvents(),
+                            getTraitNames(), getTraitDefNames(), getServiceShapeIds(), getOperationShapeIds(),
+                            getResourceShapeIds(), getMetadata());
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/plugins/ConfigurableSmithyBuildPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/plugins/ConfigurableSmithyBuildPlugin.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.plugins;
+
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.SmithyBuildPlugin;
+import software.amazon.smithy.model.node.NodeMapper;
+
+/**
+ * An abstract class used to more easily implement a Smithy build plugin
+ * that expects configuration input in a specific type, {@code T}.
+ *
+ * <p>This class will automatically deserialze the given {@code Node}
+ * value in the {@code T} and invoke {@link #executeWithConfig(PluginContext, Object)}
+ * with the deserialized configuration of type {@code T}.
+ *
+ * <p><strong>If your build plugin requires configuration, then you typically
+ * should just extend this class.</strong></p>
+ *
+ * @param <T> The configuration setting type (e.g., a POJO).
+ */
+public abstract class ConfigurableSmithyBuildPlugin<T> implements SmithyBuildPlugin {
+    /**
+     * Gets the configuration class type.
+     *
+     * <p>The referenced {@code configType} class must be a public POJO with a
+     * public, zero-arg constructor, getters, and setters. If the POJO has a
+     * public static {@code fromNode} method, it will be invoked and is
+     * expected to deserialize the Node. If the POJO has a public static
+     * {@code builder} method, it will be invoked, setters will be called
+     * on the builder POJO, and finally the result of calling the
+     * {@code build} method is used as the configuration type. Finally,
+     * the deserializer will attempt to create the type and call setters on
+     * it that correspond to property names.
+     *
+     * @return Returns the configuration class (a POJO with setters/getters).
+     */
+    public abstract Class<T> getConfigType();
+
+    @Override
+    public void execute(PluginContext context) {
+        NodeMapper mapper = new NodeMapper();
+        T config = mapper.deserialize(context.getSettings(), getConfigType());
+        executeWithConfig(context, config);
+    }
+
+    /**
+     * Executes the plugin using the deserialized configuration object.
+     *
+     * @param context Plugin context.
+     * @param config Deserialized configuration object.
+     */
+    protected abstract void executeWithConfig(PluginContext context, T config);
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/Apply.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/Apply.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.List;
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+
+/**
+ * Recursively applies transforms of other projections.
+ *
+ * <p>Note: this transform is special cased and not created using a
+ * normal factory. This is because this transformer needs to
+ * recursively transform models based on projections, and no other
+ * transform needs this functionality. We could *maybe* address
+ * this later if we really care that much.
+ */
+public class Apply extends BackwardCompatHelper<Apply.Config> {
+
+    /**
+     * {@code apply} configuration.
+     */
+    public static final class Config {
+        private List<String> projections;
+
+        /**
+         * Gets the ordered list of projections to apply by name.
+         *
+         * @return Returns the projection names to apply.
+         */
+        public List<String> getProjections() {
+            return projections;
+        }
+
+        /**
+         * Sets the ordered list of projection names to apply.
+         *
+         * @param projections Projection names to apply.
+         */
+        public void setProjections(List<String> projections) {
+            this.projections = projections;
+        }
+    }
+
+    @FunctionalInterface
+    public interface ApplyCallback {
+        Model apply(Model inputModel, String projectionName, Set<String> visited);
+    }
+
+    private final ApplyCallback applyCallback;
+
+    /**
+     * Sets the function used to apply projections.
+     *
+     * @param applyCallback Takes the projection name, model, and returns the updated model.
+     */
+    public Apply(ApplyCallback applyCallback) {
+        this.applyCallback = applyCallback;
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    public String getName() {
+        return "apply";
+    }
+
+    @Override
+    String getBackwardCompatibleNameMapping() {
+        return "projections";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Model current = context.getModel();
+        Set<String> visited = context.getVisited();
+
+        for (String projection : config.getProjections()) {
+            current = applyCallback.apply(current, projection, visited);
+        }
+
+        return current;
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/BackwardCompatHelper.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/BackwardCompatHelper.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.logging.Logger;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
+
+/**
+ * Helper class used to allow older versions of smithy-build.json files to
+ * automatically rewrite a list of strings in an object to a member named
+ * "__args" that contains the list of strings.
+ *
+ * <p>For example, the following deprecated JSON:
+ *
+ * <pre>{@code
+ * {
+ *     "version": "1.0",
+ *     "projections": {
+ *         "projection-name": {
+ *             "transforms": [
+ *                 {
+ *                     "name": "transform-name",
+ *                     "args": [
+ *                         "argument1",
+ *                         "argument2"
+ *                     ]
+ *                 }
+ *             }
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Is rewritten to the following JSON using {@code ConfigLoader}:
+ *
+ * <pre>{@code
+ * {
+ *     "version": "1.0",
+ *     "projections": {
+ *         "projection-name": {
+ *             "transforms": [
+ *                 {
+ *                     "name": "transform-name",
+ *                     "args": {
+ *                         "__args": [
+ *                             "argument1",
+ *                             "argument2"
+ *                         ]
+ *                     }
+ *                 }
+ *             }
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>And this, in turn, uses the result of {@link #getBackwardCompatibleNameMapping()}
+ * to rewrite the JSON to the preferred format:
+ *
+ * <pre>{@code
+ * {
+ *     "version": "1.0",
+ *     "projections": {
+ *         "projection-name": {
+ *             "transforms": [
+ *                 {
+ *                     "name": "transform-name",
+ *                     "args": {
+ *                         "<result of getBackwardCompatibleNameMapping()>": [
+ *                             "argument1",
+ *                             "argument2"
+ *                         ]
+ *                     }
+ *                 }
+ *             }
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T> Type of configuration object to deserialize into.
+ */
+abstract class BackwardCompatHelper<T> extends ConfigurableProjectionTransformer<T> {
+
+    private static final Logger LOGGER = Logger.getLogger(BackwardCompatHelper.class.getName());
+    private static final String ARGS = "__args";
+
+    /**
+     * Gets the name that "__args" is to be rewritten to.
+     *
+     * @return Returns the name to rewrite.
+     */
+    abstract String getBackwardCompatibleNameMapping();
+
+    @Override
+    public final Model transform(TransformContext context) {
+        ObjectNode original = context.getSettings();
+
+        if (!original.getMember(ARGS).isPresent()) {
+            return super.transform(context);
+        }
+
+        LOGGER.warning(() -> String.format(
+                "Deprecated projection transform arguments detected for `%s`; change this list of strings "
+                + "to an object with a property named `%s`", getName(), getBackwardCompatibleNameMapping()));
+
+        ObjectNode updated = original.toBuilder()
+                .withMember(getBackwardCompatibleNameMapping(), original.getMember(ARGS).get())
+                .withoutMember(ARGS)
+                .build();
+
+        return super.transform(context.toBuilder().settings(updated).build());
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByTag.java
@@ -17,21 +17,50 @@ package software.amazon.smithy.build.transforms;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.function.BiFunction;
-import software.amazon.smithy.build.ProjectionTransformer;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
 /**
- * Removes shapes if they are tagged with one or more of the given arguments.
+ * {@code excludeShapesByTag} removes shapes if they are tagged with one or more
+ * of the given arguments.
  *
  * <p>Prelude shapes are not removed by this transformer.
  */
-public final class ExcludeShapesByTag implements ProjectionTransformer {
+public final class ExcludeShapesByTag extends BackwardCompatHelper<ExcludeShapesByTag.Config> {
+
+    /**
+     * {@code excludeShapesByTag} configuration.
+     */
+    public static final class Config {
+        private Set<String> tags = Collections.emptySet();
+
+        /**
+         * Gets the set of tags that causes shapes to be removed.
+         *
+         * @return Returns the removal tags.
+         */
+        public Set<String> getTags() {
+            return tags;
+        }
+
+        /**
+         * Sets the set of tags that causes shapes to be removed.
+         *
+         * @param tags Tags that cause shapes to be removed.
+         */
+        public void setTags(Set<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
     @Override
     public String getName() {
         return "excludeShapesByTag";
@@ -43,10 +72,17 @@ public final class ExcludeShapesByTag implements ProjectionTransformer {
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        Set<String> includeTags = new HashSet<>(arguments);
-        return (transformer, model) -> transformer.filterShapes(
-                model, shape -> Prelude.isPreludeShape(shape)
-                                || shape.getTags().stream().noneMatch(includeTags::contains));
+    String getBackwardCompatibleNameMapping() {
+        return "tags";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Set<String> includeTags = config.getTags();
+        ModelTransformer transformer = context.getTransformer();
+        Model model = context.getModel();
+        return transformer.filterShapes(model, shape -> {
+            return Prelude.isPreludeShape(shape) || shape.getTags().stream().noneMatch(includeTags::contains);
+        });
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTags.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTags.java
@@ -15,17 +15,59 @@
 
 package software.amazon.smithy.build.transforms;
 
+import java.util.Collections;
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+
 /**
- * Removes tags from shapes and trait definitions that match any of the
- * provided arguments (a list of allowed tags).
+ * {@code excludeTags} removes tags from shapes and trait definitions
+ * that match any of the provided {@code tags}.
  */
-public final class ExcludeTags extends AbstractTagMapper {
-    public ExcludeTags() {
-        super(true);
+public final class ExcludeTags extends BackwardCompatHelper<ExcludeTags.Config> {
+
+    /**
+     * {@code excludeTags} configuration.
+     */
+    public static final class Config {
+        private Set<String> tags = Collections.emptySet();
+
+        /**
+         * Gets the set of tags that are removed from the model.
+         *
+         * @return Returns the tags to remove.
+         */
+        public Set<String> getTags() {
+            return tags;
+        }
+
+        /**
+         * Sets the set of tags that are removed from the model.
+         *
+         * @param tags The tags to remove from the model.
+         */
+        public void setTags(Set<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
     }
 
     @Override
     public String getName() {
         return "excludeTags";
+    }
+
+    @Override
+    String getBackwardCompatibleNameMapping() {
+        return "tags";
+    }
+
+    @Override
+    public Model transformWithConfig(TransformContext context, Config config) {
+        return TagUtils.excludeShapeTags(context.getTransformer(), context.getModel(), config.getTags());
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTraits.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTraits.java
@@ -15,11 +15,11 @@
 
 package software.amazon.smithy.build.transforms;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -27,14 +27,51 @@ import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.Pair;
 
 /**
- * Removes trait definitions and traits from shapes when a trait name
- * matches any of the given arguments.
+ * {@code excludeTraits} removes trait definitions and traits from
+ * shapes when a trait name matches any of the values given in
+ * {@code traits}.
  *
- * <p>End an arguments with "#" to exclude the traits of an entire
- * namespace.
+ * <p>Arguments that end with "#" exclude the traits of an entire
+ * namespace. Trait shape IDs that are relative are assumed to be
+ * part of the {@code smithy.api} prelude namespace.
  */
-public final class ExcludeTraits extends AbstractTraitRemoval {
+public final class ExcludeTraits extends BackwardCompatHelper<ExcludeTraits.Config> {
+
     private static final Logger LOGGER = Logger.getLogger(ExcludeTraits.class.getName());
+
+    /**
+     * {@code excludeTraits} configuration settings.
+     */
+    public static final class Config {
+        private Set<String> traits = Collections.emptySet();
+
+        /**
+         * Gets the list of trait shape IDs/namespaces to exclude.
+         *
+         * @return shape IDs to exclude.
+         */
+        public Set<String> getTraits() {
+            return traits;
+        }
+
+        /**
+         * Sets the list of trait shape IDs/namespaces to exclude.
+         *
+         * <p>Relative shape IDs are considered traits in the prelude
+         * namespace, {@code smithy.api}. Strings ending in "#" are
+         * used to exclude traits from an entire namespace.
+         *
+         * @param traits Traits to exclude.
+         */
+        public void setTraits(Set<String> traits) {
+            this.traits = traits;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
 
     @Override
     public String getName() {
@@ -42,22 +79,28 @@ public final class ExcludeTraits extends AbstractTraitRemoval {
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        Pair<Set<ShapeId>, Set<String>> namesAndNamespaces = parseTraits(arguments);
+    String getBackwardCompatibleNameMapping() {
+        return "traits";
+    }
+
+    @Override
+    public Model transformWithConfig(TransformContext context, Config config) {
+        Pair<Set<ShapeId>, Set<String>> namesAndNamespaces = TraitRemovalUtils.parseTraits(config.getTraits());
         Set<ShapeId> names = namesAndNamespaces.getLeft();
         Set<String> namespaces = namesAndNamespaces.getRight();
         LOGGER.info(() -> "Excluding traits by ID " + names + " and namespaces " + namespaces);
 
-        return (transformer, model) -> {
-            Set<Shape> removeTraits = model.getTraitShapes().stream()
-                    .filter(trait -> matchesTraitDefinition(trait, names, namespaces))
-                    .collect(Collectors.toSet());
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
 
-            if (!removeTraits.isEmpty()) {
-                LOGGER.info(() -> "Excluding traits: " + removeTraits);
-            }
+        Set<Shape> removeTraits = model.getTraitShapes().stream()
+                .filter(trait -> TraitRemovalUtils.matchesTraitDefinition(trait, names, namespaces))
+                .collect(Collectors.toSet());
 
-            return transformer.removeShapes(model, removeTraits);
-        };
+        if (!removeTraits.isEmpty()) {
+            LOGGER.info(() -> "Excluding traits: " + removeTraits);
+        }
+
+        return transformer.removeShapes(model, removeTraits);
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTraitsByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTraitsByTag.java
@@ -16,34 +16,75 @@
 package software.amazon.smithy.build.transforms;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.function.BiFunction;
-import software.amazon.smithy.build.ProjectionTransformer;
+import java.util.Collections;
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.Tagged;
 
 /**
- * Removes traits and trait definitions from a model if the trait definition
- * contains any of the provided tags.
+ * {@code excludeTraitsByTag} removes traits and trait definitions
+ * from a model if the trait definition contains any of the provided
+ * {@code tags}.
  *
  * <p>This transformer will not remove prelude trait definitions.
  */
-public final class ExcludeTraitsByTag implements ProjectionTransformer {
+public final class ExcludeTraitsByTag extends BackwardCompatHelper<ExcludeTraitsByTag.Config> {
+
+    /**
+     * {@code excludeTraitsByTag} configuration settings.
+     */
+    public static final class Config {
+        private Set<String> tags = Collections.emptySet();
+
+        /**
+         * @return the list of tags that, if present, cause the trait to be removed.
+         */
+        public Set<String> getTags() {
+            return tags;
+        }
+
+        /**
+         * Sets the list of tags that, if present, cause the trait to be removed.
+         *
+         * @param tags Tags to set.
+         */
+        public void setTags(Set<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
     @Override
     public String getName() {
         return "excludeTraitsByTag";
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        return (transformer, model) -> transformer.removeShapesIf(
-                model,
-                shape -> !Prelude.isPreludeShape(shape)
-                         && shape.hasTrait(TraitDefinition.class)
-                         && hasAnyTag(shape, arguments));
+    String getBackwardCompatibleNameMapping() {
+        return "tags";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
+        Set<String> tags = config.getTags();
+        return transformer.removeShapesIf(model, shape -> removeIfPredicate(shape, tags));
+    }
+
+    private boolean removeIfPredicate(Shape shape, Collection<String> tags) {
+        return !Prelude.isPreludeShape(shape)
+               && shape.hasTrait(TraitDefinition.class)
+               && hasAnyTag(shape, tags);
     }
 
     private boolean hasAnyTag(Tagged tagged, Collection<String> tags) {

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeMetadata.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeMetadata.java
@@ -15,17 +15,45 @@
 
 package software.amazon.smithy.build.transforms;
 
-import java.util.List;
-import java.util.function.BiFunction;
-import software.amazon.smithy.build.ProjectionTransformer;
+import java.util.Collections;
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
 /**
- * Removes metadata entries when a key does not match any of the given
- * arguments.
+ * {@code includeMetadata} keeps only metadata keys specifically
+ * defined in the provided {@code keys} setting.
  */
-public final class IncludeMetadata implements ProjectionTransformer {
+public final class IncludeMetadata extends BackwardCompatHelper<IncludeMetadata.Config> {
+
+    /**
+     * {@code includeMetadata} configuration settings.
+     */
+    public static final class Config {
+        private Set<String> keys = Collections.emptySet();
+
+        /**
+         * @return the list of keys to keep in metadata.
+         */
+        public Set<String> getKeys() {
+            return keys;
+        }
+
+        /**
+         * Sets the list of keys to keep in metadata.
+         *
+         * @param keys Metadata keys to keep.
+         */
+        public void setKeys(Set<String> keys) {
+            this.keys = keys;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
 
     @Override
     public String getName() {
@@ -33,8 +61,15 @@ public final class IncludeMetadata implements ProjectionTransformer {
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        return (transformer, model) -> transformer.filterMetadata(
-                model, (key, value) -> arguments.contains(key));
+    String getBackwardCompatibleNameMapping() {
+        return "keys";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
+        Set<String> keys = config.getKeys();
+        return transformer.filterMetadata(model, (key, value) -> keys.contains(key));
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeServices.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeServices.java
@@ -15,31 +15,63 @@
 
 package software.amazon.smithy.build.transforms;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import software.amazon.smithy.build.ProjectionTransformer;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
 /**
- * Filters out service shapes that are not included in the arguments list of
- * service shape IDs.
+ * {@code includeServices} filters out service shapes that are not
+ * included in the list of shape IDs contained in the
+ * {@code services} property.
  */
-public final class IncludeServices implements ProjectionTransformer {
+public final class IncludeServices extends BackwardCompatHelper<IncludeServices.Config> {
+
+    /**
+     * {@code includeServices} configuration.
+     */
+    public static final class Config {
+        private Set<ShapeId> services = Collections.emptySet();
+
+        /**
+         * @return Gets the list of service shapes IDs to include.
+         */
+        public Set<ShapeId> getServices() {
+            return services;
+        }
+
+        /**
+         * Sets the list of service shapes IDs to include.
+         *
+         * @param services Services to include by shape ID.
+         */
+        public void setServices(Set<ShapeId> services) {
+            this.services = services;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
     @Override
     public String getName() {
         return "includeServices";
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        Set<ShapeId> includeServices = arguments.stream()
-                .map(ShapeId::from)
-                .collect(Collectors.toSet());
-        return (transformer, model) -> transformer.filterShapes(
-                model, shape -> !shape.isServiceShape() || includeServices.contains(shape.getId()));
+    String getBackwardCompatibleNameMapping() {
+        return "services";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Set<ShapeId> services = config.getServices();
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
+        return transformer.filterShapes(model, shape -> !shape.isServiceShape() || services.contains(shape.getId()));
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeTags.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeTags.java
@@ -15,17 +15,60 @@
 
 package software.amazon.smithy.build.transforms;
 
+import java.util.Collections;
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+
 /**
- * Removes tags from shapes and trait definitions that are not in the
- * argument list (a list of allowed tags).
+ * {@code includeTags} removes tags from shapes and trait
+ * definitions that are not in the set of tags defined in
+ * the {@code tags} property.
  */
-public final class IncludeTags extends AbstractTagMapper {
-    public IncludeTags() {
-        super(false);
+public final class IncludeTags extends BackwardCompatHelper<IncludeTags.Config> {
+
+    /**
+     * {@code includeTags} configuration.
+     */
+    public static final class Config {
+        private Set<String> tags = Collections.emptySet();
+
+        /**
+         * Gets the set of tags that are retained in the model.
+         *
+         * @return Returns the tags to retain.
+         */
+        public Set<String> getTags() {
+            return tags;
+        }
+
+        /**
+         * Sets the set of tags that are retained in the model.
+         *
+         * @param tags The tags to retain in the model.
+         */
+        public void setTags(Set<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
     }
 
     @Override
     public String getName() {
         return "includeTags";
+    }
+
+    @Override
+    String getBackwardCompatibleNameMapping() {
+        return "tags";
+    }
+
+    @Override
+    public Model transformWithConfig(TransformContext context, Config config) {
+        return TagUtils.includeShapeTags(context.getTransformer(), context.getModel(), config.getTags());
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeTraitsByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeTraitsByTag.java
@@ -16,34 +16,75 @@
 package software.amazon.smithy.build.transforms;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.function.BiFunction;
-import software.amazon.smithy.build.ProjectionTransformer;
+import java.util.Collections;
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.Tagged;
 
 /**
- * Removes trait definitions from a model if the definition does
- * not contain at least one of the provided tags.
+ * {@code includeTraitsByTag} removes trait definitions from a model if
+ * the definition does not contain at least one of the provided {@code tags}.
  *
  * <p>This transformer does not remove prelude traits.
  */
-public final class IncludeTraitsByTag implements ProjectionTransformer {
+public final class IncludeTraitsByTag extends BackwardCompatHelper<IncludeTraitsByTag.Config> {
+
+    /**
+     * {@code includeTraitsByTag} configuration settings.
+     */
+    public static final class Config {
+        private Set<String> tags = Collections.emptySet();
+
+        /**
+         * @return the list of tags that must be present for a trait to be kept.
+         */
+        public Set<String> getTags() {
+            return tags;
+        }
+
+        /**
+         * Sets the list of tags that must be present for a trait to be included
+         * in the filtered model.
+         *
+         * @param tags Tags to set.
+         */
+        public void setTags(Set<String> tags) {
+            this.tags = tags;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
     @Override
     public String getName() {
         return "includeTraitsByTag";
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        return (transformer, model) -> transformer.removeShapesIf(
-                model,
-                shape -> !Prelude.isPreludeShape(shape)
-                         && shape.hasTrait(TraitDefinition.class)
-                         && !hasAnyTag(shape, arguments));
+    String getBackwardCompatibleNameMapping() {
+        return "tags";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
+        Set<String> tags = config.getTags();
+        return transformer.removeShapesIf(model, shape -> removeIfPredicate(shape, tags));
+    }
+
+    private boolean removeIfPredicate(Shape shape, Collection<String> tags) {
+        return !Prelude.isPreludeShape(shape)
+               && shape.hasTrait(TraitDefinition.class)
+               && !hasAnyTag(shape, tags);
     }
 
     private boolean hasAnyTag(Tagged tagged, Collection<String> tags) {

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
@@ -17,27 +17,55 @@ package software.amazon.smithy.build.transforms;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Predicate;
-import software.amazon.smithy.build.ProjectionTransformer;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
 /**
- * Removes shapes from the model that are not connected to any service shape.
- *
- * <p>You can export shapes that are not connected to any service shape by
- * applying specific tags to the shape and adding the list of export tags as
- * arguments to the treeShaker.
+ * {@code removeUnusedShapes} removes shapes from the model that are not
+ * connected to any service shape.
  *
  * <p>Shapes from the prelude *are* removed if they are not referenced as
  * part of a model.
  */
-public final class RemoveUnusedShapes implements ProjectionTransformer {
+public final class RemoveUnusedShapes extends BackwardCompatHelper<RemoveUnusedShapes.Config> {
+
+    /**
+     * {@code removeUnusedShapes} configuration settings.
+     */
+    public static final class Config {
+
+        private Set<String> exportTagged = Collections.emptySet();
+
+        /**
+         * You can <em>export</em> shapes that are not connected to any service
+         * shape by applying specific tags to the shape and adding the list of
+         * export tags as arguments to the treeShaker.
+         *
+         * @param exportByTags Tags that cause shapes to be exported.
+         */
+        public void setExportTagged(Set<String> exportByTags) {
+            this.exportTagged = exportByTags;
+        }
+
+        /**
+         * Gets the set of tags that are used to export shapes.
+         *
+         * @return the tags that are used to export shapes.
+         */
+        public Set<String> getExportTagged() {
+            return exportTagged;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
     @Override
     public String getName() {
         return "removeUnusedShapes";
@@ -49,21 +77,24 @@ public final class RemoveUnusedShapes implements ProjectionTransformer {
     }
 
     @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        Set<String> includeTags = new HashSet<>(arguments);
-        Predicate<Shape> keepShapesByTag = shape -> includeTags.stream().noneMatch(shape::hasTag);
-        Predicate<Shape> keepTraitDefsByTag = trait -> includeTags.stream().noneMatch(trait::hasTag);
+    public String getBackwardCompatibleNameMapping() {
+        return "exportTagged";
+    }
 
-        return (transformer, model) -> {
-            int currentShapeCount;
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Predicate<Shape> keepShapesByTag = shape -> config.getExportTagged().stream().noneMatch(shape::hasTag);
+        Predicate<Shape> keepTraitDefsByTag = trait -> config.getExportTagged().stream().noneMatch(trait::hasTag);
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
 
-            do {
-                currentShapeCount = model.toSet().size();
-                model = transformer.removeUnreferencedShapes(model, keepShapesByTag);
-                model = transformer.removeUnreferencedTraitDefinitions(model, keepTraitDefsByTag);
-            } while (currentShapeCount != model.toSet().size());
+        int currentShapeCount;
+        do {
+            currentShapeCount = model.toSet().size();
+            model = transformer.removeUnreferencedShapes(model, keepShapesByTag);
+            model = transformer.removeUnreferencedTraitDefinitions(model, keepTraitDefsByTag);
+        } while (currentShapeCount != model.toSet().size());
 
-            return model;
-        };
+        return model;
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/TagUtils.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/TagUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -17,31 +17,35 @@ package software.amazon.smithy.build.transforms;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
-import software.amazon.smithy.build.ProjectionTransformer;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 
-abstract class AbstractTagMapper implements ProjectionTransformer {
-    private final boolean exclude;
+/**
+ * Utilities for {@link ExcludeTags} and {@link IncludeTags}.
+ */
+final class TagUtils {
 
-    AbstractTagMapper(boolean exclude) {
-        this.exclude = exclude;
+    private TagUtils() {}
+
+    static Model excludeShapeTags(ModelTransformer transformer, Model model, Set<String> tags) {
+        return includeExcludeShapeTags(transformer, model, tags, true);
     }
 
-    @Override
-    public BiFunction<ModelTransformer, Model, Model> createTransformer(List<String> arguments) {
-        Set<String> tags = new HashSet<>(arguments);
-        return (transformer, model) -> removeShapeTags(transformer, model, tags);
+    static Model includeShapeTags(ModelTransformer transformer, Model model, Set<String> tags) {
+        return includeExcludeShapeTags(transformer, model, tags, false);
     }
 
-    private Model removeShapeTags(ModelTransformer transformer, Model model, Set<String> tags) {
-        return transformer.mapShapes(model, shape -> intersectIfChanged(shape.getTags(), tags)
+    private static Model includeExcludeShapeTags(
+            ModelTransformer transformer,
+            Model model,
+            Set<String> tags,
+            boolean exclude
+    ) {
+        return transformer.mapShapes(model, shape -> intersectIfChanged(shape.getTags(), tags, exclude)
                 .map(intersection -> {
                     TagsTrait.Builder builder = TagsTrait.builder();
                     intersection.forEach(builder::addValue);
@@ -50,7 +54,11 @@ abstract class AbstractTagMapper implements ProjectionTransformer {
                 .orElse(shape));
     }
 
-    private Optional<Set<String>> intersectIfChanged(Collection<String> subject, Collection<String> other) {
+    private static Optional<Set<String>> intersectIfChanged(
+            Collection<String> subject,
+            Collection<String> other,
+            boolean exclude
+    ) {
         Set<String> temp = new HashSet<>(subject);
         if (exclude) {
             temp.removeAll(other);

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/TraitRemovalUtils.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/TraitRemovalUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,27 +16,26 @@
 package software.amazon.smithy.build.transforms;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import software.amazon.smithy.build.ProjectionTransformer;
-import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.Pair;
 
-abstract class AbstractTraitRemoval implements ProjectionTransformer {
-    Pair<Set<ShapeId>, Set<String>> parseTraits(List<String> arguments) {
+/**
+ * Utilities for {@link IncludeTraits} and {@link ExcludeTraits}.
+ */
+final class TraitRemovalUtils {
+
+    private TraitRemovalUtils() {}
+
+    static Pair<Set<ShapeId>, Set<String>> parseTraits(Set<String> ids) {
         Set<ShapeId> traitNames = new HashSet<>();
         Set<String> traitNamespaces = new HashSet<>();
 
-        for (String arg : arguments) {
+        for (String arg : ids) {
             if (arg.endsWith("#")) {
                 traitNamespaces.add(arg.substring(0, arg.length() - 1));
-            } else if (arg.equals(Prelude.NAMESPACE)) {
-                // For backwards compatibility, support "smithy.api" instead
-                // of "smithy.api#".
-                traitNamespaces.add(arg);
             } else {
                 traitNames.add(ShapeId.from(Trait.makeAbsoluteName(arg)));
             }
@@ -45,7 +44,7 @@ abstract class AbstractTraitRemoval implements ProjectionTransformer {
         return Pair.of(traitNames, traitNamespaces);
     }
 
-    boolean matchesTraitDefinition(Shape traitShape, Set<ShapeId> traitNames, Set<String> traitNamespaces) {
+    static boolean matchesTraitDefinition(Shape traitShape, Set<ShapeId> traitNames, Set<String> traitNamespaces) {
         return traitNames.contains(traitShape.getId()) || traitNamespaces.contains(traitShape.getId().getNamespace());
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/ProjectionConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/ProjectionConfigTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.ProjectionConfig;
 import software.amazon.smithy.build.model.TransformConfig;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.utils.ListUtils;
 
 public class ProjectionConfigTest {
@@ -29,7 +30,7 @@ public class ProjectionConfigTest {
     public void buildsProjections() {
         TransformConfig t = TransformConfig.builder()
                 .name("foo")
-                .args(ListUtils.of("baz"))
+                .args(Node.objectNode().withMember("__args", Node.fromStrings("baz")))
                 .build();
         ProjectionConfig p = ProjectionConfig.builder()
                 .setAbstract(false)

--- a/smithy-build/src/test/java/software/amazon/smithy/build/ProjectionConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/ProjectionConfigTest.java
@@ -32,7 +32,7 @@ public class ProjectionConfigTest {
                 .args(ListUtils.of("baz"))
                 .build();
         ProjectionConfig p = ProjectionConfig.builder()
-                .isAbstract(false)
+                .setAbstract(false)
                 .transforms(ListUtils.of(t))
                 .build();
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -16,15 +16,12 @@
 package software.amazon.smithy.build;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -79,8 +76,8 @@ public class SmithyBuildTest {
     @Test
     public void throwsForUnknownTransform() throws Exception {
         Assertions.assertThrows(UnknownTransformException.class, () -> {
-            SmithyBuildConfig config = SmithyBuildConfig.load(
-                    Paths.get(getClass().getResource("unknown-transform.json").toURI()));
+            SmithyBuildConfig config = SmithyBuildConfig
+                    .load(Paths.get(getClass().getResource("unknown-transform.json").toURI()));
             new SmithyBuild().config(config).build();
         });
     }
@@ -185,6 +182,7 @@ public class SmithyBuildTest {
     public void cannotSetFiltersOrMappersOnSourceProjection() {
         Throwable thrown = Assertions.assertThrows(SmithyBuildException.class, () -> {
             SmithyBuildConfig config = SmithyBuildConfig.builder()
+                    .version(SmithyBuild.VERSION)
                     .projections(MapUtils.of("source", ProjectionConfig.builder()
                             .transforms(ListUtils.of(TransformConfig.builder().name("foo").build()))
                             .build()))
@@ -432,6 +430,7 @@ public class SmithyBuildTest {
     public void pluginsMustHaveValidNames() {
         Throwable thrown = Assertions.assertThrows(SmithyBuildException.class, () -> {
             SmithyBuildConfig config = SmithyBuildConfig.builder()
+                    .version(SmithyBuild.VERSION)
                     .plugins(MapUtils.of("!invalid", Node.objectNode()))
                     .build();
             new SmithyBuild().config(config).build();

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -400,6 +400,18 @@ public class SmithyBuildTest {
     }
 
     @Test
+    public void detectsDirectlyRecursiveApply() throws Exception {
+        Throwable thrown = Assertions.assertThrows(SmithyBuildException.class, () -> {
+            SmithyBuildConfig config = SmithyBuildConfig.builder()
+                    .load(Paths.get(getClass().getResource("apply-direct-recursion.json").toURI()))
+                    .build();
+            new SmithyBuild().config(config).build();
+        });
+
+        assertThat(thrown.getMessage(), containsString("Cannot recursively apply the same projection:"));
+    }
+
+    @Test
     public void appliesProjections() throws Exception {
         Model model = Model.assembler()
                 .addImport(Paths.get(getClass().getResource("simple-model.json").toURI()))

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.SmithyBuild;
 import software.amazon.smithy.build.SmithyBuildException;
 import software.amazon.smithy.build.SmithyBuildTest;
 import software.amazon.smithy.model.SourceException;
@@ -86,7 +87,10 @@ public class SmithyBuildConfigTest {
     @Test
     public void canAddImports() {
         String importPath = getResourcePath("simple-model.json");
-        SmithyBuildConfig config = SmithyBuildConfig.builder().imports(ListUtils.of(importPath)).build();
+        SmithyBuildConfig config = SmithyBuildConfig.builder()
+                .version(SmithyBuild.VERSION)
+                .imports(ListUtils.of(importPath))
+                .build();
 
         assertThat(config.getImports(), containsInAnyOrder(importPath));
     }
@@ -102,7 +106,9 @@ public class SmithyBuildConfigTest {
 
     @Test
     public void addsBuiltinPlugins() {
-        SmithyBuildConfig config = SmithyBuildConfig.builder().build();
+        SmithyBuildConfig config = SmithyBuildConfig.builder()
+                .version(SmithyBuild.VERSION)
+                .build();
 
         assertThat(config.getPlugins(), hasKey("build-info"));
         assertThat(config.getPlugins(), hasKey("model"));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/plugins/ConfigurableSmithyBuildPluginTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/plugins/ConfigurableSmithyBuildPluginTest.java
@@ -1,0 +1,86 @@
+package software.amazon.smithy.build.plugins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeMapper;
+
+public class ConfigurableSmithyBuildPluginTest {
+    @Test
+    public void loadsConfigurationClass() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("sources/a.smithy").getPath())
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .settings(Node.objectNode()
+                                  .withMember("foo", "hello")
+                                  .withMember("bar", 10)
+                                  .withMember("baz", true))
+                .fileManifest(manifest)
+                .model(model)
+                .originalModel(model)
+                .build();
+        new Configurable().execute(context);
+
+        String manifestString = manifest.getFileString("Config").get();
+        assertThat(manifestString, containsString("hello"));
+        assertThat(manifestString, containsString("10"));
+        assertThat(manifestString, containsString("true"));
+    }
+
+    private static final class Configurable extends ConfigurableSmithyBuildPlugin<Config> {
+        @Override
+        public String getName() {
+            return "configurable";
+        }
+
+        @Override
+        public Class<Config> getConfigType() {
+            return Config.class;
+        }
+
+        @Override
+        protected void executeWithConfig(PluginContext context, Config config) {
+            NodeMapper mapper = new NodeMapper();
+            mapper.serialize(config);
+            context.getFileManifest().writeJson("Config", mapper.serialize(config));
+        }
+    }
+
+    public static final class Config {
+        private String foo;
+        private int bar;
+        private boolean baz;
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        public int getBar() {
+            return bar;
+        }
+
+        public void setBar(int bar) {
+            this.bar = bar;
+        }
+
+        public boolean isBaz() {
+            return baz;
+        }
+
+        public void setBaz(boolean baz) {
+            this.baz = baz;
+        }
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeMetadataTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeMetadataTest.java
@@ -18,13 +18,12 @@ package software.amazon.smithy.build.transforms;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class ExcludeMetadataTest {
     @Test
@@ -35,9 +34,11 @@ public class ExcludeMetadataTest {
         Model model = Model.builder()
                 .metadata(metadata)
                 .build();
-        Model result = new ExcludeMetadata()
-                .createTransformer(Collections.singletonList("a"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("keys", Node.fromStrings("a")))
+                .build();
+        Model result = new ExcludeMetadata().transform(context);
 
         assertFalse(result.getMetadata().containsKey("a"));
         assertTrue(result.getMetadata().containsKey("b"));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTagTest.java
@@ -19,13 +19,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class ExcludeShapesByTagTest {
 
@@ -42,9 +42,11 @@ public class ExcludeShapesByTagTest {
         Model model = Model.builder()
                 .addShapes(stringA, stringB)
                 .build();
-        Model result = new ExcludeShapesByTag()
-                .createTransformer(Collections.singletonList("foo"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("tags", Node.fromStrings("foo")))
+                .build();
+        Model result = new ExcludeShapesByTag().transform(context);
 
         assertThat(result.getShape(stringA.getId()), is(Optional.empty()));
         assertThat(result.getShape(stringB.getId()), not(Optional.empty()));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsByTagTest.java
@@ -19,14 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class ExcludeTraitsByTagTest {
     @Test
@@ -35,9 +35,11 @@ public class ExcludeTraitsByTagTest {
                 .addImport(Paths.get(getClass().getResource("tree-shaking-traits.json").toURI()))
                 .assemble()
                 .unwrap();
-        Model result = new ExcludeTraitsByTag()
-                .createTransformer(Collections.singletonList("qux"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("tags", Node.fromStrings("qux")))
+                .build();
+        Model result = new ExcludeTraitsByTag().transform(context);
         Set<ShapeId> traits = result.getTraitShapes().stream()
                 .map(Shape::getId)
                 .collect(Collectors.toSet());

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsTest.java
@@ -20,16 +20,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class ExcludeTraitsTest {
 
@@ -44,9 +44,11 @@ public class ExcludeTraitsTest {
                 .addShape(stringShape)
                 .assemble()
                 .unwrap();
-        Model result = new ExcludeTraits()
-                .createTransformer(Collections.singletonList("documentation"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("traits", Node.fromStrings("documentation")))
+                .build();
+        Model result = new ExcludeTraits().transform(context);
 
         assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(DocumentationTrait.class),
                    is(Optional.empty()));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeMetadataTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeMetadataTest.java
@@ -18,13 +18,12 @@ package software.amazon.smithy.build.transforms;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class IncludeMetadataTest {
     @Test
@@ -35,9 +34,11 @@ public class IncludeMetadataTest {
         Model model = Model.builder()
                 .metadata(metadata)
                 .build();
-        Model result = new IncludeMetadata()
-                .createTransformer(Collections.singletonList("b"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("keys", Node.fromStrings("b")))
+                .build();
+        Model result = new IncludeMetadata().transform(context);
 
         assertFalse(result.getMetadata().containsKey("a"));
         assertTrue(result.getMetadata().containsKey("b"));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeNamespacesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeNamespacesTest.java
@@ -19,12 +19,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.util.Arrays;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class IncludeNamespacesTest {
 
@@ -35,9 +35,11 @@ public class IncludeNamespacesTest {
         StringShape string3 = StringShape.builder().id("ns.bar#yuck").build();
         StringShape string4 = StringShape.builder().id("ns.qux#yuck").build();
         Model model = Model.builder().addShapes(string1, string2, string3, string4).build();
-        Model result = new IncludeNamespaces()
-                .createTransformer(Arrays.asList("ns.foo", "ns.bar"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("namespaces", Node.fromStrings("ns.foo", "ns.bar")))
+                .build();
+        Model result = new IncludeNamespaces().transform(context);
 
         assertThat(result.getShape(string1.getId()), not(Optional.empty()));
         assertThat(result.getShape(string2.getId()), not(Optional.empty()));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeServicesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeServicesTest.java
@@ -19,13 +19,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class IncludeServicesTest {
 
@@ -35,9 +35,11 @@ public class IncludeServicesTest {
         ServiceShape serviceB = ServiceShape.builder().id("ns.foo#bar").version("1").build();
         StringShape string = StringShape.builder().id("ns.foo#yuck").build();
         Model model = Model.builder().addShapes(serviceA, serviceB, string).build();
-        Model result = new IncludeServices()
-                .createTransformer(Collections.singletonList("ns.foo#baz"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("services", Node.fromStrings("ns.foo#baz")))
+                .build();
+        Model result = new IncludeServices().transform(context);
 
         assertThat(result.getShape(serviceA.getId()), not(Optional.empty()));
         assertThat(result.getShape(string.getId()), not(Optional.empty()));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeShapesByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeShapesByTagTest.java
@@ -19,13 +19,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class IncludeShapesByTagTest {
 
@@ -42,9 +42,11 @@ public class IncludeShapesByTagTest {
         Model model = Model.builder()
                 .addShapes(stringA, stringB)
                 .build();
-        Model result = new IncludeShapesByTag()
-                .createTransformer(Collections.singletonList("foo"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("tags", Node.fromStrings("foo")))
+                .build();
+        Model result = new IncludeShapesByTag().transform(context);
 
         assertThat(result.getShape(stringA.getId()), not(Optional.empty()));
         assertThat(result.getShape(stringB.getId()), is(Optional.empty()));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTagsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTagsTest.java
@@ -19,13 +19,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class IncludeTagsTest {
 
@@ -41,9 +41,11 @@ public class IncludeTagsTest {
                 .build();
         Shape shape3 = StringShape.builder().id("ns.foo#shape3").build();
         Model model = Model.builder().addShapes(shape1, shape2, shape3).build();
-        Model result = new IncludeTags()
-                .createTransformer(Collections.singletonList("foo"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("tags", Node.fromStrings("foo")))
+                .build();
+        Model result = new IncludeTags().transform(context);
 
         assertThat(result.expectShape(shape1.getId()).getTags(), contains("foo"));
         assertThat(result.expectShape(shape2.getId()), equalTo(shape2));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsByTagTest.java
@@ -19,14 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 public class IncludeTraitsByTagTest {
     @Test
@@ -35,9 +35,11 @@ public class IncludeTraitsByTagTest {
                 .addImport(Paths.get(getClass().getResource("tree-shaking-traits.json").toURI()))
                 .assemble()
                 .unwrap();
-        Model result = new IncludeTraitsByTag()
-                .createTransformer(Collections.singletonList("baz"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("tags", Node.fromStrings("baz")))
+                .build();
+        Model result = new IncludeTraitsByTag().transform(context);
         Set<String> traits = result.getTraitShapes().stream()
                 .map(Shape::getId)
                 .map(ShapeId::toString)

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsTest.java
@@ -21,17 +21,16 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
-import software.amazon.smithy.model.transform.ModelTransformer;
-import software.amazon.smithy.utils.ListUtils;
 
 public class IncludeTraitsTest {
 
@@ -46,9 +45,11 @@ public class IncludeTraitsTest {
                 .addShape(stringShape)
                 .assemble()
                 .unwrap();
-        Model result = new IncludeTraits()
-                .createTransformer(ListUtils.of("documentation"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("traits", Node.fromStrings("documentation")))
+                .build();
+        Model result = new IncludeTraits().transform(context);
 
         assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(DocumentationTrait.class),
                    not(Optional.empty()));
@@ -70,9 +71,11 @@ public class IncludeTraitsTest {
                 .addShape(stringShape)
                 .assemble()
                 .unwrap();
-        Model result = new IncludeTraits()
-                .createTransformer(Collections.singletonList("smithy.api"))
-                .apply(ModelTransformer.create(), model);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("traits", Node.fromStrings("smithy.api#")))
+                .build();
+        Model result = new IncludeTraits().transform(context);
 
         assertThat(result.expectShape(ShapeId.from("ns.foo#baz")).getTrait(DocumentationTrait.class),
                    not(Optional.empty()));

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/apply-cycle.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/apply-cycle.json
@@ -3,12 +3,22 @@
   "projections": {
     "foo": {
       "transforms": [
-        {"name": "apply", "args": ["bar"]}
+        {
+          "name": "apply",
+          "args": {
+            "projections": ["bar"]
+          }
+        }
       ]
     },
     "bar": {
       "transforms": [
-        {"name": "apply", "args": ["foo"]}
+        {
+          "name": "apply",
+          "args": {
+            "projections": ["foo"]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/apply-direct-recursion.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/apply-direct-recursion.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "apply",
+                    "args": {
+                        "projections": [
+                            "foo"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/apply-invalid-projection.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/apply-invalid-projection.json
@@ -4,7 +4,14 @@
     "foo": {
       "transforms": [
         // Does not exist.
-        {"name": "apply", "args": ["bar"]}
+        {
+          "name": "apply",
+          "args": {
+            "projections": [
+              "bar"
+            ]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/apply-multiple-projections.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/apply-multiple-projections.json
@@ -3,24 +3,74 @@
   "projections": {
     "a": {
       "transforms": [
-        {"name": "includeByTag", "args": ["foo", "baz"]},
-        {"name": "apply", "args": ["excludeLength"]},
-        {"name": "excludeTraits", "args": ["documentation"]},
+        {
+          "name": "includeByTag",
+          "args": {
+            "projections": [
+              "foo",
+              "baz"
+            ]
+          }
+        },
+        {
+          "name": "apply",
+          "args": {
+            "projections": [
+              "excludeLength"
+            ]
+          }
+        },
+        {
+          "name": "excludeTraits",
+          "args": {
+            "projections": [
+              "documentation"
+            ]
+          }
+        },
         // No issue with applying it multiple times.
-        {"name": "apply", "args": ["excludeLength"]}
+        {
+          "name": "apply",
+          "args": {
+            "projections": [
+              "excludeLength"
+            ]
+          }
+        }
       ]
     },
     "excludeLength": {
       "abstract": true,
       "transforms": [
-        {"name": "excludeTraits", "args": ["length"]},
-        {"name": "apply", "args": ["excludeTags"]}
+        {
+          "name": "excludeTraits",
+          "args": {
+            "projections": [
+              "length"
+            ]
+          }
+        },
+        {
+          "name": "apply",
+          "args": {
+            "projections": [
+              "excludeTags"
+            ]
+          }
+        }
       ]
     },
     "excludeTags": {
       "abstract": true,
       "transforms": [
-        {"name": "excludeTraits", "args": ["tags"]}
+        {
+          "name": "excludeTraits",
+          "args": {
+            "traits": [
+              "tags"
+            ]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
@@ -3,7 +3,15 @@
   "projections": {
     "a": {
       "transforms": [
-        {"${NAME_KEY}": "includeByTag", "args": ["${FOO}", "\\${BAZ}"]}
+        {
+          "${NAME_KEY}": "includeByTag",
+          "args": {
+            "tags": [
+              "${FOO}",
+              "\\${BAZ}"
+            ]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/resource-model-config.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/resource-model-config.json
@@ -3,12 +3,28 @@
   "projections": {
     "valid": {
       "transforms": [
-        {"name": "includeTraits", "args": ["sensitive", "required", "readonly"]}
+        {
+          "name": "includeTraits",
+          "args": {
+            "traits": [
+              "sensitive",
+              "required",
+              "readonly"
+            ]
+          }
+        }
       ]
     },
     "invalid": {
       "transforms": [
-        {"name": "excludeTraits", "args": ["required"]}
+        {
+          "name": "excludeTraits",
+          "args": {
+            "traits": [
+              "required"
+            ]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/rewrites-args-array.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/rewrites-args-array.json
@@ -1,0 +1,13 @@
+{
+    "version": "1.0",
+    "projections": {
+        "rewrite": {
+            "transforms": [
+                {
+                    "name": "includeTraits",
+                    "args": ["sensitive"]
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/simple-config.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/simple-config.json
@@ -3,13 +3,37 @@
   "projections": {
     "a": {
       "transforms": [
-        {"name": "includeByTag", "args": ["foo", "baz"]},
-        {"name": "includeTraits", "args": ["documentation", "format"]}
+        {
+          "name": "includeByTag",
+          "args": {
+            "tags": [
+              "foo",
+              "baz"
+            ]
+          }
+        },
+        {
+          "name": "includeTraits",
+          "args": {
+            "traits": [
+              "documentation",
+              "format"
+            ]
+          }
+        }
       ]
     },
     "b": {
       "transforms": [
-        {"name": "includeTraits", "args": ["length", "range"]}
+        {
+          "name": "includeTraits",
+          "args": {
+            "traits": [
+              "length",
+              "range"
+            ]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/special-syntax.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/special-syntax.json
@@ -3,13 +3,23 @@
   "projections": {
     "valid": {
       "transforms": [
-        {"name": "includeTraits", "args": ["sensitive", "required"]}
+        {
+          "name": "includeTraits",
+          "args": {
+            "traits": ["sensitive", "required"]
+          }
+        }
       ]
     },
     "invalid": {
       "transforms": [
         // This is a comment.
-        {"name": "excludeTraits", "args": ["required"]}
+        {
+          "name": "excludeTraits",
+          "args": {
+            "traits": ["required"]
+          }
+        }
       ]
     }
   }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/unknown-transform.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/unknown-transform.json
@@ -3,7 +3,7 @@
   "projections": {
     "foo": {
       "transforms": [
-        {"name": "foo", "args": []}
+        {"name": "foo", "args": {}}
       ]
     }
   }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -88,6 +88,8 @@ public final class BuildCommand implements Command {
         if (config != null) {
             Cli.stdout(String.format("Loading Smithy configs: [%s]", String.join(" ", config)));
             config.forEach(file -> configBuilder.load(Paths.get(file)));
+        } else {
+            configBuilder.version(SmithyBuild.VERSION);
         }
 
         if (output != null) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
@@ -60,7 +60,7 @@ final class DefaultNodeDeserializers {
 
     // Deserialize an exact type if it matches (i.e., the setter expects a Node value).
     private static final ObjectCreatorFactory EXACT_CREATOR_FACTORY = (nodeType, targetType) -> {
-        return targetType == nodeType.getNodeClass()
+        return Node.class.isAssignableFrom(targetType) && targetType.isAssignableFrom(nodeType.getNodeClass())
                ? (node, target, param, pointer, mapper) -> node
                : null;
     };


### PR DESCRIPTION
* Update smithy-build to use NodeMapper
    
    ```
    The NodeMapper is now used to load smithy-build.json configuration
    files, reducing the boilerplate needed to deserialize it (and the
    error-prone need to manually update the deserialization code as things
    are added to the POJOs). The #toNode methods and methods were removed
    from the build/model/* classes for the same reasons.
    
    An explicit POJO that defines the format of smithy-build-info.json files
    was added, and the NodeMapper is now used to serialize it. This should
    give the format a well-defined structure and allow other tools to
    properly deserialize it too.
    
    Finally, a ConfigurableSmithyBuildPlugin abstract class was added that
    makes it easier to add NodeMapper deserialization into a plugin specific
    configuration POJO. Most plugins will ultimately extend from this class
    and get deserialization for free.
    ````

* Adds support for more build transform options
    ````
    This commit updates smithy-build so that model transformations accept
    an object of configuration values rather than just a list of strings.
    This makes transformers far more powerful and configurable. In order to
    maintain backward compatibility with existing smithy-build.json files,
    an array of strings provided for a transformer is automatically
    transformed into `{"__args": [X]}` where "X" is the original array of
    arguments.
    ```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
