### PR TITLE
Update NullAndEmptyHeaders protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
@@ -263,19 +263,20 @@ structure InputAndOutputWithHeadersIO {
 
 /// Null and empty headers are not sent over the wire.
 @readonly
-@http(uri: "/NullAndEmptyHeaders", method: "GET")
-operation NullAndEmptyHeaders {
+@http(uri: "/NullAndEmptyHeadersClient", method: "GET")
+@tags(["client-only"])
+operation NullAndEmptyHeadersClient {
     input: NullAndEmptyHeadersIO,
     output: NullAndEmptyHeadersIO
 }
 
-apply NullAndEmptyHeaders @httpRequestTests([
+apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
         documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
         protocol: "aws.rest-json-1.1",
         method: "GET",
-        uri: "/NullAndEmptyHeaders",
+        uri: "/NullAndEmptyHeadersClient",
         forbidHeaders: ["X-A", "X-B", "X-C"],
         body: "",
         params: {
@@ -286,7 +287,16 @@ apply NullAndEmptyHeaders @httpRequestTests([
     },
 ])
 
-apply NullAndEmptyHeaders @httpResponseTests([
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeadersServer", method: "GET")
+@tags(["server-only"])
+operation NullAndEmptyHeadersServer {
+    input: NullAndEmptyHeadersIO,
+    output: NullAndEmptyHeadersIO
+}
+
+apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
         documentation: "Do not send null or empty headers",

--- a/smithy-aws-protocol-tests/model/rest-json/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/main.smithy
@@ -19,7 +19,8 @@ service RestJson {
 
         // @httpHeader tests
         InputAndOutputWithHeaders,
-        NullAndEmptyHeaders,
+        NullAndEmptyHeadersClient,
+        NullAndEmptyHeadersServer,
         TimestampFormatHeaders,
 
         // @httpLabel tests

--- a/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
@@ -263,19 +263,20 @@ structure InputAndOutputWithHeadersIO {
 
 /// Null and empty headers are not sent over the wire.
 @readonly
-@http(uri: "/NullAndEmptyHeaders", method: "GET")
-operation NullAndEmptyHeaders {
+@http(uri: "/NullAndEmptyHeadersClient", method: "GET")
+@tags(["client-only"])
+operation NullAndEmptyHeadersClient {
     input: NullAndEmptyHeadersIO,
     output: NullAndEmptyHeadersIO
 }
 
-apply NullAndEmptyHeaders @httpRequestTests([
+apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "NullAndEmptyHeaders",
         documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
         protocol: "aws.rest-xml",
         method: "GET",
-        uri: "/NullAndEmptyHeaders",
+        uri: "/NullAndEmptyHeadersClient",
         forbidHeaders: ["X-A", "X-B", "X-C"],
         body: "",
         params: {
@@ -286,7 +287,16 @@ apply NullAndEmptyHeaders @httpRequestTests([
     },
 ])
 
-apply NullAndEmptyHeaders @httpResponseTests([
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeadersServer", method: "GET")
+@tags(["server-only"])
+operation NullAndEmptyHeadersServer {
+    input: NullAndEmptyHeadersIO,
+    output: NullAndEmptyHeadersIO
+}
+
+apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "NullAndEmptyHeaders",
         documentation: "Do not send null or empty headers",

--- a/smithy-aws-protocol-tests/model/rest-xml/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/main.smithy
@@ -19,7 +19,8 @@ service RestXml {
 
         // @httpHeader tests
         InputAndOutputWithHeaders,
-        NullAndEmptyHeaders,
+        NullAndEmptyHeadersClient,
+        NullAndEmptyHeadersServer,
         TimestampFormatHeaders,
 
         // @httpLabel tests


### PR DESCRIPTION
This commit splits the NullAndEmpty headers protocol test in to two
distinct operations, one tagged client-only and the other tagged
server-only. This is done for both aws.rest-json-1.1 and aws.rest-xml.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
