### PR TITLE
Clean up and document OpenAPI conversion

### DIFF
--- a/docs/source/spec/aws/amazon-apigateway.rst
+++ b/docs/source/spec/aws/amazon-apigateway.rst
@@ -323,7 +323,7 @@ Summary
     Defines an `API Gateway integration`_ that integrates with an actual
     backend.
 Trait selector
-    ``:test(service, operation)``
+    ``:test(service, resource, operation)``
 Value type
     ``structure``
 See also
@@ -493,7 +493,7 @@ operation within the service.
 Summary
     Defines an `API Gateway integration`_ that returns a mock response.
 Trait selector
-    ``:test(service, operation)``
+    ``:test(service, resource, operation)``
 Value type
     ``structure``
 

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddApiKeySource.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddApiKeySource.java
@@ -15,16 +15,23 @@
 
 package software.amazon.smithy.aws.apigateway.openapi;
 
+import java.util.List;
 import java.util.logging.Logger;
 import software.amazon.smithy.aws.apigateway.traits.ApiKeySourceTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.ListUtils;
 
-final class AddApiKeySource implements OpenApiMapper {
+final class AddApiKeySource implements ApiGatewayMapper {
+
     private static final String EXTENSION_NAME = "x-amazon-apigateway-api-key-source";
     private static final Logger LOGGER = Logger.getLogger(AddApiKeySource.class.getName());
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST, ApiGatewayConfig.ApiType.HTTP);
+    }
 
     @Override
     public OpenApi after(Context<? extends Trait> context, OpenApi openApi) {

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -31,7 +31,6 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveUnusedComponents;
 import software.amazon.smithy.openapi.model.ComponentsObject;
@@ -57,10 +56,16 @@ import software.amazon.smithy.utils.MapUtils;
  * should be picked up and removed by the {@link RemoveUnusedComponents}
  * mapper.
  */
-final class AddAuthorizers implements OpenApiMapper {
+final class AddAuthorizers implements ApiGatewayMapper {
+
     private static final String EXTENSION_NAME = "x-amazon-apigateway-authorizer";
     private static final String CLIENT_EXTENSION_NAME = "x-amazon-apigateway-authtype";
     private static final Logger LOGGER = Logger.getLogger(AddApiKeySource.class.getName());
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST, ApiGatewayConfig.ApiType.HTTP);
+    }
 
     @Override
     public Map<String, List<String>> updateSecurity(

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddBinaryTypes.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddBinaryTypes.java
@@ -30,8 +30,8 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.OptionalUtils;
 
 /**
@@ -41,10 +41,16 @@ import software.amazon.smithy.utils.OptionalUtils;
  * <p>This data is used by API Gateway to determine which content-types do
  * not contain UTF-8 data.
  */
-final class AddBinaryTypes implements OpenApiMapper {
+final class AddBinaryTypes implements ApiGatewayMapper {
+
     private static final Logger LOGGER = Logger.getLogger(AddBinaryTypes.class.getName());
     private static final String EXTENSION_NAME = "x-amazon-apigateway-binary-media-types";
     private static final String DEFAULT_BINARY_TYPE = "application/octet-stream";
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST, ApiGatewayConfig.ApiType.HTTP);
+    }
 
     @Override
     public OpenApi after(Context<? extends Trait> context, OpenApi openApi) {

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
@@ -34,7 +34,6 @@ import software.amazon.smithy.model.traits.CorsTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.OpenApiException;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.OperationObject;
 import software.amazon.smithy.openapi.model.ParameterObject;
@@ -63,11 +62,17 @@ import software.amazon.smithy.utils.ListUtils;
  *
  * @see <a href="https://fetch.spec.whatwg.org/#cors-preflight-fetch-0">CORS-preflight fetch</a>
  */
-final class AddCorsPreflightIntegration implements OpenApiMapper {
+final class AddCorsPreflightIntegration implements ApiGatewayMapper {
+
     private static final Logger LOGGER = Logger.getLogger(AddCorsPreflightIntegration.class.getName());
     private static final String API_GATEWAY_DEFAULT_ACCEPT_VALUE = "application/json";
     private static final String INTEGRATION_EXTENSION = "x-amazon-apigateway-integration";
     private static final String PREFLIGHT_SUCCESS = "{\"statusCode\":200}";
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST);
+    }
 
     @Override
     public PathItem updatePathItem(Context<? extends Trait> context, String path, PathItem pathItem) {

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsResponseHeaders.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsResponseHeaders.java
@@ -23,10 +23,10 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.traits.CorsTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.ParameterObject;
 import software.amazon.smithy.openapi.model.Ref;
 import software.amazon.smithy.openapi.model.ResponseObject;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Adds CORS-specific headers to every response in the API.
@@ -38,8 +38,14 @@ import software.amazon.smithy.openapi.model.ResponseObject;
  * <p>This extension only takes effect if the service being converted to
  * OpenAPI has the CORS trait.
  */
-final class AddCorsResponseHeaders implements OpenApiMapper {
+final class AddCorsResponseHeaders implements ApiGatewayMapper {
+
     private static final Logger LOGGER = Logger.getLogger(AddCorsResponseHeaders.class.getName());
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST);
+    }
 
     @Override
     public ResponseObject updateResponse(

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsToGatewayResponses.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsToGatewayResponses.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.apigateway.openapi;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -26,8 +27,8 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.traits.CorsTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Adds static CORS response headers to API Gateway "gateway" responses.
@@ -42,7 +43,7 @@ import software.amazon.smithy.openapi.model.OpenApi;
  *
  * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-gateway-responses.html">x-amazon-apigateway-gateway-responses Object</a>
  */
-final class AddCorsToGatewayResponses implements OpenApiMapper {
+final class AddCorsToGatewayResponses implements ApiGatewayMapper {
 
     private static final Logger LOGGER = Logger.getLogger(AddCorsToGatewayResponses.class.getName());
 
@@ -63,6 +64,11 @@ final class AddCorsToGatewayResponses implements OpenApiMapper {
     private static final String GATEWAY_RESPONSES_EXTENSION = "x-amazon-apigateway-gateway-responses";
     private static final String HEADER_PREFIX = "gatewayresponse.header.";
     private static final String RESPONSE_PARAMETERS_KEY = "responseParameters";
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST);
+    }
 
     @Override
     public OpenApi after(Context<? extends Trait> context, OpenApi openapi) {

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultConfigSettings.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultConfigSettings.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.List;
+import software.amazon.smithy.openapi.OpenApiConfig;
+
+/**
+ * API Gateway does not allow characters like "_".
+ */
+public final class AddDefaultConfigSettings implements ApiGatewayMapper {
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return null;
+    }
+
+    @Override
+    public void updateDefaultSettings(OpenApiConfig config) {
+        config.setAlphanumericOnlyRefs(true);
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.apigateway.openapi;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -30,8 +31,8 @@ import software.amazon.smithy.model.traits.CorsTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.OpenApiException;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OperationObject;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.Pair;
 
 /**
@@ -44,7 +45,8 @@ import software.amazon.smithy.utils.Pair;
  * a security scheme that needs it, and and Access-Control-Allow-Origin
  * header that is the result of {@link CorsTrait#getOrigin()}.
  */
-final class AddIntegrations implements OpenApiMapper {
+final class AddIntegrations implements ApiGatewayMapper {
+
     private static final Logger LOGGER = Logger.getLogger(AddIntegrations.class.getName());
     private static final String EXTENSION_NAME = "x-amazon-apigateway-integration";
     private static final String RESPONSES_KEY = "responses";
@@ -52,6 +54,11 @@ final class AddIntegrations implements OpenApiMapper {
     private static final String DEFAULT_KEY = "default";
     private static final String STATUS_CODE_KEY = "statusCode";
     private static final String RESPONSE_PARAMETERS_KEY = "responseParameters";
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST, ApiGatewayConfig.ApiType.HTTP);
+    }
 
     @Override
     public OperationObject updateOperation(

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidators.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidators.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.aws.apigateway.openapi;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,9 +25,9 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.openapi.model.OperationObject;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.OptionalUtils;
 
@@ -42,7 +43,8 @@ import software.amazon.smithy.utils.OptionalUtils;
  *
  * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html">Request validators</a>
  */
-final class AddRequestValidators implements OpenApiMapper {
+final class AddRequestValidators implements ApiGatewayMapper {
+
     private static final String REQUEST_VALIDATOR = "x-amazon-apigateway-request-validator";
     private static final String REQUEST_VALIDATORS = "x-amazon-apigateway-request-validators";
     private static final Map<String, Node> KNOWN_VALIDATORS = MapUtils.of(
@@ -55,6 +57,11 @@ final class AddRequestValidators implements OpenApiMapper {
                     .withMember("validateRequestParameters", Node.from(true))
                     .withMember("validateRequestBody", Node.from(true))
     );
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST, ApiGatewayConfig.ApiType.HTTP);
+    }
 
     @Override
     public OperationObject updateOperation(

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayConfig.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayConfig.java
@@ -15,13 +15,48 @@
 
 package software.amazon.smithy.aws.apigateway.openapi;
 
+import java.util.Objects;
+
 /**
  * API Gateway OpenAPI configuration.
  */
 public final class ApiGatewayConfig {
 
+    /**
+     * The type of API Gateway service to generate.
+     */
+    public enum ApiType {
+        /**
+         * Generates an OpenAPI model for an API Gateway "REST" API.
+         *
+         * <p>This is the default type of OpenAPI model to generate when not
+         * specified.
+         *
+         * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html">REST API</a>
+         */
+        REST,
+
+        /**
+         * Generates an OpenAPI model for an API Gateway "HTTP" API.
+         *
+         * <p>This converter does not currently support for HTTP APIs.
+         *
+         * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html">HTTP API</a>
+         */
+        HTTP,
+
+        /**
+         * Disables API Gateway OpenAPI plugins.
+         */
+        DISABLED
+    }
+
+    private ApiType apiGatewayType = ApiType.REST;
     private boolean disableCloudFormationSubstitution;
 
+    /**
+     * @return Returns true if CloudFormation substitutions are disabled.
+     */
     public boolean getDisableCloudFormationSubstitution() {
         return disableCloudFormationSubstitution;
     }
@@ -35,5 +70,23 @@ public final class ApiGatewayConfig {
      */
     public void setDisableCloudFormationSubstitution(boolean disableCloudFormationSubstitution) {
         this.disableCloudFormationSubstitution = disableCloudFormationSubstitution;
+    }
+
+    /**
+     * @return the type of API Gateway API to generate.
+     */
+    public ApiType getApiGatewayType() {
+        return apiGatewayType;
+    }
+
+    /**
+     * Sets the type of API Gateway API to generate.
+     *
+     * <p>If not set, this value defaults to a "REST" API.
+     *
+     * @param apiGatewayType API type to set.
+     */
+    public void setApiGatewayType(ApiType apiGatewayType) {
+        this.apiGatewayType = Objects.requireNonNull(apiGatewayType);
     }
 }

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayExtension.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayExtension.java
@@ -26,15 +26,16 @@ public final class ApiGatewayExtension implements Smithy2OpenApiExtension {
     @Override
     public List<OpenApiMapper> getOpenApiMappers() {
         return ListUtils.of(
-                new AddApiKeySource(),
-                new AddAuthorizers(),
-                new AddBinaryTypes(),
-                new AddIntegrations(),
-                new AddRequestValidators(),
-                new CloudFormationSubstitution(),
-                new AddCorsResponseHeaders(),
-                new AddCorsPreflightIntegration(),
-                new AddCorsToGatewayResponses()
+                ApiGatewayMapper.wrap(new AddDefaultConfigSettings()),
+                ApiGatewayMapper.wrap(new AddApiKeySource()),
+                ApiGatewayMapper.wrap(new AddAuthorizers()),
+                ApiGatewayMapper.wrap(new AddBinaryTypes()),
+                ApiGatewayMapper.wrap(new AddIntegrations()),
+                ApiGatewayMapper.wrap(new AddRequestValidators()),
+                ApiGatewayMapper.wrap(new CloudFormationSubstitution()),
+                ApiGatewayMapper.wrap(new AddCorsResponseHeaders()),
+                ApiGatewayMapper.wrap(new AddCorsPreflightIntegration()),
+                ApiGatewayMapper.wrap(new AddCorsToGatewayResponses())
         );
     }
 

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayMapper.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayMapper.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
+import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.openapi.model.OperationObject;
+import software.amazon.smithy.openapi.model.ParameterObject;
+import software.amazon.smithy.openapi.model.PathItem;
+import software.amazon.smithy.openapi.model.RequestBodyObject;
+import software.amazon.smithy.openapi.model.ResponseObject;
+import software.amazon.smithy.openapi.model.SecurityScheme;
+
+/**
+ * An API Gateway mapper that only applies when the type of API being
+ * converted matches the types of APIs handled by the mapper.
+ */
+public interface ApiGatewayMapper extends OpenApiMapper {
+
+    /**
+     * Gets the types of API Gateway APIs that this mapper applies to.
+     *
+     * <p>Return an empty list or null to apply to all possible API types
+     * other than {@link ApiGatewayConfig.ApiType#DISABLED}. However, note
+     * that it's typically safer to specify the exact API types that the
+     * mapper supports.
+     *
+     * @return Returns the list of API Gateway API types to apply to.
+     */
+    List<ApiGatewayConfig.ApiType> getApiTypes();
+
+    /**
+     * Wraps and delegates to an {@link ApiGatewayMapper} IFF the configured
+     * {@link ApiGatewayConfig.ApiType} matches the types of APIs that the
+     * wrapped mapper applies to.
+     *
+     * @param delegate Mapper to delegate to when it applies to the configured API type.
+     * @return Returns the wrapped mapper.
+     */
+    static OpenApiMapper wrap(ApiGatewayMapper delegate) {
+        return new OpenApiMapper() {
+
+            private boolean matchesApiType(Context<?> context) {
+                return matchesApiType(context.getConfig());
+            }
+
+            private boolean matchesApiType(OpenApiConfig openApiConfig) {
+                ApiGatewayConfig config = openApiConfig.getExtensions(ApiGatewayConfig.class);
+                ApiGatewayConfig.ApiType setting = config.getApiGatewayType();
+
+                // Never apply a mapper if API Gateway mappers are disabled. For
+                // example, if a dependency brings them in on the classpath and that
+                // dependency can't be removed.
+                if (setting == ApiGatewayConfig.ApiType.DISABLED) {
+                    return false;
+                }
+
+                List<ApiGatewayConfig.ApiType> supported = delegate.getApiTypes();
+
+                // Handle the case where the mapper supports any API type.
+                if (supported == null || supported.isEmpty()) {
+                    return true;
+                }
+
+                return supported.contains(setting);
+            }
+
+            @Override
+            public byte getOrder() {
+                return delegate.getOrder();
+            }
+
+            @Override
+            public void updateDefaultSettings(OpenApiConfig config) {
+                if (matchesApiType(config)) {
+                    delegate.updateDefaultSettings(config);
+                }
+            }
+
+            @Override
+            public OperationObject updateOperation(
+                    Context<? extends Trait> context,
+                    OperationShape shape,
+                    OperationObject operation,
+                    String httpMethodName, String path
+            ) {
+                return matchesApiType(context)
+                       ? delegate.updateOperation(context, shape, operation, httpMethodName, path)
+                       : operation;
+            }
+
+            @Override
+            public PathItem updatePathItem(Context<? extends Trait> context, String path, PathItem pathItem) {
+                return matchesApiType(context)
+                       ? delegate.updatePathItem(context, path, pathItem)
+                       : pathItem;
+            }
+
+            @Override
+            public ParameterObject updateParameter(
+                    Context<? extends Trait> context,
+                    OperationShape operation,
+                    String httpMethodName,
+                    String path,
+                    ParameterObject parameterObject
+            ) {
+                return matchesApiType(context)
+                       ? delegate.updateParameter(context, operation, httpMethodName, path, parameterObject)
+                       : parameterObject;
+            }
+
+            @Override
+            public RequestBodyObject updateRequestBody(
+                    Context<? extends Trait> context,
+                    OperationShape operation,
+                    String httpMethodName,
+                    String path,
+                    RequestBodyObject requestBody
+            ) {
+                return matchesApiType(context)
+                       ? delegate.updateRequestBody(context, operation, httpMethodName, path, requestBody)
+                       : requestBody;
+            }
+
+            @Override
+            public ResponseObject updateResponse(
+                    Context<? extends Trait> context,
+                    OperationShape operation,
+                    String status,
+                    String httpMethodName,
+                    String path,
+                    ResponseObject response
+            ) {
+                return matchesApiType(context)
+                       ? delegate.updateResponse(context, operation, status, httpMethodName, path, response)
+                       : response;
+            }
+
+            @Override
+            public void before(Context<? extends Trait> context, OpenApi.Builder builder) {
+                if (matchesApiType(context)) {
+                    delegate.before(context, builder);
+                }
+            }
+
+            @Override
+            public SecurityScheme updateSecurityScheme(
+                    Context<? extends Trait> context,
+                    Trait authTrait,
+                    SecurityScheme securityScheme
+            ) {
+                return matchesApiType(context)
+                       ? delegate.updateSecurityScheme(context, authTrait, securityScheme)
+                       : securityScheme;
+            }
+
+            @Override
+            public Map<String, List<String>> updateSecurity(
+                    Context<? extends Trait> context,
+                    Shape shape,
+                    SecuritySchemeConverter<? extends Trait> converter,
+                    Map<String, List<String>> requirement
+            ) {
+                return matchesApiType(context)
+                       ? delegate.updateSecurity(context, shape, converter, requirement)
+                       : requirement;
+            }
+
+            @Override
+            public OpenApi after(Context<? extends Trait> context, OpenApi openapi) {
+                return matchesApiType(context)
+                       ? delegate.after(context, openapi)
+                       : openapi;
+            }
+
+            @Override
+            public ObjectNode updateNode(Context<? extends Trait> context, OpenApi openapi, ObjectNode node) {
+                return matchesApiType(context)
+                       ? delegate.updateNode(context, openapi, node)
+                       : node;
+            }
+        };
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
@@ -35,13 +35,14 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.Context;
-import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Finds and replaces CloudFormation variables into Fn::Sub intrinsic functions.
  */
-final class CloudFormationSubstitution implements OpenApiMapper {
+final class CloudFormationSubstitution implements ApiGatewayMapper {
+
     private static final Logger LOGGER = Logger.getLogger(CloudFormationSubstitution.class.getName());
     private static final String SUBSTITUTION_KEY = "Fn::Sub";
     private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{.+}");
@@ -61,6 +62,11 @@ final class CloudFormationSubstitution implements OpenApiMapper {
             "paths/*/*/x-amazon-apigateway-integration/connectionId",
             "paths/*/*/x-amazon-apigateway-integration/credentials",
             "paths/*/*/x-amazon-apigateway-integration/uri");
+
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST, ApiGatewayConfig.ApiType.HTTP);
+    }
 
     @Override
     public byte getOrder() {

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CognitoUserPoolsConverter.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CognitoUserPoolsConverter.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.utils.SetUtils;
  * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html">Integrate a REST API with a User Pool </a>
  */
 final class CognitoUserPoolsConverter implements SecuritySchemeConverter<CognitoUserPoolsTrait> {
+
     private static final String AUTH_HEADER = "Authorization";
     private static final Set<String> REQUEST_HEADERS = SetUtils.of(AUTH_HEADER);
     private static final String AUTH_TYPE = "cognito_user_pools";

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddApiKeySourceTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddApiKeySourceTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.equalTo;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 
@@ -32,9 +33,12 @@ public class AddApiKeySourceTest {
                 .addImport(getClass().getResource("api-key-source.json"))
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("example.smithy#MyService"));
+                .convert(model);
         String source = result.getExtension("x-amazon-apigateway-api-key-source")
                 .get()
                 .expectStringNode()

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.openapi.model.SecurityScheme;
@@ -43,9 +44,12 @@ public class AddAuthorizersTest {
                 .addImport(getClass().getResource("authorizers.json"))
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("ns.foo#SomeService"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("ns.foo#SomeService"));
+                .convert(model);
         SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("sigv4");
 
         assertThat(result.getComponents().getSecuritySchemes().get("aws.v4"), nullValue());
@@ -69,9 +73,12 @@ public class AddAuthorizersTest {
                 .addImport(getClass().getResource("basic-authorizers.json"))
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("ns.foo#SomeService"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("ns.foo#SomeService"));
+                .convert(model);
         SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("sigv4");
 
         assertThat(result.getComponents().getSecuritySchemes().get("aws.v4"), nullValue());
@@ -89,9 +96,12 @@ public class AddAuthorizersTest {
                 .addImport(getClass().getResource("custom-auth-type-authorizer.json"))
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("ns.foo#SomeService"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("ns.foo#SomeService"));
+                .convert(model);
         SecurityScheme sigV4 = result.getComponents().getSecuritySchemes().get("sigv4");
 
         assertThat(result.getComponents().getSecuritySchemes().get("aws.v4"), nullValue());
@@ -109,9 +119,12 @@ public class AddAuthorizersTest {
                 .addImport(getClass().getResource("effective-authorizers.smithy"))
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#ServiceA"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("smithy.example#ServiceA"));
+                .convert(model);
 
         // The security of the service is just "foo".
         assertThat(result.getSecurity(), contains(MapUtils.of("foo", ListUtils.of())));

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddBinaryTypesTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddBinaryTypesTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 
@@ -35,9 +36,12 @@ public class AddBinaryTypesTest {
                 .assemble()
                 .unwrap();
 
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("example.smithy#MyService"));
+                .convert(model);
 
         List<String> types = result.getExtension("x-amazon-apigateway-binary-media-types")
                 .get()

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultConfigSettingsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultConfigSettingsTest.java
@@ -1,0 +1,34 @@
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.NodePointer;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+
+public class AddDefaultConfigSettingsTest {
+    @Test
+    public void addsDefaultConfigSettings() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("alphanumeric-only.json"))
+                .assemble()
+                .unwrap();
+
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+
+        // Ensure that Foo_Baz became FooBaz.
+        NodePointer pointer = NodePointer.parse("/components/schemas/FooBaz");
+        assertThat(pointer.getValue(result), not(Optional.empty()));
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrationsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrationsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
@@ -31,7 +32,9 @@ public class AddIntegrationsTest {
                 .addImport(getClass().getResource("integrations.json"))
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("integrations.openapi.json")));
 
@@ -45,7 +48,9 @@ public class AddIntegrationsTest {
                               .addImport(getClass().getResource("integrations-without-credentials.json"))
                               .assemble()
                               .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("integrations-without-credentials.openapi.json")));
 

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidatorsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidatorsTest.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 
@@ -38,9 +39,12 @@ public class AddRequestValidatorsTest {
                 .assemble()
                 .unwrap();
 
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convert(model, ShapeId.from("smithy.example#Service"));
+                .convert(model);
 
         assertThat(result.getExtension("x-amazon-apigateway-request-validator").get(), equalTo(Node.from("full")));
         ObjectNode validators = result.getExtension("x-amazon-apigateway-request-validators").get().expectObjectNode();

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayMapperTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayMapperTest.java
@@ -1,0 +1,47 @@
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+
+public class ApiGatewayMapperTest {
+
+    @Test
+    public void onlyCallsMappersWhenApiTypeMatches() {
+        Model model = Model.assembler(getClass().getClassLoader())
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("cors-model.json"))
+                .assemble()
+                .unwrap();
+
+        runTest(model, ApiGatewayConfig.ApiType.REST, true);
+        runTest(model, ApiGatewayConfig.ApiType.DISABLED, false);
+        runTest(model, ApiGatewayConfig.ApiType.HTTP, false);
+    }
+
+    private void runTest(Model model, ApiGatewayConfig.ApiType type, boolean present) {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
+        ApiGatewayConfig apiGatewayConfig = new ApiGatewayConfig();
+        apiGatewayConfig.setApiGatewayType(type);
+        config.putExtensions(apiGatewayConfig);
+
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+
+        if (present) {
+            assertThat(result.getMember("x-amazon-apigateway-gateway-responses"), not(Optional.empty()));
+        } else {
+            assertThat(result.getMember("x-amazon-apigateway-gateway-responses"), equalTo(Optional.empty()));
+        }
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
@@ -36,10 +36,12 @@ public class CloudFormationSubstitutionTest {
         ObjectNode expected = Node.parse(
                 IoUtils.readUtf8File(getClass().getResource("substitution-performed.json").getPath()))
                 .expectObjectNode();
-
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
         ObjectNode actual = OpenApiConverter.create()
+                .config(config)
                 .classLoader(getClass().getClassLoader())
-                .convertToNode(model, ShapeId.from("example.smithy#MyService"));
+                .convertToNode(model);
 
         Node.assertEquals(actual, expected);
     }
@@ -57,6 +59,7 @@ public class CloudFormationSubstitutionTest {
                 .expectObjectNode();
 
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
         ApiGatewayConfig apiGatewayConfig = new ApiGatewayConfig();
         apiGatewayConfig.setDisableCloudFormationSubstitution(true);
         config.putExtensions(apiGatewayConfig);
@@ -64,7 +67,7 @@ public class CloudFormationSubstitutionTest {
         ObjectNode actual = OpenApiConverter.create()
                 .classLoader(getClass().getClassLoader())
                 .config(config)
-                .convertToNode(model, ShapeId.from("example.smithy#MyService"));
+                .convertToNode(model);
 
         Node.assertEquals(expected, actual);
     }

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CognitoUserPoolsConverterTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CognitoUserPoolsConverterTest.java
@@ -6,6 +6,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.validation.ValidatedResultException;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
@@ -18,7 +19,9 @@ public class CognitoUserPoolsConverterTest {
                 .addImport(getClass().getResource("cognito-user-pools-security.json"))
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("cognito-user-pools-security.openapi.json")));
 
@@ -33,7 +36,9 @@ public class CognitoUserPoolsConverterTest {
                     .addImport(getClass().getResource("invalid-cognito-user-pools-security.json"))
                     .assemble()
                     .unwrap();
-            OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#Service"));
+            OpenApiConverter.create().config(config).convert(model);
         });
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CorsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CorsTest.java
@@ -5,6 +5,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
@@ -19,7 +20,9 @@ public class CorsTest {
                 .addImport(getClass().getResource("cors-model.json"))
                 .assemble()
                 .unwrap();
-        ObjectNode result = OpenApiConverter.create().convertToNode(model, ShapeId.from("example.smithy#MyService"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
+        ObjectNode result = OpenApiConverter.create().config(config).convertToNode(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("cors-model.openapi.json")));
 
@@ -33,7 +36,9 @@ public class CorsTest {
                 .addImport(getClass().getResource("cors-explicit-options.json"))
                 .assemble()
                 .unwrap();
-        ObjectNode result = OpenApiConverter.create().convertToNode(model, ShapeId.from("example.smithy#MyService"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
+        ObjectNode result = OpenApiConverter.create().config(config).convertToNode(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("cors-explicit-options.openapi.json")));
 
@@ -57,8 +62,12 @@ public class CorsTest {
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("cors-with-custom-gateway-response-headers.openapi.json")));
 
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
+
         // Create an OpenAPI model.
         ObjectNode result = OpenApiConverter.create()
+                .config(config)
                 .addOpenApiMapper(new OpenApiMapper() {
                     @Override
                     public byte getOrder() {
@@ -79,7 +88,7 @@ public class CorsTest {
                                 .build();
                     }
                 })
-                .convertToNode(model, ShapeId.from("example.smithy#MyService"));
+                .convertToNode(model);
 
         Node.assertEquals(result, expectedNode);
     }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/alphanumeric-only.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/alphanumeric-only.json
@@ -1,0 +1,43 @@
+{
+    "smithy": "1.0.0",
+    "shapes": {
+        "example.smithy#MyService": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "example.smithy#GetPayload"
+                }
+            ],
+            "traits": {
+                "aws.protocols#restJson1": {},
+                "smithy.api#httpBasicAuth": {}
+            }
+        },
+        "example.smithy#GetPayload": {
+            "type": "operation",
+            "output": {
+                "target": "example.smithy#GetPayloadOutput"
+            },
+            "traits": {
+                "smithy.api#readonly": true,
+                "smithy.api#http": {
+                    "uri": "/test",
+                    "method": "GET"
+                }
+            }
+        },
+        "example.smithy#GetPayloadOutput": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "example.smithy#Foo_Baz"
+                }
+            }
+        },
+        "example.smithy#Foo_Baz": {
+            "type": "structure",
+            "members": {}
+        }
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiMapper.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.openapi.model.OperationObject;
 import software.amazon.smithy.openapi.model.ParameterObject;
@@ -54,6 +55,18 @@ public interface OpenApiMapper {
     default byte getOrder() {
         return 0;
     }
+
+    /**
+     * Sets default values on the OpenAPI configuration object.
+     *
+     * <p>Use this method <strong>and not {@link #before}</strong>
+     * to add default settings. Adding default settings in before()
+     * is possible, but might be too late in the process for those
+     * configuration changes to take effect.
+     *
+     * @param config Configuration object to modify.
+     */
+    default void updateDefaultSettings(OpenApiConfig config) {}
 
     /**
      * Updates an operation.
@@ -230,6 +243,13 @@ public interface OpenApiMapper {
         sorted.sort(Comparator.comparingInt(OpenApiMapper::getOrder));
 
         return new OpenApiMapper() {
+            @Override
+            public void updateDefaultSettings(OpenApiConfig config) {
+                for (OpenApiMapper plugin : sorted) {
+                    plugin.updateDefaultSettings(config);
+                }
+            }
+
             @Override
             public OperationObject updateOperation(
                     Context<? extends Trait> context,

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApi.java
@@ -20,7 +20,6 @@ import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.openapi.OpenApiConfig;
-import software.amazon.smithy.openapi.OpenApiException;
 
 /**
  * Converts Smithy to an OpenAPI model and saves it as a JSON file.
@@ -43,12 +42,7 @@ public final class Smithy2OpenApi implements SmithyBuildPlugin {
         context.getPluginClassLoader().ifPresent(converter::classLoader);
         OpenApiConfig config = OpenApiConfig.fromNode(context.getSettings());
         ShapeId shapeId = config.getService();
-
-        if (shapeId == null) {
-            throw new OpenApiException(getName() + " is missing required property, `service`");
-        }
-
-        ObjectNode openApiNode = converter.convertToNode(context.getModel(), shapeId);
+        ObjectNode openApiNode = converter.convertToNode(context.getModel());
         context.getFileManifest().writeJson(shapeId.getName() + ".openapi.json", openApiNode);
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConfigTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConfigTest.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.openapi.fromsmithy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -42,5 +43,16 @@ public class OpenApiConfigTest {
 
         assertThat(config.getTags(), equalTo(true));
         assertThat(config.getIgnoreUnsupportedTraits(), equalTo(true));
+    }
+
+    @Test
+    public void putsAdditionalPropertiesInExtensions() {
+        Node mappedTest = Node.objectNode()
+                .withMember("tags", true)
+                .withMember("apiGatewayType", "REST");
+        OpenApiConfig config = OpenApiConfig.fromNode(mappedTest);
+
+        assertThat(config.getTags(), equalTo(true));
+        assertThat(config.getExtensions().getStringMap(), hasKey("apiGatewayType"));
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -58,8 +58,11 @@ public class OpenApiConverterTest {
 
     @Test
     public void convertsModelsToOpenApi() {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.rest#RestService"));
         ObjectNode result = OpenApiConverter.create()
-                .convertToNode(testService, ShapeId.from("example.rest#RestService"));
+                .config(config)
+                .convertToNode(testService);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("test-service.openapi.json")));
 
@@ -74,11 +77,12 @@ public class OpenApiConverterTest {
                 .assemble()
                 .unwrap();
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         config.setTags(true);
         config.setSupportedTags(ListUtils.of("baz", "foo"));
         OpenApi result = OpenApiConverter.create()
                 .config(config)
-                .convert(model, ShapeId.from("smithy.example#Service"));
+                .convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("tagged-service.openapi.json")));
 
@@ -93,8 +97,11 @@ public class OpenApiConverterTest {
                     .discoverModels()
                     .assemble()
                     .unwrap();
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#Service"));
             OpenApiConverter.create()
-                    .convert(model, ShapeId.from("smithy.example#Service"));
+                    .config(config)
+                    .convert(model);
         });
 
         assertThat(thrown.getMessage(), containsString("does not define any protocols"));
@@ -108,8 +115,11 @@ public class OpenApiConverterTest {
                     .discoverModels()
                     .assemble()
                     .unwrap();
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#Service"));
             OpenApiConverter.create()
-                    .convert(model, ShapeId.from("smithy.example#Service"));
+                    .config(config)
+                    .convert(model);
         });
 
         assertThat(thrown.getMessage(), containsString("Unable to find an OpenAPI service provider"));
@@ -118,10 +128,11 @@ public class OpenApiConverterTest {
     @Test
     public void loadsProtocolFromConfiguration() {
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.rest#RestService"));
         config.setProtocol(ShapeId.from("aws.protocols#restJson1"));
         ObjectNode result = OpenApiConverter.create()
                 .config(config)
-                .convertToNode(testService, ShapeId.from("example.rest#RestService"));
+                .convertToNode(testService);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("test-service.openapi.json")));
 
@@ -136,8 +147,11 @@ public class OpenApiConverterTest {
                     .discoverModels()
                     .assemble()
                     .unwrap();
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#Service"));
             OpenApiConverter.create()
-                    .convert(model, ShapeId.from("smithy.example#Service"));
+                    .config(config)
+                    .convert(model);
         });
 
         assertThat(thrown.getMessage(), containsString("defines multiple protocols"));
@@ -147,10 +161,11 @@ public class OpenApiConverterTest {
     public void failsWhenConfiguredProtocolIsNoFound() {
         Exception thrown = Assertions.assertThrows(OpenApiException.class, () -> {
             OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("example.rest#RestService"));
             config.setProtocol(ShapeId.from("aws.protocols#restJson99"));
             OpenApiConverter.create()
                     .config(config)
-                    .convertToNode(testService, ShapeId.from("example.rest#RestService"));
+                    .convertToNode(testService);
         });
 
         assertThat(thrown.getMessage(), containsString("Unable to find protocol"));
@@ -163,7 +178,9 @@ public class OpenApiConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("unsupported-http-method.openapi.json")));
 
@@ -177,8 +194,11 @@ public class OpenApiConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         OpenApi result = OpenApiConverter.create()
-                .convert(model, ShapeId.from("smithy.example#Service"));
+                .config(config)
+                .convert(model);
 
         for (PathItem pathItem : result.getPaths().values()) {
             Assertions.assertFalse(pathItem.getGet().isPresent());
@@ -199,7 +219,9 @@ public class OpenApiConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
 
         assertThat(result.getPaths().get("/").getGet().get().getResponses().values(), not(empty()));
     }
@@ -211,7 +233,9 @@ public class OpenApiConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("mixed-security-service.openapi.json")));
 
@@ -236,9 +260,12 @@ public class OpenApiConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         OpenApi result = OpenApiConverter.create()
                 .addOpenApiMapper(new NullSecurity())
-                .convert(model, ShapeId.from("smithy.example#Service"));
+                .config(config)
+                .convert(model);
 
         assertThat(result.getSecurity(), empty());
         assertThat(result.getPaths().get("/2").getGet().get().getSecurity().orElse(Collections.emptyList()), empty());
@@ -262,9 +289,12 @@ public class OpenApiConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         OpenApi result = OpenApiConverter.create()
                 .addOpenApiMapper(new ConstantSecurity())
-                .convert(model, ShapeId.from("smithy.example#Service"));
+                .config(config)
+                .convert(model);
 
         assertThat(result.getSecurity().get(0).keySet(), contains("foo_baz"));
         assertThat(result.getPaths().get("/2").getGet().get().getSecurity().get().get(0).keySet(), contains("foo_baz"));
@@ -273,10 +303,11 @@ public class OpenApiConverterTest {
     @Test
     public void mergesInSchemaDocumentExtensions() {
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.rest#RestService"));
         config.setSchemaDocumentExtensions(Node.objectNode().withMember("foo", "baz"));
         ObjectNode result = OpenApiConverter.create()
                 .config(config)
-                .convertToNode(testService, ShapeId.from("example.rest#RestService"));
+                .convertToNode(testService);
 
         assertThat(result.getMember("foo"), equalTo(Optional.of(Node.from("baz"))));
     }
@@ -290,13 +321,32 @@ public class OpenApiConverterTest {
                 .assemble()
                 .unwrap();
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Streaming"));
         config.setProtocol(ShapeId.from("aws.protocols#restJson1"));
         ObjectNode result = OpenApiConverter.create()
                 .config(config)
-                .convertToNode(model, ShapeId.from("smithy.example#Streaming"));
+                .convertToNode(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("streaming-service.openapi.json")));
 
         Node.assertEquals(result, expectedNode);
+    }
+
+    @Test
+    public void addsDefaultSettings() {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.rest#RestService"));
+        config.setSchemaDocumentExtensions(Node.objectNode().withMember("foo", "baz"));
+        OpenApiConverter.create()
+                .addOpenApiMapper(new OpenApiMapper() {
+                    @Override
+                    public void updateDefaultSettings(OpenApiConfig config) {
+                        config.putExtension("hello", "goodbye");
+                    }
+                })
+                .config(config)
+                .convertToNode(testService);
+
+        assertThat(config.getExtensions().getMember("hello"), not(Optional.empty()));
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForGreedyLabelsTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForGreedyLabelsTest.java
@@ -29,18 +29,21 @@ public class CheckForGreedyLabelsTest {
 
     @Test
     public void logsInsteadOfThrows() {
-        OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Greedy"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Greedy"));
+        OpenApiConverter.create().config(config).convert(model);
     }
 
     @Test
     public void keepsUnusedSchemas() {
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Greedy"));
         config.setForbidGreedyLabels(true);
 
         Exception thrown = Assertions.assertThrows(OpenApiException.class, () -> {
             OpenApiConverter.create()
                     .config(config)
-                    .convert(model, ShapeId.from("smithy.example#Greedy"));
+                    .convert(model);
         });
 
         Assertions.assertTrue(thrown.getMessage().contains("greedy"));

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForPrefixHeadersTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForPrefixHeadersTest.java
@@ -30,16 +30,19 @@ public class CheckForPrefixHeadersTest {
     @Test
     public void canIgnorePrefixHeaders() {
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#PrefixHeaders"));
         config.setOnHttpPrefixHeaders(OpenApiConfig.HttpPrefixHeadersStrategy.WARN);
         OpenApiConverter.create()
                 .config(config)
-                .convert(model, ShapeId.from("smithy.example#PrefixHeaders"));
+                .convert(model);
     }
 
     @Test
     public void throwsOnPrefixHeadersByDefault() {
         Exception thrown = Assertions.assertThrows(OpenApiException.class, () -> {
-            OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#PrefixHeaders"));
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#PrefixHeaders"));
+            OpenApiConverter.create().config(config).convert(model);
         });
 
         Assertions.assertTrue(thrown.getMessage().contains("httpPrefixHeaders"));

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAddTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAddTest.java
@@ -44,11 +44,12 @@ public class OpenApiJsonAddTest {
                 .build();
 
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         config.setJsonAdd(addNode.getStringMap());
 
         ObjectNode openApi = OpenApiConverter.create()
                 .config(config)
-                .convertToNode(model, ShapeId.from("smithy.example#Service"));
+                .convertToNode(model);
 
         String description = NodePointer.parse("/info/description").getValue(openApi).expectStringNode().getValue();
         String infoFoo = NodePointer.parse("/info/foo").getValue(openApi).expectStringNode().getValue();

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonSubstitutionsPluginTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonSubstitutionsPluginTest.java
@@ -35,10 +35,11 @@ public class OpenApiJsonSubstitutionsPluginTest {
                 .unwrap();
 
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         config.setSubstitutions(MapUtils.of("SUB_HELLO", Node.from("hello")));
         ObjectNode openApi = OpenApiConverter.create()
                 .config(config)
-                .convertToNode(model, ShapeId.from("smithy.example#Service"));
+                .convertToNode(model);
         String description = openApi.getObjectMember("info").get().getStringMember("description").get().getValue();
 
         Assertions.assertEquals("hello", description);

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponentsTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponentsTest.java
@@ -32,7 +32,9 @@ public class RemoveUnusedComponentsTest {
 
     @Test
     public void removesUnusedSchemas() {
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Small"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Small"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
 
         Assertions.assertTrue(result.getComponents().getSchemas().isEmpty());
     }
@@ -40,10 +42,11 @@ public class RemoveUnusedComponentsTest {
     @Test
     public void keepsUnusedSchemas() {
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Small"));
         config.setKeepUnusedComponents(true);
         OpenApi result = OpenApiConverter.create()
                 .config(config)
-                .convert(model, ShapeId.from("smithy.example#Small"));
+                .convert(model);
 
         // The input structure remains in the output even though it's unreferenced.
         Assertions.assertFalse(result.getComponents().getSchemas().isEmpty());
@@ -51,7 +54,11 @@ public class RemoveUnusedComponentsTest {
 
     @Test
     public void removesUnusedSchemes() {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Small"));
+
         OpenApi result = OpenApiConverter.create()
+                .config(config)
                 .addOpenApiMapper(new OpenApiMapper() {
                     @Override
                     public OpenApi after(Context context, OpenApi openapi) {
@@ -62,7 +69,7 @@ public class RemoveUnusedComponentsTest {
                                 .build();
                     }
                 })
-                .convert(model, ShapeId.from("smithy.example#Small"));
+                .convert(model);
 
         Assertions.assertFalse(result.getComponents().getSecuritySchemes().keySet().contains("foo"));
     }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraitsPluginTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/UnsupportedTraitsPluginTest.java
@@ -30,16 +30,19 @@ public class UnsupportedTraitsPluginTest {
     @Test
     public void logsWhenUnsupportedTraitsAreFound() {
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#EndpointService"));
         config.setIgnoreUnsupportedTraits(true);
         OpenApiConverter.create()
                 .config(config)
-                .convert(model, ShapeId.from("smithy.example#EndpointService"));
+                .convert(model);
     }
 
     @Test
     public void throwsWhenUnsupportedTraitsAreFound() {
         Exception thrown = Assertions.assertThrows(OpenApiException.class, () -> {
-            OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#EndpointService"));
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#EndpointService"));
+            OpenApiConverter.create().config(config).convert(model);
         });
 
         Assertions.assertTrue(thrown.getMessage().contains("endpoint"));

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -37,8 +37,11 @@ public class AwsRestJson1ProtocolTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         ObjectNode result = OpenApiConverter.create()
-                .convertToNode(model, ShapeId.from("smithy.example#Service"));
+                .config(config)
+                .convertToNode(model);
         String openApiModel = smithy.replace(".json", ".openapi.json");
         InputStream openApiStream = getClass().getResourceAsStream(openApiModel);
 
@@ -58,10 +61,11 @@ public class AwsRestJson1ProtocolTest {
                 .assemble()
                 .unwrap();
         OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
         config.setJsonContentType("application/x-amz-json-1.0");
         OpenApi result = OpenApiConverter.create()
                 .config(config)
-                .convert(model, ShapeId.from("smithy.example#Service"));
+                .convert(model);
 
         Assertions.assertTrue(Node.printJson(result.toNode()).contains("application/x-amz-json-1.0"));
     }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4ConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/AwsV4ConverterTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
@@ -16,7 +17,9 @@ public class AwsV4ConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("awsv4-security.openapi.json")));
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpApiKeyAuthConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpApiKeyAuthConverterTest.java
@@ -8,6 +8,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
@@ -20,7 +21,9 @@ public class HttpApiKeyAuthConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("http-api-key-security.openapi.json")));
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasicConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasicConverterTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
@@ -16,7 +17,9 @@ public class HttpBasicConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("http-basic-security.openapi.json")));
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigestConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigestConverterTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
@@ -16,7 +17,9 @@ public class HttpDigestConverterTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("http-digest-security.openapi.json")));
 


### PR DESCRIPTION
- Filled in lots of details in OpenAPI docs
- Added apiGatewayType to filter mappers based on the kind of API being
  created.
- Added filtering to API Gateway OpenAPI mappers based on apiGatewayType
  using a decorator.
- Extensions now are loaded at the top-level in JSON schema
  configuration in a flat keyspace
- Added a missing feature in the API Gateway converter that forced the
  used of alphanumeric JSON schema type names.
- Added the ability to inject default configuration settings in OpenAPI
  mappers prior to using the configuration. This allowed injecting the
  default alphanumeric properties value.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
