### PR TITLE
Allowing a shape to be selector scope

### DIFF
--- a/docs/source/spec/core/selectors.rst
+++ b/docs/source/spec/core/selectors.rst
@@ -213,7 +213,10 @@ Attributes
 ==========
 
 Selector attributes return objects that MAY have nested properties. Objects
-returned from selectors MAY be available to cast to a string.
+returned from selectors MAY be available to cast to a string. Attempting
+to select a :ref:`values-projection`, :ref:`keys-projection`, or
+:ref:`(length) attribute function <attribute-function-properties>`
+directly from a shape will return no result.
 
 .. important::
 
@@ -575,6 +578,17 @@ value:
 .. code-block:: none
 
     [@trait|range: @{min} > @{max}]
+
+The scope can also be set to the current shape being evaluated by omitting
+an expression before the ":".
+
+The following selector matches all shapes that are traits that apply
+themselves as traits (for example, this matches `smithy.api#trait`,
+`smithy.api#documentation`, etc.):
+
+.. code-block:: none
+
+    [trait|trait][@: @{trait|(keys)} = @{id}]
 
 The ``(values)`` and ``(keys)`` projections MAY be used as the scoped
 attribute context value. When the scoped attribute context value is a
@@ -1072,7 +1086,7 @@ Selectors are defined by the following ABNF_ grammar.
     selector_values                 :`selector_value` *("," `selector_value`)
     selector_comparator             :"^=" / "$=" / "*=" / "!=" / ">=" / ">" / "<=" / "<" / "?=" / "="
     selector_absolute_root_shape_id :`namespace` "#" `identifier`
