### PR TITLE
Add references to operations and resources

### DIFF
--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/errorfiles/valid-integration.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/apigateway/errorfiles/valid-integration.json
@@ -4,6 +4,11 @@
         "ns.foo#Service1": {
             "type": "service",
             "version": "2018-03-17",
+            "operations": [
+                {
+                    "target": "ns.foo#Operation"
+                }
+            ],
             "traits": {
                 "aws.api#service": {
                     "sdkId": "Some Value"

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/contains-reserved-words-validator.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/contains-reserved-words-validator.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#Service": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#_OperationBaz"
+                }
+            ]
+        },
         "ns.foo#_foo": {
             "type": "structure",
             "members": {

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-paginated-trait-validator.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-paginated-trait-validator.json
@@ -1,6 +1,45 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#Service": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#ListFoos"
+                },
+                {
+                    "target": "ns.foo#IgnoreMe"
+                },
+                {
+                    "target": "ns.foo#IgnoreMeToo"
+                },
+                {
+                    "target": "ns.foo#A"
+                },
+                {
+                    "target": "ns.foo#B"
+                },
+                {
+                    "target": "ns.foo#GetFoos"
+                },
+                {
+                    "target": "ns.foo#GetBars"
+                },
+                {
+                    "target": "ns.foo#SchwiftyFoos"
+                },
+                {
+                    "target": "ns.foo#SquanchFoos"
+                },
+                {
+                    "target": "ns.foo#SomeOperation"
+                },
+                {
+                    "target": "ns.foo#SomeOtherOperation"
+                }
+            ]
+        },
         "ns.foo#String": {
             "type": "string"
         },

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/standard-operation-verb-validator-test.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/standard-operation-verb-validator-test.json
@@ -1,6 +1,51 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#Service": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#CreateFoo"
+                },
+                {
+                    "target": "ns.foo#DeleteFoo"
+                },
+                {
+                    "target": "ns.foo#UpdateFoo"
+                },
+                {
+                    "target": "ns.foo#BatchCreateFoo"
+                },
+                {
+                    "target": "ns.foo#BatchDeleteFoo"
+                },
+                {
+                    "target": "ns.foo#BatchUpdateFoo"
+                },
+                {
+                    "target": "ns.foo#BatchMakeFoo"
+                },
+                {
+                    "target": "ns.foo#BatchDestroyFoo"
+                },
+                {
+                    "target": "ns.foo#BatchChangeFoo"
+                },
+                {
+                    "target": "ns.foo#MakeFoo"
+                },
+                {
+                    "target": "ns.foo#DestroyFoo"
+                },
+                {
+                    "target": "ns.foo#ChangeFoo"
+                },
+                {
+                    "target": "ns.foo#Batch"
+                }
+            ]
+        },
         "ns.foo#CreateFoo": {
             "type": "operation"
         },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/event-stream-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/event-stream-validator.json
