### PR TITLE
`smithy-model`: add support for `httpContentMd5` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Smithy Changelog
 
+## 0.9.8 (2020-03-26)
+
+### Features
+
+* Add `RenameShapes` model transformer ([#318](https://github.com/awslabs/smithy/pull/318))
+* Build `ValidationEvents` are now sorted ([#263](https://github.com/awslabs/smithy/pull/263))
+* Smithy CLI logging improvements ([#263](https://github.com/awslabs/smithy/pull/263))
+* Model builds fail early when syntax errors occur ([#264](https://github.com/awslabs/smithy/pull/264))
+* Warn when a deprecated trait is applied to a shape ([#279](https://github.com/awslabs/smithy/pull/279))
+
+### Bug Fixes
+
+* Fix behavior of `schemaDocumentExtensions` when converting to OpenAPI ([#320](https://github.com/awslabs/smithy/pull/320))
+* Fix discrepancies in `smithy-aws-protocol-tests` ([#309](https://github.com/awslabs/smithy/pull/309), [#321](https://github.com/awslabs/smithy/pull/321))
+* Properly format test case results ([#271](https://github.com/awslabs/smithy/pull/271))
+* Fix dropping one character text block lines ([#285](https://github.com/awslabs/smithy/pull/285))
+
+### Optimizations
+
+* Builds run parallel projections in parallel only if there are more than one ([#263](https://github.com/awslabs/smithy/pull/263))
+* Run Smithy test suites as parameterized tests ([#263](https://github.com/awslabs/smithy/pull/263))
+
+### Cleanup
+
+* Migrate protocol tests to new operation syntax ([#260](https://github.com/awslabs/smithy/pull/260))
+* Build protocol tests with the Smithy Gradle plugin ([#263](https://github.com/awslabs/smithy/pull/263))
+* Deprecate using explicitly `smithy.api` for trait removal ([#306](https://github.com/awslabs/smithy/pull/306))
+
 ## 0.9.7 (2020-01-15)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Smithy Changelog
 
+## 0.9.9 (2020-04-01)
+
+### Bug Fixes
+
+* Add security to individual operations in OpenAPI conversion ([#329](https://github.com/awslabs/smithy/pull/329))
+* Fix an issue with header casing for `x-api-key` integration with API Gateway ([#330](https://github.com/awslabs/smithy/pull/330))
+* Fix discrepancies in `smithy-aws-protocol-tests` ([#333](https://github.com/awslabs/smithy/pull/333), [#335](https://github.com/awslabs/smithy/pull/335),
+  [#349](https://github.com/awslabs/smithy/pull/349))
+
 ## 0.9.8 (2020-03-26)
 
 ### Features

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.9.7"
+    version = "0.9.8"
 }
 
 // The root project doesn't produce a JAR.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // of band with the rest of the projects.
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.9.8"
+    version = "0.9.9"
 }
 
 // The root project doesn't produce a JAR.

--- a/docs/source/guides/building-models/gradle-plugin.rst
+++ b/docs/source/guides/building-models/gradle-plugin.rst
@@ -151,12 +151,12 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.7")
+            implementation("software.amazon.smithy:smithy-model:0.9.8")
 
             // These are just examples of dependencies. This model has a dependency on
             // a "common" model package and uses the external AWS traits.
             implementation("com.foo.baz:foo-model-internal-common:1.0.0")
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
         }
 
 
@@ -193,7 +193,7 @@ build that uses the "external" projection.
                 mavenCentral()
             }
             dependencies {
-                classpath("software.amazon.smithy:smithy-aws-traits:0.9.7")
+                classpath("software.amazon.smithy:smithy-aws-traits:0.9.8")
 
                 // Take a dependency on the internal model package. This
                 // dependency *must* be a buildscript only dependency to ensure
@@ -217,12 +217,12 @@ build that uses the "external" projection.
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.7")
+            implementation("software.amazon.smithy:smithy-model:0.9.8")
 
             // Any dependencies that the projected model needs must be (re)declared
             // here. For example, let's assume that the smithy-aws-traits package is
             // needed in the projected model too.
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.7")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
         }
 
 
@@ -328,7 +328,7 @@ The above Smithy plugin also requires a ``buildscript`` dependency in
 
                 // This dependency is required in order to apply the "openapi"
                 // plugin in smithy-build.json
-                classpath("software.amazon.smithy:smithy-openapi:0.9.7")
+                classpath("software.amazon.smithy:smithy-openapi:0.9.8")
             }
         }
 

--- a/docs/source/guides/building-models/gradle-plugin.rst
+++ b/docs/source/guides/building-models/gradle-plugin.rst
@@ -151,12 +151,12 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.8")
+            implementation("software.amazon.smithy:smithy-model:0.9.9")
 
             // These are just examples of dependencies. This model has a dependency on
             // a "common" model package and uses the external AWS traits.
             implementation("com.foo.baz:foo-model-internal-common:1.0.0")
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.9")
         }
 
 
@@ -193,7 +193,7 @@ build that uses the "external" projection.
                 mavenCentral()
             }
             dependencies {
-                classpath("software.amazon.smithy:smithy-aws-traits:0.9.8")
+                classpath("software.amazon.smithy:smithy-aws-traits:0.9.9")
 
                 // Take a dependency on the internal model package. This
                 // dependency *must* be a buildscript only dependency to ensure
@@ -217,12 +217,12 @@ build that uses the "external" projection.
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:0.9.8")
+            implementation("software.amazon.smithy:smithy-model:0.9.9")
 
             // Any dependencies that the projected model needs must be (re)declared
             // here. For example, let's assume that the smithy-aws-traits package is
             // needed in the projected model too.
-            implementation("software.amazon.smithy:smithy-aws-traits:0.9.8")
+            implementation("software.amazon.smithy:smithy-aws-traits:0.9.9")
         }
 
 
@@ -328,7 +328,7 @@ The above Smithy plugin also requires a ``buildscript`` dependency in
 
                 // This dependency is required in order to apply the "openapi"
                 // plugin in smithy-build.json
-                classpath("software.amazon.smithy:smithy-openapi:0.9.8")
+                classpath("software.amazon.smithy:smithy-openapi:0.9.9")
             }
         }
 

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -106,7 +106,7 @@ specification from a Smithy model using a buildscript dependency:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.7")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
         }
     }
 
@@ -132,7 +132,7 @@ that builds an OpenAPI specification from a service for the
 
 .. important::
 
-    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.7" is
+    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.8" is
     required in order for smithy-build to map the "openapi" plugin name to the
     correct Java library implementation.
 
@@ -338,7 +338,7 @@ dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.7")
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.8")
         }
     }
 
@@ -516,7 +516,7 @@ shows how to install ``software.amazon.smithy:smithy-openapi`` through Gradle:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.7")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
         }
     }
 

--- a/docs/source/guides/converting-to-openapi.rst
+++ b/docs/source/guides/converting-to-openapi.rst
@@ -106,7 +106,7 @@ specification from a Smithy model using a buildscript dependency:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.9")
         }
     }
 
@@ -132,7 +132,7 @@ that builds an OpenAPI specification from a service for the
 
 .. important::
 
-    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.8" is
+    A buildscript dependency on "software.amazon.smithy:smithy-openapi:0.9.9" is
     required in order for smithy-build to map the "openapi" plugin name to the
     correct Java library implementation.
 
@@ -338,7 +338,7 @@ dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.8")
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:0.9.9")
         }
     }
 
@@ -516,7 +516,7 @@ shows how to install ``software.amazon.smithy:smithy-openapi`` through Gradle:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:0.9.8")
+            classpath("software.amazon.smithy:smithy-openapi:0.9.9")
         }
     }
 

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.apigateway.openapi;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 import software.amazon.smithy.aws.traits.apigateway.AuthorizerDefinition;
 import software.amazon.smithy.aws.traits.apigateway.AuthorizerIndex;
@@ -24,6 +25,7 @@ import software.amazon.smithy.aws.traits.apigateway.AuthorizerTrait;
 import software.amazon.smithy.aws.traits.apigateway.AuthorizersTrait;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.openapi.fromsmithy.Context;
@@ -32,7 +34,9 @@ import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveUnusedComponents;
 import software.amazon.smithy.openapi.model.ComponentsObject;
 import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.openapi.model.OperationObject;
 import software.amazon.smithy.openapi.model.SecurityScheme;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 /**
@@ -77,6 +81,25 @@ final class AddAuthorizers implements OpenApiMapper {
                 // Add a new scheme for this operation using the authorizer name.
                 .map(authorizer -> MapUtils.of(authorizer, requirement.values().iterator().next()))
                 .orElse(requirement);
+    }
+
+    @Override
+    public OperationObject updateOperation(Context context, OperationShape shape, OperationObject operation) {
+        ServiceShape service = context.getService();
+        AuthorizerIndex authorizerIndex = context.getModel().getKnowledge(AuthorizerIndex.class);
+
+        // Get the resolved security schemes of the service and operation, and
+        // only add security if it's different than the service.
+        String serviceAuth = authorizerIndex.getAuthorizer(service).orElse(null);
+        String operationAuth = authorizerIndex.getAuthorizer(service, shape).orElse(null);
+
+        if (operationAuth == null || Objects.equals(operationAuth, serviceAuth)) {
+            return operation;
+        }
+
+        return operation.toBuilder()
+                .addSecurity(MapUtils.of(operationAuth, ListUtils.of()))
+                .build();
     }
 
     @Override

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/effective-authorizers.smithy
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/effective-authorizers.smithy
@@ -1,0 +1,20 @@
+namespace smithy.example
+
+@protocols([{name: "aws.rest-json-1.1", auth: ["aws.v4"]}])
+@aws.apigateway#authorizer("foo")
+@aws.apigateway#authorizers(
+    foo: {scheme: "aws.v4", type: "aws", uri: "arn:foo"},
+    baz: {scheme: "aws.v4", type: "aws", uri: "arn:baz"})
+service ServiceA {
+  version: "2019-06-17",
+  operations: [OperationA, OperationB]
+}
+
+// Inherits the authorizer of ServiceA
+@http(method: "GET", uri: "/operationA")
+operation OperationA {}
+
+// Overrides the authorizer of ServiceA
+@aws.apigateway#authorizer("baz")
+@http(method: "GET", uri: "/operationB")
+operation OperationB {}

--- a/smithy-aws-protocol-tests/model/ec2-query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/input-lists.smithy
@@ -31,8 +31,8 @@ apply QueryLists @httpRequestTests([
               &ListArg.1=foo
               &ListArg.2=bar
               &ListArg.3=baz
-              &ComplexListArg.1.hi=hello
-              &ComplexListArg.2.hi=hola""",
+              &ComplexListArg.1.Hi=hello
+              &ComplexListArg.2.Hi=hola""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: ["foo", "bar", "baz"],

--- a/smithy-aws-protocol-tests/model/ec2-query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/input.smithy
@@ -243,9 +243,9 @@ apply QueryTimestamps @httpRequestTests([
         body: """
               Action=QueryTimestamps
               &Version=2020-01-08
-              &normalFormat=2015-01-25T08%3A00%3A00Z
-              &epochMember=1422172800
-              &epochTarget=1422172800""",
+              &NormalFormat=2015-01-25T08%3A00%3A00Z
+              &EpochMember=1422172800
+              &EpochTarget=1422172800""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             normalFormat: 1422172800,
@@ -330,9 +330,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000000""",
+              &Token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
     },
     {
@@ -345,9 +345,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000123""",
+              &Token=00000000-0000-4000-8000-000000000123""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"

--- a/smithy-aws-protocol-tests/model/ec2-query/main.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/main.smithy
@@ -28,10 +28,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.ec2
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// An EC2 query service that sends query requests and XML responses.
+@service(sdkId: "EC2 Protocol")
 @protocols([{"name": "aws.ec2"}])
 @xmlNamespace(uri: "https://example.com/")
 service AwsEc2 {

--- a/smithy-aws-protocol-tests/model/ec2-query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2-query/xml-lists.smithy
@@ -68,7 +68,7 @@ apply XmlLists @httpResponseTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>

--- a/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
+++ b/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
@@ -323,7 +323,7 @@
                         "method": "POST",
                         "uri": "/",
                         "params": {
-                            "Blob": "YmluYXJ5LXZhbHVl"
+                            "Blob": "binary-value"
                         },
                         "bodyMediaType": "application/json",
                         "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}"
@@ -765,7 +765,7 @@
                         "bodyMediaType": "application/json",
                         "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
                         "params": {
-                            "Blob": "YmluYXJ5LXZhbHVl"
+                            "Blob": "binary-value"
                         }
                     },
                     {

--- a/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
+++ b/smithy-aws-protocol-tests/model/json-rpc-1-1/main.json
@@ -59,7 +59,7 @@
                         "params": {},
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.EmptyOperation"
                         }
                     }
                 ],
@@ -72,7 +72,6 @@
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1"
                         },
-                        "requireHeaders": ["Content-Length"],
                         "bodyMediaType": "application/json",
                         "body": "{}",
                         "params": {}
@@ -522,7 +521,7 @@
                             "MapOfStrings": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"MapOfStrings\":[]}"
+                        "body": "{\"MapOfStrings\":{}}"
                     },
                     {
                         "id": "serializes_map_of_list_shapes",
@@ -626,7 +625,7 @@
                             "SimpleStruct": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"SimpleStruct\":[]}"
+                        "body": "{\"SimpleStruct\":{}}"
                     },
                     {
                         "id": "serializes_structure_which_have_no_members",
@@ -638,7 +637,7 @@
                             "EmptyStruct": {}
                         },
                         "bodyMediaType": "application/json",
-                        "body": "{\"EmptyStruct\":[]}"
+                        "body": "{\"EmptyStruct\":{}}"
                     },
                     {
                         "id": "serializes_recursive_structure_shapes",
@@ -1000,7 +999,9 @@
                         "code": 200,
                         "headers": {
                             "X-Amzn-Requestid": "amazon-uniq-request-id"
-                        }
+                        },
+                        "bodyMediaType": "application/json",
+                        "body": "{}"
                     }
                 ]
             }
@@ -1101,7 +1102,7 @@
                         "uri": "/",
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
                         },
                         "bodyMediaType": "application/json",
                         "body": "{}"
@@ -1117,9 +1118,8 @@
                         },
                         "headers": {
                             "Content-Type": "application/x-amz-json-1.1",
-                            "X-Amz-Target": "JsonProtocolService.OperationWithOptionalInputOutput"
+                            "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
                         },
-                        "requireHeaders": ["Content-Length"],
                         "bodyMediaType": "application/json",
                         "body": "{\"Value\":\"Hi\"}"
                     }

--- a/smithy-aws-protocol-tests/model/query/input-maps.smithy
+++ b/smithy-aws-protocol-tests/model/query/input-maps.smithy
@@ -25,7 +25,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &MapArg.entry.1.key=foo
               &MapArg.entry.1.value=Foo
@@ -49,7 +49,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &Foo.entry.1.key=foo
               &Foo.entry.1.value=Foo""",
@@ -70,7 +70,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &ComplexMapArg.entry.1.key=foo
               &ComplexMapArg.entry.1.value.hi=Foo
@@ -98,7 +98,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
@@ -115,12 +115,12 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &MapWithXmlMemberName.entry.1.K=foo
               &MapWithXmlMemberName.entry.1.V=Foo
-              &MapWithXmlMemberName.entry.1.K=bar
-              &MapWithXmlMemberName.entry.1.V=Bar""",
+              &MapWithXmlMemberName.entry.2.K=bar
+              &MapWithXmlMemberName.entry.2.V=Bar""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapWithXmlMemberName: {
@@ -139,12 +139,12 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &FlattenedMap.1.key=foo
               &FlattenedMap.1.value=Foo
-              &FlattenedMap.1.key=bar
-              &FlattenedMap.1.value=Bar""",
+              &FlattenedMap.2.key=bar
+              &FlattenedMap.2.value=Bar""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedMap: {
@@ -163,7 +163,7 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
               &Hi.1.K=foo
               &Hi.1.V=Foo
@@ -187,12 +187,14 @@ apply QueryMaps @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=QueryLists
+              Action=QueryMaps
               &Version=2020-01-08
-              &MapOfLists.entry.1.key.1=A
-              &MapOfLists.entry.1.key.2=B
-              &MapOfLists.entry.2.key.1=C
-              &MapOfLists.entry.2.key.2=D""",
+              &MapOfLists.entry.1.key=foo
+              &MapOfLists.entry.1.value.member.1=A
+              &MapOfLists.entry.1.value.member.2=B
+              &MapOfLists.entry.2.key=bar
+              &MapOfLists.entry.2.value.member.1=C
+              &MapOfLists.entry.2.value.member.2=D""",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapOfLists: {

--- a/smithy-aws-protocol-tests/model/query/input.smithy
+++ b/smithy-aws-protocol-tests/model/query/input.smithy
@@ -265,7 +265,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
@@ -280,7 +280,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
             "Content-Type": "application/x-www-form-urlencoded"
         },
         body: """
-              Action=NestedStructures
+              Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000123""",
         bodyMediaType: "application/x-www-form-urlencoded",

--- a/smithy-aws-protocol-tests/model/query/main.smithy
+++ b/smithy-aws-protocol-tests/model/query/main.smithy
@@ -2,10 +2,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.query
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A query service that sends query requests and XML responses.
+@service(sdkId: "Query Protocol")
 @protocols([{"name": "aws.query"}])
 @xmlNamespace(uri: "https://example.com/")
 service AwsQuery {

--- a/smithy-aws-protocol-tests/model/query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/query/xml-lists.smithy
@@ -69,7 +69,7 @@ apply XmlLists @httpResponseTests([
                               <member>baz</member>
                               <member>qux</member>
                           </member>
-                      <nestedStringList>
+                      </nestedStringList>
                       <renamed>
                           <item>foo</item>
                           <item>bar</item>

--- a/smithy-aws-protocol-tests/model/query/xml-maps.smithy
+++ b/smithy-aws-protocol-tests/model/query/xml-maps.smithy
@@ -81,13 +81,13 @@ apply XmlMapsXmlName @httpResponseTests([
                   <XmlMapsXmlNameResult>
                       <myMap>
                           <entry>
-                              <Name>foo</Name>
+                              <Attribute>foo</Attribute>
                               <Setting>
                                   <hi>there</hi>
                               </Setting>
                           </entry>
                           <entry>
-                              <Name>baz</Name>
+                              <Attribute>baz</Attribute>
                               <Setting>
                                   <hi>bye</hi>
                               </Setting>

--- a/smithy-aws-protocol-tests/model/query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/query/xml-structs.smithy
@@ -119,9 +119,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <normal>2014-04-29T18:30:38Z</normal>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -139,9 +139,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <dateTime>2014-04-29T18:30:38Z</dateTime>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -159,9 +159,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <epochSeconds>1398796238</epochSeconds>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -179,9 +179,9 @@ apply XmlTimestamps @httpResponseTests([
         code: 200,
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
-                  <QueryXmlTimestampsResult>
+                  <XmlTimestampsResult>
                       <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
-                  </QueryXmlTimestampsResult>
+                  </XmlTimestampsResult>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/rest-json/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/empty-input-output.smithy
@@ -22,7 +22,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-json-1.1",
         method: "POST",
-        uri: "/NoInputAndOutput"
+        uri: "/NoInputAndNoOutput"
     }
 ])
 
@@ -50,7 +50,7 @@ apply NoInputAndOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-json-1.1",
         method: "POST",
-        uri: "/NoInputAndOutput"
+        uri: "/NoInputAndOutputOutput"
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/rest-json/errors.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/errors.smithy
@@ -125,7 +125,8 @@ apply ComplexError @httpResponseTests([
         params: {},
         code: 403,
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "X-Amzn-Errortype": "ComplexError"
         },
         body: "{}",
         bodyMediaType: "application/json",

--- a/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
@@ -263,19 +263,20 @@ structure InputAndOutputWithHeadersIO {
 
 /// Null and empty headers are not sent over the wire.
 @readonly
-@http(uri: "/NullAndEmptyHeaders", method: "GET")
-operation NullAndEmptyHeaders {
+@http(uri: "/NullAndEmptyHeadersClient", method: "GET")
+@tags(["client-only"])
+operation NullAndEmptyHeadersClient {
     input: NullAndEmptyHeadersIO,
     output: NullAndEmptyHeadersIO
 }
 
-apply NullAndEmptyHeaders @httpRequestTests([
+apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
         documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
         protocol: "aws.rest-json-1.1",
         method: "GET",
-        uri: "/NullAndEmptyHeaders",
+        uri: "/NullAndEmptyHeadersClient",
         forbidHeaders: ["X-A", "X-B", "X-C"],
         body: "",
         params: {
@@ -286,7 +287,16 @@ apply NullAndEmptyHeaders @httpRequestTests([
     },
 ])
 
-apply NullAndEmptyHeaders @httpResponseTests([
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeadersServer", method: "GET")
+@tags(["server-only"])
+operation NullAndEmptyHeadersServer {
+    input: NullAndEmptyHeadersIO,
+    output: NullAndEmptyHeadersIO
+}
+
+apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
         documentation: "Do not send null or empty headers",

--- a/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-headers.smithy
@@ -6,6 +6,7 @@ $version: "0.5.0"
 namespace aws.protocols.tests.restjson
 
 use aws.protocols.tests.shared#BooleanList
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#FooEnum
 use aws.protocols.tests.shared#FooEnumList
@@ -57,7 +58,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -79,12 +80,12 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -95,7 +96,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -110,7 +111,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         uri: "/InputAndOutputWithHeaders",
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -150,7 +151,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -171,12 +172,12 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -186,7 +187,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: "aws.rest-json-1.1",
         code: 200,
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -200,7 +201,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -399,5 +400,5 @@ structure TimestampFormatHeadersIO {
     targetHttpDate: HttpDate,
 
     @httpHeader("X-targetDateTime")
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }

--- a/smithy-aws-protocol-tests/model/rest-json/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-labels.smithy
@@ -93,11 +93,11 @@ apply HttpRequestWithLabelsAndTimestampFormat @httpRequestTests([
         uri: """
              /HttpRequestWithLabelsAndTimestampFormat\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z\
              /2019-12-16T23%3A48%3A18Z\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z""",
         body: "",
         params: {

--- a/smithy-aws-protocol-tests/model/rest-json/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-labels.smithy
@@ -5,6 +5,7 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restjson
 
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#HttpDate
 use smithy.test#httpRequestTests
@@ -141,7 +142,7 @@ structure HttpRequestWithLabelsAndTimestampFormatInput {
 
     @httpLabel
     @required
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }
 
 // This example uses a greedy label and a normal label.

--- a/smithy-aws-protocol-tests/model/rest-json/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/http-query.smithy
@@ -30,7 +30,7 @@ apply AllQueryStringTypes @httpRequestTests([
         documentation: "Serializes query string parameters with all supported types",
         protocol: "aws.rest-json-1.1",
         method: "GET",
-        uri: "/AllQueryStringTypes",
+        uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
             "String=Hello%20there",
@@ -60,9 +60,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "BooleanList=false",
             "BooleanList=true",
             "Timestamp=1",
-            "TimestampList=1",
-            "TimestampList=2",
-            "TimestampList=3",
+            "TimestampList=1970-01-01T00%3A00%3A01Z",
+            "TimestampList=1970-01-01T00%3A00%3A02Z",
+            "TimestampList=1970-01-01T00%3A00%3A03Z",
             "Enum=Foo",
             "EnumList=Foo",
             "EnumList=Baz",
@@ -254,7 +254,6 @@ apply IgnoreQueryParamsInResponse @httpResponseTests([
         body: "",
         bodyMediaType: "json",
         params: {
-            baz: "bam"
         }
     }
 ])
@@ -324,10 +323,10 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         uri: "/QueryIdempotencyTokenAutoFill",
         body: "",
         queryParams: [
-            "token=00000000-0000-4000-8000-000000000123",
+            "token=00000000-0000-4000-8000-000000000000",
         ],
         params: {
-            token: "00000000-0000-4000-8000-000000000123"
+            token: "00000000-0000-4000-8000-000000000000"
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/rest-json/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/json-lists.smithy
@@ -73,14 +73,14 @@ apply JsonLists @httpRequestTests([
                           "qux"
                       ]
                   ],
-                  "structureList": [
+                  "myStructureList": [
                       {
-                          "a": "1",
-                          "b": "2"
+                          "value": "1",
+                          "other": "2"
                       },
                       {
-                          "a": "3",
-                          "b": "4"
+                          "value": "3",
+                          "other": "4"
                       }
                   ]
               }""",
@@ -211,14 +211,14 @@ apply JsonLists @httpResponseTests([
                           "qux"
                       ]
                   ],
-                  "structureList": [
+                  "myStructureList": [
                       {
-                          "a": "1",
-                          "b": "2"
+                          "value": "1",
+                          "other": "2"
                       },
                       {
-                          "a": "3",
-                          "b": "4"
+                          "value": "3",
+                          "other": "4"
                       }
                   ]
               }""",

--- a/smithy-aws-protocol-tests/model/rest-json/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/json-structs.smithy
@@ -30,7 +30,6 @@ apply SimpleScalarProperties @httpRequestTests([
         uri: "/SimpleScalarProperties",
         body: """
               {
-                  "foo": "Foo",
                   "stringValue": "string",
                   "trueBooleanValue": true,
                   "falseBooleanValue": false,
@@ -69,7 +68,6 @@ apply SimpleScalarProperties @httpResponseTests([
         code: 200,
         body: """
               {
-                  "foo": "Foo",
                   "stringValue": "string",
                   "trueBooleanValue": true,
                   "falseBooleanValue": false,
@@ -453,7 +451,7 @@ apply RecursiveShapes @httpRequestTests([
         documentation: "Serializes recursive structures",
         protocol: "aws.rest-json-1.1",
         method: "PUT",
-        uri: "/JsonEnums",
+        uri: "/RecursiveShapes",
         body: """
               {
                   "nested": {

--- a/smithy-aws-protocol-tests/model/rest-json/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/main.smithy
@@ -2,10 +2,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restjson
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A REST JSON service that sends JSON requests and responses.
+@service(sdkId: "Rest Json Protocol")
 @protocols([{"name": "aws.rest-json-1.1"}])
 service RestJson {
     version: "2019-12-16",

--- a/smithy-aws-protocol-tests/model/rest-json/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-json/main.smithy
@@ -19,7 +19,8 @@ service RestJson {
 
         // @httpHeader tests
         InputAndOutputWithHeaders,
-        NullAndEmptyHeaders,
+        NullAndEmptyHeadersClient,
+        NullAndEmptyHeadersServer,
         TimestampFormatHeaders,
 
         // @httpLabel tests

--- a/smithy-aws-protocol-tests/model/rest-xml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-lists.smithy
@@ -75,7 +75,7 @@ apply XmlLists @httpRequestTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>
@@ -166,7 +166,7 @@ apply XmlLists @httpResponseTests([
                           <member>baz</member>
                           <member>qux</member>
                       </member>
-                  <nestedStringList>
+                  </nestedStringList>
                   <renamed>
                       <item>foo</item>
                       <item>bar</item>

--- a/smithy-aws-protocol-tests/model/rest-xml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-maps.smithy
@@ -126,13 +126,13 @@ apply XmlMapsXmlName @httpRequestTests([
               <XmlMapsXmlNameInputOutput>
                   <myMap>
                       <entry>
-                          <Name>foo</Name>
+                          <Attribute>foo</Attribute>
                           <Setting>
                               <hi>there</hi>
                           </Setting>
                       </entry>
                       <entry>
-                          <Name>baz</Name>
+                          <Attribute>baz</Attribute>
                           <Setting>
                               <hi>bye</hi>
                           </Setting>
@@ -167,13 +167,13 @@ apply XmlMapsXmlName @httpResponseTests([
               <XmlMapsXmlNameInputOutput>
                   <myMap>
                       <entry>
-                          <Name>foo</Name>
+                          <Attribute>foo</Attribute>
                           <Setting>
                               <hi>there</hi>
                           </Setting>
                       </entry>
                       <entry>
-                          <Name>baz</Name>
+                          <Attribute>baz</Attribute>
                           <Setting>
                               <hi>bye</hi>
                           </Setting>

--- a/smithy-aws-protocol-tests/model/rest-xml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-structs.smithy
@@ -477,7 +477,7 @@ apply RecursiveShapes @httpRequestTests([
         documentation: "Serializes recursive structures",
         protocol: "aws.rest-xml",
         method: "PUT",
-        uri: "/XmlEnums",
+        uri: "/RecursiveShapes",
         body: """
               <RecursiveShapesInputOutput>
                   <nested>
@@ -587,7 +587,7 @@ apply XmlNamespaces @httpRequestTests([
         method: "POST",
         uri: "/XmlNamespaces",
         body: """
-              <RecursiveShapesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesInputOutput xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -595,7 +595,7 @@ apply XmlNamespaces @httpRequestTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </XmlNamespacesInputOutput>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -620,7 +620,7 @@ apply XmlNamespaces @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <RecursiveShapesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesInputOutput xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -628,7 +628,7 @@ apply XmlNamespaces @httpResponseTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </XmlNamespacesInputOutput>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/rest-xml/document-xml-attributes.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/document-xml-attributes.smithy
@@ -23,7 +23,7 @@ apply XmlAttributes @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributes",
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -45,7 +45,7 @@ apply XmlAttributes @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -84,7 +84,7 @@ apply XmlAttributesOnPayload @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributesOnPayload",
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,
@@ -108,7 +108,7 @@ apply XmlAttributesOnPayload @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <XmlAttributesInputOutput attr="test">
+              <XmlAttributesInputOutput test="test">
                   <foo>hi</foo>
               </XmlAttributesInputOutput>
               """,

--- a/smithy-aws-protocol-tests/model/rest-xml/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/empty-input-output.smithy
@@ -20,7 +20,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-xml",
         method: "POST",
-        uri: "/NoInputAndOutput",
+        uri: "/NoInputAndNoOutput",
         body: ""
     }
 ])
@@ -50,7 +50,7 @@ apply NoInputAndOutput @httpRequestTests([
         documentation: "No input serializes no payload",
         protocol: "aws.rest-xml",
         method: "POST",
-        uri: "/NoInputAndOutput",
+        uri: "/NoInputAndOutputOutput",
         body: ""
     }
 ])

--- a/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
@@ -6,6 +6,7 @@ $version: "0.5.0"
 namespace aws.protocols.tests.restxml
 
 use aws.protocols.tests.shared#BooleanList
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#FooEnum
 use aws.protocols.tests.shared#FooEnumList
@@ -57,7 +58,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -79,12 +80,12 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -95,7 +96,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -110,7 +111,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         uri: "/InputAndOutputWithHeaders",
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -150,7 +151,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
             "X-Long": "123",
             "X-Float": "1.0",
             "X-Double": "1.0",
-            "X-HeaderIntegerList": "1, 2, 3",
+            "X-IntegerList": "1, 2, 3",
         },
         body: "",
         params: {
@@ -171,12 +172,12 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         headers: {
             "X-Boolean1": "true",
             "X-Boolean2": "false",
-            "X-HeaderBooleanList": "true, false, true"
+            "X-BooleanList": "true, false, true"
         },
         body: "",
         params: {
             headerTrueBool: true,
-            headerFalseBool: true,
+            headerFalseBool: false,
             headerBooleanList: [true, false, true]
         }
     },
@@ -186,7 +187,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         headers: {
-            "X-HeaderTimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -200,7 +201,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-Enum": "Foo",
-            "X-EnumList": "Foo, Baz, Bar"
+            "X-EnumList": "Foo, Bar, Baz"
         },
         body: "",
         params: {
@@ -399,5 +400,5 @@ structure TimestampFormatHeadersIO {
     targetHttpDate: HttpDate,
 
     @httpHeader("X-targetDateTime")
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }

--- a/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-headers.smithy
@@ -263,19 +263,20 @@ structure InputAndOutputWithHeadersIO {
 
 /// Null and empty headers are not sent over the wire.
 @readonly
-@http(uri: "/NullAndEmptyHeaders", method: "GET")
-operation NullAndEmptyHeaders {
+@http(uri: "/NullAndEmptyHeadersClient", method: "GET")
+@tags(["client-only"])
+operation NullAndEmptyHeadersClient {
     input: NullAndEmptyHeadersIO,
     output: NullAndEmptyHeadersIO
 }
 
-apply NullAndEmptyHeaders @httpRequestTests([
+apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "NullAndEmptyHeaders",
         documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
         protocol: "aws.rest-xml",
         method: "GET",
-        uri: "/NullAndEmptyHeaders",
+        uri: "/NullAndEmptyHeadersClient",
         forbidHeaders: ["X-A", "X-B", "X-C"],
         body: "",
         params: {
@@ -286,7 +287,16 @@ apply NullAndEmptyHeaders @httpRequestTests([
     },
 ])
 
-apply NullAndEmptyHeaders @httpResponseTests([
+/// Null and empty headers are not sent over the wire.
+@readonly
+@http(uri: "/NullAndEmptyHeadersServer", method: "GET")
+@tags(["server-only"])
+operation NullAndEmptyHeadersServer {
+    input: NullAndEmptyHeadersIO,
+    output: NullAndEmptyHeadersIO
+}
+
+apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "NullAndEmptyHeaders",
         documentation: "Do not send null or empty headers",

--- a/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
@@ -93,11 +93,11 @@ apply HttpRequestWithLabelsAndTimestampFormat @httpRequestTests([
         uri: """
              /HttpRequestWithLabelsAndTimestampFormat\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z\
              /2019-12-16T23%3A48%3A18Z\
              /1576540098\
-             /Mon%2C+16+Dec+2019+23%3A48%3A18+GMT\
+             /Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT\
              /2019-12-16T23%3A48%3A18Z""",
         body: "",
         params: {

--- a/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-labels.smithy
@@ -5,6 +5,7 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restxml
 
+use aws.protocols.tests.shared#DateTime
 use aws.protocols.tests.shared#EpochSeconds
 use aws.protocols.tests.shared#HttpDate
 use smithy.test#httpRequestTests
@@ -141,7 +142,7 @@ structure HttpRequestWithLabelsAndTimestampFormatInput {
 
     @httpLabel
     @required
-    targetDateTime: HttpDate,
+    targetDateTime: DateTime,
 }
 
 // This example uses a greedy label and a normal label.

--- a/smithy-aws-protocol-tests/model/rest-xml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-payload.smithy
@@ -229,7 +229,7 @@ apply HttpPayloadWithXmlName @httpRequestTests([
         documentation: "Serializes a structure in the payload using a wrapper name based on xmlName",
         protocol: "aws.rest-xml",
         method: "PUT",
-        uri: "/HttpPayloadWithStructure",
+        uri: "/HttpPayloadWithXmlName",
         body: "<Hello><name>Phreddy</name></Hello>",
         bodyMediaType: "application/xml",
         headers: {
@@ -288,7 +288,7 @@ apply HttpPayloadWithXmlNamespace @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithXmlNamespace",
         body: """
-              <PayloadWithXmlNamespace xmlns="http//foo.com">
+              <PayloadWithXmlNamespace xmlns="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespace>""",
         bodyMediaType: "application/xml",
@@ -310,7 +310,7 @@ apply HttpPayloadWithXmlNamespace @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <PayloadWithXmlNamespace xmlns="http//foo.com">
+              <PayloadWithXmlNamespace xmlns="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespace>""",
         bodyMediaType: "application/xml",
@@ -351,7 +351,7 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithXmlNamespaceAndPrefix",
         body: """
-              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespaceAndPrefix>""",
         bodyMediaType: "application/xml",
@@ -373,7 +373,7 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpResponseTests([
         protocol: "aws.rest-xml",
         code: 200,
         body: """
-              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http//foo.com">
+              <PayloadWithXmlNamespaceAndPrefix xmlns:baz="http://foo.com">
                   <name>Phreddy</name>
               </PayloadWithXmlNamespaceAndPrefix>""",
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/rest-xml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/http-query.smithy
@@ -30,7 +30,7 @@ apply AllQueryStringTypes @httpRequestTests([
         documentation: "Serializes query string parameters with all supported types",
         protocol: "aws.rest-xml",
         method: "GET",
-        uri: "/AllQueryStringTypes",
+        uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
             "String=Hello%20there",
@@ -60,9 +60,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "BooleanList=false",
             "BooleanList=true",
             "Timestamp=1",
-            "TimestampList=1",
-            "TimestampList=2",
-            "TimestampList=3",
+            "TimestampList=1970-01-01T00%3A00%3A01Z",
+            "TimestampList=1970-01-01T00%3A00%3A02Z",
+            "TimestampList=1970-01-01T00%3A00%3A03Z",
             "Enum=Foo",
             "EnumList=Foo",
             "EnumList=Baz",
@@ -324,10 +324,10 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         uri: "/QueryIdempotencyTokenAutoFill",
         body: "",
         queryParams: [
-            "token=00000000-0000-4000-8000-000000000123",
+            "token=00000000-0000-4000-8000-000000000000",
         ],
         params: {
-            token: "00000000-0000-4000-8000-000000000123"
+            token: "00000000-0000-4000-8000-000000000000"
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/rest-xml/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/main.smithy
@@ -19,7 +19,8 @@ service RestXml {
 
         // @httpHeader tests
         InputAndOutputWithHeaders,
-        NullAndEmptyHeaders,
+        NullAndEmptyHeadersClient,
+        NullAndEmptyHeadersServer,
         TimestampFormatHeaders,
 
         // @httpLabel tests

--- a/smithy-aws-protocol-tests/model/rest-xml/main.smithy
+++ b/smithy-aws-protocol-tests/model/rest-xml/main.smithy
@@ -2,10 +2,12 @@ $version: "0.5.0"
 
 namespace aws.protocols.tests.restxml
 
+use aws.api#service
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 /// A REST XML service that sends XML requests and responses.
+@service(sdkId: "Rest Xml Protocol")
 @protocols([{"name": "aws.rest-xml"}])
 service RestXml {
     version: "2019-12-16",

--- a/smithy-codegen-freemarker/README.md
+++ b/smithy-codegen-freemarker/README.md
@@ -12,7 +12,7 @@ Maven
 <dependency>
     <groupId>software.amazon.smithy</groupId>
     <artifactId>smithy-codegen-freemarker</artifactId>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
 </dependency>
 ```
 

--- a/smithy-codegen-freemarker/README.md
+++ b/smithy-codegen-freemarker/README.md
@@ -12,7 +12,7 @@ Maven
 <dependency>
     <groupId>software.amazon.smithy</groupId>
     <artifactId>smithy-codegen-freemarker</artifactId>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
 </dependency>
 ```
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
@@ -53,6 +53,7 @@ import software.amazon.smithy.model.traits.EventStreamTrait;
 import software.amazon.smithy.model.traits.ExamplesTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.model.traits.HostLabelTrait;
+import software.amazon.smithy.model.traits.HttpContentMd5Trait;
 import software.amazon.smithy.model.traits.HttpErrorTrait;
 import software.amazon.smithy.model.traits.HttpHeaderTrait;
 import software.amazon.smithy.model.traits.HttpLabelTrait;
@@ -154,6 +155,7 @@ public final class Prelude {
             ExamplesTrait.ID,
             ExternalDocumentationTrait.ID,
             HostLabelTrait.ID,
+            HttpContentMd5Trait.ID,
             HttpErrorTrait.ID,
             HttpHeaderTrait.ID,
             HttpLabelTrait.ID,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpContentMd5Trait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpContentMd5Trait.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Indicates that the operation requires Content-MD5 header in its
+ * HTTP request.
+ */
+public final class HttpContentMd5Trait extends BooleanTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.api#httpContentMd5");
+
+    public HttpContentMd5Trait(SourceLocation sourceLocation) {
+        super(ID, sourceLocation);
+    }
+
+    public HttpContentMd5Trait() {
+        this(SourceLocation.NONE);
+    }
+
+    public static final class Provider extends BooleanTrait.Provider<HttpContentMd5Trait> {
+        public Provider() {
+            super(ID, HttpContentMd5Trait::new);
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ModelSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.Pair;
+
+/**
+ *  Renames shapes using ShapeId pairs while ensuring that the
+ *  transformed model is in a consistent state.
+ *
+ *  <p>Member shapes are updated when their containing shape is updated.
+ *
+ *  <p>Trait references to ShapeId values are also updated.
+ */
+final class RenameShapes {
+    private final Map<ShapeId, ShapeId> renamed;
+    private final ModelAssembler assembler;
+
+    RenameShapes(Map<ShapeId, ShapeId> renamed, Supplier<ModelAssembler> modelAssemblerSupplier) {
+        this.renamed = new HashMap<>(renamed);
+        this.assembler = modelAssemblerSupplier.get();
+    }
+
+    Model transform(ModelTransformer transformer, Model model) {
+        // Remove any no-op pairs to avoid renaming shapes unnecessarily.
+        renamed.keySet().removeIf(fromId -> fromId.equals(renamed.get(fromId)));
+        if (renamed.isEmpty()) {
+            return model;
+        }
+
+        // Creates a set that will be used for checking if a string value needs to be renamed or not.
+        Set<String> toRename = renamed.keySet().stream()
+                .map(ShapeId::toString)
+                .collect(Collectors.toSet());
+
+        // This transformer converts the model into an ObjectNode. This approach was chosen because the
+        // JSON AST format includes fully qualified shape ID values, making it possible rename shapes across
+        // the model by only needing to compare and replace StringNode values.
+        ModelSerializer serializer = ModelSerializer.builder().build();
+        ObjectNode node = serializer.serialize(model);
+
+        // Use visitor to traverse node and rebuild model.
+        Node newModel = node.accept(new RenameShapeVisitor(toRename, renamed));
+
+        return assembler.addDocumentNode(newModel)
+                .assemble()
+                .unwrap();
+    }
+
+    private static final class RenameShapeVisitor extends NodeVisitor.Default<Node> {
+
+        private final Set<String> toRename;
+        private final Map<ShapeId, ShapeId> shapeMapping;
+
+        RenameShapeVisitor(Set<String> toRename, Map<ShapeId, ShapeId> shapeMapping) {
+            this.toRename = toRename;
+            this.shapeMapping = shapeMapping;
+        }
+
+        @Override
+        protected Node getDefault(Node node) {
+            return node;
+        }
+
+        @Override
+        public Node arrayNode(ArrayNode node) {
+            return node.getElements().stream()
+                    .map(element -> element.accept(this))
+                    .collect(ArrayNode.collect());
+        }
+
+        @Override
+        public Node objectNode(ObjectNode node) {
+            return node.getMembers().entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey().accept(this), entry.getValue().accept(this)))
+                    .collect(ObjectNode.collect(pair -> pair.getLeft().expectStringNode(), Pair::getRight));
+        }
+
+        @Override
+        public Node stringNode(StringNode node) {
+            if (toRename.contains(node.getValue())) {
+                ShapeId nodeShapeId = node.expectShapeId();
+                return new StringNode(shapeMapping.get(nodeShapeId).toString(), node.getSourceLocation());
+            }
+            return node;
+        }
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -12,6 +12,7 @@ software.amazon.smithy.model.traits.EventStreamTrait$Provider
 software.amazon.smithy.model.traits.ExamplesTrait$Provider
 software.amazon.smithy.model.traits.ExternalDocumentationTrait$Provider
 software.amazon.smithy.model.traits.HostLabelTrait$Provider
+software.amazon.smithy.model.traits.HttpContentMd5Trait$Provider
 software.amazon.smithy.model.traits.HttpErrorTrait$Provider
 software.amazon.smithy.model.traits.HttpHeaderTrait$Provider
 software.amazon.smithy.model.traits.HttpLabelTrait$Provider

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -538,3 +538,7 @@ structure endpoint {
 @trait(selector: ":test(member:of(structure)[trait|required] > string)")
 @tags(["diff.error.const"])
 structure hostLabel {}
+
+/// Marks an operation as requiring Content-MD5 header in its HTTP request
+@trait(selector: "operation")
+structure httpContentMd5 {}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.Trait;
+
+public class RenameShapesTest {
+
+    @Test
+    public void returnsUnmodifiedModelIfGivenEmptyRenameMapping() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        StringShape fooTarget = StringShape.builder().id(stringId).build();
+        Model model = Model.builder()
+                .addShapes(fooTarget)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertEquals(result.shapes().count(), 1);
+        assertEquals(result.getShape(stringId).get(), fooTarget);
+    }
+
+    @Test
+    public void returnsUnmodifiedModelIfToAndFromAreEqual() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        StringShape target = StringShape.builder().id(stringId).build();
+        Model model = Model.builder()
+                .addShapes(target)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(stringId, stringId );
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertEquals(result.shapes().count(), 1);
+        assertEquals(result.getShape(stringId).get(), target);
+    }
+
+    @Test
+    public void returnsModelWithRenamedStringShape() {
+        ShapeId fromStringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId keyId = ShapeId.from("ns.foo#Container$key");
+        ShapeId valueId = ShapeId.from("ns.foo#Container$value");
+
+        StringShape target = StringShape.builder().id(fromStringId).build();
+        MemberShape keyMember = MemberShape.builder().id(keyId).target(fromStringId).build();
+        MemberShape valueMember = MemberShape.builder().id(valueId).target(fromStringId).build();
+        MapShape container = MapShape.builder().id(containerId).key(keyMember).value(valueMember).build();
+        Model model = Model.builder()
+                .addShapes(target, keyMember, valueMember, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+
+        ShapeId toStringId = ShapeId.from("ns.bar#String");
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(fromStringId, toStringId );
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertTrue(result.getShape(toStringId).isPresent());
+        assertFalse(result.getShape(fromStringId).isPresent());
+    }
+
+    @Test
+    public void updatesMetadataReferences() {
+        Model model = Model.assembler()
+                .addImport(IntegTest.class.getResource("rename-shape-test-model.json"))
+                .assemble()
+                .unwrap();
+
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        ShapeId fooUnreferenced = ShapeId.from("ns.foo#UnreferencedString");
+        ShapeId barUnreferenced = ShapeId.from("ns.bar#UnreferencedString");
+        renamed.put(fooUnreferenced, barUnreferenced);
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.renameShapes(model, renamed);
+        ArrayNode suppressions = result.getMetadata().get("suppressions").asArrayNode().get();
+        ObjectNode suppression = suppressions.getElements().get(0).asObjectNode().get();
+        ArrayNode suppressionShapes = suppression.getStringMap().get("shapes").expectArrayNode();
+        StringNode suppressionShape = suppressionShapes.getElements().get(0).asStringNode().get();
+
+        assertEquals(suppressionShape.getValue(), "ns.bar#UnreferencedString");
+        assertTrue(result.getShape(barUnreferenced).isPresent());
+        assertFalse(result.getShape(fooUnreferenced).isPresent());
+    }
+
+    @Test
+    public void updatesIdRefValues() {
+        Model model = Model.assembler()
+                .addImport(IntegTest.class.getResource("rename-shape-test-model.json"))
+                .assemble()
+                .unwrap();
+
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        ShapeId fromId = ShapeId.from("ns.foo#OldShape");
+        ShapeId toId = ShapeId.from("ns.foo#NewShape");
+        renamed.put(fromId, toId);
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.renameShapes(model, renamed);
+        StringNode node = Node.from(toId.toShapeId().toString());
+
+        assertTrue(result.getShape(toId).isPresent());
+        assertFalse(result.getShape(fromId).isPresent());
+        Shape shape = result.expectShape(ShapeId.from("ns.foo#ValidShape"));
+        Trait trait = shape.findTrait("ns.foo#integerRef").get();
+        assertEquals(trait.toNode(), node);
+    }
+
+    @Test
+    public void updatesShapeNamesAndReferences() {
+        Model model = Model.assembler()
+                .addImport(IntegTest.class.getResource("rename-shape-test-model.json"))
+                .assemble()
+                .unwrap();
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+
+        // Service
+        ShapeId fromService = ShapeId.from("ns.foo#MyService");
+        ShapeId toService = ShapeId.from("ns.bar#MyNewService");
+        renamed.put(fromService, toService);
+
+        // Operation
+        ShapeId fromOperation = ShapeId.from("ns.foo#MyOperation");
+        ShapeId toOperation = ShapeId.from("ns.baz#MyNewOperation");
+        renamed.put(fromOperation, toOperation);
+        ShapeId fromOtherOperation = ShapeId.from("ns.foo#MyOtherOperation");
+        ShapeId toOtherOperation = ShapeId.from("ns.fred#MyOtherNewOperation");
+        renamed.put(fromOtherOperation, toOtherOperation);
+
+        // Resource
+        ShapeId fromResource = ShapeId.from("ns.foo#MyResource");
+        ShapeId toResource = ShapeId.from("ns.qux#MyNewResource");
+        renamed.put(fromResource, toResource);
+
+        // Structure
+        ShapeId fromStructure = ShapeId.from("ns.foo#MyStructure");
+        ShapeId toStructure = ShapeId.from("ns.quux#MyNewStructure");
+        renamed.put(fromStructure, toStructure);
+
+        // List
+        ShapeId fromList = ShapeId.from("ns.foo#MyList");
+        ShapeId toList = ShapeId.from("ns.quuz#MyNewList");
+        renamed.put(fromList, toList);
+
+        // Map
+        ShapeId fromMap = ShapeId.from("ns.foo#MyMap");
+        ShapeId toMap = ShapeId.from("ns.corge#MyNewMap");
+        renamed.put(fromMap, toMap);
+
+        // Set
+        ShapeId fromSet = ShapeId.from("ns.foo#MySet");
+        ShapeId toSet = ShapeId.from("ns.grault#MyNewSet");
+        renamed.put(fromSet, toSet);
+
+        // Union
+        ShapeId fromUnion = ShapeId.from("ns.foo#MyUnion");
+        ShapeId toUnion = ShapeId.from("ns.garply#MyNewUnion");
+        renamed.put(fromUnion, toUnion);
+
+        // ID
+        ShapeId fromId = ShapeId.from("ns.foo#MyId");
+        ShapeId toId = ShapeId.from("ns.waldo#MyNewId");
+        renamed.put(fromId, toId);
+
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.renameShapes(model, renamed);
+
+        // All new names are present.
+        assertTrue(result.getShape(toService).isPresent());
+        assertTrue(result.getShape(toOperation).isPresent());
+        assertTrue(result.getShape(toResource).isPresent());
+        assertTrue(result.getShape(toStructure).isPresent());
+        assertTrue(result.getShape(toList).isPresent());
+        assertTrue(result.getShape(toMap).isPresent());
+        assertTrue(result.getShape(toSet).isPresent());
+        assertTrue(result.getShape(toUnion).isPresent());
+        assertTrue(result.getShape(toId).isPresent());
+
+        // All new shapes are updated as references.
+        ServiceShape service = result.getShape(toService).get().asServiceShape().get();
+        assertTrue(service.getOperations().contains(toOperation));
+        assertTrue(service.getResources().contains(toResource));
+
+        ResourceShape resource = result.getShape(toResource).get().asResourceShape().get();
+        assertEquals(resource.getIdentifiers().get("myId"), toId);
+        assertTrue(resource.getAllOperations().contains(toOtherOperation));
+
+        StructureShape operationInput = result.getShape(ShapeId.from("ns.foo#MyOperationInput")).get()
+                .asStructureShape().get();
+        MemberShape struct = operationInput.getMember("struct").get();
+        MemberShape list = operationInput.getMember("list").get();
+        MemberShape map = operationInput.getMember("map").get();
+        MemberShape set = operationInput.getMember("set").get();
+        MemberShape union = operationInput.getMember("union").get();
+        assertEquals(struct.getTarget(), toStructure);
+        assertEquals(list.getTarget(), toList);
+        assertEquals(map.getTarget(), toMap);
+        assertEquals(set.getTarget(), toSet);
+        assertEquals(union.getTarget(), toUnion);
+
+        // All old names have been removed.
+        assertFalse(result.getShape(fromService).isPresent());
+        assertFalse(result.getShape(fromOperation).isPresent());
+        assertFalse(result.getShape(fromResource).isPresent());
+        assertFalse(result.getShape(fromStructure).isPresent());
+        assertFalse(result.getShape(fromList).isPresent());
+        assertFalse(result.getShape(fromMap).isPresent());
+        assertFalse(result.getShape(fromSet).isPresent());
+        assertFalse(result.getShape(fromUnion).isPresent());
+        assertFalse(result.getShape(fromId).isPresent());
+    }
+
+    @Test
+    public void updatesListMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        ListShape container = ListShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertTrue(result.getShape(newContainerId).isPresent());
+        ListShape newContainer = result.getShape(newContainerId).get().asListShape().get();
+        assertEquals(newContainer.getMember().getId(), newMemberId);
+        assertFalse(result.getShape(containerId).isPresent());
+    }
+
+    @Test
+    public void updatesMapMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId keyId = ShapeId.from("ns.foo#Container$key");
+        ShapeId valueId = ShapeId.from("ns.foo#Container$value");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape keyMember = MemberShape.builder().id(keyId).target(stringId).build();
+        MemberShape valueMember = MemberShape.builder().id(valueId).target(stringId).build();
+        MapShape container = MapShape.builder().id(containerId).key(keyMember).value(valueMember).build();
+        Model model = Model.builder()
+                .addShapes(target, keyMember, valueMember, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newKeyId = ShapeId.from("ns.bar#Baz$key");
+        ShapeId newValueId = ShapeId.from("ns.bar#Baz$value");
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertTrue(result.getShape(newContainerId).isPresent());
+        MapShape newContainer = result.getShape(newContainerId).get().asMapShape().get();
+        assertEquals(newContainer.getKey().getId(), newKeyId);
+        assertEquals(newContainer.getValue().getId(), newValueId);
+        assertFalse(result.getShape(containerId).isPresent());
+    }
+
+    @Test
+    public void updatesSetMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        SetShape container = SetShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertTrue(result.getShape(newContainerId).isPresent());
+        SetShape newContainer = result.getShape(newContainerId).get().asSetShape().get();
+        assertEquals(newContainer.getMember().getId(), newMemberId);
+        assertFalse(result.getShape(containerId).isPresent());
+    }
+
+    @Test
+    public void updatesStructureMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        StructureShape container = StructureShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertTrue(result.getShape(newContainerId).isPresent());
+        StructureShape newContainer = result.getShape(newContainerId).get().asStructureShape().get();
+        newContainer.getMember("member").ifPresent(newMember -> {
+            assertEquals(newMember.getId(), newMemberId);
+        });
+        assertFalse(result.getShape(containerId).isPresent());
+    }
+
+    @Test
+    public void updatesUnionMembersWhenContainerUpdated() {
+        ShapeId stringId = ShapeId.from("ns.foo#String");
+        ShapeId containerId = ShapeId.from("ns.foo#Container");
+        ShapeId memberId = ShapeId.from("ns.foo#Container$member");
+
+        StringShape target = StringShape.builder().id(stringId).build();
+        MemberShape member = MemberShape.builder().id(memberId).target(target).build();
+        UnionShape container = UnionShape.builder().id(containerId).addMember(member).build();
+        Model model = Model.builder()
+                .addShapes(target, member, container)
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        ShapeId newContainerId = ShapeId.from("ns.bar#Baz");
+        ShapeId newMemberId = ShapeId.from("ns.bar#Baz$member");
+        Map<ShapeId, ShapeId> renamed = new HashMap<>();
+        renamed.put(containerId, newContainerId);
+        Model result = transformer.renameShapes(model, renamed);
+
+        assertTrue(result.getShape(newContainerId).isPresent());
+        UnionShape newContainer = result.getShape(newContainerId).get().asUnionShape().get();
+        newContainer.getMember("member").ifPresent(newMember -> {
+            assertEquals(newMember.getId(), newMemberId);
+        });
+        assertFalse(result.getShape(containerId).isPresent());
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpContentMd5-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpContentMd5-trait.errors
@@ -1,0 +1,4 @@
+[ERROR] ns.foo#InvalidInput: Trait `httpContentMd5` cannot be applied to `ns.foo#InvalidInput`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget
+[ERROR] ns.foo#InvalidOutput: Trait `httpContentMd5` cannot be applied to `ns.foo#InvalidOutput`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget
+[ERROR] ns.foo#InvalidError: Trait `httpContentMd5` cannot be applied to `ns.foo#InvalidError`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget
+[ERROR] ns.foo#InvalidStructure$Body: Trait `httpContentMd5` cannot be applied to `ns.foo#InvalidStructure$Body`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpContentMd5-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpContentMd5-trait.json
@@ -1,0 +1,90 @@
+{
+  "smithy": "0.5.0",
+  "shapes": {
+    "ns.foo#Blob": {
+      "type": "blob"
+    },
+    "ns.foo#ValidOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#Input"
+      },
+      "output": {
+        "target": "ns.foo#Output"
+      },
+      "traits": {
+        "smithy.api#httpContentMd5": true
+      }
+    },
+    "ns.foo#Input": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      }
+    },
+    "ns.foo#Output": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      }
+    },
+    "ns.foo#InvalidOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#Input"
+      },
+      "output": {
+        "target": "ns.foo#Output"
+      }
+    },
+    "ns.foo#InvalidInput": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      },
+      "traits": {
+        "smithy.api#httpContentMd5": true
+      }
+    },
+    "ns.foo#InvalidOutput": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      },
+      "traits": {
+        "smithy.api#httpContentMd5": true
+      }
+    },
+    "ns.foo#InvalidError": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpContentMd5": true
+      }
+    },
+    "ns.foo#InvalidStructure": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob",
+          "traits": {
+            "smithy.api#httpContentMd5": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-shape-test-model.json
@@ -1,0 +1,179 @@
+{
+  "smithy": "0.5.0",
+  "shapes": {
+    "ns.foo#MyService": {
+      "type": "service",
+      "version": "2017-01-17",
+      "operations": [
+        {
+          "target": "ns.foo#MyOperation"
+        }
+      ],
+      "resources": [
+        {
+          "target": "ns.foo#MyResource"
+        }
+      ],
+      "traits": {
+        "smithy.api#protocols": [
+          {
+            "name": "foo"
+          }
+        ]
+      }
+    },
+    "ns.foo#MyOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#MyOperationInput"
+      },
+      "output": {
+        "target": "ns.foo#MyOperationOutput"
+      },
+      "errors": [
+        {
+          "target": "ns.foo#MyOperationError"
+        }
+      ],
+      "traits": {
+        "smithy.api#readonly": true
+      }
+    },
+    "ns.foo#MyOperationInput": {
+      "type": "structure",
+      "members": {
+        "struct": {
+          "target": "ns.foo#MyStructure"
+        },
+        "list": {
+          "target": "ns.foo#MyList"
+        },
+        "map": {
+          "target": "ns.foo#MyMap"
+        },
+        "set": {
+          "target": "ns.foo#MySet"
+        },
+        "union": {
+          "target": "ns.foo#MyUnion"
+        }
+      }
+    },
+    "ns.foo#MyStructure": {
+      "type": "structure"
+    },
+    "ns.foo#MyList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "ns.foo#MyMap": {
+      "type": "map",
+      "key": {
+        "target": "smithy.api#String"
+      },
+      "value": {
+        "target": "smithy.api#String"
+      }
+    },
+    "ns.foo#MySet": {
+      "type": "set",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "ns.foo#MyUnion": {
+      "type": "union",
+      "members": {
+        "a": {
+          "target": "smithy.api#String"
+        },
+        "b": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#sensitive": true
+          }
+        }
+      }
+    },
+    "ns.foo#MyOperationOutput": {
+      "type": "structure"
+    },
+    "ns.foo#MyOperationError": {
+      "type": "structure",
+      "traits": {
+        "smithy.api#error": "client"
+      }
+    },
+    "ns.foo#MyResource": {
+      "type": "resource",
+      "identifiers": {
+        "myId": {
+          "target": "ns.foo#MyId"
+        }
+      },
+      "operations": [
+        {
+          "target": "ns.foo#MyOtherOperation"
+        }
+      ]
+    },
+    "ns.foo#MyId": {
+      "type": "string"
+    },
+    "ns.foo#MyOtherOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#MyOtherInput"
+      },
+      "output": {
+        "target": "ns.foo#MyStructure"
+      }
+    },
+    "ns.foo#MyOtherInput": {
+      "type": "structure",
+      "members": {
+        "myId": {
+          "target": "ns.foo#MyId",
+          "traits": {
+            "smithy.api#required": true
+          }
+        }
+      }
+
+    },
+    "ns.foo#integerRef": {
+      "type": "string",
+      "traits": {
+        "smithy.api#trait": true,
+        "smithy.api#idRef": {
+          "failWhenMissing": true,
+          "selector": "integer"
+        }
+      }
+    },
+    "ns.foo#ValidShape": {
+      "type": "string",
+      "traits": {
+        "ns.foo#integerRef": "ns.foo#OldShape",
+        "smithy.api#deprecated": {}
+      }
+    },
+    "ns.foo#OldShape": {
+      "type": "integer"
+    },
+    "ns.foo#UnreferencedString": {
+      "type": "string"
+    }
+  },
+  "metadata": {
+    "suppressions": [
+      {
+        "ids": ["UnreferencedShape"],
+        "shapes": ["ns.foo#UnreferencedString"],
+        "reason": "unreferenced shape"
+      }
+    ]
+  }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -335,6 +335,11 @@ public final class OpenApiConverter {
         addSecurityComponents(context, openapi, environment.components, mapper);
         openapi.components(environment.components.build());
 
+        // Add arbitrary extensions if they're configured.
+        context.getConfig()
+                .getObjectMember(JsonSchemaConstants.SCHEMA_DOCUMENT_EXTENSIONS)
+                .ifPresent(openapi::extensions);
+
         return mapper.after(context, openapi.build());
     }
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKey.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.openapi.fromsmithy.security;
 
