### PR TITLE
Bump version to 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Smithy Changelog
 
+## 0.9.9 (2020-04-01)
+
+### Bug Fixes
+
+* Add security to individual operations in OpenAPI conversion ([#329](https://github.com/awslabs/smithy/pull/329))
+* Fix an issue with header casing for `x-api-key` integration with API Gateway ([#330](https://github.com/awslabs/smithy/pull/330))
+* Fix discrepancies in `smithy-aws-protocol-tests` ([#333](https://github.com/awslabs/smithy/pull/333), [#335](https://github.com/awslabs/smithy/pull/335),
+  [#349](https://github.com/awslabs/smithy/pull/349))
+
 ## 0.9.8 (2020-03-26)
 
 ### Features

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.9.8"
+    version = "0.9.9"
 }
 
 // The root project doesn't produce a JAR.

--- a/docs/source/guides/building-models/gradle-plugin.rst
+++ b/docs/source/guides/building-models/gradle-plugin.rst
@@ -151,12 +151,12 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.8")
+            implementation("software.amazon.smithy:smithy-model:0.9.9")
 
             // These are just examples of dependencies. This model has a dependency on
             // a "common" model package and uses the external AWS traits.
             implementation("com.foo.baz:foo-model-internal-common:1.0.0")
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.9")
         }
 
 
@@ -193,7 +193,7 @@ build that uses the "external" projection.
                 mavenCentral()
             }
             dependencies {
-                classpath("software.amazon.smithy:smithy-aws-traits:0.9.8")
+                classpath("software.amazon.smithy:smithy-aws-traits:0.9.9")
 
                 // Take a dependency on the internal model package. This
                 // dependency *must* be a buildscript only dependency to ensure
@@ -217,12 +217,12 @@ build that uses the "external" projection.
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.8")
+            implementation("software.amazon.smithy:smithy-model:0.9.9")
 
             // Any dependencies that the projected model needs must be (re)declared
             // here. For example, let's assume that the smithy-aws-traits package is
             // needed in the projected model too.
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.9")
         }
 
 
@@ -328,7 +328,7 @@ The above Smithy plugin also requires a ``buildscript`` dependency in
 
                 // This dependency is required in order to apply the "openapi"
                 // plugin in smithy-build.json
-                classpath("software.amazon.smithy:smithy-openapi:0.9.8")
+                classpath("software.amazon.smithy:smithy-openapi:0.9.9")
             }
         }
 

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -106,7 +106,7 @@ specification from a Smithy model using a buildscript dependency:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.9")
         }
     }
 
@@ -132,7 +132,7 @@ that builds an OpenAPI specification from a service for the
 
 .. important::
 
-    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.8" is
+    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.9" is
     required in order for smithy-build to map the "openapi" plugin name to the
     correct Java library implementation.
 
@@ -338,7 +338,7 @@ dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.8")
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.9")
         }
     }
 
@@ -516,7 +516,7 @@ shows how to install ``software.amazon.smithy:smithy-openapi`` through Gradle:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.9")
         }
     }
 

--- a/smithy-codegen-freemarker/README.md
+++ b/smithy-codegen-freemarker/README.md
@@ -12,7 +12,7 @@ Maven
 <dependency>
     <groupId>software.amazon.smithy</groupId>
     <artifactId>smithy-codegen-freemarker</artifactId>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## 0.9.9 (2020-04-01)

### Bug Fixes

* Add security to individual operations in OpenAPI conversion ([#329](https://github.com/awslabs/smithy/pull/329))
* Fix an issue with header casing for `x-api-key` integration with API Gateway ([#330](https://github.com/awslabs/smithy/pull/330))
* Fix discrepancies in `smithy-aws-protocol-tests` ([#333](https://github.com/awslabs/smithy/pull/333), [#335](https://github.com/awslabs/smithy/pull/335),
  [#349](https://github.com/awslabs/smithy/pull/349))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
