### PR TITLE
Set config on OpenApiConverter in build plugin

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApi.java
@@ -42,6 +42,7 @@ public final class Smithy2OpenApi implements SmithyBuildPlugin {
         context.getPluginClassLoader().ifPresent(converter::classLoader);
         OpenApiConfig config = OpenApiConfig.fromNode(context.getSettings());
         ShapeId shapeId = config.getService();
+        converter.config(config);
         ObjectNode openApiNode = converter.convertToNode(context.getModel());
         context.getFileManifest().writeJson(shapeId.getName() + ".openapi.json", openApiNode);
     }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApiTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/Smithy2OpenApiTest.java
@@ -1,0 +1,52 @@
+package software.amazon.smithy.openapi.fromsmithy;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.openapi.OpenApiException;
+
+public class Smithy2OpenApiTest {
+    @Test
+    public void pluginConvertsModel() {
+        Model model = Model.assembler()
+                .addImport(OpenApiConverterTest.class.getResource("test-service.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .settings(Node.objectNode()
+                        .withMember("service", "example.rest#RestService")
+                )
+                .fileManifest(manifest)
+                .model(model)
+                .originalModel(model)
+                .build();
+        new Smithy2OpenApi().execute(context);
+        assertTrue(manifest.hasFile("RestService.openapi.json"));
+    }
+
+    @Test
+    public void throwsWhenServiceNotConfigured() {
+        Model model = Model.assembler()
+                .addImport(OpenApiConverterTest.class.getResource("test-service.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .settings(Node.objectNode())
+                .fileManifest(manifest)
+                .model(model)
+                .originalModel(model)
+                .build();
+        assertThrows(OpenApiException.class, () -> {
+            new Smithy2OpenApi().execute(context);
+        });
+    }
+}


### PR DESCRIPTION
This PR fixes Smithy2OpenApi plugin by correctly setting the config on the converter during the plugin's execution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
