### PR TITLE
[0.10] Apply streaming trait directly to shapes

### DIFF
--- a/docs/source/spec/core.rst
+++ b/docs/source/spec/core.rst
@@ -3353,10 +3353,7 @@ Summary
     not be stored in memory, or that the size of the data stored in the shape
     is unknown at the start of a request.
 Trait selector::
-    ``operation -[input, output]-> structure > :test(member > blob)``
-
-    This trait may only be applied to top level members of operation inputs and
-    outputs.
+    ``blob``
 Value type
     ``structure``
 
@@ -3377,6 +3374,10 @@ optional members:
         In an HTTP-based protocol, for instance, this indicates that the
         ``content-length`` header must be set.
 
+Shapes targeted by this trait MAY NOT be used outside of top level operation
+inputs and operation outputs. Additionally, only one member of a structure may
+target a shape with this trait.
+
 .. tabs::
 
     .. code-tab:: smithy
@@ -3386,9 +3387,11 @@ optional members:
         }
 
         structure StreamingOutputWrapper {
-            @streaming
-            output: Blob,
+            output: StreamingBlob,
         }
+
+        @streaming
+        blob StreamingBlob
 
 Constraint traits
 =================

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/StreamingTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/StreamingTraitValidator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.validators;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SetUtils;
+
+public class StreamingTraitValidator extends AbstractValidator {
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        Set<MemberShape> streamingMembers = model.shapes(MemberShape.class)
+                .filter(member -> member.getMemberTrait(model, StreamingTrait.class).isPresent())
+                .collect(Collectors.toSet());
+
+        List<ValidationEvent> events = validateShapesOnlyUsedAtTopLevel(model, streamingMembers);
+        events.addAll(validateOnlyOneStreamPerStructure(model, streamingMembers));
+        return events;
+    }
+
+    private List<ValidationEvent> validateShapesOnlyUsedAtTopLevel(Model model, Set<MemberShape> streamingMembers) {
+        Set<ShapeId> topLevelIoShapes = model.shapes(OperationShape.class)
+                .flatMap(operation -> SetUtils.of(operation.getInput(), operation.getOutput()).stream())
+                .flatMap(OptionalUtils::stream)
+                .collect(Collectors.toSet());
+
+        return streamingMembers.stream()
+                .filter(member -> !topLevelIoShapes.contains(member.getContainer()))
+                .map(member -> error(member, String.format(
+                        "The shape %s has the smithy.api#streaming trait, and so may only be targeted by "
+                                + "top-level operation inputs and outputs.",
+                        member.getTarget())))
+                .collect(Collectors.toList());
+    }
+
+    private List<ValidationEvent> validateOnlyOneStreamPerStructure(Model model, Set<MemberShape> streamingMembers) {
+        return streamingMembers.stream()
+                .collect(Collectors.groupingBy(MemberShape::getContainer)).entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .map(entry -> {
+                    String streamingTargets = entry.getValue().stream()
+                            .sorted()
+                            .map(member -> member.toShapeId().toString())
+                            .collect(Collectors.joining(", "));
+                    return error(model.expectShape(entry.getKey()), String.format(
+                            "Structures may only target one shape with the smithy.api#streaming trait, but found [%s]",
+                            streamingTargets));
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -29,6 +29,7 @@ software.amazon.smithy.model.validation.validators.ShapeIdConflictValidator
 software.amazon.smithy.model.validation.validators.ShapeRecursionValidator
 software.amazon.smithy.model.validation.validators.SingleOperationBindingValidator
 software.amazon.smithy.model.validation.validators.SingleResourceBindingValidator
+software.amazon.smithy.model.validation.validators.StreamingTraitValidator
 software.amazon.smithy.model.validation.validators.TargetValidator
 software.amazon.smithy.model.validation.validators.TraitConflictValidator
 software.amazon.smithy.model.validation.validators.TraitTargetValidator

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -293,8 +293,7 @@ string since
 /// Indicates that the the data stored in the shape is very large and should not
 /// be stored in memory, or that the size of the data stored in the shape is
 /// unknown at the start of a request
-@trait(selector: "operation -[input, output]-> structure > :test(member > blob)",
-       structurallyExclusive: true)
+@trait(selector: "blob")
 @tags(["diff.error.const"])
 structure streaming {
     /// Indicates that the stream must have a known size.

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.errors
@@ -1,1 +1,3 @@
-[ERROR] ns.foo#InvalidStreamingStructure$Body: Trait `streaming` cannot be applied to `ns.foo#InvalidStreamingStructure$Body`. This trait may only be applied to shapes that match the following selector: operation -[input, output]-> structure > :test(member > blob) | TraitTarget
+[ERROR] ns.foo#InvalidStreamingStructure$Body: The shape ns.foo#StreamingBlob has the smithy.api#streaming trait, and so may only be targeted by top-level operation inputs and outputs. | StreamingTrait
+[ERROR] ns.foo#InvalidStreamingStructure2$Body: The shape ns.foo#StreamingBlob2 has the smithy.api#streaming trait, and so may only be targeted by top-level operation inputs and outputs. | StreamingTrait
+[ERROR] ns.foo#InvalidStreamingOutput: Structures may only target one shape with the smithy.api#streaming trait, but found [ns.foo#InvalidStreamingOutput$StreamingBlob1, ns.foo#InvalidStreamingOutput$StreamingBlob2] | StreamingTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
@@ -17,10 +17,7 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "smithy.api#Blob",
-                    "traits": {
-                        "smithy.api#streaming": true
-                    }
+                    "target": "ns.foo#StreamingBlob"
                 }
             }
         },
@@ -28,10 +25,7 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "smithy.api#Blob",
-                    "traits": {
-                        "smithy.api#streaming": true
-                    }
+                    "target": "ns.foo#StreamingBlob"
                 }
             }
         },
