### PR TITLE
Update Protocol Tests

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/main.json
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/main.json
@@ -56,7 +56,7 @@
                         "params": {},
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.EmptyOperation"
                         }
                     }
                 ],
@@ -69,7 +69,6 @@
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1"
                         },
-                        "requireHeaders": ["Content-Length"],
                         "bodyMediaType": "application/json",
                         "body": "{}",
                         "params": {}
@@ -321,7 +320,7 @@
                         "method": "POST",
                         "uri": "/",
                         "params": {
-                            "Blob": "YmluYXJ5LXZhbHVl"
+                            "Blob": "binary-value"
                         },
                         "bodyMediaType": "application/json",
                         "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}"
@@ -519,7 +518,7 @@
                             "MapOfStrings": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"MapOfStrings\":[]}"
+                        "body": "{\"MapOfStrings\":{}}"
                     },
                     {
                         "id": "serializes_map_of_list_shapes",
@@ -623,7 +622,7 @@
                             "SimpleStruct": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"SimpleStruct\":[]}"
+                        "body": "{\"SimpleStruct\":{}}"
                     },
                     {
                         "id": "serializes_structure_which_have_no_members",
@@ -635,7 +634,7 @@
                             "EmptyStruct": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"EmptyStruct\":[]}"
+                        "body": "{\"EmptyStruct\":{}}"
                     },
                     {
                         "id": "serializes_recursive_structure_shapes",
@@ -763,7 +762,7 @@
                         "bodyMediaType": "application/json",
                         "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
                         "params": {
-                            "Blob": "YmluYXJ5LXZhbHVl"
+                            "Blob": "binary-value"
                         }
                     },
                     {
@@ -997,7 +996,9 @@
                         "code": 200,
                         "headers": {
                             "X-Amzn-Requestid": "amazon-uniq-request-id"
-                        }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{}"
                     }
                 ]
             }
@@ -1098,7 +1099,7 @@
                         "uri": "/",
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
                         },
                         "bodyMediaType": "application/json",
                         "body": "{}"
@@ -1114,7 +1115,7 @@
                         },
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
                         },
                         "requireHeaders": ["Content-Length"],
                         "bodyMediaType": "application/json",

--- a/smithy-aws-protocol-tests/model/awsQuery/input-maps.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input-maps.smithy
@@ -26,7 +26,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &MapArg.entry.1.key=foo
               &MapArg.entry.1.value=Foo
