### PR TITLE
Convert options to text

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -60,6 +60,7 @@ final class AddAuthorizers implements ApiGatewayMapper {
 
     private static final String EXTENSION_NAME = "x-amazon-apigateway-authorizer";
     private static final String CLIENT_EXTENSION_NAME = "x-amazon-apigateway-authtype";
+    private static final String DEFAULT_AUTH_TYPE = "custom";
     private static final Logger LOGGER = Logger.getLogger(AddApiKeySource.class.getName());
 
     @Override
@@ -130,7 +131,7 @@ final class AddAuthorizers implements ApiGatewayMapper {
         OpenApi.Builder builder = openApi.toBuilder();
         ComponentsObject.Builder components = openApi.getComponents().toBuilder();
 
-        for (Map.Entry<String, AuthorizerDefinition> entry : trait.getAllAuthorizers().entrySet()) {
+        for (Map.Entry<String, AuthorizerDefinition> entry : trait.getAuthorizers().entrySet()) {
             String authorizerName = entry.getKey();
             AuthorizerDefinition authorizer = entry.getValue();
             ShapeId scheme = entry.getValue().getScheme();
@@ -166,7 +167,7 @@ final class AddAuthorizers implements ApiGatewayMapper {
         T authTrait = context.getService().expectTrait(converter.getAuthSchemeType());
         SecurityScheme createdScheme = converter.createSecurityScheme(context, authTrait);
         SecurityScheme.Builder schemeBuilder = createdScheme.toBuilder();
-        schemeBuilder.putExtension(CLIENT_EXTENSION_NAME, authorizer.getAuthType());
+        schemeBuilder.putExtension(CLIENT_EXTENSION_NAME, authorizer.getCustomAuthType().orElse(DEFAULT_AUTH_TYPE));
 
         ObjectNode authorizerNode = Node.objectNodeBuilder()
                 .withOptionalMember("type", authorizer.getType().map(Node::from))

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
@@ -202,6 +202,8 @@ final class AddCorsPreflightIntegration implements ApiGatewayMapper {
         }
 
         MockIntegrationTrait.Builder integration = MockIntegrationTrait.builder()
+                // See https://forums.aws.amazon.com/thread.jspa?threadID=256140
+                .contentHandling("CONVERT_TO_TEXT")
                 .passThroughBehavior("when_no_match")
                 .putResponse("default", responseBuilder.build())
                 .putRequestTemplate(API_GATEWAY_DEFAULT_ACCEPT_VALUE, PREFLIGHT_SUCCESS);

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -84,6 +84,7 @@
         ],
         "x-amazon-apigateway-integration": {
           "passThroughBehavior": "when_no_match",
+          "contentHandling": "CONVERT_TO_TEXT",
           "requestTemplates": {
             "application/json": "{\"statusCode\":200}"
           },
@@ -252,6 +253,7 @@
         ],
         "x-amazon-apigateway-integration": {
           "passThroughBehavior": "when_no_match",
+          "contentHandling": "CONVERT_TO_TEXT",
           "requestTemplates": {
             "application/json": "{\"statusCode\":200}",
             "application/octet-stream": "{\"statusCode\":200}"

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
@@ -60,9 +61,10 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            NodeMapper mapper = new NodeMapper();
             Builder builder = builder().sourceLocation(value);
             value.expectObjectNode().getMembers().forEach((key, node) -> {
-                AuthorizerDefinition authorizer = AuthorizerDefinition.fromNode(node.expectObjectNode());
+                AuthorizerDefinition authorizer = mapper.deserialize(node, AuthorizerDefinition.class);
                 builder.putAuthorizer(key.getValue(), authorizer);
             });
             return builder.build();
@@ -93,7 +95,7 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
      *
      * @return Returns the authorizers.
      */
-    public Map<String, AuthorizerDefinition> getAllAuthorizers() {
+    public Map<String, AuthorizerDefinition> getAuthorizers() {
         return authorizers;
     }
 

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTraitValidator.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTraitValidator.java
@@ -46,7 +46,7 @@ public class AuthorizersTraitValidator extends AbstractValidator {
 
         // Create a comma separated string of authorizer names to schemes.
         String invalidMappings = service.getTrait(AuthorizersTrait.class)
-                .map(AuthorizersTrait::getAllAuthorizers)
+                .map(AuthorizersTrait::getAuthorizers)
                 .orElseGet(HashMap::new)
                 .entrySet().stream()
                 .filter(entry -> !authSchemes.contains(entry.getValue().getScheme()))

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -290,7 +290,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
      * @return Returns the request parameters.
      * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-requestParameters.html">Request parameters</a>
      */
-    public Map<String, String> getAllRequestParameters() {
+    public Map<String, String> getRequestParameters() {
         return requestParameters;
     }
 
@@ -310,7 +310,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
      * @return Returns a map of MIME types to request templates.
      * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-requestTemplates.html">Request templates</a>
      */
-    public Map<String, String> getAllRequestTemplates() {
+    public Map<String, String> getRequestTemplates() {
         return requestTemplates;
     }
 
@@ -330,7 +330,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
      * @return Returns a map of status code regular expressions to responses.
      * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-responses.html">Integration responses</a>
      */
-    public Map<String, IntegrationResponse> getAllResponses() {
+    public Map<String, IntegrationResponse> getResponses() {
         return responses;
     }
 
@@ -409,7 +409,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
+        return builder()
                 .type(type)
                 .uri(uri)
                 .credentials(credentials)
@@ -419,12 +419,11 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
                 .timeoutInMillis(timeoutInMillis)
                 .connectionId(connectionId)
                 .connectionType(connectionType)
-                .cacheNamespace(cacheNamespace);
-        cacheKeyParameters.forEach(builder::addCacheKeyParameter);
-        requestParameters.forEach(builder::putRequestParameter);
-        requestTemplates.forEach(builder::putRequestTemplate);
-        responses.forEach(builder::putResponse);
-        return builder;
+                .cacheNamespace(cacheNamespace)
+                .requestParameters(requestParameters)
+                .requestTemplates(requestTemplates)
+                .responses(responses)
+                .cacheKeyParameters(cacheKeyParameters);
     }
 
     public static final class Builder extends AbstractTraitBuilder<IntegrationTrait, Builder> {
@@ -515,7 +514,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
          *     utf-8-encoded string or passing through the text payload natively
          *     without modification</li>
          *     <li>CONVERT_TO_BINARY, for converting a text payload into
-         *     Base64-decoded blobor passing through a binary payload natively
+         *     Base64-decoded blob or passing through a binary payload natively
          *     without modification.</li>
          * </ul>
          *
@@ -586,6 +585,18 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         }
 
         /**
+         * Sets a list of request parameters whose values are to be cached.
+         *
+         * @param cacheKeyParameters Parameters to use in the cache.
+         * @return Returns the builder.
+         */
+        public Builder cacheKeyParameters(List<String> cacheKeyParameters) {
+            this.cacheKeyParameters.clear();
+            this.cacheKeyParameters.addAll(cacheKeyParameters);
+            return this;
+        }
+
+        /**
          * Removes a specific cache key parameter.
          *
          * @param cacheKeyParameter Parameter to remove.
@@ -607,15 +618,28 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         }
 
         /**
-         * Adds a request template.
+         * Adds a request parameter.
          *
          * @param input Input request expression.
          * @param output Output request expression.
          * @return Returns the builder.
-         * @see IntegrationTrait#getAllRequestParameters()
+         * @see IntegrationTrait#getRequestParameters()
          */
         public Builder putRequestParameter(String input, String output) {
             requestParameters.put(input, output);
+            return this;
+        }
+
+        /**
+         * Sets request parameters.
+         *
+         * @param requestParameters Map of parameters to add.
+         * @return Returns the builder.
+         * @see IntegrationTrait#getRequestParameters()
+         */
+        public Builder requestParameters(Map<String, String> requestParameters) {
+            this.requestParameters.clear();
+            this.requestParameters.putAll(requestParameters);
             return this;
         }
 
@@ -636,10 +660,23 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
          * @param mimeType MIME type of the request template to set.
          * @param template Request template to set.
          * @return Returns the builder.
-         * @see IntegrationTrait#getAllRequestTemplates()
+         * @see IntegrationTrait#getRequestTemplates()
          */
         public Builder putRequestTemplate(String mimeType, String template) {
             requestTemplates.put(mimeType, template);
+            return this;
+        }
+
+        /**
+         * Sets request templates.
+         *
+         * @param requestTemplates Map of MIME types to the corresponding template.
+         * @return Returns the builder.
+         * @see IntegrationTrait#getRequestTemplates()
+         */
+        public Builder requestTemplates(Map<String, String> requestTemplates) {
+            this.requestTemplates.clear();
+            this.requestTemplates.putAll(requestTemplates);
             return this;
         }
 
@@ -660,10 +697,23 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
          * @param statusCodeRegex Status code regular expression.
          * @param integrationResponse Integration response to set.
          * @return Returns the builder.
-         * @see IntegrationTrait#getAllResponses()
+         * @see IntegrationTrait#getResponses()
          */
         public Builder putResponse(String statusCodeRegex, IntegrationResponse integrationResponse) {
             responses.put(statusCodeRegex, integrationResponse);
+            return this;
+        }
+
+        /**
+         * Sets responses for the given response regular expressions.
+         *
+         * @param responses Map of regular expressions to responses.
+         * @return Returns the builder.
+         * @see IntegrationTrait#getResponses()
+         */
+        public Builder responses(Map<String, IntegrationResponse> responses) {
+            this.responses.clear();
+            this.responses.putAll(responses);
             return this;
         }
 

--- a/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -58,7 +58,7 @@
                 "customAuthType": {
                     "target": "smithy.api#String",
                     "traits": {
-                        "smithy.api#documentation": "This value is not used directly by APIGateway but will be used for OpenAPI exports. This will default to \"awsSigV4\" if your scheme is \"aws.v4\", or \"custom\" otherwise."
+                        "smithy.api#documentation": "This value is not used directly by API Gateway but will be used for OpenAPI exports. This will default to \"awsSigV4\" if your scheme is \"aws.v4\", or \"custom\" otherwise."
                     }
                 },
                 "uri": {

--- a/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitTest.java
+++ b/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class IntegrationTraitTest {
@@ -40,20 +39,8 @@ public class IntegrationTraitTest {
                 .build();
 
         assertThat(trait.toBuilder().build(), equalTo(trait));
-    }
-
-    @Test
-    public void loadsTraitFromModel() {
-        Model model = Model.assembler()
-                .discoverModels(getClass().getClassLoader())
-                .addImport(TestRunnerTest.class.getResource("errorfiles/valid-integration.json"))
-                .assemble()
-                .unwrap();
-
-        MockIntegrationTrait trait = model.expectShape(ShapeId.from("ns.foo#Operation"))
-                .getTrait(MockIntegrationTrait.class)
-                .get();
-
-        assertThat(trait.toBuilder().build(), equalTo(trait));
+        // Test round-tripping from/to node.
+        assertThat(new IntegrationTrait.Provider().createTrait(ShapeId.from("ns.foo#Operation"), trait.toNode()),
+                   equalTo(trait));
     }
 }

--- a/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTraitTest.java
+++ b/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTraitTest.java
@@ -19,15 +19,46 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 public class MockIntegrationTraitTest {
     @Test
     public void loadsValidTrait() {
         MockIntegrationTrait trait = MockIntegrationTrait.builder()
+                .contentHandling("CONVERT_TO_TEXT")
                 .passThroughBehavior("when_no_templates")
                 .putRequestParameter("x", "y")
+                .putRequestTemplate("application/json", "{}")
+                .putRequestParameter("foo", "baz")
+                .putResponse("[A-Z]+", IntegrationResponse.builder()
+                        .statusCode("200")
+                        .contentHandling("CONVERT_TO_TEXT")
+                        .build())
                 .build();
 
         assertThat(trait.toBuilder().build(), equalTo(trait));
+        // Test round-tripping from/to node.
+        assertThat(new MockIntegrationTrait.Provider().createTrait(ShapeId.from("com.foo#Baz"), trait.toNode()),
+                   equalTo(trait));
+    }
+
+    @Test
+    public void loadsTraitFromModel() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(TestRunnerTest.class.getResource("errorfiles/valid-integration.json"))
+                .assemble()
+                .unwrap();
+
+        MockIntegrationTrait trait = model.expectShape(ShapeId.from("ns.foo#Operation"))
+                .getTrait(MockIntegrationTrait.class)
+                .get();
+
+        assertThat(trait.toBuilder().build(), equalTo(trait));
+
+        // Test round-tripping from/to node.
+        assertThat(new MockIntegrationTrait.Provider().createTrait(ShapeId.from("ns.foo#Operation"), trait.toNode()),
+                   equalTo(trait));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
@@ -368,6 +368,50 @@ public class NodeMapperTest {
     }
 
     @Test
+    public void omitsEmptyValues() {
+        PojoWithEmptyValues pojo = new PojoWithEmptyValues();
+        NodeMapper mapper = new NodeMapper();
+        mapper.setOmitEmptyValues(true);
+        Node result = mapper.serialize(pojo);
+
+        assertThat(result, equalTo(Node.objectNode()));
+    }
+
+    public static final class PojoWithEmptyValues {
+        public List<String> getFoo() {
+            return Collections.emptyList();
+        }
+
+        public EmptyPojo getBaz() {
+            return new EmptyPojo();
+        }
+    }
+
+    public static final class EmptyPojo {
+    }
+
+    @Test
+    public void canDisableToNodeInsideOfClass() {
+        DisabledToNode pojo = new DisabledToNode();
+        NodeMapper mapper = new NodeMapper();
+        mapper.disableToNodeForClass(DisabledToNode.class);
+        Node result = mapper.serialize(pojo);
+
+        Node.assertEquals(result, Node.objectNode().withMember("foo", "hi"));
+    }
+
+    public static final class DisabledToNode implements ToNode {
+        @Override
+        public Node toNode() {
+            throw new RuntimeException("Was not meant to run!");
+        }
+
+        public String getFoo() {
+            return "hi";
+        }
+    }
+
+    @Test
     public void deserializesWithFromNodeFactoryAndUnknownPropertiesWithWarning() {
         Node baz = Node.parse("{\"foo\": \"hi\", \"baz\": 10, \"inner\": {\"inner\": {\"noSetter!\": \"inn!\"}}}");
         Baz result = new NodeMapper().deserialize(baz, Baz.class);


### PR DESCRIPTION
Use NodeMapper in API Gateway traits
    
    This commit updates API Gateway traits to use the NodeMapper and changes
    different getter/setter methods to use NodeMapper compatible API names.
    Further, support for omitting the toNode implementation of a class was
    added so that the NodeMapper can be used inside of a toNode method.
    Finally, support for omitting empty arrays and objects was added so the
    NodeMapper doesn't inject a bunch of empty values when it isn't
    desirable.

Add CONVERT_TO_TEXT to OPTIONS and cleanup
    
    CONVERT_TO_TEXT is necessary on OPTIONS request otherwise you may see
    500 errors from API Gateway. Further, this commit cleans up several
    getters/setters on the IntegrationTrait and MockIntegrationTrait to
    match what a code generator would produce and how the NodeMapper works.