### PR TITLE
Add references to all operations

### DIFF
--- a/smithy-aws-protocol-tests/model/ec2-query/main.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/main.smithy
@@ -59,6 +59,7 @@ service AwsEc2 {
         RecursiveXmlShapes,
         RecursiveXmlShapes,
         IgnoresWrappingXmlName,
+        XmlNamespaces,
 
         // Output error tests
         GreetingWithErrors,

--- a/smithy-aws-protocol-tests/model/query/main.smithy
+++ b/smithy-aws-protocol-tests/model/query/main.smithy
@@ -41,6 +41,7 @@ service AwsQuery {
         RecursiveXmlShapes,
         RecursiveXmlShapes,
         IgnoresWrappingXmlName,
+        XmlNamespaces,
 
         // Output error tests
         GreetingWithErrors,

--- a/smithy-aws-protocol-tests/model/rest-json/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/main.smithy
@@ -51,5 +51,6 @@ service RestJson {
         RecursiveShapes,
         JsonLists,
         JsonMaps,
+        JsonBlobs,
     ]
 }

--- a/smithy-aws-protocol-tests/model/rest-xml/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/main.smithy
@@ -49,6 +49,7 @@ service RestXml {
 
         // Synthesized XML document body tests
         SimpleScalarProperties,
+        XmlBlobs,
         XmlTimestamps,
         XmlEnums,
         RecursiveShapes,


### PR DESCRIPTION
This PR adds references to aws-protocol-tests models to unreferenced operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
