### PR TITLE
requestBody and response content schemas as references

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -184,7 +184,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetPayload200ResponsePayload"
+                  "$ref": "#/components/schemas/GetPayloadOutputPayload"
                 }
               }
             }
@@ -277,7 +277,7 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "$ref": "#/components/schemas/PutPayloadRequestBodyContent"
+                "$ref": "#/components/schemas/PutPayloadInputPayload"
               }
             }
           }
@@ -359,7 +359,7 @@
           "c"
         ]
       },
-      "GetPayload200ResponsePayload": {
+      "GetPayloadOutputPayload": {
         "type": "string",
         "format": "byte"
       },
@@ -389,7 +389,7 @@
           "id"
         ]
       },
-      "PutPayloadRequestBodyContent": {
+      "PutPayloadInputPayload": {
         "type": "string",
         "format": "byte"
       }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -184,8 +184,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "type": "string",
-                  "format": "byte"
+                  "$ref": "#/components/schemas/GetPayload200ResponsePayload"
                 }
               }
             }
@@ -278,8 +277,7 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "type": "string",
-                "format": "byte"
+                "$ref": "#/components/schemas/PutPayloadRequestBodyContent"
               }
             }
           }
@@ -361,6 +359,10 @@
           "c"
         ]
       },
+      "GetPayload200ResponsePayload": {
+        "type": "string",
+        "format": "byte"
+      },
       "ListPayloadsResponseContent": {
         "type": "object",
         "properties": {
@@ -386,6 +388,10 @@
           "createdAt",
           "id"
         ]
+      },
+      "PutPayloadRequestBodyContent": {
+        "type": "string",
+        "format": "byte"
       }
     },
     "securitySchemes": {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -272,7 +272,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             OperationShape operation
     ) {
         Schema schema = context.inlineOrReferenceSchema(binding.getMember());
-        String synthesizedName = operation.getId().getName() + "RequestBodyContent";
+        String synthesizedName = operation.getId().getName() + "InputPayload";
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
@@ -393,13 +393,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
                 .orElse(null);
 
         if (!payloadBindings.isEmpty()) {
-            createResponsePayload(mediaType,
-                    context,
-                    payloadBindings.get(0),
-                    responseBuilder,
-                    statusCode,
-                    operationOrError
-            );
+            createResponsePayload(mediaType, context, payloadBindings.get(0), responseBuilder, operationOrError);
         } else {
             createResponseDocumentIfNeeded(mediaType, context, bindingIndex, responseBuilder, operationOrError);
         }
@@ -410,11 +404,13 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             Context<T> context,
             HttpBinding binding,
             ResponseObject.Builder responseBuilder,
-            String statusCode,
             Shape operationOrError
     ) {
         Schema schema = context.inlineOrReferenceSchema(binding.getMember());
-        String synthesizedName = operationOrError.getId().getName() + statusCode + "ResponsePayload";
+        String shapeName = operationOrError.getId().getName();
+        String synthesizedName = operationOrError instanceof OperationShape
+                ? shapeName + "OutputPayload"
+                : shapeName + "ErrorPayload";
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -406,6 +406,9 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             ResponseObject.Builder responseBuilder,
             Shape operationOrError
     ) {
+        // API Gateway validation requires that in-line schemas must be objects
+        // or arrays. These schemas are synthesized as references so that
+        // any schemas with string types will pass validation.
         Schema schema = context.inlineOrReferenceSchema(binding.getMember());
         String shapeName = operationOrError.getId().getName();
         String synthesizedName = operationOrError instanceof OperationShape

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -271,6 +271,9 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             HttpBinding binding,
             OperationShape operation
     ) {
+        // API Gateway validation requires that in-line schemas must be objects
+        // or arrays. These schemas are synthesized as references so that
+        // any schemas with string types will pass validation.
         Schema schema = context.inlineOrReferenceSchema(binding.getMember());
         String synthesizedName = operation.getId().getName() + "InputPayload";
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/supports-payloads.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/supports-payloads.openapi.json
@@ -12,7 +12,7 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "$ref": "#/components/schemas/OperationRequestBodyContent"
+                "$ref": "#/components/schemas/OperationInputPayload"
               }
             }
           }
