### PR TITLE
Make enum trait a list of structures

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3322,18 +3322,12 @@ Summary
 Trait selector
     ``string``
 Value type
-    ``map`` of enum constant values to structures optionally containing a name,
-    documentation, tags, and/or a deprecation flag.
+    ``list`` of enum definition structures.
 
 Smithy models SHOULD apply the enum trait when string shapes have a fixed
 set of allowable values.
 
-The enum trait is a map of allowed string values to enum constant definition
-structures. Enum values do not allow aliasing; all enum constant values MUST be
-unique across the entire set.
-
-An enum definition is a structure that supports the following optional
-members:
+An enum definition is a structure that supports the following members:
 
 .. list-table::
     :header-rows: 1
@@ -3342,6 +3336,10 @@ members:
     * - Property
       - Type
       - Description
+    * - value
+      - string
+      - **Required**. Defines the enum value that is sent over the wire.
+        Values MUST be unique across all enum definitions in an ``enum`` trait.
     * - name
       - string
       - Defines a constant name to use when referencing an enum value.
@@ -3358,6 +3356,8 @@ members:
         (``a-z``) and SHOULD NOT start with an ASCII underscore (``_``). That
         is, enum names SHOULD match the following regular expression:
         ``^[A-Z]+[A-Z_0-9]*$``.
+
+        Names MUST be unique across all enum definitions in an ``enum`` trait.
     * - documentation
       - string
       - Defines documentation about the enum value in the CommonMark_ format.
@@ -3384,8 +3384,9 @@ The following example defines an enum of valid string values for ``MyString``.
 
     .. code-tab:: smithy
 
