### PR TITLE
Remove legacy alias functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ reference lookups. ([#287](https://github.com/awslabs/smithy/pull/287))
 * The `aws.api#service` trait no longer supports the deprecated
 `sdkServiceId`, `arnService`, or `productName` properties. ([#268](https://github.com/awslabs/smithy/pull/268))
 * The deprecated `TemplateEngine` and `DefaultDataTemplateEngine` have been removed. ([#268](https://github.com/awslabs/smithy/pull/268))
-* The deprecated `smithy.validators` and `smithy.suppressions` are no loner used as aliases for
+* The deprecated `smithy.validators` and `smithy.suppressions` are no longer used as aliases for
 validators and suppressions. ([#268](https://github.com/awslabs/smithy/pull/268))
 * The `smithy.api#references` and `smithy.api#idRef` traits no longer support relative shape IDs. ([#268](https://github.com/awslabs/smithy/pull/268))
 

--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -248,8 +248,6 @@ Applies the transforms defined in the given projection names.
 excludeShapesByTag
 ------------------
 
-Aliases: ``excludeByTag`` (deprecated)
-
 Removes shapes if they are tagged with one or more of the given ``tags`` via
 the :ref:`tags trait <tags-trait>`.
 
@@ -274,7 +272,7 @@ the :ref:`tags trait <tags-trait>`.
                 "exampleProjection": {
                     "transforms": [
                         {
-                            "name": "excludeByTag",
+                            "name": "excludeShapesByTag",
                             "args": {
                                 "tags": ["foo", "baz"]
                             }
@@ -293,8 +291,6 @@ the :ref:`tags trait <tags-trait>`.
 
 includeShapesByTag
 ------------------
-
-Aliases: ``includeByTag`` (deprecated)
 
 Removes shapes that are not tagged with at least one of the given ``tags``
 via the :ref:`tags trait <tags-trait>`.
@@ -320,7 +316,7 @@ via the :ref:`tags trait <tags-trait>`.
                 "exampleProjection": {
                     "transforms": [
                         {
-                            "name": "includeByTag",
+                            "name": "includeShapesByTag",
                             "args": {
                                 "tags": ["foo", "baz"]
                             }
@@ -745,12 +741,90 @@ orphaned shapes.
     This transformer does not remove shapes from the prelude.
 
 
+.. _excludeMetadata-transform:
+
+excludeMetadata
+---------------
+
+Removes :ref:`metadata` key-value pairs from a model if the key is in the
+provided ``keys`` list.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - keys
+      - ``[string]``
+      - The set of metadata keys that are removed from the model.
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "excludeMetadata",
+                            "args": {
+                                "keys": ["suppressions"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+
+.. _includeMetadata-transform:
+
+includeMetadata
+---------------
+
+Removes :ref:`metadata` key-value pairs from a model if the key is not in
+the provided ``keys`` list.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - keys
+      - ``[string]``
+      - The set of metadata keys that are retained in the model.
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "includeMetadata",
+                            "args": {
+                                "keys": ["authors"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+
 .. _removeUnusedShapes-transform:
 
 removeUnusedShapes
 ------------------
-
-Aliases: ``treeShaker`` (deprecated)
 
 Removes shapes from the model that are not connected to any service shape
 or to a shape definition.
@@ -824,7 +898,7 @@ Consider the following ``smithy-build.json`` file:
             "a": {
                 "transforms": [
                     {
-                        "${NAME_KEY}": "includeByTag",
+                        "${NAME_KEY}": "includeShapesByTag",
                         "args": {
                             "tags": ["${FOO}", "\\${BAZ}"]
                         }
@@ -845,7 +919,7 @@ environment variable set to "hi", this file is equivalent to:
             "a": {
                 "transforms": [
                     {
-                        "name": "includeByTag",
+                        "name": "includeShapesByTag",
                         "args": {
                             "tags": ["Hi", "${BAZ}"]
                         }

--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -687,7 +687,7 @@ The effective data classifications in the previous example are as follows:
 .. note::
 
     This trait should be used in conjunction with the
-    :ref:`sensitive-trait` trait as necessary.
+    :ref:`sensitive-trait` as necessary.
 
 
 .. _data-classifications:
@@ -710,10 +710,12 @@ applied through the ``aws.api#data`` trait.
         AWS for processing, storage or hosting by AWS services in connection
         with the customer’s accounts and any computational results that
         customers or any customer end user derive from the foregoing through
-        their use of AWS services.
+        their use of AWS services. Data of this classification should be marked
+        with the :ref:`sensitive-trait`.
     * - ``account``
       - Designates information about customers that customers provide to AWS in
         connection with the creation or administration of customers’ accounts.
+        Data of this classification should be marked with the :ref:`sensitive-trait`.
     * - ``usage``
       - Designates data related to a customer’s account, such as resource
         identifiers, usage statistics, logging data, and analytics.
@@ -721,7 +723,8 @@ applied through the ``aws.api#data`` trait.
       - Designates metadata tags applied to AWS resources.
     * - ``permissions``
       - Designates security and access roles, rules, usage policies, and
-        permissions.
+        permissions. Data of this classification should be marked with the
+        :ref:`sensitive-trait`.
 
 
 .. _aws.api#controlPlane-trait:

--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -458,7 +458,7 @@ Trait selector
 Value type
     ``structure``
 
-The length trait is a structure that contains the following members:
+The range trait is a structure that contains the following members:
 
 .. list-table::
     :header-rows: 1

--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionTransformer.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionTransformer.java
@@ -15,14 +15,12 @@
 
 package software.amazon.smithy.build;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Creates a model transformer by name.
@@ -34,15 +32,6 @@ public interface ProjectionTransformer {
      * @return Returns the name (e.g., "traits").
      */
     String getName();
-
-    /**
-     * Returns a list of aliases that the transformer also answers to.
-     *
-     * @return True if this transformer is responsible for the given name.
-     */
-    default Collection<String> getAliases() {
-        return ListUtils.of();
-    }
 
     /**
      * Transforms the given model using the provided {@link TransformContext}.
@@ -77,7 +66,6 @@ public interface ProjectionTransformer {
         Map<String, ProjectionTransformer> map = new HashMap<>();
         for (ProjectionTransformer transformer : transformers) {
             map.put(transformer.getName(), transformer);
-            transformer.getAliases().forEach(alias -> map.put(alias, transformer));
         }
         return name -> Optional.ofNullable(map.get(name));
     }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildPlugin.java
@@ -16,12 +16,10 @@
 package software.amazon.smithy.build;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Function;
-import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Plugin extension class for SmithyBuild.
@@ -37,15 +35,6 @@ public interface SmithyBuildPlugin {
      * @return Returns the name (e.g., "MyPlugin").
      */
     String getName();
-
-    /**
-     * Returns a list of aliases that the plugin also answers to.
-     *
-     * @return True if this plugin is responsible for the given name.
-     */
-    default Collection<String> getAliases() {
-        return ListUtils.of();
-    }
 
     /**
      * Plugins can choose whether or not to create artifacts based on whether
@@ -94,7 +83,7 @@ public interface SmithyBuildPlugin {
         List<SmithyBuildPlugin> pluginList = new ArrayList<>();
         plugins.forEach(pluginList::add);
         return name -> pluginList.stream()
-                .filter(plugin -> plugin.getName().equals(name) || plugin.getAliases().contains(name))
+                .filter(plugin -> plugin.getName().equals(name))
                 .findFirst();
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByTag.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.build.transforms;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import software.amazon.smithy.build.TransformContext;
@@ -64,11 +63,6 @@ public final class ExcludeShapesByTag extends BackwardCompatHelper<ExcludeShapes
     @Override
     public String getName() {
         return "excludeShapesByTag";
-    }
-
-    @Override
-    public Collection<String> getAliases() {
-        return Collections.singleton("excludeByTag");
     }
 
     @Override

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeShapesByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeShapesByTag.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.build.transforms;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import software.amazon.smithy.build.TransformContext;
@@ -65,11 +64,6 @@ public final class IncludeShapesByTag extends BackwardCompatHelper<IncludeShapes
     @Override
     public String getName() {
         return "includeShapesByTag";
-    }
-
-    @Override
-    public Collection<String> getAliases() {
-        return Collections.singleton("includeByTag");
     }
 
     @Override

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.build.transforms;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -43,7 +42,7 @@ public final class RemoveUnusedShapes extends BackwardCompatHelper<RemoveUnusedS
         /**
          * You can <em>export</em> shapes that are not connected to any service
          * shape by applying specific tags to the shape and adding the list of
-         * export tags as arguments to the treeShaker.
+         * export tags an argument to the transformer.
          *
          * @param exportByTags Tags that cause shapes to be exported.
          */
@@ -69,11 +68,6 @@ public final class RemoveUnusedShapes extends BackwardCompatHelper<RemoveUnusedS
     @Override
     public String getName() {
         return "removeUnusedShapes";
-    }
-
-    @Override
-    public Collection<String> getAliases() {
-        return Collections.singleton("treeShaker");
     }
 
     @Override

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
@@ -125,7 +125,7 @@ public class SmithyBuildConfigTest {
         TransformConfig transform = config.getProjections().get("a").getTransforms().get(0);
 
         // Did the key expand?
-        assertThat(transform.getName(), equalTo("includeByTag"));
+        assertThat(transform.getName(), equalTo("includeShapesByTag"));
         // Did the array and string values in it expand?
         assertThat(transform.getArgs(), equalTo(Node.objectNode()
                 .withMember("tags", Node.fromStrings("Hi", "${BAZ}"))));

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/apply-multiple-projections.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/apply-multiple-projections.json
@@ -4,7 +4,7 @@
     "a": {
       "transforms": [
         {
-          "name": "includeByTag",
+          "name": "includeShapesByTag",
           "args": {
             "projections": [
               "foo",

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
@@ -4,7 +4,7 @@
     "a": {
       "transforms": [
         {
-          "${NAME_KEY}": "includeByTag",
+          "${NAME_KEY}": "includeShapesByTag",
           "args": {
             "tags": [
               "${FOO}",

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/simple-config.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/simple-config.json
@@ -4,7 +4,7 @@
     "a": {
       "transforms": [
         {
-          "name": "includeByTag",
+          "name": "includeShapesByTag",
           "args": {
             "tags": [
               "foo",


### PR DESCRIPTION
This commit removes alias functionality from SmithyBuildPlugin and
ProjectionTransformer. The aliases for existing transforms have been
removed. Documentation has been updated and entries for the
includeMetadata and excludeMetadata transforms were added.

This commit contains other assorted documentation fixes as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