@@ -1,6 +1,39 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#ValidSingleEventInputOperation"
+                },
+                {
+                    "target": "ns.foo#ValidSingleEventOutputOperation"
+                },
+                {
+                    "target": "ns.foo#ValidSingleEventBidirectionalOperation"
+                },
+                {
+                    "target": "ns.foo#ValidMultiEventInputOperation"
+                },
+                {
+                    "target": "ns.foo#ValidMultiEventOutputOperation"
+                },
+                {
+                    "target": "ns.foo#ValidMultiEventBidirectionalOperation"
+                },
+                {
+                    "target": "ns.foo#EventStreamInputMemberMustNotBeRequired"
+                },
+                {
+                    "target": "ns.foo#EventStreamReferencesInvalidShape"
+                },
+                {
+                    "target": "ns.foo#EventStreamReferencesInvalidMultiEventShape"
+                }
+            ]
+        },
         "ns.foo#ValidSingleEventInputOperation": {
             "type": "operation",
             "input": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
@@ -1,6 +1,18 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#Operation"
+                },
+                {
+                    "target": "ns.foo#Operation2"
+                }
+            ]
+        },
         "ns.foo#Operation": {
             "type": "operation",
             "input": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/host-request-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/host-request-validator.json
@@ -37,6 +37,9 @@
                 },
                 {
                     "target": "ns.foo#L"
+                },
+                {
+                    "target": "ns.foo#M"
                 }
             ],
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.json
@@ -1,6 +1,48 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#A"
+                },
+                {
+                    "target": "ns.foo#B"
+                },
+                {
+                    "target": "ns.foo#C"
+                },
+                {
+                    "target": "ns.foo#D"
+                },
+                {
+                    "target": "ns.foo#E"
+                },
+                {
+                    "target": "ns.foo#F"
+                },
+                {
+                    "target": "ns.foo#G"
+                },
+                {
+                    "target": "ns.foo#H"
+                },
+                {
+                    "target": "ns.foo#I"
+                },
+                {
+                    "target": "ns.foo#J"
+                },
+                {
+                    "target": "ns.foo#K"
+                },
+                {
+                    "target": "ns.foo#L"
+                }
+            ]
+        },
         "ns.foo#A": {
             "type": "operation",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-request-response-validator.json
@@ -51,6 +51,9 @@
                     "target": "ns.foo#P"
                 },
                 {
+                    "target": "ns.foo#Q"
+                },
+                {
                     "target": "ns.foo#R"
                 }
             ],

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-response-code-semantics-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-response-code-semantics-validator.json
@@ -1,6 +1,21 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#FooService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#A"
+                },
+                {
+                    "target": "ns.foo#B"
+                },
+                {
+                    "target": "ns.foo#C"
+                }
+            ]
+        },
         "ns.foo#A": {
             "type": "operation",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-must-not-have-error-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-must-not-have-error-trait.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#MyOperation"
+                }
+            ]
+        },
         "ns.foo#MyOperation": {
             "type": "operation",
             "input": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/valid-implicit-lifecycles.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/valid-implicit-lifecycles.json
@@ -1,6 +1,21 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#ValidA"
+                },
+                {
+                    "target": "ns.foo#ValidB"
+                },
+                {
+                    "target": "ns.foo#ValidE"
+                }
+            ]
+        },
         "ns.foo#ValidA": {
             "type": "resource",
             "identifiers": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/validates-idempotent-lifecycles.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/validates-idempotent-lifecycles.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#Resource"
+                }
+            ]
+        },
         "ns.foo#Resource": {
             "type": "resource",
             "identifiers": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/validates-instance-and-collection-operations.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/validates-instance-and-collection-operations.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#ResourceA"
+                }
+            ]
+        },
         "ns.foo#ResourceA": {
             "type": "resource",
             "identifiers": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/validates-readonly-lifecycles.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/lifecycle/validates-readonly-lifecycles.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#Resource"
+                }
+            ]
+        },
         "ns.foo#Resource": {
             "type": "resource",
             "identifiers": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
@@ -40,6 +40,18 @@
                 },
                 {
                     "target": "ns.foo#Invalid9"
+                },
+                {
+                    "target": "ns.foo#ValidNestedOutputOperation"
+                },
+                {
+                    "target": "ns.foo#DeeplyNestedOutputOperation"
+                },
+                {
+                    "target": "ns.foo#InvalidNoOutput"
+                },
+                {
+                    "target": "ns.foo#InvalidNestedInput"
                 }
             ]
         },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-access.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-access.json
@@ -7,6 +7,9 @@
             "operations": [
                 {
                     "target": "smithy.private#PrivateOperation"
+                },
+                {
+                    "target": "smithy.example#InvalidOperation"
                 }
             ]
         },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/bad-ids.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/bad-ids.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#MyResource"
