### PR TITLE
Adjust auth scheme name for compatibility

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -77,8 +77,7 @@ final class AddAuthorizers implements ApiGatewayMapper {
     ) {
         // Only modify requirements that exactly match the updated scheme.
         if (requirement.size() != 1
-                || !requirement.keySet().iterator().next().equals(converter.getAuthSchemeId().toString()
-                .replace("#", "."))) {
+                || !requirement.keySet().iterator().next().equals(converter.getOpenApiAuthSchemeName())) {
             return requirement;
         }
 

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -77,7 +77,8 @@ final class AddAuthorizers implements ApiGatewayMapper {
     ) {
         // Only modify requirements that exactly match the updated scheme.
         if (requirement.size() != 1
-                || !requirement.keySet().iterator().next().equals(converter.getAuthSchemeId().toString())) {
+                || !requirement.keySet().iterator().next().equals(converter.getAuthSchemeId().toString()
+                .replace("#", "."))) {
             return requirement;
         }
 

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cognito-user-pools-security.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cognito-user-pools-security.openapi.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "aws.auth#cognitoUserPools": {
+      "aws.auth.cognitoUserPools": {
         "type": "apiKey",
         "description": "Amazon Cognito User Pools authentication",
         "name": "Authorization",
@@ -35,7 +35,7 @@
   },
   "security": [
     {
-      "aws.auth#cognitoUserPools": [ ]
+      "aws.auth.cognitoUserPools": [ ]
     }
   ]
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
@@ -73,7 +73,7 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api#httpBasicAuth": {
+      "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
         "scheme": "Basic"
@@ -82,7 +82,7 @@
   },
   "security": [
     {
-      "smithy.api#httpBasicAuth": [ ]
+      "smithy.api.httpBasicAuth": [ ]
     }
   ],
   "x-amazon-apigateway-gateway-responses": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -389,14 +389,14 @@
       }
     },
     "securitySchemes": {
-      "aws.auth#sigv4": {
+      "aws.auth.sigv4": {
         "type": "apiKey",
         "description": "AWS Signature Version 4 authentication",
         "name": "Authorization",
         "in": "header",
         "x-amazon-apigateway-authtype": "awsSigv4"
       },
-      "smithy.api#httpBasicAuth": {
+      "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
         "scheme": "Basic"
@@ -405,10 +405,10 @@
   },
   "security": [
     {
-      "smithy.api#httpBasicAuth": [ ]
+      "smithy.api.httpBasicAuth": [ ]
     },
     {
-      "aws.auth#sigv4": [ ]
+      "aws.auth.sigv4": [ ]
     }
   ],
   "x-amazon-apigateway-gateway-responses": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
@@ -73,7 +73,7 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api#httpBasicAuth": {
+      "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
         "scheme": "Basic"
@@ -82,7 +82,7 @@
   },
   "security": [
     {
-      "smithy.api#httpBasicAuth": [ ]
+      "smithy.api.httpBasicAuth": [ ]
     }
   ],
   "x-amazon-apigateway-gateway-responses": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "aws.auth#cognitoUserPools": {
+      "aws.auth.cognitoUserPools": {
         "type": "apiKey",
         "description": "Amazon Cognito User Pools authentication",
         "name": "Authorization",
@@ -36,7 +36,7 @@
   },
   "security": [
     {
-      "aws.auth#cognitoUserPools": [ ]
+      "aws.auth.cognitoUserPools": [ ]
     }
   ]
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "aws.auth#cognitoUserPools": {
+      "aws.auth.cognitoUserPools": {
         "type": "apiKey",
         "description": "Amazon Cognito User Pools authentication",
         "name": "Authorization",
@@ -36,7 +36,7 @@
   },
   "security": [
     {
-      "aws.auth#cognitoUserPools": [ ]
+      "aws.auth.cognitoUserPools": [ ]
     }
   ]
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -504,7 +504,7 @@ public final class OpenApiConverter {
                     context, authSchemeClasses);
             for (SecuritySchemeConverter<? extends Trait> converter : converters) {
                 List<String> result = createSecurityRequirements(context, converter, service);
-                String openApiAuthName = converter.getAuthSchemeId().toString();
+                String openApiAuthName = converter.getAuthSchemeId().toString().replace("#", ".");
                 Map<String, List<String>> authMap = MapUtils.of(openApiAuthName, result);
                 Map<String, List<String>> requirement = plugin.updateSecurity(context, shape, converter, authMap);
                 if (requirement != null) {
@@ -625,7 +625,7 @@ public final class OpenApiConverter {
         for (SecuritySchemeConverter<? extends Trait> converter : context.getSecuritySchemeConverters()) {
             SecurityScheme createdScheme = createAndUpdateSecurityScheme(context, plugin, converter, service);
             if (createdScheme != null) {
-                components.putSecurityScheme(converter.getAuthSchemeId().toString(), createdScheme);
+                components.putSecurityScheme(converter.getAuthSchemeId().toString().replace("#", "."), createdScheme);
             }
         }
 
@@ -637,7 +637,7 @@ public final class OpenApiConverter {
         for (SecuritySchemeConverter<? extends Trait> converter : context.getSecuritySchemeConverters()) {
             if (defaultAuthTraits.contains(converter.getAuthSchemeType())) {
                 List<String> result = createSecurityRequirements(context, converter, context.getService());
-                String authSchemeName = converter.getAuthSchemeId().toString();
+                String authSchemeName = converter.getAuthSchemeId().toString().replace("#", ".");
                 Map<String, List<String>> requirement = plugin.updateSecurity(
                         context, context.getService(), converter, MapUtils.of(authSchemeName, result));
                 if (requirement != null) {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -504,7 +504,7 @@ public final class OpenApiConverter {
                     context, authSchemeClasses);
             for (SecuritySchemeConverter<? extends Trait> converter : converters) {
                 List<String> result = createSecurityRequirements(context, converter, service);
-                String openApiAuthName = converter.getAuthSchemeId().toString().replace("#", ".");
+                String openApiAuthName = converter.getOpenApiAuthSchemeName();
                 Map<String, List<String>> authMap = MapUtils.of(openApiAuthName, result);
                 Map<String, List<String>> requirement = plugin.updateSecurity(context, shape, converter, authMap);
                 if (requirement != null) {
@@ -625,7 +625,7 @@ public final class OpenApiConverter {
         for (SecuritySchemeConverter<? extends Trait> converter : context.getSecuritySchemeConverters()) {
             SecurityScheme createdScheme = createAndUpdateSecurityScheme(context, plugin, converter, service);
             if (createdScheme != null) {
-                components.putSecurityScheme(converter.getAuthSchemeId().toString().replace("#", "."), createdScheme);
+                components.putSecurityScheme(converter.getOpenApiAuthSchemeName(), createdScheme);
             }
         }
 
@@ -637,7 +637,7 @@ public final class OpenApiConverter {
         for (SecuritySchemeConverter<? extends Trait> converter : context.getSecuritySchemeConverters()) {
             if (defaultAuthTraits.contains(converter.getAuthSchemeType())) {
                 List<String> result = createSecurityRequirements(context, converter, context.getService());
-                String authSchemeName = converter.getAuthSchemeId().toString().replace("#", ".");
+                String authSchemeName = converter.getOpenApiAuthSchemeName();
                 Map<String, List<String>> requirement = plugin.updateSecurity(
                         context, context.getService(), converter, MapUtils.of(authSchemeName, result));
                 if (requirement != null) {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/SecuritySchemeConverter.java
@@ -86,6 +86,18 @@ public interface SecuritySchemeConverter<T extends Trait> {
     }
 
     /**
+     * Gets the name of OpenApi auth scheme.
+     *
+     * <p>For compatibility with Amazon API Gateway, the `#` is replaced with
+     * an `.` when deriving the name from the auth scheme's shape ID.
+     *
+     * @return Returns the auth scheme's name.
+     */
+    default String getOpenApiAuthSchemeName() {
+        return getAuthSchemeId().toString().replace("#", ".");
+    }
+
+    /**
      * Gets the names of the headers set on HTTP requests used by this
      * authentication scheme.
      *

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
@@ -25,7 +25,7 @@
         },
         "security": [
           {
-            "smithy.api#httpBasicAuth": [ ]
+            "smithy.api.httpBasicAuth": [ ]
           }
         ]
       }
@@ -40,10 +40,10 @@
         },
         "security": [
           {
-            "smithy.api#httpBasicAuth": []
+            "smithy.api.httpBasicAuth": []
           },
           {
-            "aws.auth#sigv4": [ ]
+            "aws.auth.sigv4": [ ]
           }
         ]
       }
@@ -51,12 +51,12 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api#httpBasicAuth": {
+      "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
         "scheme": "Basic"
       },
-      "aws.auth#sigv4": {
+      "aws.auth.sigv4": {
         "type": "apiKey",
         "description": "AWS Signature Version 4 authentication",
         "name": "Authorization",
@@ -67,7 +67,7 @@
   },
   "security": [
     {
-      "aws.auth#sigv4": [ ]
+      "aws.auth.sigv4": [ ]
     }
   ]
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/awsv4-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/awsv4-security.openapi.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "aws.auth#sigv4": {
+      "aws.auth.sigv4": {
         "type": "apiKey",
         "description": "AWS Signature Version 4 authentication",
         "name": "Authorization",
@@ -29,7 +29,7 @@
   },
   "security": [
     {
-      "aws.auth#sigv4": [ ]
+      "aws.auth.sigv4": [ ]
     }
   ]
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-api-key-security.openapi.json
@@ -18,7 +18,7 @@
     },
     "components": {
         "securitySchemes": {
-            "smithy.api#httpApiKeyAuth": {
+            "smithy.api.httpApiKeyAuth": {
                 "type": "apiKey",
                 "description": "X-Api-Key authentication",
                 "name": "x-api-key",
@@ -28,7 +28,7 @@
     },
     "security": [
         {
-            "smithy.api#httpApiKeyAuth": [ ]
+            "smithy.api.httpApiKeyAuth": [ ]
         }
     ]
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-basic-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-basic-security.openapi.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api#httpBasicAuth": {
+      "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
         "scheme": "Basic"
@@ -27,7 +27,7 @@
   },
   "security": [
     {
-      "smithy.api#httpBasicAuth": [ ]
+      "smithy.api.httpBasicAuth": [ ]
     }
   ]
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-digest-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-digest-security.openapi.json
@@ -18,7 +18,7 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api#httpDigestAuth": {
+      "smithy.api.httpDigestAuth": {
         "type": "http",
         "scheme": "Digest",
         "description": "HTTP Digest authentication"
@@ -27,7 +27,7 @@
   },
   "security": [
     {
-      "smithy.api#httpDigestAuth": [ ]
+      "smithy.api.httpDigestAuth": [ ]
     }
   ]
 }


### PR DESCRIPTION
Adds getOpenApiAuthSchemeName default method which derives an auth scheme name from its shape ID by replacing the `#` with `.`.  Ensures compatibility with  API Gateway authorizer name requirements.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
