### PR TITLE
Use expect* methods more + some cleanup

### DIFF
--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/apigateway/AuthorizersTraitValidator.java
@@ -58,7 +58,7 @@ public class AuthorizersTraitValidator extends AbstractValidator {
             return Optional.empty();
         }
 
-        AuthorizersTrait authorizersTrait = service.getTrait(AuthorizersTrait.class).get();
+        AuthorizersTrait authorizersTrait = service.expectTrait(AuthorizersTrait.class);
         return Optional.of(error(service, authorizersTrait, String.format(
                 "Each `scheme` of the `%s` trait must target one of the auth schemes applied to the service "
                 + "(i.e., [%s]). The following mappings of authorizer names to schemes are invalid: %s",

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
@@ -43,15 +43,15 @@ public class ArnIndexTest {
     public void loadsFromModel() {
         ArnIndex arnIndex = new ArnIndex(model);
         ShapeId id = ShapeId.from("ns.foo#SomeService");
-        Shape someResource = model.getShape(ShapeId.from("ns.foo#SomeResource")).get();
+        Shape someResource = model.expectShape(ShapeId.from("ns.foo#SomeResource"));
         ArnTrait template1 = ArnTrait.builder()
                 .template("someresource/{someId}")
                 .build();
-        Shape childResource = model.getShape(ShapeId.from("ns.foo#ChildResource")).get();
+        Shape childResource = model.expectShape(ShapeId.from("ns.foo#ChildResource"));
         ArnTrait template2 = ArnTrait.builder()
                 .template("someresource/{someId}/{childId}")
                 .build();
-        Shape rootArnResource = model.getShape(ShapeId.from("ns.foo#RootArnResource")).get();
+        Shape rootArnResource = model.expectShape(ShapeId.from("ns.foo#RootArnResource"));
         ArnTrait template3 = ArnTrait.builder()
                 .template("rootArnResource")
                 .noAccount(true)

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
@@ -88,8 +88,8 @@ public class ServiceTraitTest {
                 .unwrap();
         ServiceShape service = result
                 .expectShape(ShapeId.from("ns.foo#SomeService"))
-                .asServiceShape().get();
-        ServiceTrait trait = service.getTrait(ServiceTrait.class).get();
+                .expectServiceShape();
+        ServiceTrait trait = service.expectTrait(ServiceTrait.class);
 
         assertThat(trait.getSdkId(), equalTo("Some Value"));
         assertThat(trait.getCloudFormationName(), equalTo("SomeService"));

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTraitTest.java
@@ -33,8 +33,8 @@ public class ClientDiscoveredEndpointTraitTest {
                 .unwrap();
         OperationShape operation = result
                 .expectShape(ShapeId.from("ns.foo#GetObject"))
-                .asOperationShape().get();
-        ClientDiscoveredEndpointTrait trait = operation.getTrait(ClientDiscoveredEndpointTrait.class).get();
+                .expectOperationShape();
+        ClientDiscoveredEndpointTrait trait = operation.expectTrait(ClientDiscoveredEndpointTrait.class);
 
         assertTrue(trait.isRequired());
     }

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTraitTest.java
@@ -42,10 +42,10 @@ public class ClientEndpointDiscoveryIdTraitTest {
                 .unwrap();
         OperationShape operation = result
                 .expectShape(ShapeId.from("ns.foo#GetObject"))
-                .asOperationShape().get();
+                .expectOperationShape();
         MemberShape member = result
                 .getShape(operation.getInput().get()).get()
-                .asStructureShape().get()
+                .expectStructureShape()
                 .getMember("Id").get();
 
         assertTrue(member.getTrait(ClientEndpointDiscoveryIdTrait.class).isPresent());

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTraitTest.java
@@ -33,8 +33,8 @@ public class ClientEndpointDiscoveryTraitTest {
                 .unwrap();
         ServiceShape service = result
                 .expectShape(ShapeId.from("ns.foo#FooService"))
-                .asServiceShape().get();
-        ClientEndpointDiscoveryTrait trait = service.getTrait(ClientEndpointDiscoveryTrait.class).get();
+                .expectServiceShape();
+        ClientEndpointDiscoveryTrait trait = service.expectTrait(ClientEndpointDiscoveryTrait.class);
 
         assertEquals(trait.getOperation(), ShapeId.from("ns.foo#DescribeEndpoints"));
         assertEquals(trait.getError(), ShapeId.from("ns.foo#InvalidEndpointError"));

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/iam/RequiredActionsTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/iam/RequiredActionsTraitTest.java
@@ -33,7 +33,7 @@ public class RequiredActionsTraitTest {
                 .assemble()
                 .unwrap();
 
-        Shape myOperation = result.getShape(ShapeId.from("smithy.example#MyOperation")).get();
+        Shape myOperation = result.expectShape(ShapeId.from("smithy.example#MyOperation"));
 
         assertTrue(myOperation.hasTrait(RequiredActionsTrait.class));
         assertThat(myOperation.getTrait(RequiredActionsTrait.class).get().getValues(), containsInAnyOrder(

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -206,23 +206,23 @@ public class SmithyBuildTest {
         Model resultB = results.getProjectionResult("b").get().getModel();
         Model resultC = results.getProjectionResult("c").get().getModel();
 
-        assertTrue(resultA.getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultA.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(SensitiveTrait.class).isPresent());
-        assertFalse(resultA.getShape(ShapeId.from("com.foo#String")).get()
+        assertFalse(resultA.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(DocumentationTrait.class).isPresent());
 
-        assertTrue(resultB.getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultB.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(SensitiveTrait.class).isPresent());
-        assertTrue(resultB.getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultB.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(DocumentationTrait.class).isPresent());
-        assertThat(resultB.getShape(ShapeId.from("com.foo#String")).get()
+        assertThat(resultB.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(DocumentationTrait.class).get().getValue(), equalTo("b.json"));
 
-        assertTrue(resultC.getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultC.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(SensitiveTrait.class).isPresent());
-        assertTrue(resultC.getShape(ShapeId.from("com.foo#String")).get()
+        assertTrue(resultC.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(DocumentationTrait.class).isPresent());
-        assertThat(resultC.getShape(ShapeId.from("com.foo#String")).get()
+        assertThat(resultC.expectShape(ShapeId.from("com.foo#String"))
                            .getTrait(DocumentationTrait.class).get().getValue(), equalTo("c.json"));
     }
 

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DefaultRefStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DefaultRefStrategy.java
@@ -121,8 +121,8 @@ final class DefaultRefStrategy implements RefStrategy {
     public boolean isInlined(Shape shape) {
         // We could add more logic here in the future if needed to account for
         // member shapes that absolutely must generate a synthesized schema.
-        if (shape.asMemberShape().isPresent()) {
-            MemberShape member = shape.asMemberShape().get();
+        if (shape.isMemberShape()) {
+            MemberShape member = shape.expectMemberShape();
             Shape target = model.expectShape(member.getTarget());
             return isInlined(target);
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
@@ -106,7 +106,7 @@ public final class EventStreamIndex implements KnowledgeIndex {
             StructureShape structure,
             MemberShape member
     ) {
-        EventStreamTrait trait = member.getTrait(EventStreamTrait.class).get();
+        EventStreamTrait trait = member.expectTrait(EventStreamTrait.class);
 
         Shape eventStreamTarget = model.getShape(member.getTarget()).orElse(null);
         if (eventStreamTarget == null) {
@@ -118,14 +118,14 @@ public final class EventStreamIndex implements KnowledgeIndex {
 
         // Compute the events of the event stream.
         Map<String, StructureShape> events = new HashMap<>();
-        if (eventStreamTarget.asUnionShape().isPresent()) {
-            for (MemberShape unionMember : eventStreamTarget.asUnionShape().get().getAllMembers().values()) {
+        if (eventStreamTarget.isUnionShape()) {
+            for (MemberShape unionMember : eventStreamTarget.expectUnionShape().getAllMembers().values()) {
                 model.getShape(unionMember.getTarget()).flatMap(Shape::asStructureShape).ifPresent(struct -> {
                     events.put(unionMember.getMemberName(), struct);
                 });
             }
-        } else if (eventStreamTarget.asStructureShape().isPresent()) {
-            events.put(member.getMemberName(), eventStreamTarget.asStructureShape().get());
+        } else if (eventStreamTarget.isStructureShape()) {
+            events.put(member.getMemberName(), eventStreamTarget.expectStructureShape());
         } else {
             // If the event target is an invalid type, then we can't create the indexed result.
             LOGGER.severe(() -> String.format(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -134,9 +134,9 @@ public final class HttpBindingIndex implements KnowledgeIndex {
         if (shape.isOperationShape()) {
             return getHttpTrait(id).getCode();
         } else if (shape.getTrait(HttpErrorTrait.class).isPresent()) {
-            return shape.getTrait(HttpErrorTrait.class).get().getCode();
+            return shape.expectTrait(HttpErrorTrait.class).getCode();
         } else if (shape.getTrait(ErrorTrait.class).isPresent()) {
-            return shape.getTrait(ErrorTrait.class).get().getDefaultHttpStatusCode();
+            return shape.expectTrait(ErrorTrait.class).getDefaultHttpStatusCode();
         }
 
         throw new IllegalStateException(shape + " must be an operation or error structure");
@@ -328,7 +328,7 @@ public final class HttpBindingIndex implements KnowledgeIndex {
 
                 // Use the @mediaType trait if available.
                 if (target.getTrait(MediaTypeTrait.class).isPresent()) {
-                    return target.getTrait(MediaTypeTrait.class).get().getValue();
+                    return target.expectTrait(MediaTypeTrait.class).getValue();
                 } else if (target.isBlobShape()) {
                     return "application/octet-stream";
                 } else if (target.isStringShape()) {
@@ -361,20 +361,20 @@ public final class HttpBindingIndex implements KnowledgeIndex {
 
         for (MemberShape member : struct.getAllMembers().values()) {
             if (member.getTrait(HttpHeaderTrait.class).isPresent()) {
-                HttpHeaderTrait trait = member.getTrait(HttpHeaderTrait.class).get();
+                HttpHeaderTrait trait = member.expectTrait(HttpHeaderTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.HEADER, trait.getValue(), trait));
             } else if (member.getTrait(HttpPrefixHeadersTrait.class).isPresent()) {
-                HttpPrefixHeadersTrait trait = member.getTrait(HttpPrefixHeadersTrait.class).get();
+                HttpPrefixHeadersTrait trait = member.expectTrait(HttpPrefixHeadersTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.PREFIX_HEADERS, trait.getValue(), trait));
             } else if (isRequest && member.getTrait(HttpQueryTrait.class).isPresent()) {
-                HttpQueryTrait trait = member.getTrait(HttpQueryTrait.class).get();
+                HttpQueryTrait trait = member.expectTrait(HttpQueryTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.QUERY, trait.getValue(), trait));
             } else if (member.getTrait(HttpPayloadTrait.class).isPresent()) {
                 foundPayload = true;
-                HttpPayloadTrait trait = member.getTrait(HttpPayloadTrait.class).get();
+                HttpPayloadTrait trait = member.expectTrait(HttpPayloadTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.PAYLOAD, member.getMemberName(), trait));
             } else if (isRequest && member.getTrait(HttpLabelTrait.class).isPresent()) {
-                HttpLabelTrait trait = member.getTrait(HttpLabelTrait.class).get();
+                HttpLabelTrait trait = member.expectTrait(HttpLabelTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.LABEL, member.getMemberName(), trait));
             } else {
                 unbound.add(member);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -100,16 +100,17 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
                     .orElseGet(HashMap::new);
             bindings.get(resource.getId()).put(operationId, computedBindings);
 
-            bindingTypes.get(resource.getId()).put(operationId, isCollection(resource, operationId)
+            BindingType operationBindingType = isCollection(resource, operationId)
                     ? BindingType.COLLECTION
-                    : BindingType.INSTANCE);
+                    : BindingType.INSTANCE;
+            bindingTypes.get(resource.getId()).put(operationId, operationBindingType);
         });
     }
 
     private boolean isCollection(ResourceShape resource, ToShapeId operationId) {
-        return resource.getCollectionOperations().contains(operationId)
-                || (resource.getCreate().isPresent() && resource.getCreate().get().toShapeId().equals(operationId))
-                || (resource.getList().isPresent() && resource.getList().get().toShapeId().equals(operationId));
+        return resource.getCollectionOperations().contains(operationId.toShapeId())
+                || (resource.getCreate().filter(id -> id.equals(operationId)).isPresent())
+                || (resource.getList().filter(id -> id.equals(operationId)).isPresent());
     }
 
     private boolean isImplicitIdentifierBinding(Map.Entry<String, MemberShape> memberEntry, ResourceShape resource) {
@@ -126,6 +127,5 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
                                 ? Stream.of(Pair.of(entry.getKey(), entry.getKey()))
                                 : Stream.empty()))
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
@@ -522,7 +522,7 @@ final class LoaderVisitor {
                 traits.put(traitId, value);
             } else if (previous.isArrayNode() && value.isArrayNode()) {
                 // You can merge trait arrays.
-                traits.put(traitId, value.asArrayNode().get().merge(previous.asArrayNode().get()));
+                traits.put(traitId, value.expectArrayNode().merge(previous.expectArrayNode()));
             } else if (previous.equals(value)) {
                 LOGGER.fine(() -> String.format(
                         "Ignoring duplicate %s trait value on %s", traitId, shapeBuilder.getId()));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigDecimalShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigDecimalShape.java
@@ -46,6 +46,11 @@ public final class BigDecimalShape extends NumberShape implements ToSmithyBuilde
         return Optional.of(this);
     }
 
+    @Override
+    public BigDecimalShape expectBigDecimalShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link BigDecimalShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigIntegerShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigIntegerShape.java
@@ -46,6 +46,11 @@ public final class BigIntegerShape extends NumberShape implements ToSmithyBuilde
         return Optional.of(this);
     }
 
+    @Override
+    public BigIntegerShape expectBigIntegerShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link BigIntegerShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BlobShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BlobShape.java
@@ -46,6 +46,11 @@ public final class BlobShape extends SimpleShape implements ToSmithyBuilder<Blob
         return Optional.of(this);
     }
 
+    @Override
+    public BlobShape expectBlobShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link BlobShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BooleanShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BooleanShape.java
@@ -46,6 +46,11 @@ public final class BooleanShape extends SimpleShape implements ToSmithyBuilder<B
         return Optional.of(this);
     }
 
+    @Override
+    public BooleanShape expectBooleanShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link BooleanShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ByteShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ByteShape.java
@@ -46,6 +46,11 @@ public final class ByteShape extends NumberShape implements ToSmithyBuilder<Byte
         return Optional.of(this);
     }
 
+    @Override
+    public ByteShape expectByteShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link ByteShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DocumentShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DocumentShape.java
@@ -46,6 +46,11 @@ public final class DocumentShape extends SimpleShape implements ToSmithyBuilder<
         return Optional.of(this);
     }
 
+    @Override
+    public DocumentShape expectDocumentShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link DocumentShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DoubleShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DoubleShape.java
@@ -46,6 +46,11 @@ public final class DoubleShape extends NumberShape implements ToSmithyBuilder<Do
         return Optional.of(this);
     }
 
+    @Override
+    public DoubleShape expectDoubleShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link DoubleShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/FloatShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/FloatShape.java
@@ -46,6 +46,11 @@ public final class FloatShape extends NumberShape implements ToSmithyBuilder<Flo
         return Optional.of(this);
     }
 
+    @Override
+    public FloatShape expectFloatShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link FloatShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntegerShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntegerShape.java
@@ -46,6 +46,11 @@ public final class IntegerShape extends NumberShape implements ToSmithyBuilder<I
         return Optional.of(this);
     }
 
+    @Override
+    public IntegerShape expectIntegerShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link IntegerShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ListShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ListShape.java
@@ -46,6 +46,11 @@ public final class ListShape extends CollectionShape implements ToSmithyBuilder<
         return Optional.of(this);
     }
 
+    @Override
+    public ListShape expectListShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link ListShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/LongShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/LongShape.java
@@ -46,6 +46,11 @@ public final class LongShape extends NumberShape implements ToSmithyBuilder<Long
         return Optional.of(this);
     }
 
+    @Override
+    public LongShape expectLongShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link LongShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
@@ -70,6 +70,11 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
         return Optional.of(this);
     }
 
+    @Override
+    public MapShape expectMapShape() {
+        return this;
+    }
+
     /**
      * Get the value member shape of the map.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
@@ -64,6 +64,11 @@ public final class MemberShape extends Shape implements ToSmithyBuilder<MemberSh
         return Optional.of(this);
     }
 
+    @Override
+    public MemberShape expectMemberShape() {
+        return this;
+    }
+
     /**
      * Get the targeted member shape ID.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -60,6 +60,11 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
         return Optional.of(this);
     }
 
+    @Override
+    public OperationShape expectOperationShape() {
+        return this;
+    }
+
     /**
      * <p>Gets the optional shape ID of the input of the operation.</p>
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -93,6 +93,11 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
     }
 
     @Override
+    public ResourceShape expectResourceShape() {
+        return this;
+    }
+
+    @Override
     public Set<ShapeId> getAllOperations() {
         return Collections.unmodifiableSet(allOperations);
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -54,6 +54,11 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
     }
 
     @Override
+    public ServiceShape expectServiceShape() {
+        return this;
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (!super.equals(other)) {
             return false;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SetShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SetShape.java
@@ -46,6 +46,11 @@ public final class SetShape extends CollectionShape implements ToSmithyBuilder<S
         return Optional.of(this);
     }
 
+    @Override
+    public SetShape expectSetShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link SetShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -418,6 +418,319 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
     }
 
     /**
+     * Gets the value as a {@link BigDecimalShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link BigDecimalShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public BigDecimalShape expectBigDecimalShape() {
+        throw expectedDifferentShapeType(ShapeType.BIG_DECIMAL);
+    }
+
+    /**
+     * Gets the value as a {@link BigIntegerShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link BigIntegerShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public BigIntegerShape expectBigIntegerShape() {
+        throw expectedDifferentShapeType(ShapeType.BIG_INTEGER);
+    }
+
+    /**
+     * Gets the value as a {@link BlobShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link BlobShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public BlobShape expectBlobShape() {
+        throw expectedDifferentShapeType(ShapeType.BLOB);
+    }
+
+    /**
+     * Gets the value as a {@link BooleanShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link BooleanShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public BooleanShape expectBooleanShape() {
+        throw expectedDifferentShapeType(ShapeType.BOOLEAN);
+    }
+
+    /**
+     * Gets the value as a {@link ByteShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link ByteShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public ByteShape expectByteShape() {
+        throw expectedDifferentShapeType(ShapeType.BYTE);
+    }
+
+    /**
+     * Gets the value as a {@link ShortShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link ShortShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public ShortShape expectShortShape() {
+        throw expectedDifferentShapeType(ShapeType.SHORT);
+    }
+
+    /**
+     * Gets the value as a {@link FloatShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link FloatShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public FloatShape expectFloatShape() {
+        throw expectedDifferentShapeType(ShapeType.FLOAT);
+    }
+
+    /**
+     * Gets the value as a {@link DocumentShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link DocumentShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public DocumentShape expectDocumentShape() {
+        throw expectedDifferentShapeType(ShapeType.DOCUMENT);
+    }
+
+    /**
+     * Gets the value as a {@link DoubleShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link DoubleShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public DoubleShape expectDoubleShape() {
+        throw expectedDifferentShapeType(ShapeType.DOUBLE);
+    }
+
+    /**
+     * Gets the value as a {@link IntegerShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link IntegerShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public IntegerShape expectIntegerShape() {
+        throw expectedDifferentShapeType(ShapeType.INTEGER);
+    }
+
+    /**
+     * Gets the value as a {@link ListShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link ListShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public ListShape expectListShape() {
+        throw expectedDifferentShapeType(ShapeType.LIST);
+    }
+
+    /**
+     * Gets the value as a {@link SetShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link SetShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public SetShape expectSetShape() {
+        throw expectedDifferentShapeType(ShapeType.SET);
+    }
+
+    /**
+     * Gets the value as a {@link LongShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link LongShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public LongShape expectLongShape() {
+        throw expectedDifferentShapeType(ShapeType.LONG);
+    }
+
+    /**
+     * Gets the value as a {@link MapShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link MapShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public MapShape expectMapShape() {
+        throw expectedDifferentShapeType(ShapeType.MAP);
+    }
+
+    /**
+     * Gets the value as a {@link MemberShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link MemberShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public MemberShape expectMemberShape() {
+        throw expectedDifferentShapeType(ShapeType.MEMBER);
+    }
+
+    /**
+     * Gets the value as a {@link OperationShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as an {@link OperationShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public OperationShape expectOperationShape() {
+        throw expectedDifferentShapeType(ShapeType.OPERATION);
+    }
+
+    /**
+     * Gets the value as a {@link ResourceShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link ResourceShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public ResourceShape expectResourceShape() {
+        throw expectedDifferentShapeType(ShapeType.RESOURCE);
+    }
+
+    /**
+     * Gets the value as a {@link ServiceShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link ServiceShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public ServiceShape expectServiceShape() {
+        throw expectedDifferentShapeType(ShapeType.SERVICE);
+    }
+
+    /**
+     * Gets the value as a {@link StringShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link StringShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public StringShape expectStringShape() {
+        throw expectedDifferentShapeType(ShapeType.STRING);
+    }
+
+    /**
+     * Gets the value as a {@link StructureShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link StructureShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public StructureShape expectStructureShape() {
+        throw expectedDifferentShapeType(ShapeType.STRUCTURE);
+    }
+
+    /**
+     * Gets the value as a {@link UnionShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link UnionShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public UnionShape expectUnionShape() {
+        throw expectedDifferentShapeType(ShapeType.UNION);
+    }
+
+    /**
+     * Gets the value as a {@link TimestampShape} or throws.
+     *
+     * <p>This method should only be used when it is known that the
+     * shape is of the desired type. Use the {@code as*} and {@code is*}
+     * methods before calling this method.
+     *
+     * @return Returns the shape as a {@link TimestampShape}.
+     * @throws ExpectationNotMetException if the shape is not of the expected type.
+     */
+    public TimestampShape expectTimestampShape() {
+        throw expectedDifferentShapeType(ShapeType.TIMESTAMP);
+    }
+
+    private ExpectationNotMetException expectedDifferentShapeType(ShapeType type) {
+        throw new ExpectationNotMetException(String.format(
+                "Expected `%s` to be a %s shape, but found a %s", getId(), type, getType()), this);
+    }
+
+    /**
      * @return Returns true if the shape is a {@link BigDecimalShape} shape.
      */
     public final boolean isBigDecimalShape() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShortShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShortShape.java
@@ -46,6 +46,11 @@ public final class ShortShape extends NumberShape implements ToSmithyBuilder<Sho
         return Optional.of(this);
     }
 
+    @Override
+    public ShortShape expectShortShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link ShortShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -521,7 +521,7 @@ public final class SmithyIdlModelSerializer {
             }
 
             if (shape != null && shape.isMemberShape()) {
-                shape = model.expectShape(shape.asMemberShape().get().getTarget());
+                shape = model.expectShape(shape.expectMemberShape().getTarget());
             }
 
             if (node.isStringNode()) {
@@ -634,7 +634,7 @@ public final class SmithyIdlModelSerializer {
                 Shape member;
                 if (shape != null && shape.isMapShape()) {
                     // For maps the value member will always be the same.
-                    member = shape.asMapShape().get().getValue();
+                    member = shape.expectMapShape().getValue();
                 } else if (shape instanceof NamedMembersShape) {
                     member = members.get(name.getValue());
                 } else {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StringShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StringShape.java
@@ -46,6 +46,11 @@ public final class StringShape extends SimpleShape implements ToSmithyBuilder<St
         return Optional.of(this);
     }
 
+    @Override
+    public StringShape expectStringShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link StringShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
@@ -49,6 +49,11 @@ public final class StructureShape extends NamedMembersShape implements ToSmithyB
         return Optional.of(this);
     }
 
+    @Override
+    public StructureShape expectStructureShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link StructureShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/TimestampShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/TimestampShape.java
@@ -45,6 +45,11 @@ public final class TimestampShape extends SimpleShape implements ToSmithyBuilder
         return Optional.of(this);
     }
 
+    @Override
+    public TimestampShape expectTimestampShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link TimestampShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
@@ -46,6 +46,11 @@ public final class UnionShape extends NamedMembersShape implements ToSmithyBuild
         return Optional.of(this);
     }
 
+    @Override
+    public UnionShape expectUnionShape() {
+        return this;
+    }
+
     /**
      * Builder used to create a {@link UnionShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/BooleanTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/BooleanTrait.java
@@ -53,7 +53,7 @@ public abstract class BooleanTrait extends AbstractTrait {
 
         @Override
         public T createTrait(ShapeId id, Node value) {
-            if (value.asObjectNode().isPresent() && value.asObjectNode().get().getMembers().isEmpty()) {
+            if (value.isObjectNode() && value.expectObjectNode().getMembers().isEmpty()) {
                 return traitFactory.apply(value.getSourceLocation());
             }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EffectiveTraitQuery.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EffectiveTraitQuery.java
@@ -54,12 +54,12 @@ public final class EffectiveTraitQuery implements ToSmithyBuilder<EffectiveTrait
             return true;
         }
 
-        if (!inheritFromContainer || !shape.asMemberShape().isPresent()) {
+        if (!inheritFromContainer || !shape.isMemberShape()) {
             return false;
         }
 
         // Check if the parent of the member is marked with the trait.
-        MemberShape memberShape = shape.asMemberShape().get();
+        MemberShape memberShape = shape.expectMemberShape();
         Shape parent = model.getShape(memberShape.getContainer()).orElse(null);
         return parent != null && parent.hasTrait(traitClass);
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/FilterShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/FilterShapes.java
@@ -50,7 +50,7 @@ final class FilterShapes {
     }
 
     private static boolean canFilterShape(Model model, Shape shape) {
-        return !shape.isMemberShape() || model.getShape(shape.asMemberShape().get().getContainer())
+        return !shape.isMemberShape() || model.getShape(shape.expectMemberShape().getContainer())
                 .filter(container -> container.isStructureShape() || container.isUnionShape())
                 .isPresent();
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ReplaceShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ReplaceShapes.java
@@ -211,14 +211,14 @@ final class ReplaceShapes {
         public Collection<Shape> unionShape(UnionShape shape) {
             return onNamedMemberContainer(
                     shape.getAllMembers(),
-                    previous.asUnionShape().get().getAllMembers());
+                    previous.expectUnionShape().getAllMembers());
         }
 
         @Override
         public Collection<Shape> structureShape(StructureShape shape) {
             return onNamedMemberContainer(
                     getStructureMemberMap(shape),
-                    getStructureMemberMap(previous.asStructureShape().get()));
+                    getStructureMemberMap(previous.expectStructureShape()));
         }
 
         private Map<String, MemberShape> getStructureMemberMap(StructureShape shape) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MemberAndShapeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MemberAndShapeTraitPlugin.java
@@ -38,9 +38,9 @@ abstract class MemberAndShapeTraitPlugin<S extends Shape, N extends Node, T exte
     @SuppressWarnings("unchecked")
     public final List<String> apply(Shape shape, Node value, Model model) {
         if (nodeClass.isInstance(value)
-                && shape.getTrait(traitClass).isPresent()
+                && shape.hasTrait(traitClass)
                 && isMatchingShape(shape, model)) {
-            return check(shape, shape.getTrait(traitClass).get(), (N) value, model);
+            return check(shape, shape.expectTrait(traitClass), (N) value, model);
         }
 
         return ListUtils.of();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
@@ -41,10 +41,10 @@ public final class TimestampFormatPlugin implements NodeValidatorPlugin {
     public List<String> apply(Shape shape, Node value, Model model) {
         if (shape instanceof TimestampShape) {
             return validate(shape, shape.getTrait(TimestampFormatTrait.class).orElse(null), value);
-        } else if (shape instanceof MemberShape && shape.getTrait(TimestampFormatTrait.class).isPresent()) {
+        } else if (shape instanceof MemberShape && shape.hasTrait(TimestampFormatTrait.class)) {
             // Only perform timestamp format validation on a member when it references
             // a timestamp shape and the member has an explicit timestampFormat trait.
-            return validate(shape, shape.getTrait(TimestampFormatTrait.class).get(), value);
+            return validate(shape, shape.expectTrait(TimestampFormatTrait.class), value);
         } else {
             // Ignore when not a timestamp or member that targets a timestamp.
             return ListUtils.of();
@@ -111,11 +111,11 @@ public final class TimestampFormatPlugin implements NodeValidatorPlugin {
     }
 
     private List<String> validateHttpDate(Node value) {
-        if (!value.asStringNode().isPresent()) {
+        if (!value.isStringNode()) {
             return createInvalidHttpDateMessage(value.getType().toString());
         }
 
-        String dateValue = value.asStringNode().get().getValue();
+        String dateValue = value.expectStringNode().getValue();
         if (!isValidFormat(dateValue, HTTP_DATE) || !dateValue.endsWith("GMT")) {
             return createInvalidHttpDateMessage(dateValue);
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthTraitValidator.java
@@ -63,8 +63,8 @@ public class AuthTraitValidator extends AbstractValidator {
             Shape shape,
             List<ValidationEvent> events
     ) {
-        if (shape.getTrait(AuthTrait.class).isPresent()) {
-            AuthTrait authTrait = shape.getTrait(AuthTrait.class).get();
+        if (shape.hasTrait(AuthTrait.class)) {
+            AuthTrait authTrait = shape.expectTrait(AuthTrait.class);
             Set<ShapeId> appliedAuthTraitValue = new TreeSet<>(authTrait.getValues());
             appliedAuthTraitValue.removeAll(serviceAuth);
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventStreamValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventStreamValidator.java
@@ -87,11 +87,11 @@ public class EventStreamValidator extends AbstractValidator {
             return Collections.emptyList();
         }
 
-        EventStreamTrait trait = member.getTrait(EventStreamTrait.class).get();
-        if (target.asUnionShape().isPresent()) {
+        EventStreamTrait trait = member.expectTrait(EventStreamTrait.class);
+        if (target.isUnionShape()) {
             // Find members that don't reference a structure and combine
             // these member names into a comma separated list.
-            String invalidMembers = target.asUnionShape().get().getAllMembers().values().stream()
+            String invalidMembers = target.expectUnionShape().getAllMembers().values().stream()
                     .map(em -> Pair.of(em.getMemberName(), model.getShape(em.getTarget()).orElse(null)))
                     .filter(pair -> pair.getRight() != null && !(pair.getRight() instanceof StructureShape))
                     .map(Pair::getLeft)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
@@ -105,8 +105,8 @@ public final class HttpUriConflictValidator extends AbstractValidator {
     }
 
     private boolean isAllowableConflict(Model model, OperationShape operation, OperationShape otherOperation) {
-        UriPattern uriPattern = operation.getTrait(HttpTrait.class).get().getUri();
-        UriPattern otherUriPattern = otherOperation.getTrait(HttpTrait.class).get().getUri();
+        UriPattern uriPattern = operation.expectTrait(HttpTrait.class).getUri();
+        UriPattern otherUriPattern = otherOperation.expectTrait(HttpTrait.class).getUri();
 
         List<Pair<Segment, Segment>> conflictingLabelSegments = uriPattern.getConflictingLabelSegments(otherUriPattern);
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/RangeTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/RangeTraitValidator.java
@@ -74,7 +74,7 @@ public class RangeTraitValidator extends AbstractValidator {
     ) {
         if (!property.remainder(BigDecimal.ONE).equals(BigDecimal.ZERO)) {
             if (shape.isMemberShape()) {
-                MemberShape member = shape.asMemberShape().get();
+                MemberShape member = shape.expectMemberShape();
                 Optional<Shape> target = model.getShape(member.getTarget());
                 if (target.isPresent() && !isDecimalShape(target.get())) {
                     return Optional.of(error(shape, trait, format(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ReferencesTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ReferencesTraitValidator.java
@@ -71,7 +71,7 @@ public final class ReferencesTraitValidator extends AbstractValidator {
                             "`references` trait reference targets a %s shape not a resource: %s",
                             targetedShape.get().getType(), reference)));
                 } else {
-                    ResourceShape resource = targetedShape.get().asResourceShape().get();
+                    ResourceShape resource = targetedShape.get().expectResourceShape();
                     events.addAll(validateSingleReference(model, reference, shape, trait, resource));
                 }
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitValueValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitValueValidator.java
@@ -52,7 +52,7 @@ public final class TraitValueValidator implements Validator {
             return ListUtils.of();
         }
 
-        Shape schema = model.getShape(shape).get();
+        Shape schema = model.expectShape(shape);
         Node coerced = Trait.coerceTraitValue(trait.toNode(), schema.getType());
 
         NodeValidationVisitor cases = NodeValidationVisitor.builder()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -270,7 +270,7 @@ public class HttpBindingIndexTest {
 
     private static MemberShape expectMember(Model model, String id) {
         ShapeId shapeId = ShapeId.from(id);
-        return model.expectShape(shapeId).asMemberShape().get();
+        return model.expectShape(shapeId).expectMemberShape();
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
@@ -57,10 +57,10 @@ public class OperationIndexTest {
     @Test
     public void indexesOperations() {
         OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
-        Shape input = model.getShape(ShapeId.from("ns.foo#Input")).get();
-        Shape output = model.getShape(ShapeId.from("ns.foo#Output")).get();
-        Shape error1 = model.getShape(ShapeId.from("ns.foo#Error1")).get();
-        Shape error2 = model.getShape(ShapeId.from("ns.foo#Error2")).get();
+        Shape input = model.expectShape(ShapeId.from("ns.foo#Input"));
+        Shape output = model.expectShape(ShapeId.from("ns.foo#Output"));
+        Shape error1 = model.expectShape(ShapeId.from("ns.foo#Error1"));
+        Shape error2 = model.expectShape(ShapeId.from("ns.foo#Error2"));
 
         assertThat(opIndex.getInput(ShapeId.from("ns.foo#B")), is(Optional.of(input)));
         assertThat(opIndex.getOutput(ShapeId.from("ns.foo#B")), is(Optional.of(output)));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -57,12 +57,9 @@ public class IdlModelLoaderTest {
                 .assemble()
                 .unwrap();
 
-        MemberShape baz = model.expectShape(ShapeId.from("smithy.example#Foo$baz"))
-                .asMemberShape().get();
-        MemberShape bar = model.expectShape(ShapeId.from("smithy.example#Foo$bar"))
-                .asMemberShape().get();
-        ResourceShape resource = model.expectShape(ShapeId.from("smithy.example#MyResource"))
-                .asResourceShape().get();
+        MemberShape baz = model.expectShape(ShapeId.from("smithy.example#Foo$baz")).expectMemberShape();
+        MemberShape bar = model.expectShape(ShapeId.from("smithy.example#Foo$bar")).expectMemberShape();
+        ResourceShape resource = model.expectShape(ShapeId.from("smithy.example#MyResource")).expectResourceShape();
 
         assertThat(baz.getTarget().toString(), equalTo("smithy.api#String"));
         assertThat(bar.getTarget().toString(), equalTo("smithy.example#Integer"));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -158,8 +158,7 @@ public class ModelAssemblerTest {
         assertThat(result.getValidationEvents(), hasSize(1));
         assertThat(result.getValidationEvents().get(0).getMessage(), containsString("Invalid shape `type`: foobaz"));
         assertThat(result.getValidationEvents().get(0).getSeverity(), is(Severity.ERROR));
-        assertTrue(result.getResult().get()
-                           .getShape(ShapeId.from("example.namespace#String")).isPresent());
+        assertTrue(result.getResult().get().getShape(ShapeId.from("example.namespace#String")).isPresent());
     }
 
     @Test
@@ -176,48 +175,48 @@ public class ModelAssemblerTest {
         assertThat(result.getValidationEvents(), empty());
         Model model = result.unwrap();
         assertTrue(model.getShape(ShapeId.from("example.namespace#String")).isPresent());
-        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String")).getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#String2")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String2")).getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#String3")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String3")).getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String")).getType(),
             is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Integer")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Integer")).getType(),
             is(ShapeType.INTEGER));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Long")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Long")).getType(),
             is(ShapeType.LONG));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Float")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Float")).getType(),
             is(ShapeType.FLOAT));
-        assertThat(model.getShape(ShapeId.from("example.namespace#BigDecimal")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#BigDecimal")).getType(),
             is(ShapeType.BIG_DECIMAL));
-        assertThat(model.getShape(ShapeId.from("example.namespace#BigInteger")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#BigInteger")).getType(),
             is(ShapeType.BIG_INTEGER));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Blob")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Blob")).getType(),
             is(ShapeType.BLOB));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Boolean")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Boolean")).getType(),
             is(ShapeType.BOOLEAN));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Timestamp")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Timestamp")).getType(),
             is(ShapeType.TIMESTAMP));
-        assertThat(model.getShape(ShapeId.from("example.namespace#List")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#List")).getType(),
             is(ShapeType.LIST));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Map")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Map")).getType(),
             is(ShapeType.MAP));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Structure")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Structure")).getType(),
             is(ShapeType.STRUCTURE));
-        assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#TaggedUnion")).getType(),
             is(ShapeType.UNION));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Resource")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Resource")).getType(),
             is(ShapeType.RESOURCE));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Operation")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Operation")).getType(),
             is(ShapeType.OPERATION));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Service")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Service")).getType(),
             is(ShapeType.SERVICE));
 
         ShapeId stringId = ShapeId.from("example.namespace#String");
         Optional<SensitiveTrait> sensitiveTrait = model
-            .getShape(stringId).get()
+            .expectShape(stringId)
             .getTrait(SensitiveTrait.class);
         assertTrue(sensitiveTrait.isPresent());
 
@@ -270,48 +269,48 @@ public class ModelAssemblerTest {
         assertThat(result.getValidationEvents(), empty());
         Model model = result.unwrap();
         assertTrue(model.getShape(ShapeId.from("example.namespace#String")).isPresent());
-        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String")).getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#String2")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String2")).getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#String3")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String3")).getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String")).getType(),
                    is(ShapeType.STRING));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Integer")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Integer")).getType(),
                    is(ShapeType.INTEGER));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Long")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Long")).getType(),
                    is(ShapeType.LONG));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Float")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Float")).getType(),
                    is(ShapeType.FLOAT));
-        assertThat(model.getShape(ShapeId.from("example.namespace#BigDecimal")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#BigDecimal")).getType(),
                    is(ShapeType.BIG_DECIMAL));
-        assertThat(model.getShape(ShapeId.from("example.namespace#BigInteger")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#BigInteger")).getType(),
                    is(ShapeType.BIG_INTEGER));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Blob")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Blob")).getType(),
                    is(ShapeType.BLOB));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Boolean")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Boolean")).getType(),
                    is(ShapeType.BOOLEAN));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Timestamp")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Timestamp")).getType(),
                    is(ShapeType.TIMESTAMP));
-        assertThat(model.getShape(ShapeId.from("example.namespace#List")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#List")).getType(),
                     is(ShapeType.LIST));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Map")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Map")).getType(),
                    is(ShapeType.MAP));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Structure")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Structure")).getType(),
                    is(ShapeType.STRUCTURE));
-        assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#TaggedUnion")).getType(),
                    is(ShapeType.UNION));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Resource")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Resource")).getType(),
                    is(ShapeType.RESOURCE));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Operation")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Operation")).getType(),
                    is(ShapeType.OPERATION));
-        assertThat(model.getShape(ShapeId.from("example.namespace#Service")).get().getType(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#Service")).getType(),
                    is(ShapeType.SERVICE));
 
         ShapeId stringId = ShapeId.from("example.namespace#String");
         Optional<SensitiveTrait> sensitiveTrait = model
-                .getShape(stringId).get()
+                .expectShape(stringId)
                 .getTrait(SensitiveTrait.class);
         assertTrue(sensitiveTrait.isPresent());
 
@@ -339,9 +338,9 @@ public class ModelAssemblerTest {
                 .assemble()
                 .unwrap();
 
-        assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getSourceLocation(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#String")).getSourceLocation(),
                 is(new SourceLocation(getClass().getResource("main.json").toString(), 4, 37)));
-        assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion$foo")).get().getSourceLocation(),
+        assertThat(model.expectShape(ShapeId.from("example.namespace#TaggedUnion$foo")).getSourceLocation(),
                 is(new SourceLocation(getClass().getResource("main.json").toString(), 69, 24)));
     }
 
@@ -399,7 +398,7 @@ public class ModelAssemblerTest {
                 .unwrap();
 
         assertEquals("hi", model2.expectShape(ShapeId.from("example.namespace#String"))
-                .getTrait(DocumentationTrait.class).get().getValue());
+                .expectTrait(DocumentationTrait.class).getValue());
     }
 
     @Test
@@ -462,7 +461,7 @@ public class ModelAssemblerTest {
         for (String id : ListUtils.of("foo.baz#A", "foo.baz#B", "foo.baz#C")) {
             ShapeId shapeId = ShapeId.from(id);
             assertTrue(model.getShape(shapeId).isPresent());
-            assertThat(model.getShape(shapeId).get().getSourceLocation().getFilename(),
+            assertThat(model.expectShape(shapeId).getSourceLocation().getFilename(),
                        startsWith("jar:file:"));
         }
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/BlobShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/BlobShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ public class BlobShapeTest {
         BlobShape shape = BlobShape.builder().id("ns.foo#bar").build();
 
         assertEquals(shape.getType(), ShapeType.BLOB);
+        assertThat(shape, is(shape.expectBlobShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/BooleanShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/BooleanShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ public class BooleanShapeTest {
         BooleanShape shape = BooleanShape.builder().id("ns.foo#bar").build();
 
         assertEquals(shape.getType(), ShapeType.BOOLEAN);
+        assertThat(shape, is(shape.expectBooleanShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ListShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ListShapeTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -34,6 +35,7 @@ public class ListShapeTest {
                 .build();
 
         assertEquals(shape.getType(), ShapeType.LIST);
+        assertThat(shape, is(shape.expectListShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MapShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MapShapeTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -34,6 +35,7 @@ public class MapShapeTest {
                 .build();
 
         assertEquals(shape.getType(), ShapeType.MAP);
+        assertThat(shape, is(shape.expectMapShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MemberShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/MemberShapeTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -48,7 +49,9 @@ public class MemberShapeTest {
                 .id(ShapeId.from("ns.foo#bar$baz"))
                 .target("ns.foo#baz")
                 .build();
+
         assertEquals(ShapeType.MEMBER, shape.getType());
+        assertThat(shape, is(shape.expectMemberShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ResourceShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ResourceShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ public class ResourceShapeTest {
         ResourceShape shape = ResourceShape.builder().id("ns.foo#Bar").build();
 
         assertEquals(shape.getType(), ShapeType.RESOURCE);
+        assertThat(shape, is(shape.expectResourceShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ public class ServiceShapeTest {
         ServiceShape shape = ServiceShape.builder().id("ns.foo#Bar").version("2017-01-17").build();
 
         assertEquals(shape.getType(), ShapeType.SERVICE);
+        assertThat(shape, is(shape.expectServiceShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
@@ -248,4 +248,15 @@ public class ShapeTest {
 
         assertEquals(shapeA, shapeB);
     }
+
+    @Test
+    public void throwsForExpectedShapeTypesByDefault() {
+        Shape shape = StringShape.builder().id("ns.foo#baz").build();
+
+        ExpectationNotMetException e = Assertions.assertThrows(
+                ExpectationNotMetException.class,
+                shape::expectByteShape);
+
+        assertThat(e.getMessage(), equalTo("Expected `ns.foo#baz` to be a byte shape, but found a string"));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StringShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StringShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ public class StringShapeTest {
         StringShape shape = StringShape.builder().id("ns.foo#bar").build();
 
         assertEquals(shape.getType(), ShapeType.STRING);
+        assertThat(shape, is(shape.expectStringShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -30,6 +31,7 @@ public class StructureShapeTest {
         StructureShape shape = StructureShape.builder().id("ns.foo#bar").build();
 
         assertEquals(shape.getType(), ShapeType.STRUCTURE);
+        assertThat(shape, is(shape.expectStructureShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/TimestampShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/TimestampShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ public class TimestampShapeTest {
         TimestampShape shape = TimestampShape.builder().id("ns.foo#bar").build();
 
         assertEquals(shape.getType(), ShapeType.TIMESTAMP);
+        assertThat(shape, is(shape.expectTimestampShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/UnionShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/UnionShapeTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.shapes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -33,6 +35,7 @@ public class UnionShapeTest {
                 .build();
 
         assertEquals(shape.getType(), ShapeType.UNION);
+        assertThat(shape, is(shape.expectUnionShape()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterShapesTest.java
@@ -105,11 +105,11 @@ public class FilterShapesTest {
         assertThat(result.getShape(structure.getId()), Matchers.not(Optional.empty()));
 
         // Make sure the structure was updated so that it no longer has the removed member shape.
-        assertThat(result.getShape(structure.getId()).get().asStructureShape().get().getMember("member1"),
+        assertThat(result.expectShape(structure.getId(), StructureShape.class).getMember("member1"),
                    Matchers.not(Optional.empty()));
-        assertThat(result.getShape(structure.getId()).get().asStructureShape().get().getMember("member3"),
+        assertThat(result.expectShape(structure.getId(), StructureShape.class).getMember("member3"),
                    Matchers.not(Optional.empty()));
-        assertThat(result.getShape(structure.getId()).get().asStructureShape().get().getMember("member2"),
+        assertThat(result.expectShape(structure.getId(), StructureShape.class).getMember("member2"),
                    Matchers.is(Optional.empty()));
     }
 
@@ -149,10 +149,10 @@ public class FilterShapesTest {
         assertThat(definitions, Matchers.hasKey(barTrait));
         assertThat(definitions, Matchers.hasValue(barTrait.getTrait(TraitDefinition.class).get()));
 
-        assertThat(result.getShape(shapeId1).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(shapeId1).get().findTrait("ns.foo#baz"), Matchers.is(Optional.empty()));
-        assertThat(result.getShape(shapeId2).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(shapeId2).get().findTrait("ns.foo#baz"), Matchers.is(Optional.empty()));
-        assertThat(result.getShape(shapeId2).get().findTrait("ns.foo#bar"), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(shapeId1).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(shapeId1).findTrait("ns.foo#baz"), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(shapeId2).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(shapeId2).findTrait("ns.foo#baz"), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(shapeId2).findTrait("ns.foo#bar"), Matchers.not(Optional.empty()));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
@@ -50,10 +50,10 @@ public class FilterTraitsTest {
                 model, (shape, trait) -> !trait.toShapeId().equals(ShapeId.from("smithy.api#sensitive")));
 
         assertThat(result.shapes().count(), Matchers.is(2L));
-        assertThat(result.getShape(aId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(result.getShape(aId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(bId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(result.getShape(bId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(aId).getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(aId).getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(bId).getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(bId).getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
     }
 
     @Test
@@ -72,9 +72,9 @@ public class FilterTraitsTest {
                                          && !trait.toShapeId().equals(ShapeId.from("smithy.api#documentation")));
 
         assertThat(result.shapes().count(), Matchers.is(1L));
-        assertThat(result.getShape(aId).get().getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
-        assertThat(result.getShape(aId).get().getTrait(DocumentationTrait.class), Matchers.is(Optional.empty()));
-        assertThat(result.getShape(aId).get().getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(aId).getTrait(SensitiveTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(aId).getTrait(DocumentationTrait.class), Matchers.is(Optional.empty()));
+        assertThat(result.expectShape(aId).getTrait(DeprecatedTrait.class), Matchers.not(Optional.empty()));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
@@ -54,7 +54,7 @@ public class ModelTransformerTest {
         ShapeId operation = ShapeId.from("ns.foo#MyOperation");
 
         assertThat(nonTraitShapes.getShape(operation), Matchers.not(Optional.empty()));
-        assertThat(nonTraitShapes.getShape(operation).get().getTrait(ReadonlyTrait.class), Matchers.not(Optional.empty()));
+        assertThat(nonTraitShapes.expectShape(operation).getTrait(ReadonlyTrait.class), Matchers.not(Optional.empty()));
         assertThat(nonTraitShapes.getShape(EnumTrait.ID), Matchers.equalTo(Optional.empty()));
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
@@ -137,7 +137,7 @@ public class RemoveShapesTest {
         assertThat(result.shapes().count(), Matchers.equalTo(2L));
         assertThat(result.getShape(container.getId()), Matchers.not(Optional.empty()));
         assertThat(result.getShape(c.getId()), Matchers.not(Optional.empty()));
-        assertThat(result.expectShape(container.getId()).asResourceShape().get().getOperations(),
+        assertThat(result.expectShape(container.getId()).expectResourceShape().getOperations(),
                    Matchers.contains(c.getId()));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -72,9 +72,9 @@ public class ReplaceShapesTest {
         Model result = transformer.replaceShapes(model, Arrays.asList(newList));
 
         assertThat(result.shapes().count(), Matchers.equalTo(3L));
-        assertThat(result.getShape(memberId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(containerId).get(), Matchers.is(newList));
-        assertThat(result.getShape(containerId).get().asListShape().get().getMember(), Matchers.is(newMember));
+        assertThat(result.expectShape(memberId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(containerId), Matchers.is(newList));
+        assertThat(result.expectShape(containerId, ListShape.class).getMember(), Matchers.is(newMember));
     }
 
     @Test
@@ -107,11 +107,11 @@ public class ReplaceShapesTest {
         Model result = transformer.replaceShapes(model, Arrays.asList(newMap));
 
         assertThat(result.shapes().count(), Matchers.equalTo(4L));
-        assertThat(result.getShape(keyId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(valueId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(containerId).get(), Matchers.is(newMap));
-        assertThat(result.getShape(containerId).get().asMapShape().get().getKey(), Matchers.is(newKey));
-        assertThat(result.getShape(containerId).get().asMapShape().get().getValue(), Matchers.is(newValue));
+        assertThat(result.expectShape(keyId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(valueId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(containerId), Matchers.is(newMap));
+        assertThat(result.expectShape(containerId, MapShape.class).getKey(), Matchers.is(newKey));
+        assertThat(result.expectShape(containerId, MapShape.class).getValue(), Matchers.is(newValue));
     }
 
     @Test
@@ -164,8 +164,8 @@ public class ReplaceShapesTest {
                 .build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMember));
 
-        assertThat(result.getShape(memberId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(containerId).get().asListShape().get().getMember(), Matchers.is(newMember));
+        assertThat(result.expectShape(memberId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(containerId, ListShape.class).getMember(), Matchers.is(newMember));
     }
 
     @Test
@@ -195,14 +195,14 @@ public class ReplaceShapesTest {
                 .build();
         Model resultWithNewValue = transformer.replaceShapes(model, Arrays.asList(newValueMember));
 
-        assertThat(resultWithNewKey.getShape(keyMemberId).get().getTrait(SensitiveTrait.class),
+        assertThat(resultWithNewKey.expectShape(keyMemberId).getTrait(SensitiveTrait.class),
                           Matchers.not(Optional.empty()));
-        assertThat(resultWithNewKey.getShape(containerId).get().asMapShape().get().getKey(),
+        assertThat(resultWithNewKey.expectShape(containerId, MapShape.class).getKey(),
                           Matchers.is(newKeyMember));
 
-        assertThat(resultWithNewValue.getShape(valueMemberId).get().getTrait(SensitiveTrait.class),
+        assertThat(resultWithNewValue.expectShape(valueMemberId).getTrait(SensitiveTrait.class),
                           Matchers.not(Optional.empty()));
-        assertThat(resultWithNewValue.getShape(containerId).get().asMapShape().get().getValue(),
+        assertThat(resultWithNewValue.expectShape(containerId, MapShape.class).getValue(),
                           Matchers.is(newValueMember));
     }
 
@@ -236,11 +236,11 @@ public class ReplaceShapesTest {
         Model result = transformer.replaceShapes(model, Arrays.asList(newMemberB));
 
         // Make sure the member has the trait that was applied.
-        assertThat(result.getShape(memberBId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(memberBId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
         // Make sure it's still optional.
-        assertTrue(result.getShape(containerId).get().asStructureShape().get().getMember("b").get().isOptional());
+        assertTrue(result.expectShape(containerId, StructureShape.class).getMember("b").get().isOptional());
         // Ensure that the structure that contains the shape was updated.
-        assertThat(result.getShape(containerId).get().asStructureShape().get().getMember("b").get(),
+        assertThat(result.expectShape(containerId, StructureShape.class).getMember("b").get(),
                    Matchers.is(newMemberB));
     }
 
@@ -266,16 +266,14 @@ public class ReplaceShapesTest {
         MemberShape newMemberB = memberB.toBuilder().addTrait(new RequiredTrait(SourceLocation.NONE)).build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMemberA, newMemberB));
 
-        assertThat(result.getShape(memberAId).get().getTrait(RequiredTrait.class), Matchers.not(Optional.empty()));
-        assertThat(result.getShape(memberBId).get().getTrait(RequiredTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(memberAId).getTrait(RequiredTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(memberBId).getTrait(RequiredTrait.class), Matchers.not(Optional.empty()));
 
         // Make sure the members got updated inside of the container.
-        assertTrue(result.getShape(containerId).get()
-                .asStructureShape().get()
+        assertTrue(result.expectShape(containerId, StructureShape.class)
                 .getMember("a").get()
                 .hasTrait(RequiredTrait.class));
-        assertTrue(result.getShape(containerId).get()
-                .asStructureShape().get()
+        assertTrue(result.expectShape(containerId, StructureShape.class)
                 .getMember("b").get()
                 .hasTrait(RequiredTrait.class));
     }
@@ -306,9 +304,9 @@ public class ReplaceShapesTest {
         Model result = transformer.replaceShapes(model, Arrays.asList(newMemberB));
 
         // Make sure the member has the trait that was applied.
-        assertThat(result.getShape(memberBId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(memberBId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
         // Ensure that the union that contains the shape was updated.
-        assertThat(result.getShape(containerId).get().asUnionShape().get().getMember("b").get(),
+        assertThat(result.expectShape(containerId, UnionShape.class).getMember("b").get(),
                    Matchers.is(newMemberB));
     }
 
@@ -339,11 +337,11 @@ public class ReplaceShapesTest {
         Model result = transformer.replaceShapes(model, Arrays.asList(newMember, newContainer));
 
         // Make sure the member has the trait that was applied.
-        assertThat(result.getShape(memberId).get().getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
+        assertThat(result.expectShape(memberId).getTrait(SensitiveTrait.class), Matchers.not(Optional.empty()));
         // Ensure that the list shape changes were not overwritten.
-        assertThat(result.getShape(containerId).get().asListShape().get().getTrait(LengthTrait.class),
+        assertThat(result.expectShape(containerId, ListShape.class).getTrait(LengthTrait.class),
                           Matchers.not(Optional.empty()));
         // Ensure that the list shape has the new member.
-        assertThat(result.getShape(containerId).get().asListShape().get().getMember(), Matchers.is(newMember));
+        assertThat(result.expectShape(containerId, ListShape.class).getMember(), Matchers.is(newMember));
     }
 }

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
@@ -64,10 +64,10 @@ public final class ResolvedTopicIndex implements KnowledgeIndex {
 
         model.shapes(OperationShape.class).forEach(operation -> {
             if (operation.hasTrait(PublishTrait.class)) {
-                PublishTrait trait = operation.getTrait(PublishTrait.class).get();
+                PublishTrait trait = operation.expectTrait(PublishTrait.class);
                 createPublishBindings(operationIndex, operation, trait);
             } else if (operation.hasTrait(SubscribeTrait.class)) {
-                SubscribeTrait trait = operation.getTrait(SubscribeTrait.class).get();
+                SubscribeTrait trait = operation.expectTrait(SubscribeTrait.class);
                 StructureShape input = operationIndex.getInput(operation).orElse(null);
                 createSubscribeBinding(input, eventStreamIndex, operation, trait);
             }

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeOutputValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeOutputValidator.java
@@ -69,7 +69,7 @@ public final class MqttSubscribeOutputValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         if (info.hasInitialMessage()) {
-            events.add(error(shape, shape.getTrait(SubscribeTrait.class).get(),
+            events.add(error(shape, shape.expectTrait(SubscribeTrait.class),
                              "Operations marked with the `smithy.mqtt#subscribe` trait must not utilize event "
                              + "streams with initial responses in their output structure."));
         }
@@ -102,7 +102,7 @@ public final class MqttSubscribeOutputValidator extends AbstractValidator {
 
             @Override
             public Stream<StructureShape> structureShape(StructureShape shape) {
-                return Stream.of(info.getEventStreamTarget().asStructureShape().get());
+                return Stream.of(info.getEventStreamTarget().expectStructureShape());
             }
         });
     }

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
@@ -57,11 +57,11 @@ public class MqttTopicLabelValidator extends AbstractValidator {
 
     private static TopicCollection createTopics(OperationShape shape) {
         if (shape.hasTrait(SubscribeTrait.class)) {
-            SubscribeTrait trait = shape.getTrait(SubscribeTrait.class).get();
+            SubscribeTrait trait = shape.expectTrait(SubscribeTrait.class);
             List<Topic> bindings = Collections.singletonList(trait.getTopic());
             return new TopicCollection(shape, trait, bindings);
         } else if (shape.hasTrait(PublishTrait.class)) {
-            PublishTrait trait = shape.getTrait(PublishTrait.class).get();
+            PublishTrait trait = shape.expectTrait(PublishTrait.class);
             List<Topic> bindings = Collections.singletonList(trait.getTopic());
             return new TopicCollection(shape, trait, bindings);
         } else {
@@ -94,7 +94,7 @@ public class MqttTopicLabelValidator extends AbstractValidator {
                 if (labels.contains(member.getMemberName())) {
                     labels.remove(member.getMemberName());
                 } else {
-                    events.add(error(member, member.getTrait(TopicLabelTrait.class).get(), String.format(
+                    events.add(error(member, member.expectTrait(TopicLabelTrait.class), String.format(
                             "This member is marked with the `smithy.mqtt#topicLabel` trait, but when this member is "
                             + "used as part of the input of the `%s` operation, a corresponding label cannot be "
                             + "found in the `%s` trait",

--- a/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/TraitTest.java
+++ b/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/TraitTest.java
@@ -16,8 +16,7 @@ public class TraitTest {
                 .assemble()
                 .unwrap();
         HttpRequestTestCase testCase = model.expectShape(ShapeId.from("smithy.example#SayHello"))
-                .getTrait(HttpRequestTestsTrait.class)
-                .get()
+                .expectTrait(HttpRequestTestsTrait.class)
                 .getTestCases()
                 .get(0);
 
@@ -33,8 +32,7 @@ public class TraitTest {
                 .assemble()
                 .unwrap();
         HttpResponseTestCase testCase = model.expectShape(ShapeId.from("smithy.example#SayGoodbye"))
-                .getTrait(HttpResponseTestsTrait.class)
-                .get()
+                .expectTrait(HttpResponseTestsTrait.class)
                 .getTestCases()
                 .get(0);
 


### PR DESCRIPTION
This commit uses the expectTrait methods and hasTrait methods more
instead of using .get(). This will give much more clear error messages
in the event of a logical error in code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