+                }
+            ]
+        },
         "ns.foo#MyStructure": {
             "type": "structure",
             "members": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/invalid-string-reference-multiple-identifiers.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/invalid-string-reference-multiple-identifiers.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#MyResource"
+                }
+            ]
+        },
         "ns.foo#MyString": {
             "type": "string",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/missing-identifier-reference.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/missing-identifier-reference.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#MyResource"
+                }
+            ]
+        },
         "ns.foo#MyStructure": {
             "type": "structure",
             "members": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/reference-id-member-not-found.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/reference-id-member-not-found.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#MyResource"
+                }
+            ]
+        },
         "ns.foo#MyStructure": {
             "type": "structure",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/valid-implicit-references.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/valid-implicit-references.json
@@ -1,6 +1,18 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#MyResource"
+                },
+                {
+                    "target": "ns.foo#MyResource2"
+                }
+            ]
+        },
         "ns.foo#MyStructure": {
             "type": "structure",
             "members": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/request-token.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/request-token.json
@@ -1,6 +1,18 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#FooService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#Valid"
+                },
+                {
+                    "target": "ns.foo#Invalid"
+                }
+            ]
+        },
         "ns.foo#Valid": {
             "type": "operation",
             "input": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-must-bind-parent-identifiers.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-must-bind-parent-identifiers.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#FooService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "resources": [
+                {
+                    "target": "ns.foo#A"
+                }
+            ]
+        },
         "ns.foo#A": {
             "type": "resource",
             "identifiers": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/sensitive-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/sensitive-trait.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0", 
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#Operation"
+                }
+            ]
+        },
         "ns.foo#Operation": {
             "type": "operation", 
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#StreamingOperation"
+                }
+            ]
+        },
         "ns.foo#Blob": {
             "type": "blob"
         },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-target.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-target.json
@@ -1,6 +1,15 @@
 {
     "smithy": "0.5.0",
     "shapes": {
+        "ns.foo#MyService": {
+            "type": "service",
+            "version": "2020-03-12",
+            "operations": [
+                {
+                    "target": "ns.foo#Invoke"
+                }
+            ]
+        },
         "ns.foo#String": {
             "type": "string",
             "traits": {

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/dropped-mqtt-headers.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/dropped-mqtt-headers.smithy
@@ -3,6 +3,11 @@
 
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Foo]
+}
+
 @smithy.mqtt#subscribe("events")
 operation Foo {
     input: FooInput,

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/mqtt-operations-with-errors.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/mqtt-operations-with-errors.smithy
@@ -2,6 +2,11 @@
 
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Foo, Baz]
+}
+
 @smithy.mqtt#subscribe("event1")
 operation Foo {
     output: FooOutput,

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/mqtt-topic-labels.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/mqtt-topic-labels.smithy
@@ -1,5 +1,10 @@
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Operation1, Operation2, Operation3, Operation4, Operation5]
+}
+
 // Missing input for {foo} property.
 @smithy.mqtt#publish("events1/{foo}")
 operation Operation1 {}

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/publish-with-eventstream.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/publish-with-eventstream.smithy
@@ -1,5 +1,10 @@
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Publish]
+}
+
 @smithy.mqtt#publish("foo")
 operation Publish {
     input: PublishInput

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-input-missing-label.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-input-missing-label.smithy
@@ -7,6 +7,11 @@ namespace smithy.example
 use smithy.mqtt#topicLabel
 use smithy.mqtt#subscribe
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Foo]
+}
+
 @subscribe("events/{foo}")
 operation Foo {
     input: FooInput,

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-missing-output.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-missing-output.smithy
@@ -2,5 +2,10 @@
 
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Foo]
+}
+
 @smithy.mqtt#subscribe("events")
 operation Foo {}

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-operation-initial-event.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-operation-initial-event.smithy
@@ -2,6 +2,11 @@
 
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Foo]
+}
+
 @smithy.mqtt#subscribe("events")
 operation Foo {
     output: FooOutput

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-operation-missing-event-stream.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/subscribe-operation-missing-event-stream.smithy
@@ -2,6 +2,11 @@
 
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [Foo]
+}
+
 @smithy.mqtt#subscribe("events")
 operation Foo {
     output: FooOutput

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/topic-conflicts.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/topic-conflicts.smithy
@@ -1,5 +1,10 @@
 namespace smithy.example
 
+service FooService {
+    version: "2020-03-12",
+    operations: [A, B, C, D, E, F]
+}
+
 // Conflicts with B, C
 @smithy.mqtt#publish("a")
 operation A {


### PR DESCRIPTION
This PR adds service references to all operations and resources in the test models for the following projects:
* smithy-aws-traits
* smithy-linters
* smithy-model
* smithy-mqtt-traits

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