@@ -50,7 +50,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &Foo.entry.1.key=foo
               &Foo.entry.1.value=Foo""",
@@ -71,7 +71,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &ComplexMapArg.entry.1.key=foo
               &ComplexMapArg.entry.1.value.hi=Foo
@@ -99,7 +99,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
@@ -116,12 +116,12 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &MapWithXmlMemberName.entry.1.K=foo
               &MapWithXmlMemberName.entry.1.V=Foo
-              &MapWithXmlMemberName.entry.1.K=bar
-              &MapWithXmlMemberName.entry.1.V=Bar""",
+              &MapWithXmlMemberName.entry.2.K=bar
+              &MapWithXmlMemberName.entry.2.V=Bar""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapWithXmlMemberName: {
@@ -140,12 +140,12 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &FlattenedMap.1.key=foo
               &FlattenedMap.1.value=Foo
-              &FlattenedMap.1.key=bar
-              &FlattenedMap.1.value=Bar""",
+              &FlattenedMap.2.key=bar
+              &FlattenedMap.2.value=Bar""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedMap: {
@@ -164,7 +164,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &Hi.1.K=foo
               &Hi.1.V=Foo
@@ -188,12 +188,14 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
-              &MapOfLists.entry.1.key.1=A
-              &MapOfLists.entry.1.key.2=B
-              &MapOfLists.entry.2.key.1=C
-              &MapOfLists.entry.2.key.2=D""",
+              &MapOfLists.entry.1.key=foo
+              &MapOfLists.entry.1.value.member.1=A
+              &MapOfLists.entry.1.value.member.2=B
+              &MapOfLists.entry.2.key=bar
+              &MapOfLists.entry.2.value.member.1=C
+              &MapOfLists.entry.2.value.member.2=D""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapOfLists: {

--- a/smithy-aws-protocol-tests/model/awsQuery/input.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input.smithy
@@ -266,7 +266,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
@@ -281,7 +281,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000123""",
         bodyMediaType: "application/x-www-form-urlencoded",

--- a/smithy-aws-protocol-tests/model/awsQuery/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/main.smithy
@@ -2,11 +2,13 @@ $version: "1.0.0"
 
 namespace aws.protocoltests.query
 
+use aws.api#service
 use aws.protocols#awsQuery
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A query service that sends query requests and XML responses.
+@service(sdkId: "Query Protocol")
 @awsQuery
 @xmlNamespace(uri: "https://example.com/")
 service AwsQuery {

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-lists.smithy
@@ -70,7 +70,7 @@ apply XmlLists @httpResponseTests([
                               <member>baz</member>
                               <member>qux</member>
                           </member>
-                      <nestedStringList>
+                      </nestedStringList>
                       <renamed>
                           <item>foo</item>
                           <item>bar</item>

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-maps.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-maps.smithy
@@ -82,13 +82,13 @@ apply XmlMapsXmlName @httpResponseTests([
                   <XmlMapsXmlNameResult>
                       <myMap>
                           <entry>
-                              <Name>foo</Name>
+                              <Attribute>foo</Attribute>
                               <Setting>
                                   <hi>there</hi>
                               </Setting>
                           </entry>
                           <entry>
-                              <Name>baz</Name>
+                              <Attribute>baz</Attribute>
                               <Setting>
                                   <hi>bye</hi>
                               </Setting>

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -120,9 +120,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <normal>2014-04-29T18:30:38Z</normal>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -140,9 +140,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <dateTime>2014-04-29T18:30:38Z</dateTime>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -160,9 +160,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <epochSeconds>1398796238</epochSeconds>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -180,9 +180,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
@@ -32,8 +32,8 @@ apply QueryLists @httpRequestTests([
               &ListArg.1=foo
               &ListArg.2=bar
               &ListArg.3=baz
-              &ComplexListArg.1.hi=hello
-              &ComplexListArg.2.hi=hola""",
+              &ComplexListArg.1.Hi=hello
+              &ComplexListArg.2.Hi=hola""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: ["foo", "bar", "baz"],

--- a/smithy-aws-protocol-tests/model/ec2Query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input.smithy
@@ -244,9 +244,9 @@ apply QueryTimestamps @httpRequestTests([
         body: """
               Action=QueryTimestamps
               &Version=2020-01-08
-              &normalFormat=2015-01-25T08%3A00%3A00Z
-              &epochMember=1422172800
-              &epochTarget=1422172800""",
+              &NormalFormat=2015-01-25T08%3A00%3A00Z
+              &EpochMember=1422172800
+              &EpochTarget=1422172800""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             normalFormat: 1422172800,
@@ -331,9 +331,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000000""",
+              &Token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
     },
     {
@@ -346,9 +346,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000123""",
+              &Token=00000000-0000-4000-8000-000000000123""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"

--- a/smithy-aws-protocol-tests/model/ec2Query/main.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/main.smithy
@@ -28,11 +28,13 @@ $version: "1.0.0"
 
 namespace aws.protocoltests.ec2
 
+use aws.api#service
 use aws.protocols#ec2Query
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// An EC2 query service that sends query requests and XML responses.
+@service(sdkId: "EC2 Protocol")
 @ec2Query
 @xmlNamespace(uri: "https://example.com/")
 service AwsEc2 {

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
@@ -69,7 +69,7 @@ apply XmlLists @httpResponseTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>

--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -23,7 +23,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: restJson1,
         method: "POST",
-        uri: "/NoInputAndOutput"
+        uri: "/NoInputAndNoOutput"
     }
 ])
 
@@ -51,7 +51,7 @@ apply NoInputAndOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: restJson1,
         method: "POST",
-        uri: "/NoInputAndOutput"
+        uri: "/NoInputAndOutputOutput"
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/errors.smithy
@@ -126,7 +126,8 @@ apply ComplexError @httpResponseTests([
         params: {},
         code: 403,
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "X-Amzn-Errortype": "ComplexError"
         },
         body: "{}",
         bodyMediaType: "application/json",

--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -7,6 +7,7 @@ namespace aws.protocoltests.restjson
 
 use aws.protocols#restJson1
 use aws.protocoltests.shared#BooleanList
+use aws.protocoltests.shared#DateTime
 use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
@@ -58,7 +59,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -80,12 +81,12 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -96,7 +97,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -111,7 +112,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         uri: "/InputAndOutputWithHeaders",
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -151,7 +152,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -172,12 +173,12 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -187,7 +188,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -201,7 +202,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -263,19 +264,20 @@ structure InputAndOutputWithHeadersIO {
 
 /// Null and empty headers are not sent over the wire.
 @readonly
-@http(uri: "/NullAndEmptyHeaders", method: "GET")
-operation NullAndEmptyHeaders {
+@http(uri: "/NullAndEmptyHeadersClient", method: "GET")
+@tags(["client-only"])
+operation NullAndEmptyHeadersClient {
     input: NullAndEmptyHeadersIO,
     output: NullAndEmptyHeadersIO
 }
 
-apply NullAndEmptyHeaders @httpRequestTests([
+apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
         documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
         protocol: restJson1,
         method: "GET",
-        uri: "/NullAndEmptyHeaders",
+        uri: "/NullAndEmptyHeadersClient",
         forbidHeaders: ["X-A", "X-B", "X-C"],
         body: "",
         params: {
@@ -286,7 +288,16 @@ apply NullAndEmptyHeaders @httpRequestTests([
     },
 ])
 
-apply NullAndEmptyHeaders @httpResponseTests([
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeadersServer", method: "GET")
+@tags(["server-only"])
+operation NullAndEmptyHeadersServer {
+ input: NullAndEmptyHeadersIO,
+ output: NullAndEmptyHeadersIO
+}
+
+apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
         documentation: "Do not send null or empty headers",
@@ -400,5 +411,5 @@ structure TimestampFormatHeadersIO {
     targetHttpDate: HttpDate,
 
     @httpHeader("X-targetDateTime")
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }

--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -6,6 +6,7 @@ $version: "1.0.0"
 namespace aws.protocoltests.restjson
 
 use aws.protocols#restJson1
+use aws.protocoltests.shared#DateTime
 use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#HttpDate
 use smithy.test#httpRequestTests
@@ -93,11 +94,11 @@ apply HttpRequestWithLabelsAndTimestampFormat @httpRequestTests([
         uri: """
              /HttpRequestWithLabelsAndTimestampFormat\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z\
              /2019-12-16T23%3A48%3A18Z\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z""",
         body: "",
         params: {
@@ -142,7 +143,7 @@ structure HttpRequestWithLabelsAndTimestampFormatInput {
 
     @httpLabel
     @required
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }
 
 // This example uses a greedy label and a normal label.

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -31,7 +31,7 @@ apply AllQueryStringTypes @httpRequestTests([
         documentation: "Serializes query string parameters with all supported types",
         protocol: restJson1,
         method: "GET",
-        uri: "/AllQueryStringTypes",
+        uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
             "String=Hello%20there",
@@ -61,9 +61,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "BooleanList=false",
             "BooleanList=true",
             "Timestamp=1",
-            "TimestampList=1",
-            "TimestampList=2",
-            "TimestampList=3",
+            "TimestampList=1970-01-01T00%3A00%3A01Z",
+            "TimestampList=1970-01-01T00%3A00%3A02Z",
+            "TimestampList=1970-01-01T00%3A00%3A03Z",
             "Enum=Foo",
             "EnumList=Foo",
             "EnumList=Baz",
@@ -255,7 +255,6 @@ apply IgnoreQueryParamsInResponse @httpResponseTests([
         body: "",
         bodyMediaType: "json",
         params: {
-            baz: "bam"
         }
     }
 ])
@@ -325,10 +324,10 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         uri: "/QueryIdempotencyTokenAutoFill",
         body: "",
         queryParams: [
-            "token=00000000-0000-4000-8000-000000000123",
+            "token=00000000-0000-4000-8000-000000000000",
         ],
         params: {
-            token: "00000000-0000-4000-8000-000000000123"
+            token: "00000000-0000-4000-8000-000000000000"
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
@@ -74,14 +74,14 @@ apply JsonLists @httpRequestTests([
                           "qux"
                       ]
                   ],
-                  "structureList": [
+                  "myStructureList": [
                       {
-                          "a": "1",
-                          "b": "2"
+                          "value": "1",
+                          "other": "2"
                       },
                       {
-                          "a": "3",
-                          "b": "4"
+                          "value": "3",
+                          "other": "4"
                       }
                   ]
               }""",
@@ -212,14 +212,14 @@ apply JsonLists @httpResponseTests([
                           "qux"
                       ]
                   ],
-                  "structureList": [
+                  "myStructureList": [
                       {
-                          "a": "1",
-                          "b": "2"
+                          "value": "1",
+                          "other": "2"
                       },
                       {
-                          "a": "3",
-                          "b": "4"
+                          "value": "3",
+                          "other": "4"
                       }
                   ]
               }""",

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -31,7 +31,6 @@ apply SimpleScalarProperties @httpRequestTests([
         uri: "/SimpleScalarProperties",
         body: """
               {
-                  "foo": "Foo",
                   "stringValue": "string",
                   "trueBooleanValue": true,
                   "falseBooleanValue": false,
@@ -70,7 +69,6 @@ apply SimpleScalarProperties @httpResponseTests([
         code: 200,
         body: """
               {
-                  "foo": "Foo",
                   "stringValue": "string",
                   "trueBooleanValue": true,
                   "falseBooleanValue": false,
@@ -454,7 +452,7 @@ apply RecursiveShapes @httpRequestTests([
         documentation: "Serializes recursive structures",
         protocol: restJson1,
         method: "PUT",
-        uri: "/JsonEnums",
+        uri: "/RecursiveShapes",
         body: """
               {
                   "nested": {

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -2,11 +2,13 @@ $version: "1.0.0"
 
 namespace aws.protocoltests.restjson
 
+use aws.api#service
 use aws.protocols#restJson1
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A REST JSON service that sends JSON requests and responses.
+@service(sdkId: "Rest Json Protocol")
 @restJson1
 service RestJson {
     version: "2019-12-16",
@@ -18,7 +20,8 @@ service RestJson {
 
         // @httpHeader tests
         InputAndOutputWithHeaders,
-        NullAndEmptyHeaders,
+        NullAndEmptyHeadersClient,
+        NullAndEmptyHeadersServer,
         TimestampFormatHeaders,
 
         // @httpLabel tests

--- a/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
@@ -76,7 +76,7 @@ apply XmlLists @httpRequestTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>
@@ -167,7 +167,7 @@ apply XmlLists @httpResponseTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>

--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -127,13 +127,13 @@ apply XmlMapsXmlName @httpRequestTests([
               <XmlMapsXmlNameInputOutput>
                   <myMap>
                       <entry>
-                          <Name>foo</Name>
+                          <Attribute>foo</Attribute>
                           <Setting>
                               <hi>there</hi>
                           </Setting>
                       </entry>
                       <entry>
-                          <Name>baz</Name>
+                          <Attribute>baz</Attribute>
                           <Setting>
                               <hi>bye</hi>
                           </Setting>
@@ -168,13 +168,13 @@ apply XmlMapsXmlName @httpResponseTests([
               <XmlMapsXmlNameInputOutput>
                   <myMap>
                       <entry>
-                          <Name>foo</Name>
+                          <Attribute>foo</Attribute>
                           <Setting>
                               <hi>there</hi>
                           </Setting>
                       </entry>
                       <entry>
-                          <Name>baz</Name>
+                          <Attribute>baz</Attribute>
                           <Setting>
                               <hi>bye</hi>
                           </Setting>

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -478,7 +478,7 @@ apply RecursiveShapes @httpRequestTests([
         documentation: "Serializes recursive structures",
         protocol: restXml,
         method: "PUT",
-        uri: "/XmlEnums",
+        uri: "/RecursiveShapes",
         body: """
               <RecursiveShapesInputOutput>
                   <nested>
@@ -588,7 +588,7 @@ apply XmlNamespaces @httpRequestTests([
         method: "POST",
         uri: "/XmlNamespaces",
         body: """
-              <RecursiveShapesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesInputOutput xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -596,7 +596,7 @@ apply XmlNamespaces @httpRequestTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </XmlNamespacesInputOutput>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -621,7 +621,7 @@ apply XmlNamespaces @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <RecursiveShapesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesInputOutput xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -629,7 +629,7 @@ apply XmlNamespaces @httpResponseTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </XmlNamespacesInputOutput>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/restXml/document-xml-attributes.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-xml-attributes.smithy
@@ -24,7 +24,7 @@ apply XmlAttributes @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributes",
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -46,7 +46,7 @@ apply XmlAttributes @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -85,7 +85,7 @@ apply XmlAttributesOnPayload @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributesOnPayload",
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -109,7 +109,7 @@ apply XmlAttributesOnPayload @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,

--- a/smithy-aws-protocol-tests/model/restXml/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/empty-input-output.smithy
@@ -21,7 +21,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: restXml,
         method: "POST",
-        uri: "/NoInputAndOutput",
+        uri: "/NoInputAndNoOutput",
         body: ""
     }
 ])
@@ -51,7 +51,7 @@ apply NoInputAndOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: restXml,
         method: "POST",
-        uri: "/NoInputAndOutput",
+        uri: "/NoInputAndOutputOutput",
         body: ""
     }
 ])

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -7,6 +7,7 @@ namespace aws.protocoltests.restxml
 
 use aws.protocols#restXml
 use aws.protocoltests.shared#BooleanList
+use aws.protocoltests.shared#DateTime
 use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
@@ -58,7 +59,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -80,12 +81,12 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -96,7 +97,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -111,7 +112,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         uri: "/InputAndOutputWithHeaders",
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -151,7 +152,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -172,12 +173,12 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -187,7 +188,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restXml,
         code: 200,
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -201,7 +202,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -263,19 +264,20 @@ structure InputAndOutputWithHeadersIO {
 
 /// Null and empty headers are not sent over the wire.
 @readonly
-@http(uri: "/NullAndEmptyHeaders", method: "GET")
-operation NullAndEmptyHeaders {
+@http(uri: "/NullAndEmptyHeadersClient", method: "GET")
+@tags(["client-only"])
+operation NullAndEmptyHeadersClient {
     input: NullAndEmptyHeadersIO,
     output: NullAndEmptyHeadersIO
 }
 
-apply NullAndEmptyHeaders @httpRequestTests([
+apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "NullAndEmptyHeaders",
         documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
         protocol: restXml,
         method: "GET",
-        uri: "/NullAndEmptyHeaders",
+        uri: "/NullAndEmptyHeadersClient",
         forbidHeaders: ["X-A", "X-B", "X-C"],
         body: "",
         params: {
@@ -286,7 +288,16 @@ apply NullAndEmptyHeaders @httpRequestTests([
     },
 ])
 
-apply NullAndEmptyHeaders @httpResponseTests([
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeadersServer", method: "GET")
+@tags(["server-only"])
+operation NullAndEmptyHeadersServer {
+ input: NullAndEmptyHeadersIO,
+ output: NullAndEmptyHeadersIO
+}
+
+apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "NullAndEmptyHeaders",
         documentation: "Do not send null or empty headers",
@@ -400,5 +411,5 @@ structure TimestampFormatHeadersIO {
     targetHttpDate: HttpDate,
 
     @httpHeader("X-targetDateTime")
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }

--- a/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
@@ -6,6 +6,7 @@ $version: "1.0.0"
 namespace aws.protocoltests.restxml
 
 use aws.protocols#restXml
+use aws.protocoltests.shared#DateTime
 use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#HttpDate
 use smithy.test#httpRequestTests
@@ -93,11 +94,11 @@ apply HttpRequestWithLabelsAndTimestampFormat @httpRequestTests([
         uri: """
              /HttpRequestWithLabelsAndTimestampFormat\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z\
              /2019-12-16T23%3A48%3A18Z\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z""",
         body: "",
         params: {
@@ -142,7 +143,7 @@ structure HttpRequestWithLabelsAndTimestampFormatInput {
 
     @httpLabel
     @required
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }
 
 // This example uses a greedy label and a normal label.

--- a/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
@@ -230,7 +230,7 @@ apply HttpPayloadWithXmlName @httpRequestTests([
         documentation: "Serializes a structure in the payload using a wrapper name based on xmlName",
         protocol: restXml,
         method: "PUT",
-        uri: "/HttpPayloadWithStructure",
+        uri: "/HttpPayloadWithXmlName",
         body: "<Hello><name>Phreddy</name></Hello>",
         bodyMediaType: "application/xml",
         headers: {
@@ -289,7 +289,7 @@ apply HttpPayloadWithXmlNamespace @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithXmlNamespace",
         body: """
-              <PayloadWithXmlNamespace xmlns="http//foo.com">
+              <PayloadWithXmlNamespace xmlns="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespace>""",
         bodyMediaType: "application/xml",
@@ -311,7 +311,7 @@ apply HttpPayloadWithXmlNamespace @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <PayloadWithXmlNamespace xmlns="http//foo.com">
+              <PayloadWithXmlNamespace xmlns="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespace>""",
         bodyMediaType: "application/xml",
@@ -352,7 +352,7 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithXmlNamespaceAndPrefix",
         body: """
-              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespaceAndPrefix>""",
         bodyMediaType: "application/xml",
@@ -374,7 +374,7 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespaceAndPrefix>""",
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -31,7 +31,7 @@ apply AllQueryStringTypes @httpRequestTests([
         documentation: "Serializes query string parameters with all supported types",
         protocol: restXml,
         method: "GET",
-        uri: "/AllQueryStringTypes",
+        uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
             "String=Hello%20there",
@@ -61,9 +61,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "BooleanList=false",
             "BooleanList=true",
             "Timestamp=1",
-            "TimestampList=1",
-            "TimestampList=2",
-            "TimestampList=3",
+            "TimestampList=1970-01-01T00%3A00%3A01Z",
+            "TimestampList=1970-01-01T00%3A00%3A02Z",
+            "TimestampList=1970-01-01T00%3A00%3A03Z",
             "Enum=Foo",
             "EnumList=Foo",
             "EnumList=Baz",
@@ -325,10 +325,10 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         uri: "/QueryIdempotencyTokenAutoFill",
         body: "",
         queryParams: [
-            "token=00000000-0000-4000-8000-000000000123",
+            "token=00000000-0000-4000-8000-000000000000",
         ],
         params: {
-            token: "00000000-0000-4000-8000-000000000123"
+            token: "00000000-0000-4000-8000-000000000000"
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/restXml/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/main.smithy
@@ -2,11 +2,13 @@ $version: "1.0.0"
 
 namespace aws.protocoltests.restxml
 
+use aws.api#service
 use aws.protocols#restXml
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A REST XML service that sends XML requests and responses.
+@service(sdkId: "Rest Xml Protocol")
 @restXml
 service RestXml {
     version: "2019-12-16",
@@ -18,7 +20,8 @@ service RestXml {
 
         // @httpHeader tests
         InputAndOutputWithHeaders,
-        NullAndEmptyHeaders,
+        NullAndEmptyHeadersClient,
+        NullAndEmptyHeadersServer,
         TimestampFormatHeaders,
 
         // @httpLabel tests


### PR DESCRIPTION
This is a reapplication of fixes in the following PRs from master:

#321
#333
#335 
#349

-----

Fixes several issues with EC2-Query tests

* Adds an aws.api#service trait, sdkId="EC2 Protocol"
* Uses correct Idempotency token property names
* Uses correct Idempotency token test Action names
* Fixes auto-generated idempotency token value
* Fixes list member name capitalization
* Adds missing "/" to a closing XML element

Fixes several issues with the JSON-RPC-1.1 tests

* Fixes service name in several x-amz-target headers
* Fixes an operation name in x-amz-target header
* Removes errant required header when not supplied
* Fixes several [] vs {} discrepancies for empty structures
* Adds missing body for operation that has a response

Fixes several issues with the Query tests

* Adds an aws.api#service trait, sdkId="Query Protocol"
* Fixes several test Action names
* Fixes auto-generated idempotency token value
* Fixes several map/list entry and value counter issues
* Fixes discrepancies with map list member serialized keys
* Adds missing "/" to a closing XML element
* Fixes several xmlName trait discrepancies
* Fixes several result wrapper shape names

Fixes several issues with the Rest-JSON tests

* Adds an aws.api#service trait, sdkId="Rest Json Protocol"
* Fixes several uri discrepancies
* Fixes missing x-amzn-errortype header
* Fixes several header name and value discrepancies
* Fixes several issues where a member indicating a dateTime was
  using a shape of the incorrect format
* Fixes auto-generated idempotency token value
* Fix requiring a param when no content can set it
* Fixes several jsonName trait discrepancies
* Removes header serialized values from bodies
* Fixes issues with label encoding
* Updates NullAndEmptyHeaders tests

Fixes several issues with the Rest-XML tests

* Adds an aws.api#service trait, sdkId="Rest Xml Protocol"
* Fixes several uri discrepancies
* Adds missing "/" to a closing XML element
* Fixes several xmlName trait discrepancies
* Fixes several request root element names
* Fixes several header name and value discrepancies
* Fixes several issues where a member indicating a dateTime was
  using a shape of the incorrect format
* Adds missing ":" to serialized namespace uris
* Fixes auto-generated idempotency token value
* Fixes incorrect default timestamp serialization format
* Fixes issues with label encoding
* Updates NullAndEmptyHeaders tests

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
