### PR TITLE
Adds security to individual operations [0.10]

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/effective-authorizers.smithy
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/effective-authorizers.smithy
@@ -1,0 +1,21 @@
+namespace smithy.example
+
+@aws.protocols#restJson1
+@aws.auth#sigv4(name: "someservice")
+@aws.apigateway#authorizer("foo")
+@aws.apigateway#authorizers(
+    foo: {scheme: "aws.auth#sigv4", type: "aws", uri: "arn:foo"},
+    baz: {scheme: "aws.auth#sigv4", type: "aws", uri: "arn:baz"})
+service ServiceA {
+  version: "2019-06-17",
+  operations: [OperationA, OperationB]
+}
+
+// Inherits the authorizer of ServiceA
+@http(method: "GET", uri: "/operationA")
+operation OperationA {}
+
+// Overrides the authorizer of ServiceA
+@aws.apigateway#authorizer("baz")
+@http(method: "GET", uri: "/operationB")
+operation OperationB {}


### PR DESCRIPTION
We previously weren't adding security to individual operations if the
operation differend from the security of the operation differed from the
service because of an applied authorizer trait.

This is equivalent to f434db76a841c062bea1d96985d159c8f7b0f2ed

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
