### PR TITLE
Add Cognito User Pools documentation to OpenAPI guide

### DIFF
--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -514,8 +514,9 @@ Amazon Cognito User Pools
 -------------------------
 
 Smithy adds Cognito User Pool based authentication to the OpenAPI model when
-the ``aws.auth#cognitoUserPools`` trait is added to a service shape. When this
-trait is present, Smithy will add a ``securitySchemes`` components entry:
+the :ref:`aws.auth#cognitoUserPools-trait` trait is added to a service shape.
+When this trait is present, Smithy will add a ``securitySchemes`` components
+entry:
 
 .. code-block:: json
 

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -513,28 +513,30 @@ uses the ``Fn::Sub`` variable syntax (``*`` means any value):
 Amazon Cognito User Pools
 -------------------------
 
-Smithy adds Cognito User Pool based authentication to the OpenAPI conversion when the
-``aws.auth#cognitoUserPools`` trait is added to a service shape.  When this trait is present, Smithy
-will add an a ``securitySchemes`` components entry:
+Smithy adds Cognito User Pool based authentication to the OpenAPI model when
+the ``aws.auth#cognitoUserPools`` trait is added to a service shape. When this
+trait is present, Smithy will add a ``securitySchemes`` components entry:
 
-    .. code-block:: json
+.. code-block:: json
 
-        {
-            "aws.auth#cognitoUserPools": {
-                "type": "apiKey",
-                "description": "Amazon Cognito User Pools authentication",
-                "name": "Authorization",
-                "in": "header",
-                "x-amazon-apigateway-authtype": "cognito_user_pools",
-                "x-amazon-apigateway-authorizer": {
-                    "type": "cognito_user_pools",
-                    "providerARNs": [
-                        "arn:aws:cognito-idp:us-east-1:123:userpool/123"
+    {
+        "aws.auth#cognitoUserPools": {
+            "type": "apiKey",
+            "description": "Amazon Cognito User Pools authentication",
+            "name": "Authorization",
+            "in": "header",
+            "x-amazon-apigateway-authtype": "cognito_user_pools",
+            "x-amazon-apigateway-authorizer": {
+                "type": "cognito_user_pools",
+                "providerARNs": [
+                    "arn:aws:cognito-idp:us-east-1:123:userpool/123"
                 ]
             }
         }
+    }
 
-In the entry, ``providerARNs`` will be populated from the ``providerArns`` list from the trait.
+In the entry, ``providerARNs`` will be populated from the ``providerArns`` list
+from the trait.
 
 
 Other traits that influence API Gateway

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -510,10 +510,31 @@ uses the ``Fn::Sub`` variable syntax (``*`` means any value):
     OpenAPI configuration property to ``true``.
 
 
-Amazon Cognito user pools
+Amazon Cognito User Pools
 -------------------------
 
-TODO
+Smithy adds Cognito User Pool based authentication to the OpenAPI conversion when the
+``aws.auth#cognitoUserPools`` trait is added to a service shape.  When this trait is present, Smithy
+will add an a ``securitySchemes`` components entry:
+
+    .. code-block:: json
+
+        {
+            "aws.auth#cognitoUserPools": {
+                "type": "apiKey",
+                "description": "Amazon Cognito User Pools authentication",
+                "name": "Authorization",
+                "in": "header",
+                "x-amazon-apigateway-authtype": "cognito_user_pools",
+                "x-amazon-apigateway-authorizer": {
+                    "type": "cognito_user_pools",
+                    "providerARNs": [
+                        "arn:aws:cognito-idp:us-east-1:123:userpool/123"
+                ]
+            }
+        }
+
+In the entry, ``providerARNs`` will be populated from the ``providerArns`` list from the trait.
 
 
 Other traits that influence API Gateway


### PR DESCRIPTION
Adds documentation for ``aws.auth#cognitoUserPools`` to the OpenAPI conversion guide.

Closes #8 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
