### PR TITLE
Constrain eventStreamHttp for protocols

### DIFF
--- a/docs/source/spec/aws-restjson1-protocol.rst
+++ b/docs/source/spec/aws-restjson1-protocol.rst
@@ -48,7 +48,8 @@ members:
       - The priority ordered list of supported HTTP protocol versions
         that are required when using :ref:`event streams <event-streams>`
         with the service. If not set, this value defaults to the value
-        of the ``http`` member.
+        of the ``http`` member. Any entry in ``eventStreamHttp`` MUST
+        also appear in ``http``.
 
 Each entry in ``http`` and ``eventStreamHttp`` SHOULD be a valid
 `Application-Layer Protocol Negotiation (ALPN) Protocol ID`_ (for example,

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/ProtocolHttpValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/ProtocolHttpValidator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits.protocols;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Ensures that every entry in {@code eventStreamHttp} also appears in
+ * the {@code http} property of a protocol trait.
+ */
+public final class ProtocolHttpValidator extends AbstractValidator {
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        return model.shapes(ServiceShape.class)
+                .flatMap(service -> validateService(service, serviceIndex).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<ValidationEvent> validateService(ServiceShape service, ServiceIndex index) {
+        List<ValidationEvent> events = new ArrayList<>();
+
+        for (Trait protocol : index.getProtocols(service).values()) {
+            if (protocol instanceof AwsProtocolTrait) {
+                AwsProtocolTrait awsProtocolTrait = (AwsProtocolTrait) protocol;
+                List<String> invalid = new ArrayList<>(awsProtocolTrait.getEventStreamHttp());
+                invalid.removeAll(awsProtocolTrait.getHttp());
+                if (!invalid.isEmpty()) {
+                    events.add(error(service, protocol, String.format(
+                            "The following values of the `eventStreamHttp` property do "
+                            + "not also appear in the `http` property of the %s protocol "
+                            + "trait: %s", protocol.toShapeId(), invalid)));
+                }
+            }
+        }
+
+        return events;
+    }
+}

--- a/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,3 +1,4 @@
 software.amazon.smithy.aws.traits.ArnTemplateValidator
 software.amazon.smithy.aws.traits.SdkServiceIdValidator
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryValidator
+software.amazon.smithy.aws.traits.protocols.ProtocolHttpValidator

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/eventStreamHttp-matches-http.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/eventStreamHttp-matches-http.errors
@@ -1,0 +1,3 @@
+[ERROR] smithy.example#InvalidService1: The following values of the `eventStreamHttp` property do not also appear in the `http` property of the aws.protocols#restJson1 protocol trait: [http/1.1] | ProtocolHttp
+[ERROR] smithy.example#InvalidService2: The following values of the `eventStreamHttp` property do not also appear in the `http` property of the aws.protocols#restJson1 protocol trait: [http/1.1] | ProtocolHttp
+[ERROR] smithy.example#InvalidService3: The following values of the `eventStreamHttp` property do not also appear in the `http` property of the aws.protocols#restJson1 protocol trait: [http/1.1, h2c] | ProtocolHttp

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/eventStreamHttp-matches-http.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/eventStreamHttp-matches-http.smithy
@@ -1,0 +1,38 @@
+namespace smithy.example
+
+use aws.protocols#restJson1
+
+@restJson1(http: ["h2", "http/1.1"], eventStreamHttp: ["h2"])
+service ValidService1 {
+    version: "2020-04-02"
+}
+
+@restJson1(http: ["h2"], eventStreamHttp: ["h2"])
+service ValidService2 {
+    version: "2020-04-02"
+}
+
+@restJson1(http: [], eventStreamHttp: [])
+service ValidService3 {
+    version: "2020-04-02"
+}
+
+@restJson1(http: ["http/1.1"], eventStreamHttp: [])
+service ValidService4 {
+    version: "2020-04-02"
+}
+
+@restJson1(eventStreamHttp: ["http/1.1"])
+service InvalidService1 {
+    version: "2020-04-02"
+}
+
+@restJson1(http: ["h2"], eventStreamHttp: ["http/1.1"])
+service InvalidService2 {
+    version: "2020-04-02"
+}
+
+@restJson1(http: ["h2"], eventStreamHttp: ["h2", "http/1.1", "h2c"])
+service InvalidService3 {
+    version: "2020-04-02"
+}


### PR DESCRIPTION
This commit requires that any entry in eventStreamHttp of an AWS
protocol trait also appears in the http property of the trait. This
prevents strange situations where a service is configured to require h2
for event streams but requires http/1.1 for all other operations. This
is both nonsensical and difficult to implement in programming languages
that require different clients for different HTTP protocol versions.

Furthermore, this commit also updates the protocol traits to treat the
values of http and eventStreamHttp as a string rather than an enum. This
will make it possible to support future protocols like h3 when they're
available without needing to version bump Smithy. It does have the
drawback of not validating the values, but clients only pick protocol
versions that they support.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
