### PR TITLE
Add ability to disable model validation

### DIFF
--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
@@ -48,6 +48,8 @@ public class Selectors {
         public Model model;
         public Selector suboptimalHttpBindingSelector = createSuboptimalHttpBindingIncompatibilitySelector();
         public Selector httpBindingSelector = createHttpBindingIncompatibilitySelector();
+        public String testIdlModelLocation = "test-model.smithy";
+        public String testJsonModelLocation = "test-model.json";
 
         @Setup
         public void prepare() {
@@ -73,6 +75,32 @@ public class Selectors {
                                   + "${operations}\n"
                                   + ":not([trait|http])");
         }
+    }
+
+    @Benchmark
+    public Model loadsIdlModelWithoutValidation(SelectorState state) {
+        return Model.assembler()
+                .addImport(Selectors.class.getResource(state.testIdlModelLocation))
+                .disableValidation()
+                .assemble()
+                .unwrap();
+    }
+
+    @Benchmark
+    public Model loadsIdlModelWithValidation(SelectorState state) {
+        return Model.assembler()
+                .addImport(Selectors.class.getResource(state.testIdlModelLocation))
+                .assemble()
+                .unwrap();
+    }
+
+    @Benchmark
+    public Model loadsJsonModelWithoutValidation(SelectorState state) {
+        return Model.assembler()
+                .addImport(Selectors.class.getResource(state.testJsonModelLocation))
+                .disableValidation()
+                .assemble()
+                .unwrap();
     }
 
     // Benchmarks just parsing the selector.

--- a/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/test-model.json
+++ b/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/test-model.json
@@ -1,0 +1,91 @@
+{
+    "smithy": "1.0.0",
+    "shapes": {
+        "smithy.example#Example": {
+            "type": "service",
+            "version": "2019-04-02",
+            "operations": [
+                {
+                    "target": "smithy.example#ServiceOperation"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "smithy.example#Resource1"
+                },
+                {
+                    "target": "smithy.example#Resource2"
+                }
+            ]
+        },
+        "smithy.example#Resource1": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "smithy.example#Resource1Operation"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "smithy.example#Resource1_1"
+                },
+                {
+                    "target": "smithy.example#Resource1_2"
+                }
+            ]
+        },
+        "smithy.example#Resource1Operation": {
+            "type": "operation"
+        },
+        "smithy.example#Resource1_1": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "smithy.example#Resource1_1_Operation"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "smithy.example#Resource1_1_1"
+                },
+                {
+                    "target": "smithy.example#Resource1_1_2"
+                }
+            ]
+        },
+        "smithy.example#Resource1_1_1": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "smithy.example#Resource1_1_1_Operation"
+                }
+            ]
+        },
+        "smithy.example#Resource1_1_1_Operation": {
+            "type": "operation"
+        },
+        "smithy.example#Resource1_1_2": {
+            "type": "resource",
+            "operations": [
+                {
+                    "target": "smithy.example#Resource1_1_2_Operation"
+                }
+            ]
+        },
+        "smithy.example#Resource1_1_2_Operation": {
+            "type": "operation"
+        },
+        "smithy.example#Resource1_1_Operation": {
+            "type": "operation"
+        },
+        "smithy.example#Resource1_2": {
+            "type": "resource"
+        },
+        "smithy.example#Resource2": {
+            "type": "resource"
+        },
+        "smithy.example#ServiceOperation": {
+            "type": "operation"
+        }
+    }
+}

--- a/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/test-model.smithy
+++ b/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/test-model.smithy
@@ -1,0 +1,40 @@
+namespace smithy.example
+
+service Example {
+    version: "2019-04-02",
+    operations: [ServiceOperation],
+    resources: [Resource1, Resource2]
+}
+
+operation ServiceOperation {}
+
+resource Resource1 {
+    operations: [Resource1Operation],
+    resources: [Resource1_1, Resource1_2]
+}
+
+operation Resource1Operation {}
+
+resource Resource1_2 {}
+
+resource Resource1_1 {
+    type: resource,
+    operations: [Resource1_1_Operation],
+    resources: [Resource1_1_1, Resource1_1_2]
+}
+
+operation Resource1_1_Operation {}
+
+resource Resource1_1_1 {
+    operations: [Resource1_1_1_Operation],
+}
+
+operation Resource1_1_1_Operation {}
+
+resource Resource1_1_2 {
+    operations: [Resource1_1_2_Operation],
+}
+
+operation Resource1_1_2_Operation {}
+
+resource Resource2 {}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -15,12 +15,12 @@
 
 package software.amazon.smithy.model.loader;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -323,12 +323,13 @@ enum AstModelLoader {
         return referenceObject.expectStringMember(TARGET).expectShapeId();
     }
 
