### PR TITLE
Fix event stream json example

### DIFF
--- a/docs/source/spec/core/stream-traits.rst
+++ b/docs/source/spec/core/stream-traits.rst
@@ -233,7 +233,7 @@ stream in its output:
                     "type": "structure",
                     "members": {
                         "movements": {
-                            "target": "smithy.example#Message"
+                            "target": "smithy.example#MovementEvents"
                         }
                     }
                 },


### PR DESCRIPTION
Fix target shape id on event stream output json example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
