### PR TITLE
Mark node validation visitors internal

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -64,6 +64,7 @@ import software.amazon.smithy.model.validation.node.StringLengthPlugin;
 import software.amazon.smithy.model.validation.node.TimestampValidationStrategy;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Validates {@link Node} values provided for {@link Shape} definitions.
@@ -465,6 +466,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
          * @param timestampValidationStrategy Timestamp validation strategy.
          * @return Returns the builder.
          */
+        @SmithyUnstableApi
         public Builder timestampValidationStrategy(TimestampValidationStrategy timestampValidationStrategy) {
             this.timestampValidationStrategy = timestampValidationStrategy;
             return this;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
@@ -23,10 +23,12 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates length trait on blob shapes and members that target blob shapes.
  */
+@SmithyInternalApi
 public final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, StringNode, LengthTrait> {
     public BlobLengthPlugin() {
         super(BlobShape.class, StringNode.class, LengthTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/CollectionLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/CollectionLengthPlugin.java
@@ -22,11 +22,13 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates the length trait on both list and set shapes or members that
  * target them.
  */
+@SmithyInternalApi
 public class CollectionLengthPlugin extends MemberAndShapeTraitPlugin<CollectionShape, ArrayNode, LengthTrait> {
     public CollectionLengthPlugin() {
         super(CollectionShape.class, ArrayNode.class, LengthTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/IdRefPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/IdRefPlugin.java
@@ -24,12 +24,14 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.IdRefTrait;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates that the value contained in a string shape is a valid shape ID
  * and that the shape ID targets a shape that is in the set of shapes
  * matching the selector.
  */
+@SmithyInternalApi
 public final class IdRefPlugin extends MemberAndShapeTraitPlugin<StringShape, StringNode, IdRefTrait> {
 
     public IdRefPlugin() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
@@ -22,10 +22,12 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates the length trait on map shapes or members that target them.
  */
+@SmithyInternalApi
 public final class MapLengthPlugin extends MemberAndShapeTraitPlugin<MapShape, ObjectNode, LengthTrait> {
     public MapLengthPlugin() {
         super(MapShape.class, ObjectNode.class, LengthTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
@@ -19,12 +19,14 @@ import java.util.List;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Applies pluggable validation when validating {@link Node} values against
  * the schema of a {@link Shape} (e.g., when validating that the values
  * provided for a trait in the model are valid for the shape of the trait).
  */
+@SmithyInternalApi
 public interface NodeValidatorPlugin {
     /**
      * Applies the plugin to the given shape, node value, and model.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
@@ -22,10 +22,12 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.PatternTrait;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates the pattern trait on string shapes or members that target them.
  */
+@SmithyInternalApi
 public final class PatternTraitPlugin extends MemberAndShapeTraitPlugin<StringShape, StringNode, PatternTrait> {
     public PatternTraitPlugin() {
         super(StringShape.class, StringNode.class, PatternTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -23,10 +23,12 @@ import software.amazon.smithy.model.node.NumberNode;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.RangeTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates the range trait on number shapes or members that target them.
  */
+@SmithyInternalApi
 public final class RangeTraitPlugin extends MemberAndShapeTraitPlugin<NumberShape, NumberNode, RangeTrait> {
     public RangeTraitPlugin() {
         super(NumberShape.class, NumberNode.class, RangeTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringEnumPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringEnumPlugin.java
@@ -22,10 +22,12 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.validation.ValidationUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates the enum trait on string shapes.
  */
+@SmithyInternalApi
 public final class StringEnumPlugin extends FilteredPlugin<StringShape, StringNode> {
     public StringEnumPlugin() {
         super(StringShape.class, StringNode.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
@@ -22,10 +22,12 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates the length trait on string shapes or members that target them.
  */
+@SmithyInternalApi
 public final class StringLengthPlugin extends MemberAndShapeTraitPlugin<StringShape, StringNode, LengthTrait> {
     public StringLengthPlugin() {
         super(StringShape.class, StringNode.class, LengthTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
@@ -26,12 +26,14 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Validates that timestamp shapes contain values that are compatible with their
  * timestampFormat traits or contain values that are numbers or an RFC 3339
  * date-time production.
  */
+@SmithyInternalApi
 public final class TimestampFormatPlugin implements NodeValidatorPlugin {
     private static final DateTimeFormatter HTTP_DATE = DateTimeFormatter.RFC_1123_DATE_TIME;
     private static final DateTimeFormatter DATE_TIME_Z = DateTimeFormatter.ISO_INSTANT;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
@@ -22,10 +22,12 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Defines how timestamps are validated.
  */
+@SmithyInternalApi
 public enum TimestampValidationStrategy implements NodeValidatorPlugin {
     /**
      * Validates timestamps by requiring that the value uses matches the


### PR DESCRIPTION
NodeValidationVisitors need to be refactored so that they emit
validation events with proper source locations (right now they aren't
tied to any source location). This will require changing the API of
NodeValidatorPlugin implementations, which would be a breaking change.
Because of this, I'm marking these APIs as internal, which will allow us
to safely break these APIs and improve them when we have the time.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
