### PR TITLE
Add CleanTraitDefinitions plugin

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform.plugins;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.AuthDefinitionTrait;
+import software.amazon.smithy.model.traits.ProtocolDefinitionTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.transform.ModelTransformerPlugin;
+
+/**
+ * Removes traits from {@link AuthDefinitionTrait} and
+ * {@link ProtocolDefinitionTrait} traits that refer to removed shapes.
+ */
+public final class CleanTraitDefinitions implements ModelTransformerPlugin {
+    @Override
+    public Model onRemove(ModelTransformer transformer, Collection<Shape> removed, Model model) {
+        Set<ShapeId> removedShapeIds = removed.stream().map(Shape::getId).collect(Collectors.toSet());
+        model = transformer.replaceShapes(model, getAuthDefShapesToReplace(model, removedShapeIds));
+
+        return transformer.replaceShapes(model, getProtocolDefShapesToReplace(model, removedShapeIds));
+    }
+
+    private Set<Shape> getAuthDefShapesToReplace(Model model, Set<ShapeId> removedShapeIds) {
+        return model.shapes(StructureShape.class)
+                .flatMap(s -> Trait.flatMapStream(s, AuthDefinitionTrait.class))
+                .flatMap(pair -> {
+                    StructureShape subject = pair.getLeft();
+                    AuthDefinitionTrait authDefTrait = pair.getRight();
+                    List<ShapeId> traits = authDefTrait.getTraits();
+                    // Build new set of traits for AuthDefinitionTrait, excluding any that have been removed.
+                    List<ShapeId> newTraits = traits.stream()
+                            .filter(trait -> !removedShapeIds.contains(trait))
+                            .collect(Collectors.toList());
+
+                    // Return early if re-built list of traits is the same as existing list.
+                    if (traits.equals(newTraits)) {
+                        return Stream.empty();
+                    }
+
+                    // Rebuild AuthDefinitionTrait with new list of traits.
+                    AuthDefinitionTrait.Builder traitBuilder = AuthDefinitionTrait.builder();
+                    traitBuilder.sourceLocation(authDefTrait.getSourceLocation());
+                    newTraits.forEach(traitBuilder::addTrait);
+
+                    // Return rebuilt shape.
+                    return Stream.of(subject.toBuilder().addTrait(traitBuilder.build()).build());
+                })
+                .collect(Collectors.toSet());
+    }
+
+    private Set<Shape> getProtocolDefShapesToReplace(Model model, Set<ShapeId> removedShapeIds) {
+        return model.shapes(StructureShape.class)
+                .flatMap(s -> Trait.flatMapStream(s, ProtocolDefinitionTrait.class))
+                .flatMap(pair -> {
+                    StructureShape subject = pair.getLeft();
+                    ProtocolDefinitionTrait protocolDefinitionTrait = pair.getRight();
+
+                    List<ShapeId> traits = protocolDefinitionTrait.getTraits();
+                    // Build new set of traits for ProtocolDefinitionTrait, excluding any that have been removed.
+                    List<ShapeId> newTraits = traits.stream()
+                            .filter(trait -> !removedShapeIds.contains(trait))
+                            .collect(Collectors.toList());
+
+                    // Return early if re-built list of traits is the same as existing list.
+                    if (traits.equals(newTraits)) {
+                        return Stream.empty();
+                    }
+
+                    // Rebuild AuthDefinitionTrait with new list of traits.
+                    ProtocolDefinitionTrait.Builder traitBuilder = ProtocolDefinitionTrait.builder();
+                    traitBuilder.sourceLocation(protocolDefinitionTrait.getSourceLocation());
+                    newTraits.forEach(traitBuilder::addTrait);
+
+                    // Return rebuilt shape.
+                    return Stream.of(subject.toBuilder().addTrait(traitBuilder.build()).build());
+                })
+                .collect(Collectors.toSet());
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
@@ -56,6 +56,8 @@ public final class CleanTraitDefinitions implements ModelTransformerPlugin {
                         return Stream.empty();
                     }
 
+                    // If the list of traits on the AuthDefinitionTrait has changed due to a trait shape being
+                    // removed from the model, return a new version of the shape with a new version of the trait.
                     return Stream.of(pair.getLeft().toBuilder().addTrait(authDefTrait.toBuilder()
                             .traits(newTraits).build()).build());
                 })
