### PR TITLE
Fix http-x-api-key

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.openapi.fromsmithy.security;
 
+import java.util.Set;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
+import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Uses an HTTP header named X-Api-Key that contains an API key.
@@ -37,8 +39,13 @@ public final class XApiKey implements SecuritySchemeConverter {
         return SecurityScheme.builder()
                 .type("apiKey")
                 .in("header")
-                .name("X-Api-Key")
+                .name("x-api-key")
                 .description("X-Api-Key authentication")
                 .build();
+    }
+
+    @Override
+    public Set<String> getAuthRequestHeaders() {
+        return SetUtils.of("x-api-key");
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKeyTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKeyTest.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.openapi.fromsmithy.security;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.IoUtils;
+
+public class XApiKeyTest {
+    @Test
+    public void addsXApiKey() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("http-api-key-security.json"))
+                .assemble()
+                .unwrap();
+        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("http-api-key-security.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.json
@@ -1,0 +1,33 @@
+{
+    "smithy": "0.5.0",
+    "shapes": {
+        "smithy.example#Service": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "smithy.example#Operation1"
+                }
+            ],
+            "traits": {
+                "smithy.api#protocols": [
+                    {
+                        "name": "aws.rest-json",
+                        "auth": [
+                            "http-x-api-key"
+                        ]
+                    }
+                ]
+            }
+        },
+        "smithy.example#Operation1": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/",
+                    "method": "GET"
+                }
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.openapi.json
@@ -1,0 +1,34 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Service",
+        "version": "2006-03-01"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "Operation1",
+                "responses": {
+                    "200": {
+                        "description": "Operation1 response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "http-x-api-key": {
+                "type": "apiKey",
+                "description": "X-Api-Key authentication",
+                "name": "x-api-key",
+                "in": "header"
+            }
+        }
+    },
+    "security": [
+        {
+            "http-x-api-key": []
+        }
+    ]
+}


### PR DESCRIPTION
Ensures that http-x-api-key adds the appropriate CORS headers and that
it uses the lowercase header name to make API Gateway happy.

Closes #327

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
