### PR TITLE
Protocol test fixes

### DIFF
--- a/smithy-aws-protocol-tests/model/ec2-query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/input-lists.smithy
@@ -31,8 +31,8 @@ apply QueryLists @httpRequestTests([
               &ListArg.1=foo
               &ListArg.2=bar
               &ListArg.3=baz
-              &ComplexListArg.1.hi=hello
-              &ComplexListArg.2.hi=hola""",
+              &ComplexListArg.1.Hi=hello
+              &ComplexListArg.2.Hi=hola""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: ["foo", "bar", "baz"],

--- a/smithy-aws-protocol-tests/model/ec2-query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/input.smithy
@@ -243,9 +243,9 @@ apply QueryTimestamps @httpRequestTests([
         body: """
               Action=QueryTimestamps
               &Version=2020-01-08
-              &normalFormat=2015-01-25T08%3A00%3A00Z
-              &epochMember=1422172800
-              &epochTarget=1422172800""",
+              &NormalFormat=2015-01-25T08%3A00%3A00Z
+              &EpochMember=1422172800
+              &EpochTarget=1422172800""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             normalFormat: 1422172800,
@@ -330,9 +330,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000000""",
+              &Token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
     },
     {
@@ -345,9 +345,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000123""",
+              &Token=00000000-0000-4000-8000-000000000123""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"

--- a/smithy-aws-protocol-tests/model/ec2-query/main.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/main.smithy
@@ -28,10 +28,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.ec2
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// An EC2 query service that sends query requests and XML responses.
+@service(sdkId: "EC2 Protocol")
 @protocols([{"name": "aws.ec2"}])
 @xmlNamespace(uri: "https://example.com/")
 service AwsEc2 {

--- a/smithy-aws-protocol-tests/model/ec2-query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/xml-lists.smithy
@@ -68,7 +68,7 @@ apply XmlLists @httpResponseTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>

--- a/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
+++ b/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
@@ -59,7 +59,7 @@
                         "params": {},
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.EmptyOperation"
                         }
                     }
                 ],
@@ -72,7 +72,6 @@
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1"
                         },
-                        "requireHeaders": ["Content-Length"],
                         "bodyMediaType": "application/json",
                         "body": "{}",
                         "params": {}
@@ -522,7 +521,7 @@
                             "MapOfStrings": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"MapOfStrings\":[]}"
+                        "body": "{\"MapOfStrings\":{}}"
                     },
                     {
                         "id": "serializes_map_of_list_shapes",
@@ -626,7 +625,7 @@
                             "SimpleStruct": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"SimpleStruct\":[]}"
+                        "body": "{\"SimpleStruct\":{}}"
                     },
                     {
                         "id": "serializes_structure_which_have_no_members",
@@ -638,7 +637,7 @@
                             "EmptyStruct": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"EmptyStruct\":[]}"
+                        "body": "{\"EmptyStruct\":{}}"
                     },
                     {
                         "id": "serializes_recursive_structure_shapes",
@@ -1000,7 +999,9 @@
                         "code": 200,
                         "headers": {
                             "X-Amzn-Requestid": "amazon-uniq-request-id"
-                        }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{}"
                     }
                 ]
             }
@@ -1101,7 +1102,7 @@
                         "uri": "/",
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
                         },
                         "bodyMediaType": "application/json",
                         "body": "{}"
@@ -1117,9 +1118,8 @@
                         },
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
                         },
-                        "requireHeaders": ["Content-Length"],
                         "bodyMediaType": "application/json",
                         "body": "{\"Value\":\"Hi\"}"
                     }

--- a/smithy-aws-protocol-tests/model/query/input-maps.smithy
+++ b/smithy-aws-protocol-tests/model/query/input-maps.smithy
@@ -25,7 +25,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &MapArg.entry.1.key=foo
               &MapArg.entry.1.value=Foo
@@ -49,7 +49,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &Foo.entry.1.key=foo
               &Foo.entry.1.value=Foo""",
@@ -70,7 +70,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &ComplexMapArg.entry.1.key=foo
               &ComplexMapArg.entry.1.value.hi=Foo
@@ -98,7 +98,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
@@ -115,12 +115,12 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &MapWithXmlMemberName.entry.1.K=foo
               &MapWithXmlMemberName.entry.1.V=Foo
-              &MapWithXmlMemberName.entry.1.K=bar
-              &MapWithXmlMemberName.entry.1.V=Bar""",
+              &MapWithXmlMemberName.entry.2.K=bar
+              &MapWithXmlMemberName.entry.2.V=Bar""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapWithXmlMemberName: {
@@ -139,12 +139,12 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &FlattenedMap.1.key=foo
               &FlattenedMap.1.value=Foo
-              &FlattenedMap.1.key=bar
-              &FlattenedMap.1.value=Bar""",
+              &FlattenedMap.2.key=bar
+              &FlattenedMap.2.value=Bar""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedMap: {
@@ -163,7 +163,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &Hi.1.K=foo
               &Hi.1.V=Foo
@@ -187,12 +187,14 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
-              &MapOfLists.entry.1.key.1=A
-              &MapOfLists.entry.1.key.2=B
-              &MapOfLists.entry.2.key.1=C
-              &MapOfLists.entry.2.key.2=D""",
+              &MapOfLists.entry.1.key=foo
+              &MapOfLists.entry.1.value.member.1=A
+              &MapOfLists.entry.1.value.member.2=B
+              &MapOfLists.entry.2.key=bar
+              &MapOfLists.entry.2.value.member.1=C
+              &MapOfLists.entry.2.value.member.2=D""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapOfLists: {

--- a/smithy-aws-protocol-tests/model/query/input.smithy
+++ b/smithy-aws-protocol-tests/model/query/input.smithy
@@ -265,7 +265,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
@@ -280,7 +280,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000123""",
         bodyMediaType: "application/x-www-form-urlencoded",

--- a/smithy-aws-protocol-tests/model/query/main.smithy
+++ b/smithy-aws-protocol-tests/model/query/main.smithy
@@ -2,10 +2,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.query
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A query service that sends query requests and XML responses.
+@service(sdkId: "Query Protocol")
 @protocols([{"name": "aws.query"}])
 @xmlNamespace(uri: "https://example.com/")
 service AwsQuery {

--- a/smithy-aws-protocol-tests/model/query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/query/xml-lists.smithy
@@ -69,7 +69,7 @@ apply XmlLists @httpResponseTests([
                               <member>baz</member>
                               <member>qux</member>
                           </member>
-                      <nestedStringList>
+                      </nestedStringList>
                       <renamed>
                           <item>foo</item>
                           <item>bar</item>

--- a/smithy-aws-protocol-tests/model/query/xml-maps.smithy
+++ b/smithy-aws-protocol-tests/model/query/xml-maps.smithy
@@ -81,13 +81,13 @@ apply XmlMapsXmlName @httpResponseTests([
                   <XmlMapsXmlNameResult>
                       <myMap>
                           <entry>
-                              <Name>foo</Name>
+                              <Attribute>foo</Attribute>
                               <Setting>
                                   <hi>there</hi>
                               </Setting>
                           </entry>
                           <entry>
-                              <Name>baz</Name>
+                              <Attribute>baz</Attribute>
                               <Setting>
                                   <hi>bye</hi>
                               </Setting>

--- a/smithy-aws-protocol-tests/model/query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/query/xml-structs.smithy
@@ -119,9 +119,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <normal>2014-04-29T18:30:38Z</normal>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -139,9 +139,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <dateTime>2014-04-29T18:30:38Z</dateTime>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -159,9 +159,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <epochSeconds>1398796238</epochSeconds>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -179,9 +179,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/rest-json/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/empty-input-output.smithy
@@ -22,7 +22,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-json-1.1",
         method: "POST",
-        uri: "/NoInputAndOutput"
+        uri: "/NoInputAndNoOutput"
     }
 ])
 
@@ -50,7 +50,7 @@ apply NoInputAndOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-json-1.1",
         method: "POST",
-        uri: "/NoInputAndOutput"
+        uri: "/NoInputAndOutputOutput"
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/rest-json/errors.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/errors.smithy
@@ -125,7 +125,8 @@ apply ComplexError @httpResponseTests([
         params: {},
         code: 403,
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "X-Amzn-Errortype": "ComplexError"
         },
         body: "{}",
         bodyMediaType: "application/json",

--- a/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
@@ -6,6 +6,7 @@ $version: "0.5.0"
 namespace aws.protocols.tests.restjson
 
 use aws.protocols.tests.shared#BooleanList
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#FooEnum
 use aws.protocols.tests.shared#FooEnumList
@@ -57,7 +58,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -79,12 +80,12 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -95,7 +96,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -110,7 +111,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         uri: "/InputAndOutputWithHeaders",
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -150,7 +151,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -171,12 +172,12 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -186,7 +187,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: "aws.rest-json-1.1",
         code: 200,
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -200,7 +201,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -399,5 +400,5 @@ structure TimestampFormatHeadersIO {
     targetHttpDate: HttpDate,
 
     @httpHeader("X-targetDateTime")
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }

--- a/smithy-aws-protocol-tests/model/rest-json/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-labels.smithy
@@ -5,6 +5,7 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restjson
 
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#HttpDate
 use smithy.test#httpRequestTests
@@ -141,7 +142,7 @@ structure HttpRequestWithLabelsAndTimestampFormatInput {
 
     @httpLabel
     @required
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }
 
 // This example uses a greedy label and a normal label.

--- a/smithy-aws-protocol-tests/model/rest-json/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-query.smithy
@@ -30,7 +30,7 @@ apply AllQueryStringTypes @httpRequestTests([
         documentation: "Serializes query string parameters with all supported types",
         protocol: "aws.rest-json-1.1",
         method: "GET",
-        uri: "/AllQueryStringTypes",
+        uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
             "String=Hello%20there",
@@ -60,9 +60,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "BooleanList=false",
             "BooleanList=true",
             "Timestamp=1",
-            "TimestampList=1",
-            "TimestampList=2",
-            "TimestampList=3",
+            "TimestampList=1970-01-01T00%3A00%3A01Z",
+            "TimestampList=1970-01-01T00%3A00%3A02Z",
+            "TimestampList=1970-01-01T00%3A00%3A03Z",
             "Enum=Foo",
             "EnumList=Foo",
             "EnumList=Baz",
@@ -254,7 +254,6 @@ apply IgnoreQueryParamsInResponse @httpResponseTests([
         body: "",
         bodyMediaType: "json",
         params: {
-            baz: "bam"
         }
     }
 ])
@@ -324,10 +323,10 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         uri: "/QueryIdempotencyTokenAutoFill",
         body: "",
         queryParams: [
-            "token=00000000-0000-4000-8000-000000000123",
+            "token=00000000-0000-4000-8000-000000000000",
         ],
         params: {
-            token: "00000000-0000-4000-8000-000000000123"
+            token: "00000000-0000-4000-8000-000000000000"
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/rest-json/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/json-lists.smithy
@@ -73,14 +73,14 @@ apply JsonLists @httpRequestTests([
                           "qux"
                       ]
                   ],
-                  "structureList": [
+                  "myStructureList": [
                       {
-                          "a": "1",
-                          "b": "2"
+                          "value": "1",
+                          "other": "2"
                       },
                       {
-                          "a": "3",
-                          "b": "4"
+                          "value": "3",
+                          "other": "4"
                       }
                   ]
               }""",
@@ -211,14 +211,14 @@ apply JsonLists @httpResponseTests([
                           "qux"
                       ]
                   ],
-                  "structureList": [
+                  "myStructureList": [
                       {
-                          "a": "1",
-                          "b": "2"
+                          "value": "1",
+                          "other": "2"
                       },
                       {
-                          "a": "3",
-                          "b": "4"
+                          "value": "3",
+                          "other": "4"
                       }
                   ]
               }""",

--- a/smithy-aws-protocol-tests/model/rest-json/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/json-structs.smithy
@@ -30,7 +30,6 @@ apply SimpleScalarProperties @httpRequestTests([
         uri: "/SimpleScalarProperties",
         body: """
               {
-                  "foo": "Foo",
                   "stringValue": "string",
                   "trueBooleanValue": true,
                   "falseBooleanValue": false,
@@ -69,7 +68,6 @@ apply SimpleScalarProperties @httpResponseTests([
         code: 200,
         body: """
               {
-                  "foo": "Foo",
                   "stringValue": "string",
                   "trueBooleanValue": true,
                   "falseBooleanValue": false,
@@ -453,7 +451,7 @@ apply RecursiveShapes @httpRequestTests([
         documentation: "Serializes recursive structures",
         protocol: "aws.rest-json-1.1",
         method: "PUT",
-        uri: "/JsonEnums",
+        uri: "/RecursiveShapes",
         body: """
               {
                   "nested": {

--- a/smithy-aws-protocol-tests/model/rest-json/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/main.smithy
@@ -2,10 +2,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restjson
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A REST JSON service that sends JSON requests and responses.
+@service(sdkId: "Rest Json Protocol")
 @protocols([{"name": "aws.rest-json-1.1"}])
 service RestJson {
     version: "2019-12-16",

--- a/smithy-aws-protocol-tests/model/rest-xml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-lists.smithy
@@ -75,7 +75,7 @@ apply XmlLists @httpRequestTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>
@@ -166,7 +166,7 @@ apply XmlLists @httpResponseTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>

--- a/smithy-aws-protocol-tests/model/rest-xml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-maps.smithy
@@ -126,13 +126,13 @@ apply XmlMapsXmlName @httpRequestTests([
               <XmlMapsXmlNameInputOutput>
                   <myMap>
                       <entry>
-                          <Name>foo</Name>
+                          <Attribute>foo</Attribute>
                           <Setting>
                               <hi>there</hi>
                           </Setting>
                       </entry>
                       <entry>
-                          <Name>baz</Name>
+                          <Attribute>baz</Attribute>
                           <Setting>
                               <hi>bye</hi>
                           </Setting>
@@ -167,13 +167,13 @@ apply XmlMapsXmlName @httpResponseTests([
               <XmlMapsXmlNameInputOutput>
                   <myMap>
                       <entry>
-                          <Name>foo</Name>
+                          <Attribute>foo</Attribute>
                           <Setting>
                               <hi>there</hi>
                           </Setting>
                       </entry>
                       <entry>
-                          <Name>baz</Name>
+                          <Attribute>baz</Attribute>
                           <Setting>
                               <hi>bye</hi>
                           </Setting>

--- a/smithy-aws-protocol-tests/model/rest-xml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-structs.smithy
@@ -477,7 +477,7 @@ apply RecursiveShapes @httpRequestTests([
         documentation: "Serializes recursive structures",
         protocol: "aws.rest-xml",
         method: "PUT",
-        uri: "/XmlEnums",
+        uri: "/RecursiveShapes",
         body: """
               <RecursiveShapesInputOutput>
                   <nested>
@@ -587,7 +587,7 @@ apply XmlNamespaces @httpRequestTests([
         method: "POST",
         uri: "/XmlNamespaces",
         body: """
-              <RecursiveShapesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesInputOutput xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -595,7 +595,7 @@ apply XmlNamespaces @httpRequestTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </XmlNamespacesInputOutput>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -620,7 +620,7 @@ apply XmlNamespaces @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <RecursiveShapesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesInputOutput xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -628,7 +628,7 @@ apply XmlNamespaces @httpResponseTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </XmlNamespacesInputOutput>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/rest-xml/document-xml-attributes.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-xml-attributes.smithy
@@ -23,7 +23,7 @@ apply XmlAttributes @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributes",
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -45,7 +45,7 @@ apply XmlAttributes @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -84,7 +84,7 @@ apply XmlAttributesOnPayload @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributesOnPayload",
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -108,7 +108,7 @@ apply XmlAttributesOnPayload @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,

--- a/smithy-aws-protocol-tests/model/rest-xml/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/empty-input-output.smithy
@@ -20,7 +20,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-xml",
         method: "POST",
-        uri: "/NoInputAndOutput",
+        uri: "/NoInputAndNoOutput",
         body: ""
     }
 ])
@@ -50,7 +50,7 @@ apply NoInputAndOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-xml",
         method: "POST",
-        uri: "/NoInputAndOutput",
+        uri: "/NoInputAndOutputOutput",
         body: ""
     }
 ])

--- a/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
@@ -6,6 +6,7 @@ $version: "0.5.0"
 namespace aws.protocols.tests.restxml
 
 use aws.protocols.tests.shared#BooleanList
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#FooEnum
 use aws.protocols.tests.shared#FooEnumList
@@ -57,7 +58,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -79,12 +80,12 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -95,7 +96,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -110,7 +111,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         uri: "/InputAndOutputWithHeaders",
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -150,7 +151,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -171,12 +172,12 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -186,7 +187,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -200,7 +201,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -399,5 +400,5 @@ structure TimestampFormatHeadersIO {
     targetHttpDate: HttpDate,
 
     @httpHeader("X-targetDateTime")
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }

--- a/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
@@ -5,6 +5,7 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restxml
 
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#HttpDate
 use smithy.test#httpRequestTests
@@ -141,7 +142,7 @@ structure HttpRequestWithLabelsAndTimestampFormatInput {
 
     @httpLabel
     @required
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }
 
 // This example uses a greedy label and a normal label.

--- a/smithy-aws-protocol-tests/model/rest-xml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-payload.smithy
@@ -229,7 +229,7 @@ apply HttpPayloadWithXmlName @httpRequestTests([
         documentation: "Serializes a structure in the payload using a wrapper name based on xmlName",
         protocol: "aws.rest-xml",
         method: "PUT",
-        uri: "/HttpPayloadWithStructure",
+        uri: "/HttpPayloadWithXmlName",
         body: "<Hello><name>Phreddy</name></Hello>",
         bodyMediaType: "application/xml",
         headers: {
@@ -288,7 +288,7 @@ apply HttpPayloadWithXmlNamespace @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithXmlNamespace",
         body: """
-              <PayloadWithXmlNamespace xmlns="http//foo.com">
+              <PayloadWithXmlNamespace xmlns="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespace>""",
         bodyMediaType: "application/xml",
@@ -310,7 +310,7 @@ apply HttpPayloadWithXmlNamespace @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <PayloadWithXmlNamespace xmlns="http//foo.com">
+              <PayloadWithXmlNamespace xmlns="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespace>""",
         bodyMediaType: "application/xml",
@@ -351,7 +351,7 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithXmlNamespaceAndPrefix",
         body: """
-              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespaceAndPrefix>""",
         bodyMediaType: "application/xml",
@@ -373,7 +373,7 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespaceAndPrefix>""",
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/rest-xml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-query.smithy
@@ -30,7 +30,7 @@ apply AllQueryStringTypes @httpRequestTests([
         documentation: "Serializes query string parameters with all supported types",
         protocol: "aws.rest-xml",
         method: "GET",
-        uri: "/AllQueryStringTypes",
+        uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
             "String=Hello%20there",
@@ -60,9 +60,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "BooleanList=false",
             "BooleanList=true",
             "Timestamp=1",
-            "TimestampList=1",
-            "TimestampList=2",
-            "TimestampList=3",
+            "TimestampList=1970-01-01T00%3A00%3A01Z",
+            "TimestampList=1970-01-01T00%3A00%3A02Z",
+            "TimestampList=1970-01-01T00%3A00%3A03Z",
             "Enum=Foo",
             "EnumList=Foo",
             "EnumList=Baz",
@@ -324,10 +324,10 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         uri: "/QueryIdempotencyTokenAutoFill",
         body: "",
         queryParams: [
-            "token=00000000-0000-4000-8000-000000000123",
+            "token=00000000-0000-4000-8000-000000000000",
         ],
         params: {
-            token: "00000000-0000-4000-8000-000000000123"
+            token: "00000000-0000-4000-8000-000000000000"
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/rest-xml/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/main.smithy
@@ -2,10 +2,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restxml
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A REST XML service that sends XML requests and responses.
+@service(sdkId: "Rest Xml Protocol")
 @protocols([{"name": "aws.rest-xml"}])
 service RestXml {
     version: "2019-12-16",


### PR DESCRIPTION
Fixes several issues with EC2-Query tests

* Adds an aws.api#service trait, sdkId="EC2 Protocol"
* Uses correct Idempotency token property names
* Uses correct Idempotency token test Action names
* Fixes auto-generated idempotency token value
* Fixes list member name capitalization
* Adds missing "/" to a closing XML element

Fixes several issues with the JSON-RPC-1.1 tests

* Fixes service name in several x-amz-target headers
* Fixes an operation name in x-amz-target header
* Removes errant required header when not supplied
* Fixes several [] vs {} discrepancies for empty structures
* Adds missing body for operation that has a response

Fixes several issues with the Query tests

* Adds an aws.api#service trait, sdkId="Query Protocol"
* Fixes several test Action names
* Fixes auto-generated idempotency token value
* Fixes several map/list entry and value counter issues
* Fixes discrepancies with map list member serialized keys
* Adds missing "/" to a closing XML element
* Fixes several xmlName trait discrepancies
* Fixes several result wrapper shape names

Fixes several issues with the Rest-XML tests

* Adds an aws.api#service trait, sdkId="Rest Xml Protocol"
* Fixes several uri discrepancies
* Adds missing "/" to a closing XML element
* Fixes several xmlName trait discrepancies
* Fixes several request root element names
* Fixes several header name and value discrepancies
* Fixes several issues where a member indicating a dateTime was
  using a shape of the incorrect format
* Adds missing ":" to serialized namespace uris
* Fixes auto-generated idempotency token value
* Fixes incorrect default timestamp serialization format

Fixes several issues with the Rest-JSON tests

* Adds an aws.api#service trait, sdkId="Rest Json Protocol"
* Fixes several uri discrepancies
* Fixes missing x-amzn-errortype header
* Fixes several header name and value discrepancies
* Fixes several issues where a member indicating a dateTime was
  using a shape of the incorrect format
* Fixes auto-generated idempotency token value
* Fix requiring a param when no content can set it
* Fixes several jsonName trait discrepancies
* Removes header serialized values from bodies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