@@ -39,7 +39,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/Operation200ResponsePayload"
+                  "$ref": "#/components/schemas/OperationOutputPayload"
                 }
               }
             }
@@ -49,7 +49,7 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error404ResponsePayload"
+                  "$ref": "#/components/schemas/ErrorErrorPayload"
                 }
               }
             }
@@ -60,14 +60,14 @@
   },
   "components": {
     "schemas": {
-      "Error404ResponsePayload": {
+      "ErrorErrorPayload": {
         "type": "string"
       },
-      "Operation200ResponsePayload": {
+      "OperationInputPayload": {
         "type": "string",
         "format": "byte"
       },
-      "OperationRequestBodyContent": {
+      "OperationOutputPayload": {
         "type": "string",
         "format": "byte"
       }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/supports-payloads.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/supports-payloads.openapi.json
@@ -12,8 +12,7 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "type": "string",
-                "format": "byte"
+                "$ref": "#/components/schemas/OperationRequestBodyContent"
               }
             }
           }
@@ -40,8 +39,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "type": "string",
-                  "format": "byte"
+                  "$ref": "#/components/schemas/Operation200ResponsePayload"
                 }
               }
             }
@@ -51,12 +49,27 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/Error404ResponsePayload"
                 }
               }
             }
           }
         }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error404ResponsePayload": {
+        "type": "string"
+      },
+      "Operation200ResponsePayload": {
+        "type": "string",
+        "format": "byte"
+      },
+      "OperationRequestBodyContent": {
+        "type": "string",
+        "format": "byte"
       }
     }
   }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.openapi.json
@@ -14,7 +14,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/StreamingOperation200ResponsePayload"
+                                    "$ref": "#/components/schemas/StreamingOperationOutputPayload"
                                 }
                             }
                         }
@@ -25,7 +25,7 @@
     },
     "components": {
         "schemas": {
-            "StreamingOperation200ResponsePayload": {
+            "StreamingOperationOutputPayload": {
                 "type": "string",
                 "format": "byte"
             }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.openapi.json
@@ -14,13 +14,20 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "type": "string",
-                                    "format": "byte"
+                                    "$ref": "#/components/schemas/StreamingOperation200ResponsePayload"
                                 }
                             }
                         }
                     }
                 }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "StreamingOperation200ResponsePayload": {
+                "type": "string",
+                "format": "byte"
             }
         }
     }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -57,8 +57,7 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "type": "string",
-                "format": "byte"
+                "$ref": "#/components/schemas/PutPayloadRequestBodyContent"
               }
             }
           }
@@ -116,8 +115,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "type": "string",
-                  "format": "byte"
+                  "$ref": "#/components/schemas/PutPayload200ResponsePayload"
                 }
               }
             }
@@ -192,6 +190,14 @@
           "type": "string",
           "format": "password"
         }
+      },
+      "PutPayloadRequestBodyContent": {
+        "type": "string",
+        "format": "byte"
+      },
+      "PutPayload200ResponsePayload": {
+        "type": "string",
+        "format": "byte"
       },
       "TaggedUnion": {
         "oneOf": [

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -57,7 +57,7 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "$ref": "#/components/schemas/PutPayloadRequestBodyContent"
+                "$ref": "#/components/schemas/PutPayloadInputPayload"
               }
             }
           }
@@ -115,7 +115,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/PutPayload200ResponsePayload"
+                  "$ref": "#/components/schemas/PutPayloadOutputPayload"
                 }
               }
             }
@@ -191,11 +191,11 @@
           "format": "password"
         }
       },
-      "PutPayloadRequestBodyContent": {
+      "PutPayloadInputPayload": {
         "type": "string",
         "format": "byte"
       },
-      "PutPayload200ResponsePayload": {
+      "PutPayloadOutputPayload": {
         "type": "string",
         "format": "byte"
       },


### PR DESCRIPTION
This PR updates the OpenAPI Converter to write requestBody and response content schemas to as references instead of in-line schema definitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
