### PR TITLE
Remove Basic Auth test

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.json
@@ -14,7 +14,9 @@
             ],
             "traits": {
                 "aws.protocols#restJson1": {},
-                "smithy.api#httpBasicAuth": {},
+                "aws.auth#sigv4": {
+                    "name": "myservice"
+                },
                 "smithy.api#cors": {
                     "origin": "https://foo.com"
                 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
@@ -73,16 +73,18 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api.httpBasicAuth": {
-        "type": "http",
-        "description": "HTTP Basic authentication",
-        "scheme": "Basic"
+      "aws.auth.sigv4": {
+        "type": "apiKey",
+        "description": "AWS Signature Version 4 authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "awsSigv4"
       }
     }
   },
   "security": [
     {
-      "smithy.api.httpBasicAuth": [ ]
+      "aws.auth.sigv4": [ ]
     }
   ],
   "x-amazon-apigateway-gateway-responses": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
@@ -11,7 +11,6 @@
             ],
             "traits": {
                 "aws.protocols#restJson1": {},
-                "smithy.api#httpBasicAuth": {},
                 "aws.auth#sigv4": {
                     "name": "myservice"
                 },

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -395,18 +395,10 @@
         "name": "Authorization",
         "in": "header",
         "x-amazon-apigateway-authtype": "awsSigv4"
-      },
-      "smithy.api.httpBasicAuth": {
-        "type": "http",
-        "description": "HTTP Basic authentication",
-        "scheme": "Basic"
       }
     }
   },
   "security": [
-    {
-      "smithy.api.httpBasicAuth": [ ]
-    },
     {
       "aws.auth.sigv4": [ ]
     }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
@@ -73,16 +73,18 @@
   },
   "components": {
     "securitySchemes": {
-      "smithy.api.httpBasicAuth": {
-        "type": "http",
-        "description": "HTTP Basic authentication",
-        "scheme": "Basic"
+      "aws.auth.sigv4": {
+        "type": "apiKey",
+        "description": "AWS Signature Version 4 authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "awsSigv4"
       }
     }
   },
   "security": [
     {
-      "smithy.api.httpBasicAuth": [ ]
+      "aws.auth.sigv4": [ ]
     }
   ],
   "x-amazon-apigateway-gateway-responses": {


### PR DESCRIPTION
API Gateway requires a Lambda integration to use Basic Auth.

This PR removes the Basic Auth test cases so that test models will pass validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
