### PR TITLE
Bump version to 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Smithy Changelog
 
+## 0.9.8 (2020-03-26)
+
+### Features
+
+* Add `RenameShapes` model transformer ([#318](https://github.com/awslabs/smithy/pull/318))
+* Build `ValidationEvents` are now sorted ([#263](https://github.com/awslabs/smithy/pull/263))
+* Smithy CLI logging improvements ([#263](https://github.com/awslabs/smithy/pull/263))
+* Model builds fail early when syntax errors occur ([#264](https://github.com/awslabs/smithy/pull/264))
+* Warn when a deprecated trait is applied to a shape ([#279](https://github.com/awslabs/smithy/pull/279))
+
+### Bug Fixes
+
+* Fix behavior of `schemaDocumentExtensions` when converting to OpenAPI ([#320](https://github.com/awslabs/smithy/pull/320))
+* Fix discrepancies in `smithy-aws-protocol-tests` ([#309](https://github.com/awslabs/smithy/pull/309), [#321](https://github.com/awslabs/smithy/pull/321))
+* Properly format test case results ([#271](https://github.com/awslabs/smithy/pull/271))
+* Fix dropping one character text block lines ([#285](https://github.com/awslabs/smithy/pull/285))
+
+### Optimizations
+
+* Builds run parallel projections in parallel only if there are more than one ([#263](https://github.com/awslabs/smithy/pull/263))
+* Run Smithy test suites as parameterized tests ([#263](https://github.com/awslabs/smithy/pull/263))
+
+### Cleanup
+
+* Migrate protocol tests to new operation syntax ([#260](https://github.com/awslabs/smithy/pull/260))
+* Build protocol tests with the Smithy Gradle plugin ([#263](https://github.com/awslabs/smithy/pull/263))
+* Deprecate using explicitly `smithy.api` for trait removal ([#306](https://github.com/awslabs/smithy/pull/306))
+
 ## 0.9.7 (2020-01-15)
 
 ### Features

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.9.7"
+    version = "0.9.8"
 }
 
 // The root project doesn't produce a JAR.

--- a/docs/source/guides/building-models/gradle-plugin.rst
+++ b/docs/source/guides/building-models/gradle-plugin.rst
@@ -151,12 +151,12 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.7")
+            implementation("software.amazon.smithy:smithy-model:0.9.8")
 
             // These are just examples of dependencies. This model has a dependency on
             // a "common" model package and uses the external AWS traits.
             implementation("com.foo.baz:foo-model-internal-common:1.0.0")
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
         }
 
 
@@ -193,7 +193,7 @@ build that uses the "external" projection.
                 mavenCentral()
             }
             dependencies {
-                classpath("software.amazon.smithy:smithy-aws-traits:0.9.7")
+                classpath("software.amazon.smithy:smithy-aws-traits:0.9.8")
 
                 // Take a dependency on the internal model package. This
                 // dependency *must* be a buildscript only dependency to ensure
@@ -217,12 +217,12 @@ build that uses the "external" projection.
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.7")
+            implementation("software.amazon.smithy:smithy-model:0.9.8")
 
             // Any dependencies that the projected model needs must be (re)declared
             // here. For example, let's assume that the smithy-aws-traits package is
             // needed in the projected model too.
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
         }
 
 
@@ -328,7 +328,7 @@ The above Smithy plugin also requires a ``buildscript`` dependency in
 
                 // This dependency is required in order to apply the "openapi"
                 // plugin in smithy-build.json
-                classpath("software.amazon.smithy:smithy-openapi:0.9.7")
+                classpath("software.amazon.smithy:smithy-openapi:0.9.8")
             }
         }
 

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -106,7 +106,7 @@ specification from a Smithy model using a buildscript dependency:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.7")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
         }
     }
 
@@ -132,7 +132,7 @@ that builds an OpenAPI specification from a service for the
 
 .. important::
 
-    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.7" is
+    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.8" is
     required in order for smithy-build to map the "openapi" plugin name to the
     correct Java library implementation.
 
@@ -338,7 +338,7 @@ dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.7")
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.8")
         }
     }
 
@@ -516,7 +516,7 @@ shows how to install ``software.amazon.smithy:smithy-openapi`` through Gradle:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.7")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
         }
     }
 

--- a/smithy-codegen-freemarker/README.md
+++ b/smithy-codegen-freemarker/README.md
@@ -12,7 +12,7 @@ Maven
 <dependency>
     <groupId>software.amazon.smithy</groupId>
     <artifactId>smithy-codegen-freemarker</artifactId>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## 0.9.8 (2020-03-26)

### Features

* Add `RenameShapes` model transformer ([#318](https://github.com/awslabs/smithy/pull/318))
* Build `ValidationEvents` are now sorted ([#263](https://github.com/awslabs/smithy/pull/263))
* Smithy CLI logging improvements ([#263](https://github.com/awslabs/smithy/pull/263))
* Model builds fail early when syntax errors occur ([#264](https://github.com/awslabs/smithy/pull/264))
* Warn when a deprecated trait is applied to a shape ([#279](https://github.com/awslabs/smithy/pull/279))

### Bug Fixes

* Fix behavior of `schemaDocumentExtensions` when converting to OpenAPI ([#320](https://github.com/awslabs/smithy/pull/320))
* Fix discrepancies in `smithy-aws-protocol-tests` ([#309](https://github.com/awslabs/smithy/pull/309), [#321](https://github.com/awslabs/smithy/pull/321))
* Properly format test case results ([#271](https://github.com/awslabs/smithy/pull/271))
* Fix dropping one character text block lines ([#285](https://github.com/awslabs/smithy/pull/285))

### Optimizations

* Builds run parallel projections in parallel only if there are more than one ([#263](https://github.com/awslabs/smithy/pull/263))
* Run Smithy test suites as parameterized tests ([#263](https://github.com/awslabs/smithy/pull/263))

### Cleanup

* Migrate protocol tests to new operation syntax ([#260](https://github.com/awslabs/smithy/pull/260))
* Build protocol tests with the Smithy Gradle plugin ([#263](https://github.com/awslabs/smithy/pull/263))
* Deprecate using explicitly `smithy.api` for trait removal ([#306](https://github.com/awslabs/smithy/pull/306))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
