### PR TITLE
Disallow traits applied to public prelude shapes

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
@@ -235,6 +235,16 @@ public final class Prelude {
         return PUBLIC_PRELUDE_SHAPE_IDS.contains(toId) || PRELUDE_TRAITS.contains(toId);
     }
 
+    /**
+     * Checks if the given shape is an immutable public shape.
+     *
+     * @param id Shape to check.
+     * @return Returns true if the shape is immutable.
+     */
+    static boolean isImmutablePublicPreludeShape(ToShapeId id) {
+        return PUBLIC_PRELUDE_SHAPE_IDS.contains(id.toShapeId());
+    }
+
     // Used by the ModelAssembler to load the prelude into another visitor.
     static Model getPreludeModel() {
         return PreludeHolder.PRELUDE;

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/apply-trait-to-prelude.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/apply-trait-to-prelude.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.api#String: Cannot apply `smithy.api#deprecated` to an immutable prelude shape defined in `smithy.api`. | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/apply-trait-to-prelude.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/apply-trait-to-prelude.smithy
@@ -1,0 +1,3 @@
+namespace com.foo
+
+apply smithy.api#String @deprecated


### PR DESCRIPTION
Applying a trait to a prelude shape is a recipe for disaster. For
example, if someone marked the smithy.api#String shape as private,
virtually every model would break.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
