### PR TITLE
Validate b64 encoding for json-rpc-1.1

### DIFF
--- a/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
+++ b/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
@@ -323,7 +323,7 @@
                         "method": "POST",
                         "uri": "/",
                         "params": {
-                            "Blob": "YmluYXJ5LXZhbHVl"
+                            "Blob": "binary-value"
                         },
                         "bodyMediaType": "application/json",
                         "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}"
@@ -765,7 +765,7 @@
                         "bodyMediaType": "application/json",
                         "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
                         "params": {
-                            "Blob": "YmluYXJ5LXZhbHVl"
+                            "Blob": "binary-value"
                         }
                     },
                     {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
