### PR TITLE
Ignore CamelCasing on auth and protocol shape traits

### DIFF
--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
@@ -24,6 +24,8 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.AuthDefinitionTrait;
+import software.amazon.smithy.model.traits.ProtocolDefinitionTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -125,6 +127,8 @@ public final class CamelCaseValidator extends AbstractValidator {
         // Trait shapes are expected to be lower camel.
         model.shapes()
                 .filter(shape -> shape.hasTrait(TraitDefinition.class))
+                .filter(shape -> !shape.hasTrait(AuthDefinitionTrait.class))
+                .filter(shape -> !shape.hasTrait(ProtocolDefinitionTrait.class))
                 .filter(shape -> !MemberNameHandling.LOWER.getRegex().matcher(shape.getId().getName()).find())
                 .map(shape -> danger(shape, format(
                         "%s trait definition, `%s`, is not lower camel case",

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.errors
@@ -12,3 +12,5 @@
 [DANGER] ns.foo#upperStructureTrait$snake_case: Member shape member name, `snake_case`, is not lower camel case | DefaultCamelCase
 [DANGER] ns.foo#upperStructureTrait$snake_case: Member shape member name, `snake_case`, is not upper camel case | OppositeOfDefaults
 [DANGER] ns.foo#lowerStructureTrait$lowerCamelCase: Member shape member name, `lowerCamelCase`, is not upper camel case | OppositeOfDefaults
+[DANGER] foo.protocols#fooJson1_1$foo: Member shape member name, `foo`, is not upper camel case | OppositeOfDefaults
+[DANGER] foo.auth#v1_1$name: Member shape member name, `name`, is not upper camel case | OppositeOfDefaults

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.json
@@ -63,6 +63,38 @@
                     "target": "ns.foo#Foo"
                 }
             }
+        },
+        "foo.protocols#fooJson1_1": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "service"
+                },
+                "smithy.api#protocolDefinition": {
+                    "traits": [
+                        "smithy.api#jsonName"
+                    ]
+                }
+            }
+        },
+        "foo.auth#v1_1": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "service"
+                },
+                "smithy.api#authDefinition": true
+            }
         }
     },
     "metadata": {


### PR DESCRIPTION
Closes #354 

This PR updates the CamelCaseValidator to ignore trait shapes marked with authDefinition or protocolDefinition traits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
