### PR TITLE
Adds security to individual operations

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.apigateway.openapi;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 import software.amazon.smithy.aws.traits.apigateway.AuthorizerDefinition;
 import software.amazon.smithy.aws.traits.apigateway.AuthorizerIndex;
@@ -24,6 +25,7 @@ import software.amazon.smithy.aws.traits.apigateway.AuthorizerTrait;
 import software.amazon.smithy.aws.traits.apigateway.AuthorizersTrait;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.openapi.fromsmithy.Context;
@@ -32,7 +34,9 @@ import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveUnusedComponents;
 import software.amazon.smithy.openapi.model.ComponentsObject;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.openapi.model.OperationObject;
 import software.amazon.smithy.openapi.model.SecurityScheme;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 /**
@@ -77,6 +81,25 @@ final class AddAuthorizers implements OpenApiMapper {
                 // Add a new scheme for this operation using the authorizer name.
                 .map(authorizer -> MapUtils.of(authorizer, requirement.values().iterator().next()))
                 .orElse(requirement);
+    }
+
+    @Override
+    public OperationObject updateOperation(Context context, OperationShape shape, OperationObject operation) {
+        ServiceShape service = context.getService();
+        AuthorizerIndex authorizerIndex = context.getModel().getKnowledge(AuthorizerIndex.class);
+
+        // Get the resolved security schemes of the service and operation, and
+        // only add security if it's different than the service.
+        String serviceAuth = authorizerIndex.getAuthorizer(service).orElse(null);
+        String operationAuth = authorizerIndex.getAuthorizer(service, shape).orElse(null);
+
+        if (operationAuth == null || Objects.equals(operationAuth, serviceAuth)) {
+            return operation;
+        }
+
+        return operation.toBuilder()
+                .addSecurity(MapUtils.of(operationAuth, ListUtils.of()))
+                .build();
     }
 
     @Override

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/effective-authorizers.smithy
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/effective-authorizers.smithy
@@ -1,0 +1,20 @@
+namespace smithy.example
+
+@protocols([{name: "aws.rest-json-1.1", auth: ["aws.v4"]}])
+@aws.apigateway#authorizer("foo")
+@aws.apigateway#authorizers(
+    foo: {scheme: "aws.v4", type: "aws", uri: "arn:foo"},
+    baz: {scheme: "aws.v4", type: "aws", uri: "arn:baz"})
+service ServiceA {
+  version: "2019-06-17",
+  operations: [OperationA, OperationB]
+}
+
+// Inherits the authorizer of ServiceA
+@http(method: "GET", uri: "/operationA")
+operation OperationA {}
+
+// Overrides the authorizer of ServiceA
+@aws.apigateway#authorizer("baz")
+@http(method: "GET", uri: "/operationB")
+operation OperationB {}


### PR DESCRIPTION
We previously weren't adding security to individual operations if the
operation differend from the security of the operation differed from the
service because of an applied authorizer trait.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
