### PR TITLE
Update 1.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,166 @@
 # Smithy Changelog
 
-## 0.10.0 (2020-??-??)
+## 1.0.0 (2020-??-??)
+
+***Note***: Changes marked with "[BC]" are breaking changes more accurately described in the
+specific section. A list of further intended breaking changes have a specific section near
+the end of this entry.
+
+### Features
+
+#### General
+
+* The model format version has beeen updated to `1.0.0` and contains several updates: [BC] ([#357](https://github.com/awslabs/smithy/pull/357), [#381](https://github.com/awslabs/smithy/pull/381))
+  * The JSON AST representation requires describing annotation traits as `{}` instead of `true`.
+  * Annotation traits in the IDL are now provided as `@foo` or `@foo()`. Explicit `@foo(true)` and
+  `@foo(null)` support was removed.
+* Smithy models can now be serialized to the IDL. ([#284](https://github.com/awslabs/smithy/pull/284))
+* Added a Node-based object mapper to simplify the process of building and using Java components
+from Smithy `Node`s. ([#301](https://github.com/awslabs/smithy/pull/301))
+  * Many packages have seen significant updates to use this functionality. ([#305](https://github.com/awslabs/smithy/pull/305), [#364](https://github.com/awslabs/smithy/pull/364))
+* Made error messages clearer when encountering duplicate shapes. ([#324](https://github.com/awslabs/smithy/pull/324))
+* Model loaders now warn on additional shape properties instead of fail. ([#374](https://github.com/awslabs/smithy/pull/374))
+* Added expect* methods to the base `Shape`. ([#314](https://github.com/awslabs/smithy/pull/314))
+* Added `@SmithyUnstableApi`, `@SmithyInternalApi` and `@SmithyGenerated` Java annotations. ([#297](https://github.com/awslabs/smithy/pull/297))
+* `NodeValidationVisitor`s are marked as internal and/or unstable. ([#375](https://github.com/awslabs/smithy/pull/375))
+
+#### Trait updates
+
+* Individual protocols are now defined as individual traits that are annotated with
+[the `protocolDefinition` trait.](https://awslabs.github.io/smithy/spec/core/protocol-traits.html#protocoldefinition-trait) [BC] ([#273](https://github.com/awslabs/smithy/pull/273), [#280](https://github.com/awslabs/smithy/pull/280), [#379](https://github.com/awslabs/smithy/pull/379), [#390](https://github.com/awslabs/smithy/pull/390))
+  * Previously listed [AWS protocols now have trait implementations.](https://awslabs.github.io/smithy/spec/aws/index.html#aws-protocols)
+* Individual authentication schemes are now defined as individual traits that are annotated with
+[the `authDefinition` trait.](https://awslabs.github.io/smithy/spec/core/auth-traits.html#authdefinition-trait) [BC] ([#273](https://github.com/awslabs/smithy/pull/273), [#280](https://github.com/awslabs/smithy/pull/280))
+  * Previously listed [authentication schemes now have trait implementations.](https://awslabs.github.io/smithy/spec/core/auth-traits.html)
+* The `smithy.api#enum` trait is now a list of enum definitions instead of a map of string keys to
+enum definitions to improve clarity and encourage adding more properties to definitions. [BC] ([#326](https://github.com/awslabs/smithy/pull/326))
+* The `aws.api#streaming` trait is now applied to shapes directly instead of members. [BC] ([#340](https://github.com/awslabs/smithy/pull/340))
+* The `smithy.api#eventStream` trait has been removed. Event streams are now indicated by applying
+the `smithy.api#streaming` trait to unions. [BC] ([#365](https://github.com/awslabs/smithy/pull/365))
+* The `smithy.api#requiresLength` trait has been split out of the `smithy.api#streaming` trait to
+improve clarity around event stream modeling. [BC] ([#368](https://github.com/awslabs/smithy/pull/368))
+* The `smithy.api#externalDocumentation` trait is now a map instead of a single string to allow for
+multiple links per trait. [BC] ([#363](https://github.com/awslabs/smithy/pull/363))
+* Added the `smithy.api#noReplace` trait to indicate a PUT lifecycle operation cannot replace the
+existing resource. ([#351](https://github.com/awslabs/smithy/pull/351))
+* Added the `smithy.api#unstable` trait to indicate a shape MAY change. ([#290](https://github.com/awslabs/smithy/pull/290))
+* Added the `aws.protocols#httpContentMd5` trait to indicate an operation requrest requires a
+sending a Content-MD5 header. ([#372](https://github.com/awslabs/smithy/pull/372))
+* Simplified `aws.api#unsignedPayload` to be an annotation. [BC] ([#270](https://github.com/awslabs/smithy/pull/270))
+* Annotation traits are now lossless when loaded with additional properties, meaning they will
+contain those properties when serialized. ([#385](https://github.com/awslabs/smithy/pull/385))
+
+#### Selector updates
+
+Selectors have received significant updates: ([#388](https://github.com/awslabs/smithy/pull/388))
+
+* Attribute selectors can now evaluate scoped comparisons using `@foo:` to define a scope
+and `@{bar}` to define a context value. ([#391](https://github.com/awslabs/smithy/pull/391))
+* And logic, via `&&`, has been added to allow multiple attribute comparisons. ([#391](https://github.com/awslabs/smithy/pull/391))
+* Support for selecting nested trait properties with `|`, including list/object values and object
+keys, was added.
+* An opt-in `trait` relationship has been added. ([#384](https://github.com/awslabs/smithy/pull/384))
+* The recursive neighbor selector, `~>`, has been added. ([#386](https://github.com/awslabs/smithy/pull/386))
+* A not equal comparison, `!=`, was added.
+* An exists comparison, `?=`, was added. ([#391](https://github.com/awslabs/smithy/pull/391))
+* Support for numbers in attribute selectors was added.
+* Numeric comparisons (`>`, `>=`, `<`, `<=`) were added.
+* The `(length)` function property was added. ([#391](https://github.com/awslabs/smithy/pull/391))
+* Attribute selectors now support CSV values, allowing matching on one or more target values.
+* The `:each` selector is now `:is` for clarity. [BC]
+* Shape IDs with members must now be quoted. [BC]
+* Selector parsing and evaluating now tolerates unknown relationship types. ([#377](https://github.com/awslabs/smithy/pull/377))
+
+#### Validation updates
+
+* Services must now contain a closure of shapes that have case-insensitively unique names. [BC] ([#337](https://github.com/awslabs/smithy/pull/337))
+* The `UnreferencedShape` validator has moved to `smithy-model` and is now always run. [BC] ([#319](https://github.com/awslabs/smithy/pull/319))
+
+#### JSON Schema conversion
+
+The conversion to JSON schema was significantly overhauled. [BC] ([#274](https://github.com/awslabs/smithy/pull/274))
+
+* Configuration for the build plugin was significantly overhauled. [BC] ([#364](https://github.com/awslabs/smithy/pull/364))
+* The strategy for shape inlining has been changed. [BC]
+* The strategy for naming shapes and handling shape id conflicts has been changed. [BC]
+* Output schema error detection was improved.
+* The Java API surface has been reduced. [BC]
+* Added the ability to select schemas from a document using a JSON pointer.
+
+#### OpenAPI conversion
+
+The conversion to OpenAPI was significantly overhauled. [BC] ([#275](https://github.com/awslabs/smithy/pull/275))
+
+* Configuration for the build plugin was significantly overhauled.  [BC] ([#364](https://github.com/awslabs/smithy/pull/364))
+* Protocol conversion was updated to utilize the new traits. ([#275](https://github.com/awslabs/smithy/pull/275), [#392](https://github.com/awslabs/smithy/pull/392))
+* Schemas are now generated for requests and responses instead of being inlined. [BC]
+* Fixed several issues with CORS integrations.
+
+#### API Gateway OpenAPI conversion
+
+The API Gateway specific OpenAPI mappers have been updated. [BC] ([#367](https://github.com/awslabs/smithy/pull/367))
+
+*  The `ApiGatewayMapper` interface was added, allowing mappers to control which API Gateway API
+type(s) they support.
+* Fixed several issues with CORS integrations. ([#370](https://github.com/awslabs/smithy/pull/370))
+* Added support for JSON Patch-like OpenAPI schema changes based on JSON Pointers. ([#293](https://github.com/awslabs/smithy/pull/293))
+* Added support for event streams in OpenAPI conversion. ([#334](https://github.com/awslabs/smithy/pull/334))
+
+### Bug Fixes
+
+* Fixed an issue in JSON schema conversion where member traits were dropped in some scenarios. ([#274](https://github.com/awslabs/smithy/pull/274))
+* Fixed an issue where authorization headers were not properly added to CORS configurations. ([#328](https://github.com/awslabs/smithy/pull/328))
+* Fixed an issue where operation response headers were being applied to error responses in OpenAPI
+conversions. ([#275](https://github.com/awslabs/smithy/pull/275))
+* Fixed an issue where `apply` statements wouldn't resolve target shapes properly in some cases. ([#287](https://github.com/awslabs/smithy/pull/287))
+* Fixed an issue with the selector for the `smithy.api#title` trait. ([#387](https://github.com/awslabs/smithy/pull/387))
+* Fixed several issues with the `smithy.api#httpApiKeyAuth` trait and its related conversions. ([#291](https://github.com/awslabs/smithy/pull/291))
+* Fixed a bug with timestamp validation in specific versions of Java. ([#316](https://github.com/awslabs/smithy/pull/316))
+
+### Optimizations
+
+* The `TraitTargetValidator` now performs as few checks on and selections of the entire model. ([#389](https://github.com/awslabs/smithy/pull/389))
+* The dependency on `jackson-core` was replaced with a vendored version of `minimal-json` to reduce
+the chances of dependency conflicts. [BC] ([#323](https://github.com/awslabs/smithy/pull/323))
+* Sped up model loading time by loading JSON models before IDL models to reduce forward
+reference lookups. ([#287](https://github.com/awslabs/smithy/pull/287))
 
 ### Breaking changes
 
-* aws.api#ec2QueryName was renamed to `aws.protocols#ec2QueryName`.
-* aws.api#unsignedPayload was renamed to `aws.auth#unsignedPayload` and no longer takes an array of values.
-  All auth schemes that honor this trait should be considered unsigned when this trait is applied.
-* The `smithy-codegen-freemarker` package has been removed.
+* The `BooleanTrait` abstract class in `smithy-model` was renamed `AnnotationTrait`. ([#381](https://github.com/awslabs/smithy/pull/381))
+* The traits in the `aws.apigateway` namespace have moved from `smithy-aws-traits` to the
+`smithy-aws-apigateway-traits` package for more granular use. ([#322](https://github.com/awslabs/smithy/pull/322))
+  * Tooling that referenced these traits has also been updated.
+* The traits in the `aws.iam` namespace have moved from `smithy-aws-traits` to the
+`smithy-aws-iam-traits` package for more granular use. ([#322](https://github.com/awslabs/smithy/pull/322))
+  * Tooling that referenced these traits has also been updated.
+* The `aws.api#ec2QueryName` trait has moved to `aws.protocols#ec2QueryName`. ([#286](https://github.com/awslabs/smithy/pull/286))
+* The `aws.api#unsignedPayload ` trait has moved to `aws.auth#unsignedPayload `. ([#286](https://github.com/awslabs/smithy/pull/286))
+* The `smithy-codegen-freemarker` package has been removed. ([#382](https://github.com/awslabs/smithy/pull/382))
+* Traits can no longer be applied to public Smithy Prelude shapes. ([#317](https://github.com/awslabs/smithy/pull/317))
+* Smithy's `Pattern` class is renamed to `SmithyPattern` to remove the conflict with Java's regex
+`Pattern` class. ([#315](https://github.com/awslabs/smithy/pull/315))
+* Removed the `Triple` class from `smithy-utils`. ([#313](https://github.com/awslabs/smithy/pull/313))
+* Normalized class names for OpenAPI `SecurityScemeConverter` implementations. ([#291](https://github.com/awslabs/smithy/pull/291))
+
+#### Deprecation cleanup
+
+* The deprecated IDL operation syntax has been removed ([#373](https://github.com/awslabs/smithy/pull/373))
+* The deprecated `NodeFactory` interface has been removed. ([#265](https://github.com/awslabs/smithy/pull/265))
+* The deprecated `ShapeIndex` class and all related APIs have been removed. ([#266](https://github.com/awslabs/smithy/pull/266))
+* Support for the deprecated `0.4.0` model version has been removed. ([#267](https://github.com/awslabs/smithy/pull/267))
+* The `aws.api#service` trait no longer supports the deprecated
+`sdkServiceId`, `arnService`, or `productName` properties. ([#268](https://github.com/awslabs/smithy/pull/268))
+* The deprecated `TemplateEngine` and `DefaultDataTemplateEngine` have been removed. ([#268](https://github.com/awslabs/smithy/pull/268))
+* The deprecated `smithy.validators` and `smithy.suppressions` are no loner used as aliases for
+validators and suppressions. ([#268](https://github.com/awslabs/smithy/pull/268))
+* The `smithy.api#references` and `smithy.api#idRef` traits no longer support relative shape IDs. ([#268](https://github.com/awslabs/smithy/pull/268))
+
+### Documentation
+
+A significant overhaul of the specification and guides has been completed. This includes a better
+flow to the spec, more complete guides, deeper documentation of AWS specific components, and a
+complete redesign. Many direct links to components of the documentation will have changed.
 
 ## 0.9.9 (2020-04-01)
 

--- a/docs/source/spec/aws/aws-cross-protocol.rst
+++ b/docs/source/spec/aws/aws-cross-protocol.rst
@@ -8,7 +8,7 @@ This specification defines traits that are not restricted to use in a single
 AWS protocol, but are specific to the AWS suite of protocols.
 
 .. contents:: Table of contents
-    :depth 2
+    :depth: 2
     :local:
     :backlinks: none
 


### PR DESCRIPTION
This commit updates the changelog entry for the 1.0.0 release with
contents through PR 394. Breaking changes are annotated with
[BC] or contained in the Breaking Changes section.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

-----

*Ed. Note: The minor line break issues below are related to copy/paste into the PR description.*

## 1.0.0 (2020-??-??)

***Note***: Changes marked with "[BC]" are breaking changes more accurately described in the
specific section. A list of further intended breaking changes have a specific section near
the end of this entry.

### Features

#### General

* The model format version has beeen updated to `1.0.0` and contains several updates: [BC] ([#357](https://github.com/awslabs/smithy/pull/357), [#381](https://github.com/awslabs/smithy/pull/381))
  * The JSON AST representation requires describing annotation traits as `{}` instead of `true`.
  * The IDL representation requires describing annotation traits without `true` or `null` values.
* Smithy models can now be serialized to the IDL. ([#284](https://github.com/awslabs/smithy/pull/284))
* Added a Node-based object mapper to simplify the process of building and using Java components
from Smithy `Node`s. ([#301](https://github.com/awslabs/smithy/pull/301))
  * Many packages have seen significant updates to use this functionality. ([#305](https://github.com/awslabs/smithy/pull/305), [#364](https://github.com/awslabs/smithy/pull/364))
* Made error messages clearer when encountering duplicate shapes. ([#324](https://github.com/awslabs/smithy/pull/324))
* Model loaders now warn on additional shape properties instead of fail. ([#374](https://github.com/awslabs/smithy/pull/374))
* Added expect* methods to the base `Shape`. ([#314](https://github.com/awslabs/smithy/pull/314))
* Added `@SmithyUnstableApi`, `@SmithyInternalApi` and `@SmithyGenerated` Java annotations. ([#297](https://github.com/awslabs/smithy/pull/297))
* `NodeValidationVisitor`s are marked as internal and/or unstable. ([#375](https://github.com/awslabs/smithy/pull/375))

#### Trait updates

* Individual protocols are now defined as individual traits that are annotated with
[the `protocolDefinition` trait.](https://awslabs.github.io/smithy/spec/core/protocol-traits.html#protocoldefinition-trait) [BC] ([#273](https://github.com/awslabs/smithy/pull/273), [#280](https://github.com/awslabs/smithy/pull/280), [#379](https://github.com/awslabs/smithy/pull/379), [#390](https://github.com/awslabs/smithy/pull/390))
  * Previously listed [AWS protocols now have trait implementations.](https://awslabs.github.io/smithy/spec/aws/index.html#aws-protocols)
* Individual authentication schemes are now defined as individual traits that are annotated with
[the `authDefinition` trait.](https://awslabs.github.io/smithy/spec/core/auth-traits.html#authdefinition-trait) [BC] ([#273](https://github.com/awslabs/smithy/pull/273), [#280](https://github.com/awslabs/smithy/pull/280))
  * Previously listed [authentication schemes now have trait implementations.](https://awslabs.github.io/smithy/spec/core/auth-traits.html)
* The `smithy.api#enum` trait is now a list of enum definitions instead of a map of string keys to
enum definitions to improve clarity and encourage adding more properties to definitions. [BC] ([#326](https://github.com/awslabs/smithy/pull/326))
* The `aws.api#streaming` trait is now applied to shapes directly instead of members. [BC] ([#340](https://github.com/awslabs/smithy/pull/340))
* The `smithy.api#eventStream` trait has been removed. Event streams are now indicated by applying
the `smithy.api#streaming` trait to unions. [BC] ([#365](https://github.com/awslabs/smithy/pull/365))
* The `smithy.api#requiresLength` trait has been split out of the `smithy.api#streaming` trait to
improve clarity around event stream modeling. [BC] ([#368](https://github.com/awslabs/smithy/pull/368))
* The `smithy.api#externalDocumentation` trait is now a map instead of a single string to allow for
multiple links per trait. [BC] ([#363](https://github.com/awslabs/smithy/pull/363))
* Added the `smithy.api#noReplace` trait to indicate a PUT lifecycle operation cannot replace the
existing resource. ([#351](https://github.com/awslabs/smithy/pull/351))
* Added the `smithy.api#unstable` trait to indicate a shape MAY change. ([#290](https://github.com/awslabs/smithy/pull/290))
* Added the `aws.protocols#httpContentMd5` trait to indicate an operation requrest requires a
sending a Content-MD5 header. ([#372](https://github.com/awslabs/smithy/pull/372))
* Simplified `aws.api#unsignedPayload` to be an annotation. [BC] ([#270](https://github.com/awslabs/smithy/pull/270))
* Annotation traits are now lossless when loaded with additional properties, meaning they will
contain those properties when serialized. ([#385](https://github.com/awslabs/smithy/pull/385))

#### Selector updates

Selectors have received significant updates: ([#388](https://github.com/awslabs/smithy/pull/388))

* Support for selecting nested trait properties with `|`, including list/object values and object
keys, was added.
* An opt-in `trait` relationship has been added. ([#384](https://github.com/awslabs/smithy/pull/384))
* The recursive neighbor selector, `~>`, has been added. ([#386](https://github.com/awslabs/smithy/pull/386))
* A not equal comparison, `!=`, was added.
* Support for numbers in attribute selectors was added.
* Numeric comparisons (`>`, `>=`, `<`, `<=`) were added.
* Attribute selectors now support CSV values, allowing matching on one or more target values.
* The `:each` selector is now `:is` for clarity. [BC]
* Shape IDs with members must now be quoted. [BC]
* Selector parsing and evaluating now tolerates unknown relationship types. ([#377](https://github.com/awslabs/smithy/pull/377))

#### Validation updates

* Services must now contain a closure of shapes that have case-insensitively unique names. [BC] ([#337](https://github.com/awslabs/smithy/pull/337))
* The `UnreferencedShape` validator has moved to `smithy-model` and is now always run. [BC] ([#319](https://github.com/awslabs/smithy/pull/319))

#### JSON Schema conversion

The conversion to JSON schema was significantly overhauled. [BC] ([#274](https://github.com/awslabs/smithy/pull/274))

* Configuration for the build plugin was significantly overhauled. [BC] ([#364](https://github.com/awslabs/smithy/pull/364))
* The strategy for shape inlining has been changed. [BC]
* The strategy for naming shapes and handling shape id conflicts has been changed. [BC]
* Output schema error detection was improved.
* The Java API surface has been reduced. [BC]
* Added the ability to select schemas from a document using a JSON pointer.

#### OpenAPI conversion

The conversion to OpenAPI was significantly overhauled. [BC] ([#275](https://github.com/awslabs/smithy/pull/275))

* Configuration for the build plugin was significantly overhauled.  [BC] ([#364](https://github.com/awslabs/smithy/pull/364))
* Protocol conversion was updated to utilize the new traits. ([#275](https://github.com/awslabs/smithy/pull/275), [#392](https://github.com/awslabs/smithy/pull/392))
* Schemas are now generated for requests and responses instead of being inlined. [BC]
* Fixed several issues with CORS integrations.

#### API Gateway OpenAPI conversion

The API Gateway specific OpenAPI mappers have been updated. [BC] ([#367](https://github.com/awslabs/smithy/pull/367))

*  The `ApiGatewayMapper` interface was added, allowing mappers to control which API Gateway API
type(s) they support.
* Fixed several issues with CORS integrations. ([#370](https://github.com/awslabs/smithy/pull/370))
* Added support for JSON Patch-like OpenAPI schema changes based on JSON Pointers. ([#293](https://github.com/awslabs/smithy/pull/293))
* Added support for event streams in OpenAPI conversion. ([#334](https://github.com/awslabs/smithy/pull/334))

### Bug Fixes

* Fixed an issue in JSON schema conversion where member traits were dropped in some scenarios. ([#274](https://github.com/awslabs/smithy/pull/274))
* Fixed an issue where authorization headers were not properly added to CORS configurations. ([#328](https://github.com/awslabs/smithy/pull/328))
* Fixed an issue where operation response headers were being applied to error responses in OpenAPI
conversions. ([#275](https://github.com/awslabs/smithy/pull/275))
* Fixed an issue where `apply` statements wouldn't resolve target shapes properly in some cases. ([#287](https://github.com/awslabs/smithy/pull/287))
* Fixed an issue with the selector for the `smithy.api#title` trait. ([#387](https://github.com/awslabs/smithy/pull/387))
* Fixed several issues with the `smithy.api#httpApiKeyAuth` trait and its related conversions. ([#291](https://github.com/awslabs/smithy/pull/291))
* Fixed a bug with timestamp validation in specific versions of Java. ([#316](https://github.com/awslabs/smithy/pull/316))

### Optimizations

* The `TraitTargetValidator` now performs as few checks on and selections of the entire model. ([#389](https://github.com/awslabs/smithy/pull/389))
* The dependency on `jackson-core` was replaced with a vendored version of `minimal-json` to reduce
the chances of dependency conflicts. [BC] ([#323](https://github.com/awslabs/smithy/pull/323))
* Sped up model loading time by loading JSON models before IDL models to reduce forward
reference lookups. ([#287](https://github.com/awslabs/smithy/pull/287))

### Breaking changes

* The `BooleanTrait` abstract class in `smithy-model` was renamed `AnnotationTrait`. ([#381](https://github.com/awslabs/smithy/pull/381))
* The traits in the `aws.apigateway` namespace have moved from `smithy-aws-traits` to the
`smithy-aws-apigateway-traits` package for more granular use. ([#322](https://github.com/awslabs/smithy/pull/322))
  * Tooling that referenced these traits has also been updated.
* The traits in the `aws.iam` namespace have moved from `smithy-aws-traits` to the
`smithy-aws-iam-traits` package for more granular use. ([#322](https://github.com/awslabs/smithy/pull/322))
  * Tooling that referenced these traits has also been updated.
* The `aws.api#ec2QueryName` trait has moved to `aws.protocols#ec2QueryName`. ([#286](https://github.com/awslabs/smithy/pull/286))
* The `aws.api#unsignedPayload ` trait has moved to `aws.auth#unsignedPayload `. ([#286](https://github.com/awslabs/smithy/pull/286))
* The `smithy-codegen-freemarker` package has been removed. ([#382](https://github.com/awslabs/smithy/pull/382))
* Traits can no longer be applied to public Smithy Prelude shapes. ([#317](https://github.com/awslabs/smithy/pull/317))
* Smithy's `Pattern` class is renamed to `SmithyPattern` to remove the conflict with Java's regex
`Pattern` class. ([#315](https://github.com/awslabs/smithy/pull/315))
* Removed the `Triple` class from `smithy-utils`. ([#313](https://github.com/awslabs/smithy/pull/313))
* Normalized class names for OpenAPI `SecurityScemeConverter` implementations. ([#291](https://github.com/awslabs/smithy/pull/291))

#### Deprecation cleanup

* The deprecated IDL operation syntax has been removed ([#373](https://github.com/awslabs/smithy/pull/373))
* The deprecated `NodeFactory` interface has been removed. ([#265](https://github.com/awslabs/smithy/pull/265))
* The deprecated `ShapeIndex` class and all related APIs have been removed. ([#266](https://github.com/awslabs/smithy/pull/266))
* Support for the deprecated `0.4.0` model version has been removed. ([#267](https://github.com/awslabs/smithy/pull/267))
* The `aws.api#service` trait no longer supports the deprecated
`sdkServiceId`, `arnService`, or `productName` properties. ([#268](https://github.com/awslabs/smithy/pull/268))
* The deprecated `TemplateEngine` and `DefaultDataTemplateEngine` have been removed. ([#268](https://github.com/awslabs/smithy/pull/268))
* The deprecated `smithy.validators` and `smithy.suppressions` are no loner used as aliases for
validators and suppressions. ([#268](https://github.com/awslabs/smithy/pull/268))
* The `smithy.api#references` and `smithy.api#idRef` traits no longer support relative shape IDs. ([#268](https://github.com/awslabs/smithy/pull/268))

### Documentation

A significant overhaul of the specification and guides has been completed. This includes a better
flow to the spec, more complete guides, deeper documentation of AWS specific components, and a
complete redesign. Many direct links to components of the documentation will have changed.