-    private List<ShapeId> loadOptionalTargetList(
-            LoaderVisitor visitor, ShapeId id, ObjectNode node, String member) {
-        return node.getArrayMember(member)
-                .map(array -> array.getElements().stream()
-                        .map(e -> loadReferenceBody(visitor, id, e))
-                        .collect(Collectors.toList()))
-                .orElseGet(Collections::emptyList);
+    private List<ShapeId> loadOptionalTargetList(LoaderVisitor visitor, ShapeId id, ObjectNode node, String member) {
+        return node.getArrayMember(member).map(array -> {
+            List<ShapeId> ids = new ArrayList<>(array.size());
+            for (Node element : array.getElements()) {
+                ids.add(loadReferenceBody(visitor, id, element));
+            }
+            return ids;
+        }).orElseGet(Collections::emptyList);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -81,6 +81,7 @@ public final class ModelAssembler {
 
     private TraitFactory traitFactory;
     private ValidatorFactory validatorFactory;
+    private boolean disableValidation;
 
     /**
      * A map of files to parse and load into the Model.
@@ -144,6 +145,7 @@ public final class ModelAssembler {
         assembler.metadata.putAll(metadata);
         assembler.disablePrelude = disablePrelude;
         assembler.properties.putAll(properties);
+        assembler.disableValidation = disableValidation;
         return assembler;
     }
 
@@ -161,6 +163,7 @@ public final class ModelAssembler {
      *     <li>Models registered via {@link #addModel}</li>
      *     <li>Shape registered via {@link #addModel}</li>
      *     <li>Metadata registered via {@link #putMetadata}</li>
+     *     <li>Validation is re-enabled if it was disabled.</li>
      * </ul>
      *
      * <p>The state of {@link #disablePrelude} is reset such that the prelude
@@ -176,6 +179,7 @@ public final class ModelAssembler {
         validators.clear();
         documentNodes.clear();
         disablePrelude = false;
+        disableValidation = false;
         return this;
     }
 
@@ -452,6 +456,16 @@ public final class ModelAssembler {
     }
 
     /**
+     * Disables additional validation of the model.
+     *
+     * @return Returns the assembler.
+     */
+    public ModelAssembler disableValidation() {
+        this.disableValidation = true;
+        return this;
+    }
+
+    /**
      * Assembles the model and returns the validated result.
      *
      * @return Returns the validated result that optionally contains a Model
@@ -510,6 +524,10 @@ public final class ModelAssembler {
     }
 
     private ValidatedResult<Model> validate(Model model, List<ValidationEvent> modelResultEvents) {
+        if (disableValidation) {
+            return new ValidatedResult<>(model, modelResultEvents);
+        }
+
         if (validatorFactory == null) {
             validatorFactory = LazyValidatorFactoryHolder.INSTANCE;
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -468,4 +468,17 @@ public class ModelAssemblerTest {
         assertTrue(result.getResult().isPresent());
         assertTrue(result.getResult().get().getShape(ShapeId.from("foo.baz#MyString")).isPresent());
     }
+
+    @Test
+    public void canDisableValidation() {
+        String document = "namespace foo.baz\n"
+                          + "@idempotent\n" // < this is invalid
+                          + "string MyString\n";
+        ValidatedResult<Model> result = new ModelAssembler()
+                .addUnparsedModel("foo.smithy", document)
+                .disableValidation()
+                .assemble();
+
+        assertFalse(result.isBroken());
+    }
 }


### PR DESCRIPTION
This commit adds a setting to disable model validation in the assembler,
and adds some new JMH benches to test loading the IDL/AST models
with/without validation (~92% of the time loading a model is spent
validating models, so I suspect that only applying validators if 1 or
more instances of a trait were found would help here).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
