### PR TITLE
Add request parameters and response members to example

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.json
@@ -60,6 +60,20 @@
         },
         "smithy.example#Operation1": {
             "type": "operation",
+            "input": {
+                "target": "smithy.example#OperationInput"
+            },
+            "output": {
+                "target": "smithy.example#OperationOutput"
+            },
+            "errors": [
+                {
+                    "target": "smithy.example#Default"
+                },
+                {
+                    "target": "smithy.example#Redirect"
+                }
+            ],
             "traits": {
                 "smithy.api#http": {
                     "method": "POST",
@@ -69,6 +83,20 @@
         },
         "smithy.example#Operation2": {
             "type": "operation",
+            "input": {
+                "target": "smithy.example#OperationInput"
+            },
+            "output": {
+                "target": "smithy.example#OperationOutput"
+            },
+            "errors": [
+                {
+                    "target": "smithy.example#Default"
+                },
+                {
+                    "target": "smithy.example#Redirect"
+                }
+            ],
             "traits": {
                 "smithy.api#http": {
                     "method": "POST",
@@ -109,6 +137,75 @@
                     }
                 }
             }
+        },
+        "smithy.example#Default": {
+            "type": "structure",
+            "members": {
+                "testMethodResponseHeader": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "test-method-response-header"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "smithy.example#Redirect": {
+            "type": "structure",
+            "members": {
+                "location": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "Location"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 302
+            }
+        },
+        "smithy.example#OperationInput": {
+            "type": "structure",
+            "members": {
+                "vendor": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#httpQuery": "vendor",
+                        "smithy.api#required": {}
+                    }
+                },
+                "version": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#httpQuery": "version",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "smithy.example#OperationOutput": {
+            "type": "structure",
+            "members": {
+                "requestId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "requestId"
+                    }
+                }
+            }
         }
+    },
+    "metadata": {
+        "suppressions": [
+            {
+                "ids": ["HttpResponseCodeSemantics"],
+                "shapes": ["smithy.example#Redirect"],
+                "reason": "model redirect as error"
+            }
+        ]
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.openapi.json
@@ -8,9 +8,58 @@
     "/1": {
       "post": {
         "operationId": "Operation1",
+        "parameters": [
+          {
+            "name": "vendor",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Operation1 response"
+            "description": "Operation1 200 response",
+            "headers": {
+              "requestId": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Redirect 302 response",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default 400 response",
+            "headers": {
+              "test-method-response-header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "x-amazon-apigateway-integration": {
@@ -56,9 +105,58 @@
     "/2": {
       "post": {
         "operationId": "Operation2",
+        "parameters": [
+          {
+            "name": "vendor",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Operation2 response"
+            "description": "Operation2 200 response",
+            "headers": {
+              "requestId": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Redirect 302 response",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default 400 response",
+            "headers": {
+              "test-method-response-header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "x-amazon-apigateway-integration": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
@@ -61,6 +61,20 @@
         },
         "smithy.example#Operation1": {
             "type": "operation",
+            "input": {
+                "target": "smithy.example#OperationInput"
+            },
+            "output": {
+                "target": "smithy.example#OperationOutput"
+            },
+            "errors": [
+                {
+                    "target": "smithy.example#Default"
+                },
+                {
+                    "target": "smithy.example#Redirect"
+                }
+            ],
             "traits": {
                 "smithy.api#http": {
                     "method": "POST",
@@ -70,6 +84,20 @@
         },
         "smithy.example#Operation2": {
             "type": "operation",
+            "input": {
+                "target": "smithy.example#OperationInput"
+            },
+            "output": {
+                "target": "smithy.example#OperationOutput"
+            },
+            "errors": [
+                {
+                    "target": "smithy.example#Default"
+                },
+                {
+                    "target": "smithy.example#Redirect"
+                }
+            ],
             "traits": {
                 "smithy.api#http": {
                     "method": "POST",
@@ -110,6 +138,75 @@
                     }
                 }
             }
+        },
+        "smithy.example#Default": {
+            "type": "structure",
+            "members": {
+                "testMethodResponseHeader": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "test-method-response-header"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "smithy.example#Redirect": {
+            "type": "structure",
+            "members": {
+                "location": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "Location"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 302
+            }
+        },
+        "smithy.example#OperationInput": {
+            "type": "structure",
+            "members": {
+                "vendor": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#httpQuery": "vendor",
+                        "smithy.api#required": {}
+                    }
+                },
+                "version": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#httpQuery": "version",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "smithy.example#OperationOutput": {
+            "type": "structure",
+            "members": {
+                "requestId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "requestId"
+                    }
+                }
+            }
         }
+    },
+    "metadata": {
+        "suppressions": [
+            {
+                "ids": ["HttpResponseCodeSemantics"],
+                "shapes": ["smithy.example#Redirect"],
+                "reason": "model redirect as error"
+            }
+        ]
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
@@ -8,9 +8,58 @@
     "/1": {
       "post": {
         "operationId": "Operation1",
+        "parameters": [
+          {
+            "name": "vendor",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Operation1 response"
+            "description": "Operation1 200 response",
+            "headers": {
+              "requestId": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Redirect 302 response",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default 400 response",
+            "headers": {
+              "test-method-response-header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "x-amazon-apigateway-integration": {
@@ -57,9 +106,58 @@
     "/2": {
       "post": {
         "operationId": "Operation2",
+        "parameters": [
+          {
+            "name": "vendor",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "int32",
+              "nullable": true
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Operation2 response"
+            "description": "Operation2 200 response",
+            "headers": {
+              "requestId": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Redirect 302 response",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default 400 response",
+            "headers": {
+              "test-method-response-header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "x-amazon-apigateway-integration": {


### PR DESCRIPTION
Updates `x-amazon-apigateway-integration` test examples with request parameters and responses to pass validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
