### PR TITLE
Clean up mkdocs doc gen

### DIFF
--- a/mkdocs
+++ b/mkdocs
@@ -35,6 +35,8 @@ cd -
 ./gradlew javadoc
 # Always build javadoc into each version.
 cp -R build/docs/javadoc/* /tmp/_smithy-docs/javadoc/${library_version}
+# Remove this unnecessary duplicate copy of the docs.
+rm -rf /tmp/_smithy-docs/javadoc/${library_version}/latest
 # Create a redirect from "latest" to the version:
 rm -rf /tmp/_smithy-docs/javadoc/latest
 mkdir -p /tmp/_smithy-docs/javadoc/latest
@@ -66,6 +68,14 @@ git status
 #### Deploy the docs ####
 
 # We can automate this eventually
+
+read -p "Show full diff? [y/n]" -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    git diff
+fi
+
 read -p "Publish docs? [y/n]" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]


### PR DESCRIPTION
This commit updates the doc generation script to clear out the
/version/latest directory since it's not supposed to be there, and adds
a prompt for viewing the full diff.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
