### PR TITLE
Fix idRef doc examples

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3558,35 +3558,35 @@ Given the following model,
                 "smithy.example#InvalidShape1": {
                     "type": "string",
                     "traits": {
-                        "smithy.api#integerRef": "NotFound"
+                        "smithy.example#integerRef": "NotFound"
                     }
                 },
                 "smithy.example#InvalidShape2": {
                     "type": "string",
                     "traits": {
-                        "smithy.api#integerRef": "String"
+                        "smithy.example#integerRef": "String"
                     }
                 },
                 "smithy.example#InvalidShape3": {
                     "type": "string",
                     "traits": {
-                        "smithy.api#integerRef": "invalid-shape-id!"
+                        "smithy.example#integerRef": "invalid-shape-id!"
                     }
                 },
                 "smithy.example#ValidShape": {
                     "type": "string",
                     "traits": {
-                        "smithy.api#integerRef": "Integer"
+                        "smithy.example#integerRef": "Integer"
                     }
                 },
                 "smithy.example#ValidShape2": {
                     "type": "string",
                     "traits": {
-                        "smithy.api#integerRef": "MyShape"
+                        "smithy.example#integerRef": "smithy.example#MyShape"
                     }
                 },
                 "smithy.example#MyShape": {
-                    "type": "string"
+                    "type": "integer"
                 }
             }
         }

--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3548,7 +3548,7 @@ Given the following model,
         @integerRef(MyShape)
         string ValidShape2
 
-        string MyShape
+        integer MyShape
 
     .. code-tab:: json
 


### PR DESCRIPTION
This PR fixes idRef doc examples to use the correct trait namespace, target type and fully qualified shapeId.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
