### PR TITLE
Fix title trait selector

### DIFF
--- a/docs/source/spec/core/documentation-traits.rst
+++ b/docs/source/spec/core/documentation-traits.rst
@@ -341,13 +341,13 @@ tags trait are arbitrary and up to the model author.
 ---------------
 
 Summary
-    Defines a proper name for a service or resource shape. This title can be
+    Defines a proper name for a service or operation shape. This title can be
     used in automatically generated documentation and other contexts to
-    provide a user friendly name for services and resources.
+    provide a user friendly name for services and operations.
 Trait selector
-    ``:test(service, resource)``
+    ``:test(service, operation)``
 
-    *Any service or resource*
+    *Any service or operation*
 Value type
     ``string``
 

--- a/docs/source/spec/core/documentation-traits.rst
+++ b/docs/source/spec/core/documentation-traits.rst
@@ -341,13 +341,13 @@ tags trait are arbitrary and up to the model author.
 ---------------
 
 Summary
-    Defines a proper name for a service or operation shape. This title can be
+    Defines a proper name for a service or resource shape. This title can be
     used in automatically generated documentation and other contexts to
-    provide a user friendly name for services and operations.
+    provide a user friendly name for services and resources.
 Trait selector
-    ``:test(service, operation)``
+    ``:test(service, resource)``
 
-    *Any service or operation*
+    *Any service or resource*
 Value type
     ``string``
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -335,7 +335,7 @@ list tags {
     member: String
 }
 
-/// Defines a proper name for a service or resource shape.
+/// Defines a proper name for a service or operation shape.
 ///
 /// This title can be used in automatically generated documentation
 /// and other contexts to provide a user friendly name for services

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -335,12 +335,12 @@ list tags {
     member: String
 }
 
-/// Defines a proper name for a service or operation shape.
+/// Defines a proper name for a service or resource shape.
 ///
 /// This title can be used in automatically generated documentation
 /// and other contexts to provide a user friendly name for services
 /// and resources.
-@trait(selector: ":test(service, operation)")
+@trait(selector: ":test(service, resource)")
 string title
 
 /// Constrains the acceptable values of a string to a fixed set


### PR DESCRIPTION
Fixes title trait selector to correctly allow the trait to be applied to services and resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
