### PR TITLE
Avoid wrapping request payload schemas

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/payloads.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/payloads.json
@@ -57,8 +57,14 @@
         "example.smithy#FooOperationOutput": {
             "type": "structure",
             "members": {
+                "payload": {
+                    "target": "example.smithy#FooOperationPayload"
+                },
                 "baz": {
-                    "target": "smithy.api#String"
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "X-Baz-Header"
+                    }
                 }
             }
         }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/payloads.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/payloads.openapi.json
@@ -29,6 +29,13 @@
         "responses": {
           "200": {
             "description": "FooOperation 200 response",
+            "headers": {
+              "X-Baz-Header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -54,8 +61,8 @@
       "FooOperationResponseContent": {
         "type": "object",
         "properties": {
-          "baz": {
-            "type": "string"
+          "payload": {
+            "$ref": "#/components/schemas/FooOperationPayload"
           }
         }
       }


### PR DESCRIPTION
When creating request payload schemas, the synthesized schema was unnecessarily creating an additional schema layer.  This PR detects when a synthesized schema is effectively just a wrapper for another schema, and removes that wrapper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
