### PR TITLE
Make annotation traits lossless

### DIFF
--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DisableConditionKeyInferenceTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DisableConditionKeyInferenceTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.aws.iam.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
@@ -25,12 +26,12 @@ import software.amazon.smithy.model.traits.AnnotationTrait;
 public final class DisableConditionKeyInferenceTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("aws.iam#disableConditionKeyInference");
 
-    public DisableConditionKeyInferenceTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public DisableConditionKeyInferenceTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public DisableConditionKeyInferenceTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<DisableConditionKeyInferenceTrait> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ControlPlaneTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ControlPlaneTrait.java
@@ -15,19 +15,20 @@
 
 package software.amazon.smithy.aws.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
 public final class ControlPlaneTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("aws.api#controlPlane");
 
-    public ControlPlaneTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public ControlPlaneTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public ControlPlaneTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<ControlPlaneTrait> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/DataPlaneTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/DataPlaneTrait.java
@@ -15,19 +15,20 @@
 
 package software.amazon.smithy.aws.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
 public final class DataPlaneTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("aws.api#dataPlane");
 
-    public DataPlaneTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public DataPlaneTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public DataPlaneTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<DataPlaneTrait> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/UnsignedPayloadTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/UnsignedPayloadTrait.java
@@ -15,8 +15,8 @@
 
 package software.amazon.smithy.aws.traits.auth;
 
-import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
@@ -26,12 +26,12 @@ import software.amazon.smithy.model.traits.AnnotationTrait;
 public final class UnsignedPayloadTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("aws.auth#unsignedPayload");
 
