### PR TITLE
Rename Pattern to SmithyPattern

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/pattern/SmithyPattern.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/pattern/SmithyPattern.java
@@ -41,12 +41,12 @@ import java.util.stream.Collectors;
  * must be the last label in a pattern. Greedy labels may be disabled for a
  * pattern as part of the builder construction.
  */
-public class Pattern {
+public class SmithyPattern {
 
     private final String pattern;
     private final List<Segment> segments;
 
-    protected Pattern(Builder builder) {
+    protected SmithyPattern(Builder builder) {
         pattern = Objects.requireNonNull(builder.pattern);
         segments = Objects.requireNonNull(builder.segments);
 
@@ -107,7 +107,7 @@ public class Pattern {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof Pattern && pattern.equals(((Pattern) other).pattern);
+        return other instanceof SmithyPattern && pattern.equals(((SmithyPattern) other).pattern);
     }
 
     @Override
@@ -145,14 +145,14 @@ public class Pattern {
     }
 
     /**
-     * @return Returns a builder used to create a Pattern.
+     * @return Returns a builder used to create a SmithyPattern.
      */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Builder used to create a Pattern.
+     * Builder used to create a SmithyPattern.
      */
     public static final class Builder {
         private boolean allowsGreedyLabels = true;
@@ -176,13 +176,13 @@ public class Pattern {
             return this;
         }
 
-        public Pattern build() {
-            return new Pattern(this);
+        public SmithyPattern build() {
+            return new SmithyPattern(this);
         }
     }
 
     /**
-     * Segment within a Pattern.
+     * Segment within a SmithyPattern.
      */
     public static final class Segment {
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/pattern/UriPattern.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/pattern/UriPattern.java
@@ -40,7 +40,7 @@ import software.amazon.smithy.utils.Pair;
  * "{label+}". Only a single greedy label may appear in a pattern, and it
  * must be the last label in a pattern.
  */
-public final class UriPattern extends Pattern {
+public final class UriPattern extends SmithyPattern {
 
     private final Map<String, String> queryLiterals;
 
@@ -121,7 +121,7 @@ public final class UriPattern extends Pattern {
     /**
      * Determines if the pattern conflicts with another pattern.
      *
-     * @param otherPattern Pattern to check against.
+     * @param otherPattern SmithyPattern to check against.
      * @return Returns true if there is a conflict.
      */
     public boolean conflictsWith(UriPattern otherPattern) {
@@ -160,7 +160,7 @@ public final class UriPattern extends Pattern {
      * Gets a list of explicitly conflicting uri label segments between this
      * pattern and another.
      *
-     * @param otherPattern Pattern to check against.
+     * @param otherPattern SmithyPattern to check against.
      * @return A list of Segment Pairs where each pair represents a conflict
      *     and where the left side of the Pair is a segment from this pattern.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.model.traits;
 
 import static java.lang.String.format;
-import static software.amazon.smithy.model.pattern.Pattern.Segment;
+import static software.amazon.smithy.model.pattern.SmithyPattern.Segment;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,7 +26,7 @@ import java.util.StringTokenizer;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.pattern.InvalidPatternException;
-import software.amazon.smithy.model.pattern.Pattern;
+import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -36,7 +36,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final class EndpointTrait extends AbstractTrait implements ToSmithyBuilder<EndpointTrait> {
     public static final ShapeId ID = ShapeId.from("smithy.api#endpoint");
 
-    private final Pattern hostPrefix;
+    private final SmithyPattern hostPrefix;
 
     private EndpointTrait(Builder builder) {
         super(ID, builder.sourceLocation);
@@ -67,7 +67,7 @@ public final class EndpointTrait extends AbstractTrait implements ToSmithyBuilde
             position += token.length();
         }
 
-        this.hostPrefix = Pattern.builder()
+        this.hostPrefix = SmithyPattern.builder()
                 .allowsGreedyLabels(false)
                 .segments(segments)
                 .pattern(hostPrefix)
@@ -88,7 +88,7 @@ public final class EndpointTrait extends AbstractTrait implements ToSmithyBuilde
         }
     }
 
-    public Pattern getHostPrefix() {
+    public SmithyPattern getHostPrefix() {
         return hostPrefix;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.pattern.Pattern;
+import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -82,7 +82,7 @@ public class HostLabelTraitValidator extends AbstractValidator {
             events.add(error(operation, endpoint, format(
                     "`endpoint` trait hostPrefix contains labels (%s), but operation has no input.",
                     ValidationUtils.tickedList(endpoint.getHostPrefix().getLabels().stream()
-                            .map(Pattern.Segment::getContent).collect(Collectors.toSet())))));
+                            .map(SmithyPattern.Segment::getContent).collect(Collectors.toSet())))));
         } else {
             // Only validate the bindings if the input is a structure. Typing
             // validation of the input is handled elsewhere.
@@ -101,13 +101,13 @@ public class HostLabelTraitValidator extends AbstractValidator {
             StructureShape input
     ) {
         List<ValidationEvent> events = new ArrayList<>();
-        Pattern hostPrefix = endpoint.getHostPrefix();
+        SmithyPattern hostPrefix = endpoint.getHostPrefix();
 
         // Create a set of labels and remove from the set when a match is
         // found. If any labels remain after looking at all members, then
         // there are unmatched labels.
         Set<String> labels = hostPrefix.getLabels().stream()
-                .map(Pattern.Segment::getContent)
+                .map(SmithyPattern.Segment::getContent)
                 .collect(Collectors.toSet());
 
         input.getAllMembers().values().stream()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
@@ -24,7 +24,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
-import software.amazon.smithy.model.pattern.Pattern.Segment;
+import software.amazon.smithy.model.pattern.SmithyPattern.Segment;
 import software.amazon.smithy.model.pattern.UriPattern;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;

--- a/smithy-model/src/test/java/software/amazon/smithy/model/pattern/SmithyPatternTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/pattern/SmithyPatternTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static software.amazon.smithy.model.pattern.Pattern.Segment;
+import static software.amazon.smithy.model.pattern.SmithyPattern.Segment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +28,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class PatternTest {
+public class SmithyPatternTest {
 
     private static List<Segment> parser(String target) {
         String[] unparsedSegments = target.split(java.util.regex.Pattern.quote("/"));
@@ -45,7 +45,7 @@ public class PatternTest {
     @Test
     public void parsesGreedyLabels() {
         String target = "/foo/baz/{bar+}";
-        Pattern pattern = Pattern.builder()
+        SmithyPattern pattern = SmithyPattern.builder()
                 .segments(parser(target))
                 .pattern(target)
                 .build();
@@ -58,12 +58,12 @@ public class PatternTest {
     @Test
     public void computesHashAndEquals() {
         String target1 = "/foo";
-        Pattern pattern1 = Pattern.builder()
+        SmithyPattern pattern1 = SmithyPattern.builder()
                 .segments(parser(target1))
                 .pattern(target1)
                 .build();
         String target2 = "/foo/{baz+}/";
-        Pattern pattern2 = Pattern.builder()
+        SmithyPattern pattern2 = SmithyPattern.builder()
                 .segments(parser(target2))
                 .pattern(target2)
                 .build();
@@ -79,7 +79,7 @@ public class PatternTest {
     @Test
     public void labelsAreCaseInsensitive() {
         String target = "/foo/{baz}";
-        Pattern pattern = Pattern.builder()
+        SmithyPattern pattern = SmithyPattern.builder()
                                   .segments(parser(target))
                 .pattern(target)
                 .build();
@@ -93,7 +93,7 @@ public class PatternTest {
     public void labelsMustNotIncludeEmptySegments() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "//baz";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();
@@ -106,7 +106,7 @@ public class PatternTest {
     public void labelsMustNotBeRepeated() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/{foo}/{Foo}";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();
@@ -119,7 +119,7 @@ public class PatternTest {
     public void restrictsGreedyLabels() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/foo/{baz+}";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .allowsGreedyLabels(false)
                     .segments(parser(target))
                     .pattern(target)
@@ -133,7 +133,7 @@ public class PatternTest {
     public void noMoreThanOneGreedyLabel() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/{foo+}/{baz+}";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();
@@ -146,7 +146,7 @@ public class PatternTest {
     public void greedyLabelsMustBeLastLabelInPattern() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/{foo+}/{baz}";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();
@@ -159,7 +159,7 @@ public class PatternTest {
     public void noEmptyLabels() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/{}";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();
@@ -172,7 +172,7 @@ public class PatternTest {
     public void labelsMustMatchRegex() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/{!}";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();
@@ -185,7 +185,7 @@ public class PatternTest {
     public void labelsMustSpanEntireSegment() {
         Throwable thrown = Assertions.assertThrows(InvalidPatternException.class, () -> {
             String target = "/{foo}baz";
-            Pattern.builder()
+            SmithyPattern.builder()
                     .segments(parser(target))
                     .pattern(target)
                     .build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/pattern/UriPatternTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/pattern/UriPatternTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static software.amazon.smithy.model.pattern.Pattern.Segment;
+import static software.amazon.smithy.model.pattern.SmithyPattern.Segment;
 
 import java.util.Arrays;
 import java.util.Collection;


### PR DESCRIPTION
SmithyPattern is a lot less annoying to use since it doesn't conflict
with the Java regex Pattern.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