@@ -39,10 +33,44 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "smithy.api#Blob",
-                    "traits": {
-                        "smithy.api#streaming": true
-                    }
+                    "target": "ns.foo#StreamingBlob"
+                }
+            }
+        },
+        "ns.foo#StreamingBlob": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#streaming": true
+            }
+        },
+        "ns.foo#InvalidStreamingStructure2": {
+            "type": "structure",
+            "members": {
+                "Body": {
+                    "target": "ns.foo#StreamingBlob2"
+                }
+            }
+        },
+        "ns.foo#StreamingBlob2": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#streaming": true
+            }
+        },
+        "ns.foo#InvalidStreamingOperation": {
+            "type": "operation",
+            "output": {
+                "target": "ns.foo#InvalidStreamingOutput"
+            }
+        },
+        "ns.foo#InvalidStreamingOutput": {
+            "type": "structure",
+            "members": {
+                "StreamingBlob1": {
+                    "target": "ns.foo#StreamingBlob"
+                },
+                "StreamingBlob2": {
+                    "target": "ns.foo#StreamingBlob2"
                 }
             }
         }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.smithy
@@ -14,8 +14,8 @@ operation StreamingOperation {
 
 structure Output {
   @httpPayload
-  @streaming
   body: StreamingPayload,
 }
 
+@streaming
 blob StreamingPayload


### PR DESCRIPTION
This updates the streaming trait to apply directly to shapes instead of
members. This was previously restricted to members because it made the
model easier to validate and grok at a glance. However, keeping it on
members introduces potential errors in code generation. A given blob
could have both the streaming trait and the media type trait, for
instance. Both of these traits could result in a new type being created,
but since the streaming trait is applied to a member that type is
implicit. The code generator would have to try to generate a name that
doesn't conflict with any existing names, which is very error prone and
likely would result in unfortunate names. Moving this trait to the
shape directly makes the naming concern an explicit part of modeling,
where it will only have to be handled once.

This also brings the trait in line with the general best practice of
having traits that impact the type generated apply directly to the
shapes they impact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
