### PR TITLE
Fix cognitoUserPools trait documentation formatting

### DIFF
--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -514,7 +514,7 @@ Amazon Cognito User Pools
 -------------------------
 
 Smithy adds Cognito User Pool based authentication to the OpenAPI model when
-the :ref:`aws.auth#cognitoUserPools-trait` trait is added to a service shape.
+the :ref:`aws.auth#cognitoUserPools-trait` is added to a service shape.
 When this trait is present, Smithy will add a ``securitySchemes`` components
 entry:
 

--- a/docs/source/spec/aws-auth.rst
+++ b/docs/source/spec/aws-auth.rst
@@ -145,9 +145,9 @@ literal string ``UNSIGNED-PAYLOAD`` is used when constructing a
 
 .. _aws.auth#cognitoUserPools-trait:
 
--------------------------
-aws.auth#cognitoUserPools
--------------------------
+-----------------------------------
+``aws.auth#cognitoUserPools`` trait
+-----------------------------------
 
 Trait summary
     The ``aws.auth#cognitoUserPools`` trait adds support for


### PR DESCRIPTION
Fixes formatting for ```aws.auth#cognitoUserPools``` trait to match other authentication traits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
