### PR TITLE
Ensure that schemaDocumentExtensions are added

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -335,6 +335,11 @@ public final class OpenApiConverter {
         addSecurityComponents(context, openapi, environment.components, mapper);
         openapi.components(environment.components.build());
 
+        // Add arbitrary extensions if they're configured.
+        context.getConfig()
+                .getObjectMember(JsonSchemaConstants.SCHEMA_DOCUMENT_EXTENSIONS)
+                .ifPresent(openapi::extensions);
+
         return mapper.after(context, openapi.build());
     }
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/Component.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/Component.java
@@ -99,6 +99,10 @@ public abstract class Component implements ToNode {
             return (B) this;
         }
 
+        public B extensions(ObjectNode extensions) {
+            return extensions(extensions.getStringMap());
+        }
+
         @SuppressWarnings("unchecked")
         public B putExtension(String key, Node value) {
             extensions.put(key, value);

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
@@ -94,7 +94,8 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
                 .info(info)
                 .paths(paths)
                 .components(components)
-                .externalDocs(externalDocs);
+                .externalDocs(externalDocs)
+                .extensions(getExtensions());
         security.forEach(builder::addSecurity);
         servers.forEach(builder::addServer);
         tags.forEach(builder::addTag);

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.jsonschema.JsonSchemaConstants;
 import software.amazon.smithy.model.Model;
@@ -43,6 +44,17 @@ import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 public class OpenApiConverterTest {
+    private static Model testService;
+
+    @BeforeAll
+    private static void setup() {
+        testService = Model.assembler()
+                .addImport(OpenApiConverterTest.class.getResource("test-service.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+    }
+
     @Test
     public void convertsModelsToOpenApi() {
         Model model = Model.assembler()

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -19,13 +19,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.jsonschema.JsonSchemaConstants;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -233,5 +236,15 @@ public class OpenApiConverterTest {
 
         assertThat(result.getSecurity().get(0).keySet(), contains("foo_baz"));
         assertThat(result.getPaths().get("/2").getGet().get().getSecurity().get().get(0).keySet(), contains("foo_baz"));
+    }
+
+    @Test
+    public void mergesInSchemaDocumentExtensions() {
+        ObjectNode result = OpenApiConverter.create()
+                .putSetting(JsonSchemaConstants.SCHEMA_DOCUMENT_EXTENSIONS, Node.objectNode()
+                        .withMember("foo", "baz"))
+                .convertToNode(testService, ShapeId.from("example.rest#RestService"));
+
+        assertThat(result.getMember("foo"), equalTo(Optional.of(Node.from("baz"))));
     }
 }


### PR DESCRIPTION
Backports fix from 0.10 to ensure that schemaDocumentExtensions are added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
