### PR TITLE
`smithy-model`: add support for `httpContentMd5` trait

### DIFF
--- a/docs/source/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source/spec/aws/aws-restxml-protocol.rst
@@ -56,4 +56,31 @@ See
             }
         }
 
+
+.. _aws.protocols#httpContentMd5-trait:
+
+--------------------------------------
+``aws.protocols#httpContentMd5`` trait
+--------------------------------------
+
+Summary
+    Indicates that an operation requires the Content-MD5 header set in its HTTP
+    request.
+Trait selector
+    ``operation``
+Value type
+    Annotation trait.
+See
+    :rfc:`1864`
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        @httpContentMd5
+        operation PutSomething {
+            input: PutSomethingInput,
+            output: PutSomethingOutput
+        }
+
 *TODO: Add specifications, protocol examples, etc.*

--- a/docs/source/spec/core/behavior-traits.rst
+++ b/docs/source/spec/core/behavior-traits.rst
@@ -77,8 +77,8 @@ Conflicts with
     .. code-tab:: smithy
 
         @idempotent
-        operation GetSomething {
-            input: DeleteSomething,
+        operation DeleteSomething {
+            input: DeleteSomethingInput,
             output: DeleteSomethingOutput
         }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/HttpContentMd5Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/HttpContentMd5Trait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,26 +15,27 @@
 
 package software.amazon.smithy.aws.traits.protocols;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.BooleanTrait;
+import software.amazon.smithy.model.traits.AnnotationTrait;
 
 /**
  * Indicates that the operation requires Content-MD5 header in its
  * HTTP request.
  */
-public final class HttpContentMd5Trait extends BooleanTrait {
+public final class HttpContentMd5Trait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("aws.protocols#httpContentMd5");
 
-    public HttpContentMd5Trait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HttpContentMd5Trait(ObjectNode node) {
+        super(ID, node);
     }
 
     public HttpContentMd5Trait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public static final class Provider extends BooleanTrait.Provider<HttpContentMd5Trait> {
+    public static final class Provider extends AnnotationTrait.Provider<HttpContentMd5Trait> {
         public Provider() {
             super(ID, HttpContentMd5Trait::new);
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/HttpContentMd5Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/HttpContentMd5Trait.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits.protocols;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.BooleanTrait;
+
+/**
+ * Indicates that the operation requires Content-MD5 header in its
+ * HTTP request.
+ */
+public final class HttpContentMd5Trait extends BooleanTrait {
+    public static final ShapeId ID = ShapeId.from("aws.protocols#httpContentMd5");
+
+    public HttpContentMd5Trait(SourceLocation sourceLocation) {
+        super(ID, sourceLocation);
+    }
+
+    public HttpContentMd5Trait() {
+        this(SourceLocation.NONE);
+    }
+
+    public static final class Provider extends BooleanTrait.Provider<HttpContentMd5Trait> {
+        public Provider() {
+            super(ID, HttpContentMd5Trait::new);
+        }
+    }
+}

--- a/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -16,4 +16,5 @@ software.amazon.smithy.aws.traits.protocols.RestJson1Trait$Provider
 software.amazon.smithy.aws.traits.protocols.RestXmlTrait$Provider
 software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait$Provider
 software.amazon.smithy.aws.traits.protocols.AwsJson1_1Trait$Provider
+software.amazon.smithy.aws.traits.protocols.HttpContentMd5Trait$Provider
 software.amazon.smithy.aws.traits.auth.SigV4Trait$Provider

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
@@ -165,6 +165,15 @@
             "traits": {
                 "smithy.api#private": {}
             }
+        },
+        "aws.protocols#httpContentMd5": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "operation"
+                },
+                "smithy.api#documentation": "Defines if an operation requires Content-MD5 header set in its HTTP request"
+            }
         }
     }
 }

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
@@ -172,7 +172,7 @@
                 "smithy.api#trait": {
                     "selector": "operation"
                 },
-                "smithy.api#documentation": "Defines if an operation requires Content-MD5 header set in its HTTP request"
+                "smithy.api#documentation": "Defines if an operation requires the Content-MD5 header set in its HTTP request"
             }
         }
     }

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/httpContentMd5-trait.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/httpContentMd5-trait.errors
@@ -1,0 +1,4 @@
+[ERROR] ns.foo#InvalidInput: Trait `aws.protocols#httpContentMd5` cannot be applied to `ns.foo#InvalidInput`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget
+[ERROR] ns.foo#InvalidOutput: Trait `aws.protocols#httpContentMd5` cannot be applied to `ns.foo#InvalidOutput`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget
+[ERROR] ns.foo#InvalidError: Trait `aws.protocols#httpContentMd5` cannot be applied to `ns.foo#InvalidError`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget
+[ERROR] ns.foo#InvalidStructure$Body: Trait `aws.protocols#httpContentMd5` cannot be applied to `ns.foo#InvalidStructure$Body`. This trait may only be applied to shapes that match the following selector: operation | TraitTarget

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/httpContentMd5-trait.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/httpContentMd5-trait.json
@@ -1,0 +1,90 @@
+{
+  "smithy": "1.0.0",
+  "shapes": {
+    "ns.foo#Blob": {
+      "type": "blob"
+    },
+    "ns.foo#ValidOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#Input"
+      },
+      "output": {
+        "target": "ns.foo#Output"
+      },
+      "traits": {
+        "aws.protocols#httpContentMd5": true
+      }
+    },
+    "ns.foo#Input": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      }
+    },
+    "ns.foo#Output": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      }
+    },
+    "ns.foo#InvalidOperation": {
+      "type": "operation",
+      "input": {
+        "target": "ns.foo#Input"
+      },
+      "output": {
+        "target": "ns.foo#Output"
+      }
+    },
+    "ns.foo#InvalidInput": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      },
+      "traits": {
+        "aws.protocols#httpContentMd5": true
+      }
+    },
+    "ns.foo#InvalidOutput": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      },
+      "traits": {
+        "aws.protocols#httpContentMd5": true
+      }
+    },
+    "ns.foo#InvalidError": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob"
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "aws.protocols#httpContentMd5": true
+      }
+    },
+    "ns.foo#InvalidStructure": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "smithy.api#Blob",
+          "traits": {
+            "aws.protocols#httpContentMd5": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/httpContentMd5-trait.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/httpContentMd5-trait.json
@@ -13,7 +13,7 @@
         "target": "ns.foo#Output"
       },
       "traits": {
-        "aws.protocols#httpContentMd5": true
+        "aws.protocols#httpContentMd5": {}
       }
     },
     "ns.foo#Input": {
@@ -49,7 +49,7 @@
         }
       },
       "traits": {
-        "aws.protocols#httpContentMd5": true
+        "aws.protocols#httpContentMd5": {}
       }
     },
     "ns.foo#InvalidOutput": {
@@ -60,7 +60,7 @@
         }
       },
       "traits": {
-        "aws.protocols#httpContentMd5": true
+        "aws.protocols#httpContentMd5": {}
       }
     },
     "ns.foo#InvalidError": {
@@ -72,7 +72,7 @@
       },
       "traits": {
         "smithy.api#error": "client",
-        "aws.protocols#httpContentMd5": true
+        "aws.protocols#httpContentMd5": {}
       }
     },
     "ns.foo#InvalidStructure": {
@@ -81,7 +81,7 @@
         "Body": {
           "target": "smithy.api#Blob",
           "traits": {
-            "aws.protocols#httpContentMd5": true
+            "aws.protocols#httpContentMd5": {}
           }
         }
       }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add support for `httpContentMd5` trait

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
