### PR TITLE
Add RenameShapes model transformer

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -135,12 +135,11 @@ public final class ModelTransformer {
     }
 
     /**
-     * Maps over all shapes in the model using a mapping function, allowing
-     * shapes to be replaced with completely different shapes or slightly
-     * modified shapes.
+     *  Renames shapes using ShapeId pairs while ensuring that the
+     *  transformed model is in a consistent state.
      *
-     * <p>An exception is thrown if a mapper returns a shape with a different
-     * shape ID or a different type.
+     *  This transformer ensures that when an aggregate shape is renamed, all
+     *  members are updated in the model.
      *
      * @param model Model to transform.
      * @param renamed Map of shapeIds

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.transform;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.BiFunction;
@@ -29,6 +30,7 @@ import software.amazon.smithy.model.neighbor.UnreferencedShapes;
 import software.amazon.smithy.model.neighbor.UnreferencedTraitDefinitions;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
@@ -130,6 +132,22 @@ public final class ModelTransformer {
      */
     public Model removeShapesIf(Model model, Predicate<Shape> predicate) {
         return filterShapes(model, FunctionalUtils.not(predicate));
+    }
+
+    /**
+     * Maps over all shapes in the model using a mapping function, allowing
+     * shapes to be replaced with completely different shapes or slightly
+     * modified shapes.
+     *
+     * <p>An exception is thrown if a mapper returns a shape with a different
+     * shape ID or a different type.
+     *
+     * @param model Model to transform.
+     * @param renamed Map of shapeIds
+     * @return Returns the transformed model.base.
+     */
+    public Model renameShapes(Model model, Map<ShapeId, ShapeId> renamed) {
+        return new RenameShapes(renamed).transform(this, model);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.AbstractShapeBuilder;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.DynamicTrait;
+import software.amazon.smithy.model.traits.IdRefTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.Pair;
+
+/**
+ *  Renames shapes using a mapping function while ensuring that the
+ *  transformed model is in a consistent state.
+ *
+ *  This transformer ensures that when an aggregate shape is renamed, all
+ *  members are updated in the model.
+ *
+ * @see ModelTransformer#renameShapes
+ */
+final class RenameShapes {
+    private final Map<ShapeId, ShapeId> renamed;
+
+    RenameShapes(Map<ShapeId, ShapeId> renamed) {
+        this.renamed = renamed;
+    }
+
+    Model transform(ModelTransformer transformer, Model model) {
+        renamed.keySet().removeIf(fromId -> fromId.equals(renamed.get(fromId)));
+        if (renamed.isEmpty()) {
+            return model;
+        }
+        Model.Builder builder = createRenamedModelBuilder(model, renamed);
+
+        getUpdatedIdRefShapes(model, renamed).forEach(builder::addShape);
+
+        return transformer.removeShapes(builder.build(), getShapesToRemove(model, renamed));
+    }
+
+    private Model.Builder createRenamedModelBuilder(Model model, Map<ShapeId, ShapeId> renamed) {
+        Model.Builder builder = model.toBuilder();
+        renamed.forEach((fromId, toId) -> {
+            RenameShapeVisitor renameShapeVisitor = new RenameShapeVisitor(toId);
+            Shape newShape = model.expectShape(fromId).accept(renameShapeVisitor);
+            builder.addShape(newShape);
+            builder.addShapes(newShape.members());
+        });
+        return builder;
+    }
+
+    private Set<Shape> getShapesToRemove(Model model, Map<ShapeId, ShapeId> renamed) {
+        return renamed.keySet().stream()
+                .map(model::expectShape).collect(Collectors.toSet());
+    }
+
+    private Set<Shape> getUpdatedIdRefShapes(Model model, Map<ShapeId, ShapeId> renamed) {
+        Set<ShapeId> traitShapeIdsWithIdRef = model.getTraitDefinitions().keySet().stream()
+                .filter(shape -> shape.hasTrait(IdRefTrait.class))
+                .map(Shape::getId)
+                .collect(Collectors.toSet());
+        Map<Shape, Set<Trait>> shapeToIdRefTraitsMapping = model.shapes()
+                .filter(shape -> traitShapeIdsWithIdRef.stream().anyMatch(shape::hasTrait))
+                .map(shape -> getIdRefTraitsPair(shape, traitShapeIdsWithIdRef))
+                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+        return shapeToIdRefTraitsMapping.entrySet().stream()
+                .map(entry -> buildShapeWithNewIdRefs(entry.getKey(), entry.getValue(), renamed))
+                .collect(Collectors.toSet());
+    }
+
+    private Shape buildShapeWithNewIdRefs(Shape shape, Set<Trait> idRefTraits, Map<ShapeId, ShapeId> renamed) {
+        Collection<Trait> traits = new ArrayList<Trait>();
+        shape.getAllTraits().forEach((traitId, trait) -> {
+            if (idRefTraits.contains(trait)) {
+                StringNode node = trait.toNode().expectStringNode();
+                ShapeId nodeValue = ShapeId.from(node.getValue());
+                if (renamed.containsKey(nodeValue)) {
+                    StringNode newNode = new StringNode(renamed.get(nodeValue).toString(), node.getSourceLocation());
+                    Trait newTrait = new DynamicTrait(trait.toShapeId(), newNode);
+                    traits.add(newTrait);
+                } else {
+                    traits.add(trait);
+                }
+            } else {
+                traits.add(trait);
+            }
+        });
+        return Shape.shapeToBuilder(shape).clearTraits().addTraits(traits).build();
+    }
+
+    private Pair<Shape, Set<Trait>> getIdRefTraitsPair(Shape shape, Set<ShapeId> traitShapeIdsWithIdRef) {
+        Set<Trait> idRefTraits = new HashSet<Trait>();
+        shape.getAllTraits().forEach((key, trait) -> {
+            if (traitShapeIdsWithIdRef.contains(trait.toShapeId())) {
+                idRefTraits.add(trait);
+            }
+        });
+        return Pair.of(shape, idRefTraits);
+    }
+
+    private static final class RenameShapeVisitor extends ShapeVisitor.Default<Shape> {
+
+        private final ShapeId toId;
+
+        RenameShapeVisitor(ShapeId toId) {
+            this.toId = toId;
+        }
+
+        @Override
+        public Shape getDefault(Shape fromShape) {
+            return Shape.shapeToBuilder(fromShape).id(toId).build();
+        }
+
+        @Override
+        public Shape listShape(ListShape fromShape) {
+            ListShape.Builder builder = fromShape.toBuilder().id(toId);
+            return buildShape(fromShape, builder);
+        }
+
+        @Override
+        public Shape mapShape(MapShape fromShape) {
+            ShapeId keyId = ShapeId.fromParts(toId.getNamespace(), toId.getName(), "key");
+            ShapeId valueId = ShapeId.fromParts(toId.getNamespace(), toId.getName(), "value");
+            return fromShape.toBuilder().id(toId).key(keyId).value(valueId).build();
+        }
+
+        @Override
+        public Shape setShape(SetShape fromShape) {
+            SetShape.Builder builder = fromShape.toBuilder().id(toId);
+            return buildShape(fromShape, builder);
+        }
+
+        @Override
+        public Shape structureShape(StructureShape fromShape) {
+            StructureShape.Builder builder = fromShape.toBuilder().id(toId);
+            return buildShape(fromShape, builder);
+        }
+
+        @Override
+        public Shape unionShape(UnionShape fromShape) {
+            UnionShape.Builder builder = fromShape.toBuilder().id(toId);
+            return buildShape(fromShape, builder);
+        }
+
+        private Shape buildShape(Shape fromShape, AbstractShapeBuilder<?, ?> builder) {
+            fromShape.members().forEach(member -> {
+                ShapeId memberId = updateMemberId(member, toId);
+                builder.addMember(member.toBuilder().id(memberId).build());
+            });
+            return (Shape) builder.build();
+        }
+
+        private ShapeId updateMemberId(MemberShape member, ShapeId newContainerId) {
+            return ShapeId.fromParts(newContainerId.getNamespace(), newContainerId.getName(), member.getMemberName());
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -39,7 +39,7 @@ import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.Pair;
 
 /**
- *  Renames shapes using a mapping function while ensuring that the
+ *  Renames shapes using ShapeId pairs while ensuring that the
  *  transformed model is in a consistent state.
  *
  *  This transformer ensures that when an aggregate shape is renamed, all

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -1,0 +1,242 @@
+package software.amazon.smithy.model.transform;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.Trait;
+
+public class RenameShapesTest {
+
+    @Test
+    public void returnsUnmodifiedModelIfGivenEmptyRenameMapping() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        StringShape fooTarget = StringShape.builder().id(stringId).build();
+        Model model = Model.builder()
+                .addShapes(fooTarget)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(1L));
+        assertThat(result.getShape(stringId).get(), Matchers.is(fooTarget));
+    }
+
+    @Test
+    public void returnsUnmodifiedModelIfToAndFromAreEqual() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        StringShape target = StringShape.builder().id(stringId).build();
+        Model model = Model.builder()
+                .addShapes(target)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {
+            { put(stringId, stringId ); }
+        };
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(1L));
+        assertThat(result.getShape(stringId).get(), Matchers.is(target));
+    }
+
+    @Test
+    public void returnsModelWithRenamedStringShape() {
+        ShapeId fromStringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId keyId = ShapeId.from("ns.foo#Container$key");
+        ShapeId valueId = ShapeId.from("ns.foo#Container$value");
+
+        StringShape target = StringShape.builder().id(fromStringId).build();
+        MemberShape keyMember = MemberShape.builder().id(keyId).target(fromStringId).build();
+        MemberShape valueMember = MemberShape.builder().id(valueId).target(fromStringId).build();
+        MapShape container = MapShape.builder().id(containerId).key(keyMember).value(valueMember).build();
+        Model model = Model.builder()
+                .addShapes(target, keyMember, valueMember, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+
+        ShapeId toStringId = ShapeId.from("ns.bar#String");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {{
+           put(fromStringId, toStringId);
+        }};
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.shapes().count(), Matchers.equalTo(4L));
+        assertThat(result.getShape(toStringId).isPresent(), Matchers.is(true));
+        assertThat(result.getShape(fromStringId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesIdRefsWhenValueRenamed() {
+        Model model = Model.assembler()
+                .addImport(IntegTest.class.getResource("rename-shape-test-model.json"))
+                .assemble()
+                .unwrap();
+
+        ShapeId fromId = ShapeId.from("ns.foo#OldShape");
+        ShapeId toId = ShapeId.from("ns.foo#NewShape");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {
+            { put(fromId, toId ); }
+        };
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.renameShapes(model, renamed);
+        StringNode node = Node.from(toId.toShapeId().toString());
+        assertThat(result.getShape(toId).isPresent(), Matchers.is(true));
+        Shape shape = result.expectShape(ShapeId.from("ns.foo#ValidShape"));
+        Trait trait = shape.findTrait("ns.foo#integerRef").get();
+        assertThat(trait.toNode(), Matchers.equalTo(node));
+        assertThat(result.getShape(fromId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesListMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        ListShape container = ListShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {{
+            put(containerId, newContainerId);
+        }};
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(3L));
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        ListShape newContainer = result.getShape(newContainerId).get().asListShape().get();
+        assertThat(newContainer.getMember().getId(), Matchers.is(newMemberId));
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesMapMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId keyId = ShapeId.from("ns.foo#Container$key");
+        ShapeId valueId = ShapeId.from("ns.foo#Container$value");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape keyMember = MemberShape.builder().id(keyId).target(stringId).build();
+        MemberShape valueMember = MemberShape.builder().id(valueId).target(stringId).build();
+        MapShape container = MapShape.builder().id(containerId).key(keyMember).value(valueMember).build();
+        Model model = Model.builder()
+                .addShapes(target, keyMember, valueMember, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newKeyId = ShapeId.from("ns.bar#Baz$key");
+        ShapeId newValueId = ShapeId.from("ns.bar#Baz$value");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {{
+            put(containerId, newContainerId);
+        }};
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(4L));
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        MapShape newContainer = result.getShape(newContainerId).get().asMapShape().get();
+        assertThat(newContainer.getKey().getId(), Matchers.is(newKeyId));
+        assertThat(newContainer.getValue().getId(), Matchers.is(newValueId));
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesSetMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        SetShape container = SetShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {{
+            put(containerId, newContainerId);
+        }};
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(3L));
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        SetShape newContainer = result.getShape(newContainerId).get().asSetShape().get();
+        assertThat(newContainer.getMember().getId(), Matchers.is(newMemberId));
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesStructureMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        StructureShape container = StructureShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {{
+            put(containerId, newContainerId);
+        }};
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(3L));
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        StructureShape newContainer = result.getShape(newContainerId).get().asStructureShape().get();
+        newContainer.getMember("member").ifPresent(newMember -> {
+            assertThat(newMember.getId(), Matchers.is(newMemberId));
+        });
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesUnionMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        UnionShape container = UnionShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {{
+            put(containerId, newContainerId);
+        }};
+
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(3L));
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        UnionShape newContainer = result.getShape(newContainerId).get().asUnionShape().get();
+        newContainer.getMember("member").ifPresent(newMember -> {
+            assertThat(newMember.getId(), Matchers.is(newMemberId));
+        });
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
@@ -1,0 +1,25 @@
+{
+  "smithy": "0.5.0",
+  "shapes": {
+    "ns.foo#integerRef": {
+      "type": "string",
+      "traits": {
+        "smithy.api#trait": true,
+        "smithy.api#idRef": {
+          "failWhenMissing": true,
+          "selector": "integer"
+        }
+      }
+    },
+    "ns.foo#ValidShape": {
+      "type": "string",
+      "traits": {
+        "ns.foo#integerRef": "ns.foo#OldShape",
+        "smithy.api#deprecated": {}
+      }
+    },
+    "ns.foo#OldShape": {
+      "type": "integer"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a RenameShapes model transformer that takes a map of ShapeId to ShapeId pairs.

Shape members are updated for consistency when any member-containing aggregate shape has been renamed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