-    selector_scoped_attr            :"[@" `selector_key` ":" `selector_scoped_assertions` "]"
+    selector_scoped_attr            :"[@" [`selector_key`] ":" `selector_scoped_assertions` "]"
     selector_scoped_assertions      :`selector_scoped_assertion` *("&&" `selector_scoped_assertion`)
     selector_scoped_assertion       :`selector_scoped_value` `selector_comparator` `selector_scoped_values` ["i"]
     selector_scoped_value           :`selector_value` / `selector_context_value`

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
@@ -29,13 +30,13 @@ import software.amazon.smithy.model.shapes.Shape;
  */
 final class AttributeSelector implements Selector {
 
-    private final AttributeValue.Factory key;
+    private final Function<Shape, AttributeValue> key;
     private final List<AttributeValue> expected;
     private final AttributeComparator comparator;
     private final boolean caseInsensitive;
 
     AttributeSelector(
-            AttributeValue.Factory key,
+            Function<Shape, AttributeValue> key,
             List<String> expected,
             AttributeComparator comparator,
             boolean caseInsensitive
@@ -50,12 +51,12 @@ final class AttributeSelector implements Selector {
         } else {
             this.expected = new ArrayList<>(expected.size());
             for (String validValue : expected) {
-                this.expected.add(new AttributeValue.Literal(validValue));
+                this.expected.add(AttributeValue.literal(validValue));
             }
         }
     }
 
-    static AttributeSelector existence(AttributeValue.Factory key) {
+    static AttributeSelector existence(Function<Shape, AttributeValue> key) {
         return new AttributeSelector(key, null, null, false);
     }
 
@@ -67,7 +68,7 @@ final class AttributeSelector implements Selector {
     }
 
     private boolean matchesAttribute(Shape shape) {
-        AttributeValue lhs = key.create(shape);
+        AttributeValue lhs = key.apply(shape);
 
         if (expected.isEmpty()) {
             return lhs.isPresent();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeValue.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeValue.java
@@ -15,110 +15,48 @@
 
 package software.amazon.smithy.model.selector;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import software.amazon.smithy.model.node.ArrayNode;
-import software.amazon.smithy.model.node.BooleanNode;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeVisitor;
-import software.amazon.smithy.model.node.NullNode;
-import software.amazon.smithy.model.node.NumberNode;
-import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
-import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.Trait;
 
 /**
  * Selector attribute values are the data model of selectors.
  */
-abstract class AttributeValue {
+interface AttributeValue {
 
-    /** Value used when a property or attribute value does not exist. **/
-    static final AttributeValue NULL = new AttributeValue() {
-        @Override
-        boolean isPresent() {
-            return false;
-        }
-
-        @Override
-        AttributeValue getProperty(String key) {
-            return NULL;
-        }
-    };
-
-    /** Value created and used when a property does not exist. */
-    static final Factory NULL_FACTORY = shape -> NULL;
-
-    private static final Logger LOGGER = Logger.getLogger(AttributeValue.class.getName());
-    private static final String KEYS = "(keys)";
-    private static final String VALUES = "(values)";
-    private static final String LENGTH = "(length)";
-
-    @FunctionalInterface
-    interface Factory {
-        AttributeValue create(Shape shape);
-    }
-
+    /**
+     * Returns the string version of an attribute value.
+     *
+     * @return Returns the string representation or an empty string.
+     */
     @Override
-    public String toString() {
-        return "";
-    }
+    String toString();
 
     /**
      * Gets a property from the attribute value.
      *
      * <p>This method never returns null. It should instead return
-     * {@link #NULL} when the property does not exist.
+     * a null value object when the property does not exist.
      *
      * @param key Property to get.
      * @return Returns the nested property.
      */
-    abstract AttributeValue getProperty(String key);
+    AttributeValue getProperty(String key);
 
     /**
-     * Checks if the attribute value is considered present.
+     * Gets a property using a path to the property.
      *
-     * <p>Attribute value are considered present if they are not null. If the
-     * attribute value is a projection, then it is considered present if it is
-     * not empty.
-     *
-     * @return Returns true if present.
+     * @param path The path to select from the value.
+     * @return Returns the created attribute value.
      */
-    boolean isPresent() {
-        return true;
-    }
-
-    /**
-     * Gets all of the attribute values contained in the attribute value.
-     *
-     * <p>This will yield a single result for normal attributes, or a list
-     * of multiple values for projections.
-     *
-     * @return Returns the flattened attribute values contained in the attribute value.
-     */
-    Collection<? extends AttributeValue> getFlattenedValues() {
-        return Collections.singleton(this);
-    }
-
-    /**
-     * Creates the most efficient kind of selector value for the given path.
-     *
-     * @param current Value to path into.
-     * @param path The parsed path to select from the value.
-     * @return Returns the created selector value.
-     */
-    static AttributeValue createPathSelector(AttributeValue current, List<String> path) {
-        if (path.isEmpty()) {
-            return current;
+    default AttributeValue getPath(List<String> path) {
+        if (!isPresent() || path.isEmpty()) {
+            return this;
         }
 
+        AttributeValue current = this;
         for (String segment : path) {
             current = current.getProperty(segment);
             if (!current.isPresent()) {
@@ -130,347 +68,66 @@ abstract class AttributeValue {
     }
 
     /**
-     * An attribute that contains a static, scalar String value.
+     * Checks if the attribute value is considered present.
+     *
+     * <p>Attribute value are considered present if they are not null. If the
+     * attribute value is a projection, then it is considered present if it is
+     * not empty.
+     *
+     * @return Returns true if present.
      */
-    static final class Literal extends AttributeValue {
-        final Object value;
-
-        Literal(Object value) {
-            this.value = Objects.requireNonNull(value);
-        }
-
-        @Override
-        public String toString() {
-            return value.toString();
-        }
-
-        @Override
-        public AttributeValue getProperty(String key) {
-            if (key.equals(LENGTH)) {
-                return new Literal(toString().length());
-            } else {
-                return NULL;
-            }
-        }
+    default boolean isPresent() {
+        return true;
     }
 
     /**
-     * An attribute that contains a {@link Node}.
+     * Gets all of the attribute values contained in the attribute value.
      *
-     * <p>This kind of attribute is typically used when traversing into trait values.
-     * Properties of object nodes can be selected by name. {@link NullNode} are
-     * not considered present. The (values) pseudo-property can be used on object
-     * nodes and array nodes. The (keys) pseudo-property can be used on object nodes.
+     * <p>This will yield a single result for normal attributes, or a list
+     * of multiple values for projections.
+     *
+     * @return Returns the flattened attribute values contained in the attribute value.
      */
-    static final class NodeValue extends AttributeValue {
-        static final NodeVisitor<String> TO_STRING = new NodeToString();
-        final Node value;
-
-        NodeValue(Node value) {
-            this.value = value;
-        }
-
-        @Override
-        public boolean isPresent() {
-            return !value.isNullNode();
-        }
-
-        @Override
-        public String toString() {
-            return value.accept(TO_STRING);
-        }
-
-        @Override
-        AttributeValue getProperty(String key) {
-            switch (value.getType()) {
-                case OBJECT:
-                    ObjectNode objectNode = value.expectObjectNode();
-                    switch (key) {
-                        case KEYS:
-                            return project(objectNode.getMembers().keySet());
-                        case VALUES:
-                            return project(objectNode.getMembers().values());
-                        case LENGTH:
-                            return new Literal(objectNode.getMembers().size());
-                        default:
-                            return value.expectObjectNode()
-                                    .getMember(key)
-                                    .<AttributeValue>map(NodeValue::new)
-                                    .orElse(NULL);
-                    }
-                case ARRAY:
-                    ArrayNode arrayNode = value.expectArrayNode();
-                    switch (key) {
-                        case VALUES:
-                            return project(arrayNode.getElements());
-                        case LENGTH:
-                            return new Literal(arrayNode.size());
-                        default:
-                            return NULL;
-                    }
-                case STRING:
-                    if (key.equals(LENGTH)) {
-                        return new Literal(value.expectStringNode().getValue().length());
-                    }
-                    // fall through
-                default:
-                    return NULL;
-            }
-        }
-
-        private AttributeValue project(Collection<? extends Node> nodes) {
-            return new Projection(nodes.stream().map(NodeValue::new).collect(Collectors.toList()));
-        }
-
-        // Only string, numbers, and booleans are converted to strings.
-        private static final class NodeToString extends NodeVisitor.Default<String> {
-            @Override
-            protected String getDefault(software.amazon.smithy.model.node.Node node) {
-                return "";
-            }
-
-            @Override
-            public String stringNode(StringNode node) {
-                return node.getValue();
-            }
-
-            @Override
-            public String numberNode(NumberNode node) {
-                return node.getValue().toString();
-            }
-
-            @Override
-            public String booleanNode(BooleanNode node) {
-                return Boolean.toString(node.getValue());
-            }
-        }
+    default Collection<? extends AttributeValue> getFlattenedValues() {
+        return Collections.singleton(this);
     }
 
     /**
-     * A projected attribute value that matches N values contained within it.
+     * Creates an {@code AttributeValue} for the given shape.
      *
-     * <p>Projections wrap other values and match if any contained value matches,
-     * are only considered present if there are 1 or more values, and return
-     * new projections based on properties contained within the projection.
+     * @param shape Shape to path into.
+     * @return Returns the created selector value.
      */
-    static final class Projection extends AttributeValue {
-        final Collection<? extends AttributeValue> values;
-        Collection<? extends AttributeValue> flattened;
-
-        Projection(Collection<? extends AttributeValue> values) {
-            this.values = values;
-        }
-
-        @Override
-        AttributeValue getProperty(String key) {
-            // All of the values that are yielded from the projected values
-            // come together to create a new projection.
-            List<AttributeValue> result = new ArrayList<>();
-            for (AttributeValue value : values) {
-                AttributeValue next = value.getProperty(key);
-                if (next.isPresent()) {
-                    result.add(next);
-                }
-            }
-
-            return new Projection(result);
-        }
-
-        /**
-         * Computes the flattened values of the projection.
-         *
-         * @return Returns the flattened values of the projection.
-         */
-        Collection<? extends AttributeValue> getFlattenedValues() {
-            if (flattened == null) {
-                List<AttributeValue> result = new ArrayList<>(values.size());
-                for (AttributeValue value : values) {
-                    // Projections need to be flattened!
-                    if (value instanceof Projection) {
-                        result.addAll(((Projection) value).getFlattenedValues());
-                    } else {
-                        result.add(value);
-                    }
-                }
-                flattened = result;
-            }
-
-            return flattened;
-        }
-
-        @Override
-        boolean isPresent() {
-            // An empty projection is not considered present.
-            return !values.isEmpty();
-        }
+    static AttributeValue shape(Shape shape) {
+        return new AttributeValueImpl.ShapeValue(shape);
     }
 
     /**
-     * Attribute that contains service shape properties.
+     * Creates a null {@code AttributeValue} object.
      *
-     * <p>Using this attribute as a string yields an empty string. This
-     * attribute has the following properties:
-     *
-     * <ul>
-     *     <li>version: The service version as a string.</li>
-     * </ul>
+     * @return Returns the created selector value.
      */
-    static final class Service extends AttributeValue {
-        final ServiceShape service;
-
-        Service(ServiceShape service) {
-            this.service = service;
-        }
-
-        static AttributeValue.Factory createFactory(List<String> path) {
-            // Optimization to help with debugging selectors.
-            if (path.size() > 1) {
-                LOGGER.warning("Too many path segments for `service` attribute: " + path);
-            }
-
-            return shape -> shape.asServiceShape()
-                    .<AttributeValue>map(Service::new)
-                    .map(value -> AttributeValue.createPathSelector(value, path))
-                    .orElse(NULL);
-        }
-
-        @Override
-        AttributeValue getProperty(String key) {
-            switch (key) {
-                case "version":
-                    return new Literal(service.getVersion());
-                case KEYS:
-                    return new Projection(Collections.singleton(new Literal("version")));
-                case VALUES:
-                    return new Projection(Collections.singleton(new Literal(service.getVersion())));
-                case LENGTH:
-                    // Returns the number of elements in the object. It's only "version"
-                    // for services.
-                    return new Literal(1);
-                default:
-                    return NULL;
-            }
-        }
+    static AttributeValue nullValue() {
+        return AttributeValueImpl.NULL;
     }
 
     /**
-     * Grabs values out of a {@link ShapeId} or uses the shape ID directly
-     * as a string, and when cast to a string, returns the absolute shape ID.
+     * Creates an {@code AttributeValue} that contains a literal value.
      *
-     * <p>This attribute has the following properties:
-     *
-     * <ul>
-     *     <li>namespace: The shape ID namespace.</li>
-     *     <li>name: The shape ID name.</li>
-     *     <li>member: The optionally present shape ID member.</li>
-     * </ul>
+     * @param literal Literal value to wrap.
+     * @return Returns the created selector value.
      */
-    static final class Id extends AttributeValue {
-        final ShapeId id;
-
-        Id(ShapeId id) {
-            this.id = id;
-        }
-
-        static AttributeValue.Factory createFactory(List<String> path) {
-            if (path.size() > 1) {
-                // Make debugging selectors easier.
-                LOGGER.warning("Too many selector path segments provided when selecting into `id`: " + path);
-            }
-
-            return shape -> createPathSelector(new Id(shape.getId()), path);
-        }
-
-        @Override
-        public String toString() {
-            return id.toString();
-        }
-
-        @Override
-        AttributeValue getProperty(String property) {
-            switch (property) {
-                case "name":
-                    return new Literal(id.getName());
-                case "namespace":
-                    return new Literal(id.getNamespace());
-                case "member":
-                    return id.getMember()
-                            .<AttributeValue>map(Literal::new)
-                            .orElse(NULL);
-                case KEYS:
-                    List<AttributeValue> keys = new ArrayList<>(3);
-                    keys.add(new Literal("namespace"));
-                    keys.add(new Literal("name"));
-                    id.getMember().ifPresent(member -> keys.add(new Literal("member")));
-                    return new Projection(keys);
-                case VALUES:
-                    List<AttributeValue> values = new ArrayList<>(3);
-                    values.add(new Literal(id.getNamespace()));
-                    values.add(new Literal(id.getName()));
-                    id.getMember().ifPresent(member -> values.add(new Literal(member)));
-                    return new Projection(values);
-                case LENGTH:
-                    // Length returns the length of the shape ID.
-                    return new Literal(id.toString().length());
-                default:
-                    return NULL;
-            }
-        }
+    static AttributeValue literal(Object literal) {
+        return new AttributeValueImpl.Literal(literal);
     }
 
     /**
-     * Grabs values out of the traits of a shape.
+     * Creates an {@code AttributeValue} for a {@link Node}.
      *
-     * <p>This attribute value can be indexed using absolute shape IDs or
-     * relative shape IDs. When a relative shape ID is provided, it is
-     * resolved to the 'smithy.api' namespace.
-     *
-     * <p>Calling (values) on this attribute will return a projection that
-     * contains all of the traits applied to the shape as Node values.
-     *
-     * <p>Calling (keys) on this attribute will return a projection that
-     * contains all of the shape IDs of each trait applied to a shape.
+     * @param node Node to create the value from.
+     * @return Returns the created attribute value.
      */
-    static final class Traits extends AttributeValue {
-        final Shape shape;
-
-        Traits(Shape shape) {
-            this.shape = Objects.requireNonNull(shape);
-        }
-
-        static AttributeValue.Factory createFactory(List<String> path) {
-            return shape -> createPathSelector(new Traits(shape), path);
-        }
-
-        @Override
-        AttributeValue getProperty(String property) {
-            switch (property) {
-                case KEYS:
-                    // This allows the projected keys to be used like shape IDs:
-                    // [trait|(keys)|namespace='com.foo']
-                    List<AttributeValue> keyValues = new ArrayList<>();
-                    for (ShapeId id : shape.getAllTraits().keySet()) {
-                        keyValues.add(new Id(id));
-                    }
-                    return new Projection(keyValues);
-                case VALUES:
-                    // This allows the projected values to be used as nodes. This
-                    // selector finds all traits that have 'foo' property.
-                    // [trait|(values)|foo]
-                    List<AttributeValue> values = new ArrayList<>();
-                    for (Trait trait : shape.getAllTraits().values()) {
-                        values.add(new NodeValue(trait.toNode()));
-                    }
-                    return new Projection(values);
-                case LENGTH:
-                    return new Literal(shape.getAllTraits().size());
-                default:
-                    // A normal property getter. This allows relative trait shape IDs
-                    // and absolute IDs. Relative IDs resolve to 'smithy.api'.
-                    return shape.findTrait(ShapeId.from(Trait.makeAbsoluteName(property)))
-                            .<AttributeValue>map(trait -> new NodeValue(trait.toNode()))
-                            .orElse(NULL);
-            }
-        }
+    static AttributeValue node(Node node) {
+        return new AttributeValueImpl.NodeValue(node);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeValueImpl.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeValueImpl.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.selector;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.BooleanNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.NullNode;
+import software.amazon.smithy.model.node.NumberNode;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
+
+/**
+ * Package private implementations of attribute values.
+ */
+final class AttributeValueImpl {
+
+    /** Value used when a property or attribute value does not exist. **/
+    static final AttributeValue NULL = new AttributeValue() {
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public boolean isPresent() {
+            return false;
+        }
+
+        @Override
+        public AttributeValue getProperty(String key) {
+            return NULL;
+        }
+    };
+
+    private static final Logger LOGGER = Logger.getLogger(AttributeValue.class.getName());
+    private static final String KEYS = "(keys)";
+    private static final String VALUES = "(values)";
+    private static final String LENGTH = "(length)";
+
+    /**
+     * An attribute that contains a static, scalar String value.
+     */
+    static final class Literal implements AttributeValue {
+        final Object value;
+
+        Literal(Object value) {
+            this.value = Objects.requireNonNull(value);
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
+        }
+
+        @Override
+        public AttributeValue getProperty(String key) {
+            if (key.equals(LENGTH)) {
+                return AttributeValue.literal(toString().length());
+            } else {
+                return NULL;
+            }
+        }
+    }
+
+    /**
+     * An attribute that contains a {@link Node}.
+     *
+     * <p>This kind of attribute is typically used when traversing into trait values.
+     * Properties of object nodes can be selected by name. {@link NullNode} are
+     * not considered present. The (values) pseudo-property can be used on object
+     * nodes and array nodes. The (keys) pseudo-property can be used on object nodes.
+     */
+    static final class NodeValue implements AttributeValue {
+        static final NodeVisitor<String> TO_STRING = new NodeToString();
+        final Node value;
+
+        NodeValue(Node value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean isPresent() {
+            return !value.isNullNode();
+        }
+
+        @Override
+        public String toString() {
+            return value.accept(TO_STRING);
+        }
+
+        @Override
+        public AttributeValue getProperty(String key) {
+            switch (value.getType()) {
+                case OBJECT:
+                    ObjectNode objectNode = value.expectObjectNode();
+                    switch (key) {
+                        case KEYS:
+                            return project(objectNode.getMembers().keySet());
+                        case VALUES:
+                            return project(objectNode.getMembers().values());
+                        case LENGTH:
+                            return AttributeValue.literal(objectNode.getMembers().size());
+                        default:
+                            return value.expectObjectNode()
+                                    .getMember(key)
+                                    .<AttributeValue>map(NodeValue::new)
+                                    .orElse(NULL);
+                    }
+                case ARRAY:
+                    ArrayNode arrayNode = value.expectArrayNode();
+                    switch (key) {
+                        case VALUES:
+                            return project(arrayNode.getElements());
+                        case LENGTH:
+                            return AttributeValue.literal(arrayNode.size());
+                        default:
+                            return NULL;
+                    }
+                case STRING:
+                    if (key.equals(LENGTH)) {
+                        return AttributeValue.literal(value.expectStringNode().getValue().length());
+                    }
+                    // fall through
+                default:
+                    return NULL;
+            }
+        }
+
+        private AttributeValue project(Collection<? extends Node> nodes) {
+            return new Projection(nodes.stream().map(NodeValue::new).collect(Collectors.toList()));
+        }
+
+        // Only string, numbers, and booleans are converted to strings.
+        private static final class NodeToString extends NodeVisitor.Default<String> {
+            @Override
+            protected String getDefault(software.amazon.smithy.model.node.Node node) {
+                return "";
+            }
+
+            @Override
+            public String stringNode(StringNode node) {
+                return node.getValue();
+            }
+
+            @Override
+            public String numberNode(NumberNode node) {
+                return node.getValue().toString();
+            }
+
+            @Override
+            public String booleanNode(BooleanNode node) {
+                return Boolean.toString(node.getValue());
+            }
+        }
+    }
+
+    /**
+     * A projected attribute value that matches N values contained within it.
+     *
+     * <p>Projections wrap other values and match if any contained value matches,
+     * are only considered present if there are 1 or more values, and return
+     * new projections based on properties contained within the projection.
+     */
+    static final class Projection implements AttributeValue {
+        final Collection<? extends AttributeValue> values;
+        Collection<? extends AttributeValue> flattened;
+
+        Projection(Collection<? extends AttributeValue> values) {
+            this.values = values;
+        }
+
+        @Override
+        public AttributeValue getProperty(String key) {
+            // All of the values that are yielded from the projected values
+            // come together to create a new projection.
+            List<AttributeValue> result = new ArrayList<>();
+            for (AttributeValue value : values) {
+                AttributeValue next = value.getProperty(key);
+                if (next.isPresent()) {
+                    result.add(next);
+                }
+            }
+
+            return new Projection(result);
+        }
+
+        /**
+         * Computes the flattened values of the projection.
+         *
+         * @return Returns the flattened values of the projection.
+         */
+        public Collection<? extends AttributeValue> getFlattenedValues() {
+            if (flattened == null) {
+                List<AttributeValue> result = new ArrayList<>(values.size());
+                for (AttributeValue value : values) {
+                    // Projections need to be flattened!
+                    if (value instanceof Projection) {
+                        result.addAll(((Projection) value).getFlattenedValues());
+                    } else {
+                        result.add(value);
+                    }
+                }
+                flattened = result;
+            }
+
+            return flattened;
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public boolean isPresent() {
+            // An empty projection is not considered present.
+            return !values.isEmpty();
+        }
+    }
+
+    /**
+     * Attribute that contains service shape properties.
+     *
+     * <p>Using this attribute as a string yields an empty string. This
+     * attribute has the following properties:
+     *
+     * <ul>
+     *     <li>version: The service version as a string.</li>
+     * </ul>
+     */
+    static final class Service implements AttributeValue {
+        final ServiceShape service;
+
+        Service(ServiceShape service) {
+            this.service = service;
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public AttributeValue getProperty(String key) {
+            switch (key) {
+                case "version":
+                    return AttributeValue.literal(service.getVersion());
+                case KEYS:
+                    return new Projection(Collections.singleton(AttributeValue.literal("version")));
+                case VALUES:
+                    return new Projection(Collections.singleton(AttributeValue.literal(service.getVersion())));
+                case LENGTH:
+                    // Returns the number of elements in the object. It's only "version"
+                    // for services.
+                    return AttributeValue.literal(1);
+                default:
+                    return NULL;
+            }
+        }
+    }
+
+    /**
+     * Grabs values out of a {@link ShapeId} or uses the shape ID directly
+     * as a string, and when cast to a string, returns the absolute shape ID.
+     *
+     * <p>This attribute has the following properties:
+     *
+     * <ul>
+     *     <li>namespace: The shape ID namespace.</li>
+     *     <li>name: The shape ID name.</li>
+     *     <li>member: The optionally present shape ID member.</li>
+     * </ul>
+     */
+    static final class Id implements AttributeValue {
+        final ShapeId id;
+
+        Id(ShapeId id) {
+            this.id = id;
+        }
+
+        @Override
+        public String toString() {
+            return id.toString();
+        }
+
+        @Override
+        public AttributeValue getProperty(String property) {
+            switch (property) {
+                case "name":
+                    return AttributeValue.literal(id.getName());
+                case "namespace":
+                    return AttributeValue.literal(id.getNamespace());
+                case "member":
+                    return id.getMember()
+                            .<AttributeValue>map(Literal::new)
+                            .orElse(NULL);
+                case KEYS:
+                    List<AttributeValue> keys = new ArrayList<>(3);
+                    keys.add(AttributeValue.literal("namespace"));
+                    keys.add(AttributeValue.literal("name"));
+                    id.getMember().ifPresent(member -> keys.add(AttributeValue.literal("member")));
+                    return new Projection(keys);
+                case VALUES:
+                    List<AttributeValue> values = new ArrayList<>(3);
+                    values.add(AttributeValue.literal(id.getNamespace()));
+                    values.add(AttributeValue.literal(id.getName()));
+                    id.getMember().ifPresent(member -> values.add(AttributeValue.literal(member)));
+                    return new Projection(values);
+                case LENGTH:
+                    // Length returns the length of the shape ID.
+                    return AttributeValue.literal(id.toString().length());
+                default:
+                    return NULL;
+            }
+        }
+    }
+
+    /**
+     * Grabs values out of the traits of a shape.
+     *
+     * <p>This attribute value can be indexed using absolute shape IDs or
+     * relative shape IDs. When a relative shape ID is provided, it is
+     * resolved to the 'smithy.api' namespace.
+     *
+     * <p>Calling (values) on this attribute will return a projection that
+     * contains all of the traits applied to the shape as Node values.
+     *
+     * <p>Calling (keys) on this attribute will return a projection that
+     * contains all of the shape IDs of each trait applied to a shape.
+     */
+    static final class Traits implements AttributeValue {
+        final Shape shape;
+
+        Traits(Shape shape) {
+            this.shape = Objects.requireNonNull(shape);
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public AttributeValue getProperty(String property) {
+            switch (property) {
+                case KEYS:
+                    // This allows the projected keys to be used like shape IDs:
+                    // [trait|(keys)|namespace='com.foo']
+                    List<AttributeValue> keyValues = new ArrayList<>();
+                    for (ShapeId id : shape.getAllTraits().keySet()) {
+                        keyValues.add(new Id(id));
+                    }
+                    return new Projection(keyValues);
+                case VALUES:
+                    // This allows the projected values to be used as nodes. This
+                    // selector finds all traits that have 'foo' property.
+                    // [trait|(values)|foo]
+                    List<AttributeValue> values = new ArrayList<>();
+                    for (Trait trait : shape.getAllTraits().values()) {
+                        values.add(new NodeValue(trait.toNode()));
+                    }
+                    return new Projection(values);
+                case LENGTH:
+                    return AttributeValue.literal(shape.getAllTraits().size());
+                default:
+                    // A normal property getter. This allows relative trait shape IDs
+                    // and absolute IDs. Relative IDs resolve to 'smithy.api'.
+                    return shape.findTrait(ShapeId.from(Trait.makeAbsoluteName(property)))
+                            .<AttributeValue>map(trait -> new NodeValue(trait.toNode()))
+                            .orElse(NULL);
+            }
+        }
+    }
+
+    static final class ShapeValue implements AttributeValue {
+        final Shape shape;
+
+        ShapeValue(Shape shape) {
+            this.shape = Objects.requireNonNull(shape);
+        }
+
+        @Override
+        public String toString() {
+            return shape.getId().toString();
+        }
+
+        @Override
+        public AttributeValue getProperty(String property) {
+            switch (property) {
+                case "trait":
+                    return new Traits(shape);
+                case "id":
+                    return new Id(shape.getId());
+                case "service":
+                    return shape.asServiceShape().<AttributeValue>map(Service::new).orElse(NULL);
+                default:
+                    LOGGER.warning("Unsupported shape selector attribute: " + property);
+                    return NULL;
+            }
+        }
+    }
+
+    private AttributeValueImpl() {}
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.selector;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
@@ -57,10 +58,10 @@ final class ScopedAttributeSelector implements Selector {
         AttributeValue create(AttributeValue value);
     }
 
-    private final AttributeValue.Factory keyScope;
+    private final Function<Shape, AttributeValue> keyScope;
     private final List<Assertion> assertions;
 
-    ScopedAttributeSelector(AttributeValue.Factory keyScope, List<Assertion> assertions) {
+    ScopedAttributeSelector(Function<Shape, AttributeValue> keyScope, List<Assertion> assertions) {
         this.keyScope = keyScope;
         this.assertions = assertions;
     }
@@ -74,7 +75,7 @@ final class ScopedAttributeSelector implements Selector {
 
     private boolean matchesAssertions(Shape shape) {
         // First resolve the scope of the assertions.
-        AttributeValue scope = keyScope.create(shape);
+        AttributeValue scope = keyScope.apply(shape);
 
         // If it's not present, then nothing could ever match.
         if (!scope.isPresent()) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/AndSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/AndSelectorTest.java
@@ -35,7 +35,8 @@ public class AndSelectorTest {
     public void matchesAllPredicates() {
         Selector selector = AndSelector.of(Arrays.asList(
                 new ShapeTypeSelector(ShapeType.STRING),
-                AttributeSelector.existence(AttributeValue.Traits.createFactory(ListUtils.of("sensitive")))));
+                AttributeSelector.existence(
+                        shape -> AttributeValue.shape(shape).getPath(ListUtils.of("trait", "sensitive")))));
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait()).build();
         Model model = Model.builder().addShapes(a, b).build();
@@ -48,7 +49,8 @@ public class AndSelectorTest {
     public void shortCircuits() {
         Selector selector = AndSelector.of(Arrays.asList(
                 new ShapeTypeSelector(ShapeType.BIG_INTEGER),
-                AttributeSelector.existence(AttributeValue.Traits.createFactory(ListUtils.of("sensitive")))));
+                AttributeSelector.existence(
+                        shape -> AttributeValue.shape(shape).getPath(ListUtils.of("trait", "sensitive")))));
         Shape a = IntegerShape.builder().id("foo.baz#Bar").build();
         Shape b = StringShape.builder().id("foo.baz#Bam").addTrait(new SensitiveTrait()).build();
         Model model = Model.builder().addShapes(a, b).build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/OfSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/OfSelectorTest.java
@@ -41,7 +41,8 @@ public class OfSelectorTest {
         Model model = createModel();
         // Containing shape must have the sensitive trait.
         Selector selector = new OfSelector(Collections.singletonList(
-                AttributeSelector.existence(AttributeValue.Traits.createFactory(ListUtils.of("sensitive")))));
+                AttributeSelector.existence(
+                        shape -> AttributeValue.shape(shape).getPath(ListUtils.of("trait", "sensitive")))));
 
         Set<Shape> result = selector.select(model);
         assertThat(result, hasSize(1));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 
 import java.util.List;
@@ -663,7 +664,9 @@ public class SelectorTest {
                 "[@trait: @{foo|baz|bam|(boo)}=@{foo|bar|(boo)|baz}]",
                 "[@trait: @{foo|baz|bam|(boo)}=@{foo|bar|(boo)|baz}, @{foo|bam}]",
                 // Comma separated values are or'd together.
-                "[@trait: @{foo|baz|bam|(boo)}=@{foo|bar|(boo)|baz}, @{foo|bam} i && 10=10 i]");
+                "[@trait: @{foo|baz|bam|(boo)}=@{foo|bar|(boo)|baz}, @{foo|bam} i && 10=10 i]",
+                "[@: foo=bar]",
+                "[@    :  foo   = bam  ]");
 
         for (String expr : exprs) {
             Selector.parse(expr);
@@ -697,7 +700,11 @@ public class SelectorTest {
                 "[@foo: @{abc|}=10]",
                 "[@foo: @{abc|def(baz)}=10]", // not a valid segment
                 "[@foo: @{abc|()}=10]", // missing contents of ()
-                "[@foo: @{abc|(.)}=10]"); // invalid contents of ());
+                "[@foo: @{abc|(.)}=10]", // invalid contents of ());
+                "[@:",
+                "[@: bar",
+                "[@: bar]",
+                "[@: bar=bam");
 
         for (String expr : exprs) {
             Assertions.assertThrows(SelectorSyntaxException.class, () -> Selector.parse(expr));
@@ -811,5 +818,13 @@ public class SelectorTest {
                 "[id|namespace='smithy.example'][trait|enum|(values)|tags|(length) > 1]");
 
         assertThat(shapes, contains("smithy.example#DocumentedString1"));
+    }
+
+    @Test
+    public void canBindShapeAsContext() {
+        assertThat(ids(traitModel, "[trait|trait][@: @{trait|(keys)} = @{id}]"),
+                   hasItems("smithy.example#recursiveTrait",
+                            "smithy.api#trait",
+                            "smithy.api#documentation"));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/nested-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/nested-traits.smithy
@@ -111,3 +111,7 @@ list ListyTraitMember2 {
 structure ListyTraitStruct {
     foo: String
 }
+
+@trait
+@recursiveTrait("Wow!")
+string recursiveTrait


### PR DESCRIPTION
A shape can now be used as a selector scope allowing for selecting and
comparing multiple top-level attributes of shapes.

This commit also updates AttributeValue to be ready to expose as a
public interface if needed for more advanced selector message formatting
functionality.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
