### PR TITLE
Fix doc build warning for favicon

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,7 +97,7 @@ html_theme_path = ['../themes']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
@@ -161,7 +161,7 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-html_favicon = "favicon.png"
+html_favicon = "../themes/smithy/static/favicon.png"
 
 def setup(sphinx):
     sphinx.add_lexer("smithy", SmithyLexer(startinline=True))


### PR DESCRIPTION
Fixes doc build warnings:

```WARNING: html_static_path entry '/...smithy/docs/source/_static' does not exist```
```WARNING: favicon file '_static/favicon.png' does not exist```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
