### PR TITLE
Fix Java ISO_INSTANT timestamp validation

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3082,8 +3082,8 @@ in JSON.
       - number | string
       - If a number is provided, it represents Unix epoch seconds with optional
         millisecond precision. If a string is provided, it MUST be a valid
-        :rfc:`3339` string with optional millisecond precision
-        (e.g., ``1990-12-31T23:59:60Z``).
+        :rfc:`3339` string with optional millisecond precision and no
+        UTC offset (for example, ``1990-12-31T23:59:60Z``).
     * - list
       - array
       - Each value in the array MUST be compatible with the referenced member.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
@@ -100,7 +100,10 @@ public final class TimestampFormatPlugin implements NodeValidatorPlugin {
         }
 
         String timestamp = value.expectStringNode().getValue();
-        if (isValidFormat(timestamp, DATE_TIME_Z)) {
+        // Newer versions of Java support parsing instants that have an offset.
+        // See: https://bugs.openjdk.java.net/browse/JDK-8166138
+        // However, Smithy doesn't allow offsets for timestamp shapes.
+        if (timestamp.endsWith("Z") && isValidFormat(timestamp, DATE_TIME_Z)) {
             return ListUtils.of();
         } else {
             return ListUtils.of(


### PR DESCRIPTION
Closes #155

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