+import java.util.Set;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
 import software.amazon.smithy.openapi.model.SecurityScheme;
+import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Uses an HTTP header named X-Api-Key that contains an API key.
@@ -37,8 +39,13 @@ public final class XApiKey implements SecuritySchemeConverter {
         return SecurityScheme.builder()
                 .type("apiKey")
                 .in("header")
-                .name("X-Api-Key")
+                .name("x-api-key")
                 .description("X-Api-Key authentication")
                 .build();
+    }
+
+    @Override
+    public Set<String> getAuthRequestHeaders() {
+        return SetUtils.of("x-api-key");
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/Component.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/Component.java
@@ -99,6 +99,10 @@ public abstract class Component implements ToNode {
             return (B) this;
         }
 
+        public B extensions(ObjectNode extensions) {
+            return extensions(extensions.getStringMap());
+        }
+
         @SuppressWarnings("unchecked")
         public B putExtension(String key, Node value) {
             extensions.put(key, value);

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
@@ -94,7 +94,8 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
                 .info(info)
                 .paths(paths)
                 .components(components)
-                .externalDocs(externalDocs);
+                .externalDocs(externalDocs)
+                .extensions(getExtensions());
         security.forEach(builder::addSecurity);
         servers.forEach(builder::addServer);
         tags.forEach(builder::addTag);

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKeyTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/XApiKeyTest.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.openapi.fromsmithy.security;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.IoUtils;
+
+public class XApiKeyTest {
+    @Test
+    public void addsXApiKey() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("http-api-key-security.json"))
+                .assemble()
+                .unwrap();
+        OpenApi result = OpenApiConverter.create().convert(model, ShapeId.from("smithy.example#Service"));
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("http-api-key-security.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.json
@@ -1,0 +1,33 @@
+{
+    "smithy": "0.5.0",
+    "shapes": {
+        "smithy.example#Service": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "smithy.example#Operation1"
+                }
+            ],
+            "traits": {
+                "smithy.api#protocols": [
+                    {
+                        "name": "aws.rest-json",
+                        "auth": [
+                            "http-x-api-key"
+                        ]
+                    }
+                ]
+            }
+        },
+        "smithy.example#Operation1": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/",
+                    "method": "GET"
+                }
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.openapi.json
@@ -1,0 +1,34 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Service",
+        "version": "2006-03-01"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "Operation1",
+                "responses": {
+                    "200": {
+                        "description": "Operation1 response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "http-x-api-key": {
+                "type": "apiKey",
+                "description": "X-Api-Key authentication",
+                "name": "x-api-key",
+                "in": "header"
+            }
+        }
+    },
+    "security": [
+        {
+            "http-x-api-key": []
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds support for httpContentMd5 trait


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