@@ -75,6 +77,9 @@ public final class CleanTraitDefinitions implements ModelTransformerPlugin {
                         return Stream.empty();
                     }
 
+                    // If the list of traits on the ProtocolDefinitionTrait has changed due to a trait shape
+                    // being removed from the model, return a new version of the shape with a new version of
+                    // the trait.
                     return Stream.of(pair.getLeft().toBuilder().addTrait(protocolDefinitionTrait.toBuilder()
                             .traits(newTraits).build()).build());
                 })

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -57,21 +56,10 @@ public final class CleanTraitDefinitions implements ModelTransformerPlugin {
                         return Stream.empty();
                     }
 
-                    return rebuildShapeWithAuthDef(pair.getLeft(), authDefTrait.getSourceLocation(), newTraits);
+                    return Stream.of(pair.getLeft().toBuilder().addTrait(authDefTrait.toBuilder()
+                            .traits(newTraits).build()).build());
                 })
                 .collect(Collectors.toSet());
-    }
-
-    private Stream<Shape> rebuildShapeWithAuthDef(
-            StructureShape shape,
-            SourceLocation location,
-            List<ShapeId> traits
-    ) {
-        AuthDefinitionTrait.Builder traitBuilder = AuthDefinitionTrait.builder();
-        traitBuilder.sourceLocation(location);
-        traits.forEach(traitBuilder::addTrait);
-
-        return Stream.of(shape.toBuilder().addTrait(traitBuilder.build()).build());
     }
 
     private Set<Shape> getProtocolDefShapesToReplace(Model model, Set<ShapeId> removedShapeIds) {
@@ -87,24 +75,10 @@ public final class CleanTraitDefinitions implements ModelTransformerPlugin {
                         return Stream.empty();
                     }
 
-                    return rebuildShapeWithProtocolDef(
-                            pair.getLeft(),
-                            protocolDefinitionTrait.getSourceLocation(),
-                            newTraits);
+                    return Stream.of(pair.getLeft().toBuilder().addTrait(protocolDefinitionTrait.toBuilder()
+                            .traits(newTraits).build()).build());
                 })
                 .collect(Collectors.toSet());
-    }
-
-    private Stream<Shape> rebuildShapeWithProtocolDef(
-            StructureShape shape,
-            SourceLocation location,
-            List<ShapeId> traits
-    ) {
-        ProtocolDefinitionTrait.Builder traitBuilder = ProtocolDefinitionTrait.builder();
-        traitBuilder.sourceLocation(location);
-        traits.forEach(traitBuilder::addTrait);
-
-        return Stream.of(shape.toBuilder().addTrait(traitBuilder.build()).build());
     }
 
     private List<ShapeId> excludeTraitsInSet(List<ShapeId> traits, Set<ShapeId> shapeIds) {

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.transform.ModelTransformerPlugin
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.transform.ModelTransformerPlugin
@@ -2,4 +2,5 @@ software.amazon.smithy.model.transform.plugins.CleanBindings
 software.amazon.smithy.model.transform.plugins.CleanOperationStructures
 software.amazon.smithy.model.transform.plugins.CleanResourceReferences
 software.amazon.smithy.model.transform.plugins.CleanStructureAndUnionMembers
+software.amazon.smithy.model.transform.plugins.CleanTraitDefinitions
 software.amazon.smithy.model.transform.plugins.RemoveTraits

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.transform;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/remove-shapes.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/remove-shapes.json
@@ -1,0 +1,47 @@
+{
+    "smithy": "1.0.0",
+    "shapes": {
+        "ns.foo#auth": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "service"
+                },
+                "smithy.api#authDefinition": {
+                    "traits": [
+                        "ns.foo#bar"
+                    ]
+                }
+            }
+        },
+        "ns.foo#bar": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "operation"
+                }
+            }
+        },
+        "ns.foo#protocol": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "service"
+                },
+                "smithy.api#protocolDefinition": {
+                    "traits": [
+                        "ns.foo#baz"
+                    ]
+                }
+            }
+        },
+        "ns.foo#baz": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "operation"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds CleanTraitDefinitions transformer plugin that removes traits listed on AuthDefinitionTrait and ProtocolDefinitionTrait traits when a shape is removed from a model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