-    public UnsignedPayloadTrait(FromSourceLocation sourceLocation) {
-        super(ID, sourceLocation.getSourceLocation());
+    public UnsignedPayloadTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public UnsignedPayloadTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<UnsignedPayloadTrait> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.aws.traits.clientendpointdiscovery;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
@@ -26,12 +27,12 @@ import software.amazon.smithy.model.traits.AnnotationTrait;
 public final class ClientEndpointDiscoveryIdTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("aws.api#clientEndpointDiscoveryId");
 
-    public ClientEndpointDiscoveryIdTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public ClientEndpointDiscoveryIdTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public ClientEndpointDiscoveryIdTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<ClientEndpointDiscoveryIdTrait> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsQueryTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsQueryTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.aws.traits.protocols;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
@@ -29,12 +30,12 @@ public final class AwsQueryTrait extends AnnotationTrait {
 
     public static final ShapeId ID = ShapeId.from("aws.protocols#awsQuery");
 
-    public AwsQueryTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public AwsQueryTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public AwsQueryTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<AwsQueryTrait> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/Ec2QueryTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/Ec2QueryTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.aws.traits.protocols;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
@@ -30,12 +31,12 @@ public final class Ec2QueryTrait extends AnnotationTrait {
 
     public static final ShapeId ID = ShapeId.from("aws.protocols#ec2Query");
 
-    public Ec2QueryTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public Ec2QueryTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public Ec2QueryTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<Ec2QueryTrait> {

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeTraitsTest.java
@@ -37,7 +37,7 @@ public class ExcludeTraitsTest {
     public void removesTraitsInList() {
         StringShape stringShape = StringShape.builder()
                 .id("ns.foo#baz")
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .build();
         Model model = Model.assembler()

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeTraitsTest.java
@@ -64,7 +64,7 @@ public class IncludeTraitsTest {
     public void includesBuiltinTraits() {
         StringShape stringShape = StringShape.builder()
                 .id("ns.foo#baz")
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .build();
         Model model = Model.assembler()

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/DifferencesTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/DifferencesTest.java
@@ -85,7 +85,7 @@ public class DifferencesTest {
         Shape shape1 = StringShape.builder().id("foo.bar#Baz").build();
         Shape shape2 = StringShape.builder()
                 .id("foo.bar#Baz")
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model previous = Model.assembler().addShape(shape1).assemble().unwrap();
         Model current = Model.assembler().addShape(shape2).assemble().unwrap();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/BoxTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/BoxTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class BoxTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#box");
 
-    public BoxTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public BoxTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public BoxTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<BoxTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EventHeaderTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EventHeaderTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -27,12 +28,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class EventHeaderTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#eventHeader");
 
-    public EventHeaderTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public EventHeaderTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public EventHeaderTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<EventHeaderTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EventPayloadTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EventPayloadTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -27,12 +28,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class EventPayloadTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#eventPayload");
 
-    public EventPayloadTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public EventPayloadTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public EventPayloadTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<EventPayloadTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HostLabelTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HostLabelTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -25,12 +26,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class HostLabelTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#hostLabel");
 
-    public HostLabelTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HostLabelTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public HostLabelTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<HostLabelTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBasicAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBasicAuthTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -26,11 +27,11 @@ public final class HttpBasicAuthTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#httpBasicAuth");
 
     public HttpBasicAuthTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public HttpBasicAuthTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HttpBasicAuthTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public static final class Provider extends AnnotationTrait.Provider<HttpBasicAuthTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -26,11 +27,11 @@ public final class HttpBearerAuthTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#httpBearerAuth");
 
     public HttpBearerAuthTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public HttpBearerAuthTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HttpBearerAuthTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public static final class Provider extends AnnotationTrait.Provider<HttpBearerAuthTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpDigestAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpDigestAuthTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -26,11 +27,11 @@ public final class HttpDigestAuthTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#httpDigestAuth");
 
     public HttpDigestAuthTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public HttpDigestAuthTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HttpDigestAuthTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public static final class Provider extends AnnotationTrait.Provider<HttpDigestAuthTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpLabelTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpLabelTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -25,12 +26,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class HttpLabelTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#httpLabel");
 
-    public HttpLabelTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HttpLabelTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public HttpLabelTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<HttpLabelTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpPayloadTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpPayloadTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class HttpPayloadTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#httpPayload");
 
-    public HttpPayloadTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public HttpPayloadTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public HttpPayloadTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<HttpPayloadTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdempotencyTokenTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdempotencyTokenTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -25,12 +26,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class IdempotencyTokenTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#idempotencyToken");
 
-    public IdempotencyTokenTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public IdempotencyTokenTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public IdempotencyTokenTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<IdempotencyTokenTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdempotentTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdempotentTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class IdempotentTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#idempotent");
 
-    public IdempotentTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public IdempotentTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public IdempotentTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<IdempotentTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/NoReplaceTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/NoReplaceTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -26,12 +27,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class NoReplaceTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#noReplace");
 
-    public NoReplaceTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public NoReplaceTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public NoReplaceTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<NoReplaceTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/OptionalAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/OptionalAuthTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -25,11 +26,11 @@ public final class OptionalAuthTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#optionalAuth");
 
     public OptionalAuthTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public OptionalAuthTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public OptionalAuthTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public static final class Provider extends AnnotationTrait.Provider<OptionalAuthTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/PrivateTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/PrivateTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -25,12 +26,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class PrivateTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#private");
 
-    public PrivateTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public PrivateTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public PrivateTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<PrivateTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReadonlyTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReadonlyTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class ReadonlyTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#readonly");
 
-    public ReadonlyTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public ReadonlyTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public ReadonlyTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<ReadonlyTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequiredTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequiredTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class RequiredTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#required");
 
-    public RequiredTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public RequiredTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public RequiredTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<RequiredTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequiresLengthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequiresLengthTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class RequiresLengthTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#requiresLength");
 
-    public RequiresLengthTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public RequiresLengthTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public RequiresLengthTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<RequiresLengthTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/SensitiveTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/SensitiveTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -25,12 +26,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class SensitiveTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#sensitive");
 
-    public SensitiveTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public SensitiveTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public SensitiveTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<SensitiveTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/StreamingTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/StreamingTrait.java
@@ -16,7 +16,8 @@
 package software.amazon.smithy.model.traits;
 
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -29,12 +30,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class StreamingTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#streaming");
 
-    public StreamingTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public StreamingTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public StreamingTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<StreamingTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/UniqueItemsTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/UniqueItemsTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class UniqueItemsTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#uniqueItems");
 
-    public UniqueItemsTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public UniqueItemsTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public UniqueItemsTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<UniqueItemsTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/UnstableTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/UnstableTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class UnstableTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#unstable");
 
-    public UnstableTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public UnstableTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public UnstableTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<UnstableTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlAttributeTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlAttributeTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -24,12 +25,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class XmlAttributeTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#xmlAttribute");
 
-    public XmlAttributeTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public XmlAttributeTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public XmlAttributeTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<XmlAttributeTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlFlattenedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlFlattenedTrait.java
@@ -15,18 +15,19 @@
 
 package software.amazon.smithy.model.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class XmlFlattenedTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.api#xmlFlattened");
 
-    public XmlFlattenedTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public XmlFlattenedTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public XmlFlattenedTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<XmlFlattenedTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -274,7 +274,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
                         String key = keyNode.getValue();
                         if (!members.containsKey(key)) {
                             events.add(event("Invalid structure member `" + key + "` found for `"
-                                             + shape.getId() + "`"));
+                                             + shape.getId() + "`", Severity.WARNING));
                         } else {
                             events.addAll(withNode(key, value).memberShape(members.get(key)));
                         }
@@ -369,9 +369,13 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
     }
 
     private ValidationEvent event(String message) {
+        return event(message, Severity.ERROR);
+    }
+
+    private ValidationEvent event(String message, Severity severity) {
         return ValidationEvent.builder()
                 .eventId(eventId)
-                .severity(Severity.ERROR)
+                .severity(severity)
                 .sourceLocation(value.getSourceLocation())
                 .shapeId(eventShapeId)
                 .message(context.isEmpty() ? message : context + ": " + message)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -148,7 +148,7 @@ public class HttpBindingIndexTest {
                 expectMember(model, "ns.foo#ServiceOperationExplicitBodyOutput$baz"),
                 HttpBinding.Location.PAYLOAD,
                 "baz",
-                new HttpPayloadTrait(SourceLocation.NONE))));
+                new HttpPayloadTrait())));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class HttpBindingIndexTest {
                 .addMember(MemberShape.builder()
                                    .id("ns.foo#Input$bar")
                                    .target("ns.foo#String")
-                                   .addTrait(new HttpPayloadTrait(SourceLocation.NONE))
+                                   .addTrait(new HttpPayloadTrait())
                                    .build())
                 .addMember(MemberShape.builder().id("ns.foo#Input$baz").target("ns.foo#String").build())
                 .build();
@@ -213,7 +213,7 @@ public class HttpBindingIndexTest {
         Shape shape = MemberShape.builder()
                 .target("smithy.api#Timestamp")
                 .id("smithy.example#Baz$bar")
-                .addTrait(new HttpLabelTrait(SourceLocation.NONE))
+                .addTrait(new HttpLabelTrait())
                 .build();
 
         assertThat(HttpBindingIndex.hasHttpRequestBindings(shape), is(true));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndexTest.java
@@ -54,7 +54,7 @@ public class IdentifierBindingIndexTest {
                 .id("ns.foo#Input")
                 .addMember(MemberShape.builder()
                                    .id("ns.foo#Input$abc")
-                                   .addTrait(new RequiredTrait(SourceLocation.NONE))
+                                   .addTrait(new RequiredTrait())
                                    .target("ns.foo#Id").build())
                 .build();
         OperationShape operation = OperationShape.builder().id("ns.foo#Operation").input(input.getId()).build();
@@ -125,7 +125,7 @@ public class IdentifierBindingIndexTest {
                 .id("ns.foo#Input")
                 .addMember(MemberShape.builder()
                         .id("ns.foo#Input$def")
-                        .addTrait(new RequiredTrait(SourceLocation.NONE))
+                        .addTrait(new RequiredTrait())
                         .addTrait(new ResourceIdentifierTrait("abc", SourceLocation.NONE))
                         .target("smithy.api#String").build())
                 .build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/BottomUpNeighborVisitorTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.empty;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
@@ -252,16 +251,16 @@ public class BottomUpNeighborVisitorTest {
         OperationShape createOperation = OperationShape.builder().id("ns.foo#Create").build();
         OperationShape getOperation = OperationShape.builder()
                 .id("ns.foo#Get")
-                .addTrait(new ReadonlyTrait(SourceLocation.NONE))
+                .addTrait(new ReadonlyTrait())
                 .build();
         OperationShape updateOperation = OperationShape.builder().id("ns.foo#Update").build();
         OperationShape deleteOperation = OperationShape.builder()
                 .id("ns.foo#Delete")
-                .addTrait(new IdempotentTrait(SourceLocation.NONE))
+                .addTrait(new IdempotentTrait())
                 .build();
         OperationShape listOperation = OperationShape.builder()
                 .id("ns.foo#List")
-                .addTrait(new ReadonlyTrait(SourceLocation.NONE))
+                .addTrait(new ReadonlyTrait())
                 .build();
         OperationShape namedOperation = OperationShape.builder()
                 .id("ns.foo#Named")

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.empty;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.BooleanShape;
 import software.amazon.smithy.model.shapes.ListShape;
@@ -235,16 +234,16 @@ public class NeighborVisitorTest {
         OperationShape createOperation = OperationShape.builder().id("ns.foo#Create").build();
         OperationShape getOperation = OperationShape.builder()
                 .id("ns.foo#Get")
-                .addTrait(new ReadonlyTrait(SourceLocation.NONE))
+                .addTrait(new ReadonlyTrait())
                 .build();
         OperationShape updateOperation = OperationShape.builder().id("ns.foo#Update").build();
         OperationShape deleteOperation = OperationShape.builder()
                 .id("ns.foo#Delete")
-                .addTrait(new IdempotentTrait(SourceLocation.NONE))
+                .addTrait(new IdempotentTrait())
                 .build();
         OperationShape listOperation = OperationShape.builder()
                 .id("ns.foo#List")
-                .addTrait(new ReadonlyTrait(SourceLocation.NONE))
+                .addTrait(new ReadonlyTrait())
                 .build();
         OperationShape namedOperation = OperationShape.builder()
                 .id("ns.foo#Named")

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/UnreferencedShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/UnreferencedShapesTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
@@ -77,7 +76,7 @@ public class UnreferencedShapesTest {
 
     private Model createPrivateShapeModel(ShapeId id) {
         return Model.assembler()
-                .addShape(StringShape.builder().id(id).addTrait(new PrivateTrait(SourceLocation.NONE)).build())
+                .addShape(StringShape.builder().id(id).addTrait(new PrivateTrait()).build())
                 .assemble()
                 .unwrap();
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/AndSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/AndSelectorTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -37,7 +36,7 @@ public class AndSelectorTest {
                 new ShapeTypeSelector(ShapeType.STRING),
                 new AttributeSelector(new TraitAttributeKey("sensitive"))));
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
-        Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait(SourceLocation.NONE)).build();
+        Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait()).build();
         Model model = Model.builder().addShapes(a, b).build();
         Set<Shape> result = selector.select(model);
 
@@ -50,7 +49,7 @@ public class AndSelectorTest {
                 new ShapeTypeSelector(ShapeType.BIG_INTEGER),
                 new AttributeSelector(new TraitAttributeKey("sensitive"))));
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
-        Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait(SourceLocation.NONE)).build();
+        Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait()).build();
         Model model = Model.builder().addShapes(a, b).build();
         Set<Shape> result = selector.select(model);
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/OfSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/OfSelectorTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -71,7 +70,7 @@ public class OfSelectorTest {
                 .build();
         Shape b = StructureShape.builder().id("foo.baz#B")
                 .addMember(bMember)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         MemberShape cMember = MemberShape.builder()
                 .id("foo.baz#C$member")

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -91,7 +91,7 @@ public class ModelSerializerTest {
     public void canFilterTraits() {
         Shape shape = StringShape.builder()
                 .id("ns.foo#baz")
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .build();
         Model model = Model.assembler().addShape(shape).assemble().unwrap();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/AnnotationTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/AnnotationTraitTest.java
@@ -9,8 +9,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.MapUtils;
 
 public class AnnotationTraitTest {
     @Test
@@ -30,5 +32,15 @@ public class AnnotationTraitTest {
         Assertions.assertThrows(ExpectationNotMetException.class, () -> {
             new SensitiveTrait.Provider().createTrait(ShapeId.from("foo#bar"), arrayNode);
         });
+    }
+
+    @Test
+    public void annotationTraitsAreNotLossy() {
+        ObjectNode objectNode = new ObjectNode(
+                MapUtils.of(Node.from("hi"), Node.from("bye")),
+                SourceLocation.NONE);
+        SensitiveTrait trait = new SensitiveTrait.Provider().createTrait(ShapeId.from("foo#bar"), objectNode);
+
+        assertThat(trait.toNode(), equalTo(objectNode));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterShapesTest.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
@@ -42,7 +41,7 @@ public class FilterShapesTest {
         ShapeId aId = ShapeId.from("ns.foo#A");
         StringShape a = StringShape.builder()
                 .id(aId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         ShapeId bId = ShapeId.from("ns.foo#B");
         StringShape b = StringShape.builder().id(bId).build();
@@ -128,14 +127,14 @@ public class FilterShapesTest {
         StringShape shape1 = StringShape.builder()
                 .id(shapeId1)
                 .addTrait(new DynamicTrait(ShapeId.from("foo.baz#foo"), Node.from(true)))
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         ShapeId shapeId2 = ShapeId.from("ns.foo#id2");
         StringShape shape2 = StringShape.builder()
                 .id(shapeId2)
                 .addTrait(new DynamicTrait(ShapeId.from("ns.foo#baz"), Node.from(true)))
                 .addTrait(new DynamicTrait(ShapeId.from("ns.foo#bar"), Node.from(true)))
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model model = Model.builder()
                 .addShapes(shape1, shape2, bazTrait, barTrait)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterTraitsTest.java
@@ -35,13 +35,13 @@ public class FilterTraitsTest {
         ShapeId aId = ShapeId.from("ns.foo#A");
         StringShape a = StringShape.builder()
                 .id(aId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(DeprecatedTrait.builder().build())
                 .build();
         ShapeId bId = ShapeId.from("ns.foo#B");
         StringShape b = StringShape.builder()
                 .id(bId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(DeprecatedTrait.builder().build())
                 .build();
         Model model = Model.builder().addShapes(a, b).build();
@@ -61,7 +61,7 @@ public class FilterTraitsTest {
         ShapeId aId = ShapeId.from("ns.foo#A");
         StringShape a = StringShape.builder()
                 .id(aId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .addTrait(DeprecatedTrait.builder().build())
                 .build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapShapesTest.java
@@ -37,7 +37,7 @@ public class MapShapesTest {
         ShapeId shapeId = ShapeId.from("ns.foo#id1");
         StringShape shape = StringShape.builder()
                 .id(shapeId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model model = Model.builder().addShape(shape).build();
         ModelTransformer transformer = ModelTransformer.create();
@@ -63,7 +63,7 @@ public class MapShapesTest {
         ShapeId shapeId = ShapeId.from("ns.foo#id1");
         StringShape shape = StringShape.builder()
                 .id(shapeId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .addTrait(new DocumentationTrait("docs", SourceLocation.NONE))
                 .build();
         Model model = Model.builder().addShape(shape).build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapTraitsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MapTraitsTest.java
@@ -36,7 +36,7 @@ public class MapTraitsTest {
         ShapeId shapeId = ShapeId.from("ns.foo#id1");
         StringShape shape = StringShape.builder()
                 .id(shapeId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model model = Model.builder().addShape(shape).build();
         ModelTransformer transformer = ModelTransformer.create();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -125,7 +124,7 @@ public class RemoveShapesTest {
                 .build();
         OperationShape a = OperationShape.builder()
                 .id("ns.foo#A")
-                .addTrait(new ReadonlyTrait(SourceLocation.NONE))
+                .addTrait(new ReadonlyTrait())
                 .build();
         OperationShape b = OperationShape.builder().id("ns.foo#B").build();
         OperationShape c = OperationShape.builder().id("ns.foo#C").build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -66,7 +66,7 @@ public class ReplaceShapesTest {
         MemberShape newMember = MemberShape.builder()
                 .id(memberId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         ListShape newList = ListShape.builder().id(containerId).member(newMember).build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newList));
@@ -96,12 +96,12 @@ public class ReplaceShapesTest {
         MemberShape newKey = MemberShape.builder()
                 .id(keyId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         MemberShape newValue = MemberShape.builder()
                 .id(valueId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         MapShape newMap = MapShape.builder().id(containerId).key(newKey).value(newValue).build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMap));
@@ -129,7 +129,7 @@ public class ReplaceShapesTest {
         // Add a trait to a replaced member3.
         MemberShape newMember3 = MemberShape.builder()
                 .id("ns.foo#Shape$member3")
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .target("ns.foo#String")
                 .build();
         // Replace the union with a shape that has the new member3.
@@ -160,7 +160,7 @@ public class ReplaceShapesTest {
         MemberShape newMember = MemberShape.builder()
                 .id(memberId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMember));
 
@@ -185,13 +185,13 @@ public class ReplaceShapesTest {
         MemberShape newKeyMember = MemberShape.builder()
                 .id(keyMemberId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model resultWithNewKey = transformer.replaceShapes(model, Arrays.asList(newKeyMember));
         MemberShape newValueMember = MemberShape.builder()
                 .id(valueMemberId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model resultWithNewValue = transformer.replaceShapes(model, Arrays.asList(newValueMember));
 
@@ -216,7 +216,7 @@ public class ReplaceShapesTest {
         MemberShape memberA = MemberShape.builder()
                 .id(memberAId)
                 .target(stringId)
-                .addTrait(new RequiredTrait(SourceLocation.NONE))
+                .addTrait(new RequiredTrait())
                 .build();
         MemberShape memberB = MemberShape.builder().id(memberBId).target(stringId).build();
         StructureShape container = StructureShape.builder()
@@ -231,7 +231,7 @@ public class ReplaceShapesTest {
         MemberShape newMemberB = MemberShape.builder()
                 .id(memberBId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMemberB));
 
@@ -262,8 +262,8 @@ public class ReplaceShapesTest {
                 .addShapes(target, memberA, memberB, container)
                 .build();
         ModelTransformer transformer = ModelTransformer.create();
-        MemberShape newMemberA = memberA.toBuilder().addTrait(new RequiredTrait(SourceLocation.NONE)).build();
-        MemberShape newMemberB = memberB.toBuilder().addTrait(new RequiredTrait(SourceLocation.NONE)).build();
+        MemberShape newMemberA = memberA.toBuilder().addTrait(new RequiredTrait()).build();
+        MemberShape newMemberB = memberB.toBuilder().addTrait(new RequiredTrait()).build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMemberA, newMemberB));
 
         assertThat(result.getShape(memberAId).get().getTrait(RequiredTrait.class), Matchers.not(Optional.empty()));
@@ -301,7 +301,7 @@ public class ReplaceShapesTest {
         MemberShape newMemberB = MemberShape.builder()
                 .id(memberBId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMemberB));
 
@@ -334,7 +334,7 @@ public class ReplaceShapesTest {
         MemberShape newMember = MemberShape.builder()
                 .id(memberId)
                 .target(stringId)
-                .addTrait(new SensitiveTrait(SourceLocation.NONE))
+                .addTrait(new SensitiveTrait())
                 .build();
         Model result = transformer.replaceShapes(model, Arrays.asList(newMember, newContainer));
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/annotation-trait-extra-properties.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/annotation-trait-extra-properties.errors
@@ -1,0 +1,1 @@
+[WARNING] ns.foo#Baz: Error validating trait `sensitive`: Invalid structure member `test` found for `smithy.api#sensitive` | TraitValue

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/annotation-trait-extra-properties.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/annotation-trait-extra-properties.json
@@ -1,0 +1,13 @@
+{
+    "smithy": "1.0.0",
+    "shapes": {
+        "ns.foo#Baz": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {
+                    "test": 123
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
@@ -1,5 +1,5 @@
 [ERROR] ns.foo#Operation2: Input parameters provided for operation with no input structure members: `Testing 3` | ExamplesTrait
 [ERROR] ns.foo#Operation2: Output parameters provided for operation with no output structure members: `Testing 3` | ExamplesTrait
 [ERROR] ns.foo#Operation: Example input of `Testing 2`: Missing required structure member `foo` for `ns.foo#OperationInput` | ExamplesTrait
-[ERROR] ns.foo#Operation: Example output of `Testing 2`: Invalid structure member `additional` found for `ns.foo#OperationOutput` | ExamplesTrait
+[WARNING] ns.foo#Operation: Example output of `Testing 2`: Invalid structure member `additional` found for `ns.foo#OperationOutput` | ExamplesTrait
 [ERROR] ns.foo#Operation: Example output of `Testing 2`: Missing required structure member `bam` for `ns.foo#OperationOutput` | ExamplesTrait

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/MqttJsonTrait.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/MqttJsonTrait.java
@@ -15,19 +15,20 @@
 
 package software.amazon.smithy.mqtt.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
 public final class MqttJsonTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.mqtt#mqttJson");
 
-    public MqttJsonTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public MqttJsonTrait(ObjectNode node) {
+        super(ID, node);
     }
 
     public MqttJsonTrait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<MqttJsonTrait> {

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/TopicLabelTrait.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/TopicLabelTrait.java
@@ -15,7 +15,8 @@
 
 package software.amazon.smithy.mqtt.traits;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AnnotationTrait;
 
@@ -25,8 +26,12 @@ import software.amazon.smithy.model.traits.AnnotationTrait;
 public final class TopicLabelTrait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.mqtt#topicLabel");
 
-    public TopicLabelTrait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public TopicLabelTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public TopicLabelTrait() {
+        this(Node.objectNode());
     }
 
     public static final class Provider extends AnnotationTrait.Provider<TopicLabelTrait> {

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-params.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-params.errors
@@ -1,3 +1,3 @@
 [ERROR] smithy.example#MyError: smithy.test#httpResponseTests.0.params.foo: Expected number value for integer shape, `smithy.api#Integer`; found string value, `Hi` | HttpResponseTestsError
-[ERROR] smithy.example#SayGoodbye: smithy.test#httpResponseTests.0.params: Invalid structure member `invalid` found for `smithy.example#SayGoodbyeOutput` | HttpResponseTestsOutput
+[WARNING] smithy.example#SayGoodbye: smithy.test#httpResponseTests.0.params: Invalid structure member `invalid` found for `smithy.example#SayGoodbyeOutput` | HttpResponseTestsOutput
 [ERROR] smithy.example#SayHello: smithy.test#httpRequestTests.0.params.badType: Expected boolean value for boolean shape, `smithy.api#Boolean`; found string value, `hi` | HttpRequestTestsInput


### PR DESCRIPTION
This commit updates annotation traits to now accept an ObjectNode that
contains the actual value found in a model rather than just the source
location. This makes it possible to a) validate that the values provided
for an annotation trait are valid b) persist unknown annotation trait
properties when serializing a model. Extraneous trait properties
previously resulted in an ERROR, but now they are a WARNING, since
adding new properties isn't meant to be a breaking change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
