### PR TITLE
Add a basic Dockerfile to Smithy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM gradle:5.4.1-jdk12
+USER root
+ADD ./ /smithy
+WORKDIR /smithy
+RUN gradle :smithy-cli:runtime
+WORKDIR /work
+
+ENTRYPOINT [ "/smithy/smithy-cli/build/image/bin/smithy" ]


### PR DESCRIPTION
*Description of changes:*

Allows Smithy to be built and used as a Docker image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 