-        @enum(
-            t2.nano: {
+        @enum([
+            {
+                value: "t2.nano",
                 name: "T2_NANO",
                 documentation: """
                     T2 instances are Burstable Performance
@@ -3394,7 +3395,8 @@ The following example defines an enum of valid string values for ``MyString``.
                     baseline.""",
                 tags: ["ebsOnly"]
             },
-            t2.micro: {
+            {
+                value: "t2.micro",
                 name: "T2_MICRO",
                 documentation: """
                     T2 instances are Burstable Performance
@@ -3403,11 +3405,12 @@ The following example defines an enum of valid string values for ``MyString``.
                     baseline.""",
                 tags: ["ebsOnly"]
             },
-            m256.mega: {
+            {
+                value: "m256.mega",
                 name: "M256_MEGA",
                 deprecated: true
             }
-        )
+        ])
         string MyString
 
     .. code-tab:: json
@@ -3418,26 +3421,29 @@ The following example defines an enum of valid string values for ``MyString``.
                 "smithy.example#MyString": {
                     "type": "string",
                     "traits": {
-                        "smithy.api#enum": {
-                            "t2.nano": {
+                        "smithy.api#enum": [
+                            {
+                                "value": "t2.nano",
                                 "name": "T2_NANO",
                                 "documentation": "T2 instances are ...",
                                 "tags": [
                                     "ebsOnly"
                                 ]
                             },
-                            "t2.micro": {
+                            {
+                                "value": "t2.micro",
                                 "name": "T2_MICRO",
                                 "documentation": "T2 instances are ...",
                                 "tags": [
                                     "ebsOnly"
                                 ]
                             },
-                            "m256.mega": {
+                            {
+                                "value": "m256.mega",
                                 "name": "M256_MEGA",
                                 "deprecated": true
                             }
-                        }
+                        ]
                     }
                 }
             }
@@ -5022,7 +5028,7 @@ can also support configuration settings.
     }
 
     @private
-    @enum("SHA-2": {})
+    @enum([{value": "SHA-2"}])
     string AlgorithmAuthAlgorithm
 
     @algorithmAuth(algorithm: "SHA-2")

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
@@ -198,14 +198,16 @@
         "example.smithy#EnumString": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "a": {
+                "smithy.api#enum": [
+                    {
+                        "value": "a",
                         "name": "A"
                     },
-                    "c": {
+                    {
+                        "value": "c",
                         "name": "C"
                     }
-                }
+                ]
             }
         },
         "example.smithy#PayloadDescriptions": {

--- a/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -219,20 +219,24 @@
         "aws.apigateway#IntegrationType": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "aws": {
+                "smithy.api#enum": [
+                    {
+                        "value": "aws",
                         "name": "AWS"
                     },
-                    "aws_proxy": {
+                    {
+                        "value": "aws_proxy",
                         "name": "AWS_PROXY"
                     },
-                    "http": {
+                    {
+                        "value": "http",
                         "name": "HTTP"
                     },
-                    "http_proxy": {
+                    {
+                        "value": "http_proxy",
                         "name": "HTTP_PROXY"
                     }
-                }
+                ]
             }
         },
         "aws.apigateway#IamRoleArn": {
@@ -283,27 +287,30 @@
             "type": "string",
             "traits": {
                 "smithy.api#private": true,
-                "smithy.api#enum": {
-                    "INTERNET": {},
-                    "VPC_LINK": {}
-                }
+                "smithy.api#enum": [
+                    {"value": "INTERNET"},
+                    {"value": "VPC_LINK"}
+                ]
             }
         },
         "aws.apigateway#PassThroughBehavior": {
             "type": "string",
             "traits": {
                 "smithy.api#documentation": "Defines the passThroughBehavior for the integration",
-                "smithy.api#enum": {
-                    "when_no_templates": {
+                "smithy.api#enum": [
+                    {
+                        "value": "when_no_templates",
                         "name": "WHEN_NO_TEMPLATES"
                     },
-                    "when_no_match": {
+                    {
+                        "value": "when_no_match",
                         "name": "WHEN_NO_MATCH"
                     },
-                    "never": {
+                    {
+                        "value": "never",
                         "name": "NEVER"
                     }
-                },
+                ],
                 "smithy.api#private": true
             }
         },
@@ -311,14 +318,10 @@
             "type": "string",
             "traits": {
                 "smithy.api#documentation": "Defines the contentHandling for the integration",
-                "smithy.api#enum": {
-                    "CONVERT_TO_TEXT": {
-                        "name": "CONVERT_TO_TEXT"
-                    },
-                    "CONVERT_TO_BINARY": {
-                        "name": "CONVERT_TO_BINARY"
-                    }
-                },
+                "smithy.api#enum": [
+                    {"value": "CONVERT_TO_TEXT", "name": "CONVERT_TO_TEXT"},
+                    {"value": "CONVERT_TO_BINARY", "name": "CONVERT_TO_BINARY"}
+                ],
                 "smithy.api#private": true
             }
         },

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
@@ -90,22 +90,22 @@
             "traits": {
                 "smithy.api#private": true,
                 "smithy.api#documentation": "The IAM policy type of the value that will supplied for this context key",
-                "smithy.api#enum": {
-                    "ARN": {},
-                    "ArrayOfARN": {},
-                    "Binary": {},
-                    "ArrayOfBinary": {},
-                    "String": {},
-                    "ArrayOfString": {},
-                    "Numeric": {},
-                    "ArrayOfNumeric": {},
-                    "Date": {},
-                    "ArrayOfDate": {},
-                    "Bool": {},
-                    "ArrayOfBool": {},
-                    "IPAddress": {},
-                    "ArrayOfIPAddress": {}
-                }
+                "smithy.api#enum": [
+                    {"value": "ARN"},
+                    {"value": "ArrayOfARN"},
+                    {"value": "Binary"},
+                    {"value": "ArrayOfBinary"},
+                    {"value": "String"},
+                    {"value": "ArrayOfString"},
+                    {"value": "Numeric"},
+                    {"value": "ArrayOfNumeric"},
+                    {"value": "Date"},
+                    {"value": "ArrayOfDate"},
+                    {"value": "Bool"},
+                    {"value": "ArrayOfBool"},
+                    {"value": "IPAddress"},
+                    {"value": "ArrayOfIPAddress"}
+                ]
             }
         }
     }

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -56,13 +56,13 @@ list TimestampList {
     member: Timestamp,
 }
 
-@enum(
-    Foo: {},
-    Baz: {},
-    Bar: {},
-    "1": {},
-    "0": {},
-)
+@enum([
+    {value: "Foo"},
+    {value: "Baz"},
+    {value: "Bar"},
+    {value: "1"},
+    {value: "0"},
+])
 string FooEnum
 
 list FooEnumList {

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
@@ -79,28 +79,33 @@
                 "smithy.api#trait": {
                     "selector": ":test(simpleType, collection, structure, union, member)"
                 },
-                "smithy.api#enum": {
-                    "content": {
+                "smithy.api#enum": [
+                    {
+                        "value": "content",
                         "name": "CUSTOMER_CONTENT",
                         "documentation": "Customer content means any software (including machine images), data, text, audio, video or images that customers or any customer end user transfers to AWS for processing, storage or hosting by AWS services in connection with the customer\u2019s accounts and any computational results that customers or any customer end user derive from the foregoing through their use of AWS services."
                     },
-                    "account": {
+                    {
+                        "value": "account",
                         "name": "CUSTOMER_ACCOUNT_INFORMATION",
                         "documentation": "Account information means information about customers that customers provide to AWS in connection with the creation or administration of customers\u2019 accounts."
                     },
-                    "usage": {
+                    {
+                        "value": "usage",
                         "name": "SERVICE_ATTRIBUTES",
                         "documentation": "Service Attributes means service usage data related to a customer\u2019s account, such as resource identifiers, metadata tags, security and access roles, rules, usage policies, permissions, usage statistics, logging data, and analytics."
                     },
-                    "tagging": {
+                    {
+                        "value": "tagging",
                         "name": "TAG_DATA",
                         "documentation": "Designates metadata tags applied to AWS resources."
                     },
-                    "permissions": {
+                    {
+                        "value": "permissions",
                         "name": "PERMISSIONS_DATA",
                         "documentation": "Designates security and access roles, rules, usage policies, and permissions."
                     }
-                },
+                ],
                 "smithy.api#documentation": "Designates the target as containing data of a known classification level."
             }
         },

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -34,14 +34,14 @@ public class ChangedEnumTraitTest {
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
-                        .addEnum("foo", EnumConstantBody.builder().build())
+                        .addEnum(EnumDefinition.builder().value("foo").build())
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
-                        .addEnum("foo", EnumConstantBody.builder().build())
-                        .addEnum("baz", EnumConstantBody.builder().build())
+                        .addEnum(EnumDefinition.builder().value("foo").build())
+                        .addEnum(EnumDefinition.builder().value("baz").build())
                         .build())
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
@@ -57,14 +57,14 @@ public class ChangedEnumTraitTest {
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
-                        .addEnum("foo", EnumConstantBody.builder().build())
-                        .addEnum("baz", EnumConstantBody.builder().build())
+                        .addEnum(EnumDefinition.builder().value("foo").build())
+                        .addEnum(EnumDefinition.builder().value("baz").build())
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
-                        .addEnum("foo", EnumConstantBody.builder().build())
+                        .addEnum(EnumDefinition.builder().value("foo").build())
                         .build())
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
@@ -80,13 +80,13 @@ public class ChangedEnumTraitTest {
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
-                        .addEnum("foo", EnumConstantBody.builder().name("OLD").build())
+                        .addEnum(EnumDefinition.builder().value("foo").name("OLD").build())
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
-                        .addEnum("foo", EnumConstantBody.builder().name("NEW").build())
+                        .addEnum(EnumDefinition.builder().value("foo").name("NEW").build())
                         .build())
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.jsonschema;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
@@ -283,8 +282,7 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
         }
 
         shape.getTrait(EnumTrait.class)
-                .map(EnumTrait::getValues)
-                .map(Map::keySet)
+                .map(EnumTrait::getEnumDefinitionValues)
                 .ifPresent(builder::enumValues);
 
         return builder;

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
@@ -56,7 +56,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
-import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
@@ -400,7 +400,7 @@ public class JsonSchemaConverterTest {
     public void supportsEnum() {
         StringShape string = StringShape.builder()
                 .id("smithy.api#String")
-                .addTrait(EnumTrait.builder().addEnum("foo", EnumConstantBody.builder().build()).build())
+                .addTrait(EnumTrait.builder().addEnum(EnumDefinition.builder().value("foo").build()).build())
                 .build();
         Model model = Model.builder().addShapes(string).build();
         SchemaDocument document = JsonSchemaConverter.builder().model(model).build().convertShape(string);

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.json
@@ -217,14 +217,16 @@
         "example.rest#EnumString": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "a": {
+                "smithy.api#enum": [
+                    {
+                        "value": "a",
                         "name": "A"
                     },
-                    "c": {
+                    {
+                        "value": "c",
                         "name": "C"
                     }
-                }
+                ]
             }
         },
         "example.rest#TaggedUnion": {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumDefinition.java
@@ -27,23 +27,30 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 /**
  * An enum definition for the enum trait.
  */
-public final class EnumConstantBody implements ToSmithyBuilder<EnumConstantBody>, Tagged {
+public final class EnumDefinition implements ToSmithyBuilder<EnumDefinition>, Tagged {
+    public static final String VALUE = "value";
     public static final String NAME = "name";
     public static final String DOCUMENTATION = "documentation";
     public static final String TAGS = "tags";
 
+    private final String value;
     private final String documentation;
     private final List<String> tags;
     private final String name;
 
-    private EnumConstantBody(Builder builder) {
+    private EnumDefinition(Builder builder) {
+        value = SmithyBuilder.requiredState("value", builder.value);
+        name = builder.name;
         documentation = builder.documentation;
         tags = new ArrayList<>(builder.tags);
-        name = builder.name;
     }
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public String getValue() {
+        return value;
     }
 
     public Optional<String> getName() {
@@ -61,46 +68,53 @@ public final class EnumConstantBody implements ToSmithyBuilder<EnumConstantBody>
 
     @Override
     public Builder toBuilder() {
-        return builder().tags(tags).documentation(documentation).name(name);
+        return builder().value(value).tags(tags).documentation(documentation).name(name);
     }
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof EnumConstantBody)) {
+        if (!(other instanceof EnumDefinition)) {
             return false;
         }
 
-        EnumConstantBody otherEnum = (EnumConstantBody) other;
-        return Objects.equals(name, otherEnum.name)
+        EnumDefinition otherEnum = (EnumDefinition) other;
+        return value.equals(otherEnum.value)
+                && Objects.equals(name, otherEnum.name)
                 && Objects.equals(documentation, otherEnum.documentation)
                 && tags.equals(otherEnum.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, tags, documentation);
+        return Objects.hash(value, name, tags, documentation);
     }
 
     /**
-     * Builds a {@link EnumConstantBody}.
+     * Builds a {@link EnumDefinition}.
      */
-    public static final class Builder implements SmithyBuilder<EnumConstantBody> {
+    public static final class Builder implements SmithyBuilder<EnumDefinition> {
+        private String value;
         private String documentation;
         private String name;
         private final List<String> tags = new ArrayList<>();
 
         @Override
-        public EnumConstantBody build() {
-            return new EnumConstantBody(this);
+        public EnumDefinition build() {
+            return new EnumDefinition(this);
         }
 
-        public Builder documentation(String documentation) {
-            this.documentation = documentation;
+        public Builder value(String value) {
+            this.value = Objects.requireNonNull(value);
             return this;
         }
 
         public Builder name(String name) {
             this.name = name;
+            return this;
+        }
+
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringEnumPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringEnumPlugin.java
@@ -36,10 +36,11 @@ public final class StringEnumPlugin extends FilteredPlugin<StringShape, StringNo
         List<String> messages = new ArrayList<>();
         // Validate the enum trait.
         shape.getTrait(EnumTrait.class).ifPresent(trait -> {
-            if (!trait.getValues().containsKey(node.getValue())) {
+            List<String> values = trait.getEnumDefinitionValues();
+            if (!values.contains(node.getValue())) {
                 messages.add(String.format(
                         "String value provided for `%s` must be one of the following values: %s",
-                        shape.getId(), ValidationUtils.tickedList(trait.getValues().keySet())));
+                        shape.getId(), ValidationUtils.tickedList(values)));
             }
         });
         return messages;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EnumTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EnumTraitValidator.java
@@ -18,14 +18,13 @@ package software.amazon.smithy.model.validation.validators;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -33,6 +32,10 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
  * Ensures that enum traits are valid.
+ *
+ * <p>If one enum definition contains a name, then all definitions must contain
+ * a name. All enum values and names must be unique across the list of
+ * definitions.
  */
 public class EnumTraitValidator extends AbstractValidator {
     private static final Pattern RECOMMENDED_NAME_PATTERN = Pattern.compile("^[A-Z]+[A-Z_0-9]*$");
@@ -48,29 +51,42 @@ public class EnumTraitValidator extends AbstractValidator {
     private List<ValidationEvent> validateEnumTrait(Shape shape, EnumTrait trait) {
         List<ValidationEvent> events = new ArrayList<>();
         Set<String> names = new HashSet<>();
-        for (Map.Entry<String, EnumConstantBody> entry : trait.getValues().entrySet()) {
-            if (entry.getValue().getName().isPresent()) {
-                String name = entry.getValue().getName().get();
-                if (names.contains(name)) {
+        Set<String> values = new HashSet<>();
+
+        // Ensure that names are unique.
+        for (EnumDefinition definition : trait.getValues()) {
+            if (!values.add(definition.getValue())) {
+                events.add(error(shape, trait, String.format(
+                        "Duplicate enum trait values found with the same `value` property of '%s'",
+                        definition.getValue())));
+            }
+        }
+
+        // Ensure that names are unique.
+        for (EnumDefinition definition : trait.getValues()) {
+            if (definition.getName().isPresent()) {
+                String name = definition.getName().get();
+                if (!names.add(name)) {
                     events.add(error(shape, trait, String.format(
                             "Duplicate enum trait values found with the same `name` property of '%s'", name)));
                 }
                 if (!RECOMMENDED_NAME_PATTERN.matcher(name).find()) {
                     events.add(warning(shape, trait, String.format(
-                            "The name `%s` does not match our recommended enum name format of beginning with an "
+                            "The name `%s` does not match the recommended enum name format of beginning with an "
                             + "uppercase letter, followed by any number of uppercase letters, numbers, or underscores.",
                             name)));
                 }
-                names.add(name);
             }
         }
 
+        // If one enum definition has a name, then they all must have names.
         if (!names.isEmpty()) {
-            for (Map.Entry<String, EnumConstantBody> entry : trait.getValues().entrySet()) {
-                if (!entry.getValue().getName().isPresent()) {
+            for (EnumDefinition definition : trait.getValues()) {
+                if (!definition.getName().isPresent()) {
                     events.add(error(shape, trait, String.format(
                             "`%s` enum value body is missing the `name` property; if any enum trait value contains a "
-                            + "`name` property, then all values must contain the `name` property.", entry.getKey())));
+                            + "`name` property, then all values must contain the `name` property.",
+                            definition.getValue())));
                 }
             }
         }

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -127,7 +127,9 @@ structure httpApiKeyAuth {
 }
 
 @private
-@enum(header: {},  query: {})
+@enum([
+    {value: "header"},
+    {value: "query"}])
 string HttpApiKeyLocations
 
 /// Indicates that an operation can be called without authentication.
@@ -158,8 +160,9 @@ structure Example {
 /// targeted with this trait.
 @trait(selector: "structure", conflicts: [trait])
 @tags(["diff.error.const"])
-@enum(client: {name: "CLIENT"},
-      server: {name: "SERVER"})
+@enum([
+    {value: "client", name: "CLIENT"},
+    {value: "server", name: "SERVER"}])
 string error
 
 /// Indicates that an error MAY be retried by the client.
@@ -317,21 +320,26 @@ string title
 /// of constant values.
 @trait(selector: "string")
 @tags(["diff.error.add", "diff.error.remove"])
-map enum {
-    key: String,
-    value: EnumConstantBody
+@length(min: 1)
+list enum {
+    member: EnumDefinition
 }
 
 /// An enum definition for the enum trait.
 @private
-structure EnumConstantBody {
+structure EnumDefinition {
+    /// Defines the enum value that is sent over the wire.
+    @required
+    value: NonEmptyString,
+
+    /// Defines the name, or label, that is used in code to represent this variant.
+    name: EnumConstantBodyName,
+
     /// Provides optional documentation about the enum constant value.
     documentation: String,
 
     /// Applies a list of tags to the enum constant.
     tags: NonEmptyStringList,
-
-    name: EnumConstantBodyName,
 }
 
 /// The optional name or label of the enum constant value.
@@ -559,23 +567,30 @@ structure idRef {
 
 @trait(selector: ":test(timestamp, member > timestamp)")
 @tags(["diff.error.const"])
-@enum(
-    "date-time": {
+@enum([
+    {
+        value: "date-time",
+        name: "DATE_TIME",
         documentation: """
             Date time as defined by the date-time production in RFC3339 section 5.6
             with no UTC offset (for example, 1985-04-12T23:20:50.52Z)."""
     },
-    "epoch-seconds": {
+    {
+        value: "epoch-seconds",
+        name: "EPOCH_SECONDS",
         documentation: """
             Also known as Unix time, the number of seconds that have elapsed since
             00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970,
             with decimal precision (for example, 1515531081.1234)."""
     },
-    "http-date": {
+    {
+        value: "http-date",
+        name: "HTTP_DATE",
         documentation: """
             An HTTP date as defined by the IMF-fixdate production in
             RFC 7231#section-7.1.1.1 (for example, Tue, 29 Apr 2014 18:30:38 GMT)."""
-    })
+    }
+])
 string timestampFormat
 
 /// Configures a custom operation endpoint.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/EnumTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/EnumTraitTest.java
@@ -16,8 +16,8 @@
 package software.amazon.smithy.model.traits;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Assertions;
@@ -29,14 +29,14 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public class EnumTraitTest {
     @Test
     public void loadsTrait() {
-        Node node = Node.parse("{\"foo\": {}, \"bam\": {}, \"boozled\": {}}");
+        Node node = Node.parse("[{\"value\": \"foo\"}, "
+                               + "{\"value\": \"bam\"}, "
+                               + "{\"value\": \"boozled\"}]");
         EnumTrait trait = new EnumTrait.Provider().createTrait(ShapeId.from("ns.foo#baz"), node);
 
         assertThat(trait.toNode(), equalTo(node));
         assertThat(trait.toBuilder().build(), equalTo(trait));
-        assertThat(trait.getValues(), hasKey("foo"));
-        assertThat(trait.getValues(), hasKey("bam"));
-        assertThat(trait.getValues(), hasKey("boozled"));
+        assertThat(trait.getEnumDefinitionValues(), contains("foo", "bam", "boozled"));
     }
 
     @Test
@@ -49,7 +49,8 @@ public class EnumTraitTest {
 
     @Test
     public void checksIfAllDefineNames() {
-        Node node = Node.parse("{\"foo\": {\"name\": \"FOO\"}, \"bam\": {\"name\": \"BAM\"}}");
+        Node node = Node.parse("[{\"value\": \"foo\", \"name\": \"FOO\"}, "
+                               + "{\"value\": \"bam\", \"name\": \"BAM\"}]");
         EnumTrait trait = new EnumTrait.Provider().createTrait(ShapeId.from("ns.foo#baz"), node);
 
         assertThat(trait.hasNames(), is(true));

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/enum-trait-validation.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/enum-trait-validation.errors
@@ -1,9 +1,10 @@
+[WARNING] ns.foo#Warn1: The name `_bar` does not match the recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
+[WARNING] ns.foo#Warn1: The name `baz` does not match the recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
+[WARNING] ns.foo#Invalid2: The name `invalid!` does not match the recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
+[WARNING] ns.foo#Invalid2: The name `invalid2!` does not match the recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
+[WARNING] ns.foo#Invalid3: The name `a` does not match the recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
 [ERROR] ns.foo#Invalid1: `foo` enum value body is missing the `name` property; if any enum trait value contains a `name` property, then all values must contain the `name` property. | EnumTrait
-[ERROR] ns.foo#Invalid2: Error validating trait `enum`.bar.name: String value provided for `smithy.api#EnumConstantBodyName` must match regular expression: ^[a-zA-Z_]+[a-zA-Z_0-9]*$ | TraitValue
-[ERROR] ns.foo#Invalid2: Error validating trait `enum`.foo.name: String value provided for `smithy.api#EnumConstantBodyName` must match regular expression: ^[a-zA-Z_]+[a-zA-Z_0-9]*$ | TraitValue
+[ERROR] ns.foo#Invalid2: Error validating trait `enum`.0.name: String value provided for `smithy.api#EnumConstantBodyName` must match regular expression: ^[a-zA-Z_]+[a-zA-Z_0-9]*$ | TraitValue
+[ERROR] ns.foo#Invalid2: Error validating trait `enum`.1.name: String value provided for `smithy.api#EnumConstantBodyName` must match regular expression: ^[a-zA-Z_]+[a-zA-Z_0-9]*$ | TraitValue
 [ERROR] ns.foo#Invalid3: Duplicate enum trait values found with the same `name` property of 'a' | EnumTrait
-[WARNING] ns.foo#Invalid2: The name `invalid!` does not match our recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
-[WARNING] ns.foo#Invalid2: The name `invalid2!` does not match our recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
-[WARNING] ns.foo#Invalid3: The name `a` does not match our recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
-[WARNING] ns.foo#Warn1: The name `_bar` does not match our recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
-[WARNING] ns.foo#Warn1: The name `baz` does not match our recommended enum name format of beginning with an uppercase letter, followed by any number of uppercase letters, numbers, or underscores. | EnumTrait
+[ERROR] ns.foo#Invalid4: Duplicate enum trait values found with the same `value` property of 'a' | EnumTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/enum-trait-validation.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/enum-trait-validation.json
@@ -4,17 +4,18 @@
         "ns.foo#Valid1": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "foo": {},
-                    "bar": {}
-                }
+                "smithy.api#enum": [
+                    {"value": "foo"},
+                    {"value": "bar"}
+                ]
             }
         },
         "ns.foo#Valid2": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "foo": {
+                "smithy.api#enum": [
+                    {
+                        "value": "foo",
                         "name": "FOO",
                         "documentation": "foo",
                         "tags": [
@@ -22,7 +23,8 @@
                             "b"
                         ]
                     },
-                    "bar": {
+                    {
+                        "value": "bar",
                         "name": "BAR",
                         "documentation": "bar",
                         "tags": [
@@ -30,28 +32,33 @@
                             "b"
                         ]
                     }
-                }
+                ]
             }
         },
         "ns.foo#Warn1": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "bar": {
+                "smithy.api#enum": [
+                    {
+                        "value": "bar",
                         "name": "_bar"
                     },
-                    "baz": {
+                    {
+                        "value": "baz",
                         "name": "baz"
                     }
-                }
+                ]
             }
         },
         "ns.foo#Invalid1": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "foo": {},
-                    "bar": {
+                "smithy.api#enum": [
+                    {
+                        "value": "foo"
+                    },
+                    {
+                        "value": "bar",
                         "name": "BAR",
                         "documentation": "bar",
                         "tags": [
@@ -59,33 +66,34 @@
                             "b"
                         ]
                     }
-                }
+                ]
             }
         },
         "ns.foo#Invalid2": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "foo": {
-                        "name": "invalid!"
-                    },
-                    "bar": {
-                        "name": "invalid2!"
-                    }
-                }
+                "smithy.api#enum": [
+                    {"value": "foo", "name": "invalid!"},
+                    {"value": "bar", "name": "invalid2!"}
+                ]
             }
         },
         "ns.foo#Invalid3": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "foo": {
-                        "name": "a"
-                    },
-                    "bar": {
-                        "name": "a"
-                    }
-                }
+                "smithy.api#enum": [
+                    {"value": "a", "name": "a"},
+                    {"value": "b", "name": "a"}
+                ]
+            }
+        },
+        "ns.foo#Invalid4": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {"value": "a"},
+                    {"value": "a"}
+                ]
             }
         }
     }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
@@ -91,14 +91,10 @@
         "ns.foo#String3": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "foo": {
-                        "name": "FOO"
-                    },
-                    "bar": {
-                        "name": "BAR"
-                    }
-                }
+                "smithy.api#enum": [
+                    {"value": "foo", "name": "FOO"},
+                    {"value": "bar", "name": "BAR"}
+                ]
             }
         },
         "ns.foo#String4": {

--- a/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/job-service.smithy
+++ b/smithy-mqtt-traits/src/test/resources/software/amazon/smithy/mqtt/traits/errorfiles/job-service.smithy
@@ -47,17 +47,17 @@ structure RejectedError {
   executionState: JobExecutionState,
 }
 
-@enum(
-  InvalidTopic: {},
-  InvalidJson: {},
-  InvalidRequest: {},
-  InvalidStateTransition: {},
-  ResourceNotFound: {},
-  VersionMismatch: {},
-  InternalError: {},
-  RequestThrottled: {},
-  TerminalStateReached: {},
-)
+@enum([
+  {value: "InvalidTopic"},
+  {value: "InvalidJson"},
+  {value: "InvalidRequest"},
+  {value: "InvalidStateTransition"},
+  {value: "ResourceNotFound"},
+  {value: "VersionMismatch"},
+  {value: "InternalError"},
+  {value: "RequestThrottled"},
+  {value: "TerminalStateReached"},
+])
 string RejectedErrorCode
 
 // ------ GetPendingJobExecutions -------
@@ -192,16 +192,16 @@ structure JobExecutionData {
   executionNumber: smithy.api#Long,
 }
 
-@enum(
-  QUEUED: {},
-  IN_PROGRESS: {},
-  TIMED_OUT: {},
-  FAILED: {},
-  SUCCEEDED: {},
-  CANCELED: {},
-  REJECTED: {},
-  REMOVED: {},
-)
+@enum([
+  {value: "QUEUED"},
+  {value: "IN_PROGRESS"},
+  {value: "TIMED_OUT"},
+  {value: "FAILED"},
+  {value: "SUCCEEDED"},
+  {value: "CANCELED"},
+  {value: "REJECTED"},
+  {value: "REMOVED"},
+])
 string JobStatus
 
 

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json
@@ -235,14 +235,10 @@
         "example.rest#EnumString": {
             "type": "string",
             "traits": {
-                "smithy.api#enum": {
-                    "a": {
-                        "name": "A"
-                    },
-                    "c": {
-                        "name": "C"
-                    }
-                }
+                "smithy.api#enum": [
+                    {"value": "a", "name": "A"},
+                    {"value": "c", "name": "C"}
+                ]
             }
         },
         "example.rest#TaggedUnion": {


### PR DESCRIPTION
The enum trait is currently a map of enum value to the enum definition.
This means that models often look like this:

```
@enum(foo: {}, bar: {})
string MyString
```

Ideally, a name and documentation are provided too:

```
@enum(
    foo: {name: "FOO", documentation: "foo docs..."},
    bar: {name: "BAR", documentation: "bar docs..."})
```

However, the difference between the key and "name" has resulted in
confusion as to which is which. This is caused by a couple things:

1. The key doesn't tell you what it defines. You have to know that the
the key defines the value of the enum to make sense of the trait.
2. The key has to be quoted if it deviates from the allows ABNF for node
object keys. This has also led to confusion.

Although this is a breaking change, using a list of structures where
everything has a name will result in models that are easier to
understand, and hopefully modelers will more often include properties
like `name` and `documentation`.

This now looks like:

```
@enum([
    {
        value: "foo",
        name: "FOO",
        documentation: "foo docs..."
    },
    {
        value: "bar",
        name: "BAR",
        documentation: "bar docs..."
    }
])
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
