### PR TITLE
Add RenameShapes model transformer

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.transform;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.BiFunction;
@@ -29,6 +30,7 @@ import software.amazon.smithy.model.neighbor.UnreferencedShapes;
 import software.amazon.smithy.model.neighbor.UnreferencedTraitDefinitions;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
@@ -130,6 +132,21 @@ public final class ModelTransformer {
      */
     public Model removeShapesIf(Model model, Predicate<Shape> predicate) {
         return filterShapes(model, FunctionalUtils.not(predicate));
+    }
+
+    /**
+     *  Renames shapes using ShapeId pairs while ensuring that the
+     *  transformed model is in a consistent state.
+     *
+     *  This transformer ensures that when an aggregate shape is renamed, all
+     *  members are updated in the model.
+     *
+     * @param model Model to transform.
+     * @param renamed Map of shapeIds
+     * @return Returns the transformed model.base.
+     */
+    public Model renameShapes(Model model, Map<ShapeId, ShapeId> renamed) {
+        return new RenameShapes(renamed).transform(this, model);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -25,7 +25,9 @@ import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.neighbor.UnreferencedShapes;
 import software.amazon.smithy.model.neighbor.UnreferencedTraitDefinitions;
 import software.amazon.smithy.model.node.Node;
@@ -138,7 +140,7 @@ public final class ModelTransformer {
      *  Renames shapes using ShapeId pairs while ensuring that the
      *  transformed model is in a consistent state.
      *
-     *  This transformer ensures that when an aggregate shape is renamed, all
+     *  <p>This transformer ensures that when an aggregate shape is renamed, all
      *  members are updated in the model.
      *
      * @param model Model to transform.
@@ -147,6 +149,23 @@ public final class ModelTransformer {
      */
     public Model renameShapes(Model model, Map<ShapeId, ShapeId> renamed) {
         return new RenameShapes(renamed).transform(this, model);
+    }
+
+    /**
+     *  Renames shapes using ShapeId pairs while ensuring that the
+     *  transformed model is in a consistent state.
+     *
+     *  <p>This transformer ensures that when an aggregate shape is renamed, all
+     *  members are updated in the model.
+     *
+     * @param model Model to transform.
+     * @param renamed Map of shapeIds
+     * @param modelAssemblerSupplier Supplier used to create {@link ModelAssembler}s in each transform.
+     * @return Returns the transformed model.base.
+     */
+    public Model renameShapes(Model model, Map<ShapeId, ShapeId> renamed,
+                              Supplier<ModelAssembler> modelAssemblerSupplier) {
+        return new RenameShapes(renamed, modelAssemblerSupplier).transform(this, model);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -147,8 +147,11 @@ public final class ModelTransformer {
      * @param renamed Map of shapeIds
      * @return Returns the transformed model.base.
      */
-    public Model renameShapes(Model model, Map<ShapeId, ShapeId> renamed) {
-        return new RenameShapes(renamed).transform(this, model);
+    public Model renameShapes(
+            Model model,
+            Map<ShapeId, ShapeId> renamed
+    ) {
+        return new RenameShapes(renamed, Model::assembler).transform(this, model);
     }
 
     /**
@@ -163,8 +166,11 @@ public final class ModelTransformer {
      * @param modelAssemblerSupplier Supplier used to create {@link ModelAssembler}s in each transform.
      * @return Returns the transformed model.base.
      */
-    public Model renameShapes(Model model, Map<ShapeId, ShapeId> renamed,
-                              Supplier<ModelAssembler> modelAssemblerSupplier) {
+    public Model renameShapes(
+            Model model,
+            Map<ShapeId, ShapeId> renamed,
+            Supplier<ModelAssembler> modelAssemblerSupplier
+    ) {
         return new RenameShapes(renamed, modelAssemblerSupplier).transform(this, model);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -151,7 +151,7 @@ public final class ModelTransformer {
             Model model,
             Map<ShapeId, ShapeId> renamed
     ) {
-        return new RenameShapes(renamed, Model::assembler).transform(this, model);
+        return this.renameShapes(model, renamed, Model::assembler);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -164,7 +164,7 @@ public final class ModelTransformer {
      * @param model Model to transform.
      * @param renamed Map of shapeIds
      * @param modelAssemblerSupplier Supplier used to create {@link ModelAssembler}s in each transform.
-     * @return Returns the transformed model.base.
+     * @return Returns the transformed model.
      */
     public Model renameShapes(
             Model model,
@@ -183,7 +183,7 @@ public final class ModelTransformer {
      *
      * @param model Model to transform.
      * @param predicate Predicate that filters shapes.
-     * @return Returns the transformed model.base.
+     * @return Returns the transformed model.
      */
     public Model filterShapes(Model model, Predicate<Shape> predicate) {
         return new FilterShapes(predicate).transform(this, model);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -56,7 +56,9 @@ final class RenameShapes {
         }
 
         // Creates a set that will be used for checking if a string value needs to be renamed or not.
-        Set<String> toRename = renamed.keySet().stream().map(ShapeId::toString).collect(Collectors.toSet());
+        Set<String> toRename = renamed.keySet().stream()
+                .map(ShapeId::toString)
+                .collect(Collectors.toSet());
 
         // This transformer converts the model into an ObjectNode. This approach was chosen because the
         // JSON AST format includes fully qualified shape ID values, making it possible rename shapes across

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ModelSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.Pair;
+
+/**
+ *  Renames shapes using ShapeId pairs while ensuring that the
+ *  transformed model is in a consistent state.
+ *
+ *  Member shapes are updated when their containing shape is updated.
+ *
+ *  Trait references to ShapeId values are also updated.
+ */
+
+final class RenameShapes {
+    private final Map<ShapeId, ShapeId> renamed;
+
+    RenameShapes(Map<ShapeId, ShapeId> renamed) {
+        this.renamed = renamed;
+    }
+
+    Model transform(ModelTransformer transformer, Model model) {
+
+        renamed.keySet().removeIf(fromId -> fromId.equals(renamed.get(fromId)));
+        if (renamed.isEmpty()) {
+            return model;
+        }
+
+        Set<String> toRename = renamed.keySet().stream().map(ShapeId::toString).collect(Collectors.toSet());
+
+        ModelSerializer serializer = ModelSerializer.builder().build();
+        ObjectNode node = serializer.serialize(model);
+
+        return Model.assembler()
+                .addDocumentNode(node.accept(new RenameShapeVisitor(toRename, renamed)))
+                .assemble()
+                .unwrap();
+    }
+
+    private static final class RenameShapeVisitor extends NodeVisitor.Default<Node> {
+
+        private final Set<String> toRename;
+        private final Map<ShapeId, ShapeId> shapeMapping;
+
+        RenameShapeVisitor(Set<String> toRename, Map<ShapeId, ShapeId> shapeMapping) {
+            this.toRename = toRename;
+            this.shapeMapping = shapeMapping;
+        }
+
+        @Override
+        protected Node getDefault(Node node) {
+            return node;
+        }
+
+        @Override
+        public Node arrayNode(ArrayNode node) {
+            return node.getElements().stream().map(element -> element.accept(this)).collect(ArrayNode.collect());
+        }
+
+        @Override
+        public Node objectNode(ObjectNode node) {
+            return node.getMembers().entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey().accept(this), entry.getValue().accept(this)))
+                    .collect(ObjectNode.collect(pair -> pair.getLeft().expectStringNode(), Pair::getRight));
+        }
+
+        @Override
+        public Node stringNode(StringNode node) {
+            if (toRename.contains(node.getValue())) {
+                ShapeId nodeShapeId = node.expectShapeId();
+                return new StringNode(shapeMapping.get(nodeShapeId).toString(), node.getSourceLocation());
+            }
+            return node;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -62,7 +62,7 @@ final class RenameShapes {
 
         // This transformer converts the model into an ObjectNode. This approach was chosen because the
         // JSON AST format includes fully qualified shape ID values, making it possible rename shapes across
-        // the model by only needing to compare and replace only StringNode values.
+        // the model by only needing to compare and replace StringNode values.
         ModelSerializer serializer = ModelSerializer.builder().build();
         ObjectNode node = serializer.serialize(model);
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.Trait;
+
+public class RenameShapesTest {
+
+    @Test
+    public void returnsUnmodifiedModelIfGivenEmptyRenameMapping() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        StringShape fooTarget = StringShape.builder().id(stringId).build();
+        Model model = Model.builder()
+                .addShapes(fooTarget)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(1L));
+        assertThat(result.getShape(stringId).get(), Matchers.is(fooTarget));
+    }
+
+    @Test
+    public void returnsUnmodifiedModelIfToAndFromAreEqual() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        StringShape target = StringShape.builder().id(stringId).build();
+        Model model = Model.builder()
+                .addShapes(target)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {
+            { put(stringId, stringId ); }
+        };
+        Model result = transformer.renameShapes(model, renamed);
+        assertThat(result.shapes().count(), Matchers.equalTo(1L));
+        assertThat(result.getShape(stringId).get(), Matchers.is(target));
+    }
+
+    @Test
+    public void returnsModelWithRenamedStringShape() {
+        ShapeId fromStringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId keyId = ShapeId.from("ns.foo#Container$key");
+        ShapeId valueId = ShapeId.from("ns.foo#Container$value");
+
+        StringShape target = StringShape.builder().id(fromStringId).build();
+        MemberShape keyMember = MemberShape.builder().id(keyId).target(fromStringId).build();
+        MemberShape valueMember = MemberShape.builder().id(valueId).target(fromStringId).build();
+        MapShape container = MapShape.builder().id(containerId).key(keyMember).value(valueMember).build();
+        Model model = Model.builder()
+                .addShapes(target, keyMember, valueMember, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+
+        ShapeId toStringId = ShapeId.from("ns.bar#String");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(fromStringId, toStringId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(toStringId).isPresent(), Matchers.is(true));
+        assertThat(result.getShape(fromStringId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesIdRefsWhenValueRenamed() {
+        Model model = Model.assembler()
+                .addImport(IntegTest.class.getResource("rename-shape-test-model.json"))
+                .assemble()
+                .unwrap();
+
+        ShapeId fromId = ShapeId.from("ns.foo#OldShape");
+        ShapeId toId = ShapeId.from("ns.foo#NewShape");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(fromId, toId);
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.renameShapes(model, renamed);
+        StringNode node = Node.from(toId.toShapeId().toString());
+
+        assertThat(result.getShape(toId).isPresent(), Matchers.is(true));
+        Shape shape = result.expectShape(ShapeId.from("ns.foo#ValidShape"));
+        Trait trait = shape.findTrait("ns.foo#integerRef").get();
+        assertThat(trait.toNode(), Matchers.equalTo(node));
+        assertThat(result.getShape(fromId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void testArrayNode() {
+        Model model = Model.assembler()
+                .addImport(IntegTest.class.getResource("test-model.json"))
+                .assemble()
+                .unwrap();
+
+        ShapeId fromId = ShapeId.from("ns.foo#MyOperation");
+        ShapeId toId = ShapeId.from("ns.foo#MyNewOperation");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(fromId, toId);
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(toId).isPresent(), Matchers.is(true));
+        assertThat(result.getShape(fromId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesListMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        ListShape container = ListShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        ListShape newContainer = result.getShape(newContainerId).get().asListShape().get();
+        assertThat(newContainer.getMember().getId(), Matchers.is(newMemberId));
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesMapMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId keyId = ShapeId.from("ns.foo#Container$key");
+        ShapeId valueId = ShapeId.from("ns.foo#Container$value");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape keyMember = MemberShape.builder().id(keyId).target(stringId).build();
+        MemberShape valueMember = MemberShape.builder().id(valueId).target(stringId).build();
+        MapShape container = MapShape.builder().id(containerId).key(keyMember).value(valueMember).build();
+        Model model = Model.builder()
+                .addShapes(target, keyMember, valueMember, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newKeyId = ShapeId.from("ns.bar#Baz$key");
+        ShapeId newValueId = ShapeId.from("ns.bar#Baz$value");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        MapShape newContainer = result.getShape(newContainerId).get().asMapShape().get();
+        assertThat(newContainer.getKey().getId(), Matchers.is(newKeyId));
+        assertThat(newContainer.getValue().getId(), Matchers.is(newValueId));
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesSetMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        SetShape container = SetShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        SetShape newContainer = result.getShape(newContainerId).get().asSetShape().get();
+        assertThat(newContainer.getMember().getId(), Matchers.is(newMemberId));
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesStructureMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        StructureShape container = StructureShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        StructureShape newContainer = result.getShape(newContainerId).get().asStructureShape().get();
+        newContainer.getMember("member").ifPresent(newMember -> {
+            assertThat(newMember.getId(), Matchers.is(newMemberId));
+        });
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void updatesUnionMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        UnionShape container = UnionShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertThat(result.getShape(newContainerId).isPresent(), Matchers.is(true));
+        UnionShape newContainer = result.getShape(newContainerId).get().asUnionShape().get();
+        newContainer.getMember("member").ifPresent(newMember -> {
+            assertThat(newMember.getId(), Matchers.is(newMemberId));
+        });
+        assertThat(result.getShape(containerId).isPresent(), Matchers.is(false));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -45,8 +45,9 @@ public class RenameShapesTest {
                 .addShapes(fooTarget)
                 .build();
         ModelTransformer transformer = ModelTransformer.create();
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         Model result = transformer.renameShapes(model, renamed);
+
         assertThat(result.shapes().count(), Matchers.equalTo(1L));
         assertThat(result.getShape(stringId).get(), Matchers.is(fooTarget));
     }
@@ -59,10 +60,10 @@ public class RenameShapesTest {
                 .addShapes(target)
                 .build();
         ModelTransformer transformer = ModelTransformer.create();
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>() {
-            { put(stringId, stringId ); }
-        };
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(stringId, stringId );
         Model result = transformer.renameShapes(model, renamed);
+
         assertThat(result.shapes().count(), Matchers.equalTo(1L));
         assertThat(result.getShape(stringId).get(), Matchers.is(target));
     }
@@ -84,8 +85,8 @@ public class RenameShapesTest {
         ModelTransformer transformer = ModelTransformer.create();
 
         ShapeId toStringId = ShapeId.from("ns.bar#String");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
-        renamed.put(fromStringId, toStringId);
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(fromStringId, toStringId );
         Model result = transformer.renameShapes(model, renamed);
 
         assertThat(result.getShape(toStringId).isPresent(), Matchers.is(true));
@@ -101,7 +102,7 @@ public class RenameShapesTest {
 
         ShapeId fromId = ShapeId.from("ns.foo#OldShape");
         ShapeId toId = ShapeId.from("ns.foo#NewShape");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(fromId, toId);
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.renameShapes(model, renamed);
@@ -123,7 +124,7 @@ public class RenameShapesTest {
 
         ShapeId fromId = ShapeId.from("ns.foo#MyOperation");
         ShapeId toId = ShapeId.from("ns.foo#MyNewOperation");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(fromId, toId);
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.renameShapes(model, renamed);
@@ -147,7 +148,7 @@ public class RenameShapesTest {
         ModelTransformer transformer = ModelTransformer.create();
         ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
         ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(containerId, newContainerId);
         Model result = transformer.renameShapes(model, renamed);
 
@@ -175,7 +176,7 @@ public class RenameShapesTest {
         ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
         ShapeId newKeyId = ShapeId.from("ns.bar#Baz$key");
         ShapeId newValueId = ShapeId.from("ns.bar#Baz$value");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(containerId, newContainerId);
         Model result = transformer.renameShapes(model, renamed);
 
@@ -201,7 +202,7 @@ public class RenameShapesTest {
         ModelTransformer transformer = ModelTransformer.create();
         ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
         ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(containerId, newContainerId);
         Model result = transformer.renameShapes(model, renamed);
 
@@ -226,7 +227,7 @@ public class RenameShapesTest {
         ModelTransformer transformer = ModelTransformer.create();
         ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
         ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(containerId, newContainerId);
         Model result = transformer.renameShapes(model, renamed);
 
@@ -253,7 +254,7 @@ public class RenameShapesTest {
         ModelTransformer transformer = ModelTransformer.create();
         ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
         ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
-        Map<ShapeId, ShapeId> renamed = new HashMap<ShapeId, ShapeId>();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
         renamed.put(containerId, newContainerId);
         Model result = transformer.renameShapes(model, renamed);
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -157,7 +157,7 @@ public class RenameShapesTest {
 
         // Operation
         ShapeId fromOperation = ShapeId.from("ns.foo#MyOperation");
-        ShapeId toOperation = ShapeId.from("ns.baz#MyNewService");
+        ShapeId toOperation = ShapeId.from("ns.baz#MyNewOperation");
         renamed.put(fromOperation,toOperation);
 
         // Resource

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
@@ -1,0 +1,25 @@
+{
+  "smithy": "0.5.0",
+  "shapes": {
+    "ns.foo#integerRef": {
+      "type": "string",
+      "traits": {
+        "smithy.api#trait": true,
+        "smithy.api#idRef": {
+          "failWhenMissing": true,
+          "selector": "integer"
+        }
+      }
+    },
+    "ns.foo#ValidShape": {
+      "type": "string",
+      "traits": {
+        "ns.foo#integerRef": "ns.foo#OldShape",
+        "smithy.api#deprecated": {}
+      }
+    },
+    "ns.foo#OldShape": {
+      "type": "integer"
+    }
+  }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
@@ -20,6 +20,18 @@
     },
     "ns.foo#OldShape": {
       "type": "integer"
+    },
+    "ns.foo#UnreferencedString": {
+      "type": "string"
     }
+  },
+  "metadata": {
+    "suppressions": [
+      {
+        "ids": ["UnreferencedShape"],
+        "shapes": ["ns.foo#UnreferencedString"],
+        "reason": "unreferenced shape"
+      }
+    ]
   }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
@@ -1,6 +1,122 @@
 {
   "smithy": "0.5.0",
   "shapes": {
+    "ns.foo#MyService": {
+      "type": "service",
+      "version": "2017-01-17",
+      "operations": [
+        {
+          "target": "ns.foo#MyOperation"
+        }
+      ],
+      "resources": [
+        {
+          "target": "ns.foo#MyResource"
+        }
+      ],
+      "traits": {
+        "smithy.api#protocols": [
+          {
+            "name": "foo"
+          }
+        ]
+      }
+    },
+    "ns.foo#MyOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#MyOperationInput"
+      },
+      "output": {
+        "target": "ns.foo#MyOperationOutput"
+      },
+      "errors": [
+        {
+          "target": "ns.foo#MyOperationError"
+        }
+      ],
+      "traits": {
+        "smithy.api#readonly": true
+      }
+    },
+    "ns.foo#MyOperationInput": {
+      "type": "structure",
+      "members": {
+        "struct": {
+          "target": "ns.foo#MyStructure"
+        },
+        "list": {
+          "target": "ns.foo#MyList"
+        },
+        "map": {
+          "target": "ns.foo#MyMap"
+        },
+        "set": {
+          "target": "ns.foo#MySet"
+        },
+        "union": {
+          "target": "ns.foo#MyUnion"
+        }
+      }
+    },
+    "ns.foo#MyStructure": {
+      "type": "structure"
+    },
+    "ns.foo#MyList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "ns.foo#MyMap": {
+      "type": "map",
+      "key": {
+        "target": "smithy.api#String"
+      },
+      "value": {
+        "target": "smithy.api#String"
+      }
+    },
+    "ns.foo#MySet": {
+      "type": "set",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "ns.foo#MyUnion": {
+      "type": "union",
+      "members": {
+        "a": {
+          "target": "smithy.api#String"
+        },
+        "b": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#sensitive": true
+          }
+        }
+      }
+    },
+    "ns.foo#MyOperationOutput": {
+      "type": "structure"
+    },
+    "ns.foo#MyOperationError": {
+      "type": "structure",
+      "traits": {
+        "smithy.api#error": "client"
+      }
+    },
+    "ns.foo#MyResource": {
+      "type": "resource",
+      "identifiers": {
+        "myId": {
+          "target": "ns.foo#MyId"
+        }
+      }
+    },
+    "ns.foo#MyId": {
+      "type": "string"
+    },
     "ns.foo#integerRef": {
       "type": "string",
       "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
@@ -112,10 +112,36 @@
         "myId": {
           "target": "ns.foo#MyId"
         }
-      }
+      },
+      "operations": [
+        {
+          "target": "ns.foo#MyOtherOperation"
+        }
+      ]
     },
     "ns.foo#MyId": {
       "type": "string"
+    },
+    "ns.foo#MyOtherOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#MyOtherInput"
+      },
+      "output": {
+        "target": "ns.foo#MyStructure"
+      }
+    },
+    "ns.foo#MyOtherInput": {
+      "type": "structure",
+      "members": {
+        "myId": {
+          "target": "ns.foo#MyId",
+          "traits": {
+            "smithy.api#required": true
+          }
+        }
+      }
+
     },
     "ns.foo#integerRef": {
       "type": "string",


### PR DESCRIPTION
This PR adds a RenameShapes model transformer that takes a map of ShapeId to ShapeId pairs.

Shape members are updated for consistency when any member-containing aggregate shape has been renamed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
