### PR TITLE
Add `ast` command and indent JSON 4 spaces

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.cli;
 
 import java.util.List;
+import software.amazon.smithy.cli.commands.AstCommand;
 import software.amazon.smithy.cli.commands.BuildCommand;
 import software.amazon.smithy.cli.commands.DiffCommand;
 import software.amazon.smithy.cli.commands.SelectCommand;
@@ -88,6 +89,7 @@ public final class SmithyCli {
         cli.addCommand(new BuildCommand());
         cli.addCommand(new DiffCommand());
         cli.addCommand(new SelectCommand());
+        cli.addCommand(new AstCommand());
         cli.run(args);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.Cli;
+import software.amazon.smithy.cli.Command;
+import software.amazon.smithy.cli.Parser;
+import software.amazon.smithy.cli.SmithyCli;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ModelSerializer;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class AstCommand implements Command {
+    @Override
+    public String getName() {
+        return "ast";
+    }
+
+    @Override
+    public String getSummary() {
+        return "Reads Smithy models in and writes out a single JSON AST model";
+    }
+
+    @Override
+    public Parser getParser() {
+        return Parser.builder()
+                .option(SmithyCli.ALLOW_UNKNOWN_TRAITS, "Ignores unknown traits when validating models")
+                .option(SmithyCli.DISCOVER, "-d", "Enables model discovery, merging in models found inside of jars")
+                .parameter(SmithyCli.DISCOVER_CLASSPATH, "Enables model discovery using a custom classpath for models")
+                .positional("<MODELS>", "Path to Smithy models or directories")
+                .build();
+    }
+
+    @Override
+    public void execute(Arguments arguments, ClassLoader classLoader) {
+        // Don't write the summary to STDOUT, but do write errors to STDERR.
+        Model model = CommandUtils.buildModel(arguments, classLoader, SetUtils.of(Validator.Feature.QUIET));
+        ModelSerializer serializer = ModelSerializer.builder().build();
+        Cli.stdout(Node.prettyPrintJson(serializer.serialize(model)));
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/AstCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/AstCommandTest.java
@@ -1,0 +1,67 @@
+package software.amazon.smithy.cli.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.cli.CliError;
+import software.amazon.smithy.cli.SmithyCli;
+
+public class AstCommandTest {
+    @Test
+    public void hasAstCommand() throws Exception {
+        PrintStream out = System.out;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+        System.setOut(printStream);
+        SmithyCli.create().run("ast", "--help");
+        System.setOut(out);
+        String help = outputStream.toString("UTF-8");
+
+        assertThat(help, containsString("Reads"));
+    }
+
+    @Test
+    public void usesModelDiscoveryWithCustomValidClasspath() throws Exception {
+        PrintStream out = System.out;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+        System.setOut(printStream);
+
+        String dir = getClass().getResource("valid.jar").getPath();
+        SmithyCli.create().run("ast", "--debug", "--discover-classpath", dir);
+        System.setOut(out);
+
+        String output = outputStream.toString("UTF-8");
+        assertThat(output, containsString("{"));
+    }
+
+    @Test
+    public void usesModelDiscoveryWithCustomInvalidClasspath() {
+        CliError e = Assertions.assertThrows(CliError.class, () -> {
+            String dir = getClass().getResource("invalid.jar").getPath();
+            SmithyCli.create().run("ast", "--debug", "--discover-classpath", dir);
+        });
+
+        assertThat(e.getMessage(), containsString("1 ERROR(s)"));
+    }
+
+    @Test
+    public void failsOnUnknownTrait() {
+        CliError e = Assertions.assertThrows(CliError.class, () -> {
+            String model = getClass().getResource("unknown-trait.smithy").getPath();
+            SmithyCli.create().run("ast", model);
+        });
+
+        assertThat(e.getMessage(), containsString("1 ERROR(s)"));
+    }
+
+    @Test
+    public void allowsUnknownTrait() {
+        String model = getClass().getResource("unknown-trait.smithy").getPath();
+        SmithyCli.create().run("ast", "--allow-unknown-traits", model);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -138,7 +138,7 @@ public abstract class Node implements FromSourceLocation, ToNode {
      * @return Returns the serialized Node.
      */
     public static String prettyPrintJson(Node node) {
-        return prettyPrintJson(node, "  ");
+        return prettyPrintJson(node, "    ");
     }
 
     /**

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/DefaultNodeWriterTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/DefaultNodeWriterTest.java
@@ -42,14 +42,22 @@ public class DefaultNodeWriterTest {
                 {new NullNode(SourceLocation.none()), "null"},
                 {new ArrayNode(
                         Arrays.asList(Node.from(1), Node.from(2)),
-                        SourceLocation.none()), String.format("[%n  1,%n  2%n]")},
+                        SourceLocation.none()), String.format("[%n    1,%n    2%n]")},
                 {Node.objectNode()
                          .withMember("foo", Node.from("foo"))
                          .withMember("baz", Node.from(1))
                          .withMember("bar", Node.objectNode()
                              .withMember("qux", Node.arrayNode()
                                      .withValue(Node.from("ipsum")))),
-                 String.format("{%n  \"foo\": \"foo\",%n  \"baz\": 1,%n  \"bar\": {%n    \"qux\": [%n      \"ipsum\"%n    ]%n  }%n}")
+                 String.format("{%n"
+                               + "    \"foo\": \"foo\",%n"
+                               + "    \"baz\": 1,%n"
+                               + "    \"bar\": {%n"
+                               + "        \"qux\": [%n"
+                               + "            \"ipsum\"%n"
+                               + "        ]%n"
+                               + "    }%n"
+                               + "}")
                 },
                 {Node.objectNode()
                          .withMember("foo", Node.objectNode()
@@ -58,7 +66,18 @@ public class DefaultNodeWriterTest {
                          .withMember("bam", Node.arrayNode()
                                  .withValue(Node.objectNode()
                                          .withMember("abc", Node.from(123)))),
-                        String.format("{%n  \"foo\": {%n    \"bar\": [%n      \"baz\"%n    ]%n  },%n  \"bam\": [%n    {%n      \"abc\": 123%n    }%n  ]%n}")
+                        String.format("{%n"
+                                      + "    \"foo\": {%n"
+                                      + "        \"bar\": [%n"
+                                      + "            \"baz\"%n"
+                                      + "        ]%n"
+                                      + "    },%n"
+                                      + "    \"bam\": [%n"
+                                      + "        {%n"
+                                      + "            \"abc\": 123%n"
+                                      + "        }%n"
+                                      + "    ]%n"
+                                      + "}")
                 }
         });
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeSerializerTest.java
@@ -12,10 +12,10 @@ public class NodeSerializerTest {
 
         assertThat(Node.printJson(node), equalTo("{\"foo\":\"bar\",\"baz\":true,\"bam\":false,\"boo\":10}"));
         assertThat(Node.prettyPrintJson(node), equalTo("{\n"
-                                                       + "  \"foo\": \"bar\",\n"
-                                                       + "  \"baz\": true,\n"
-                                                       + "  \"bam\": false,\n"
-                                                       + "  \"boo\": 10\n"
+                                                       + "    \"foo\": \"bar\",\n"
+                                                       + "    \"baz\": true,\n"
+                                                       + "    \"bam\": false,\n"
+                                                       + "    \"boo\": 10\n"
                                                        + "}"));
         assertThat(Node.prettyPrintJson(node, "\t"), equalTo("{\n"
                                                              + "\t\"foo\": \"bar\",\n"
@@ -47,22 +47,22 @@ public class NodeSerializerTest {
                 + "\"boo\":10},10,true,false,{},[],\"\",\" \",null,-1,-1.0]"));
         assertThat(Node.prettyPrintJson(node), equalTo(
                 "[\n"
-                + "  {\n"
-                + "    \"foo\": \"\uD83D\uDCA9\",\n"
-                + "    \"baz\": true,\n"
-                + "    \"bam\": false,\n"
-                + "    \"boo\": 10\n"
-                + "  },\n"
-                + "  10,\n"
-                + "  true,\n"
-                + "  false,\n"
-                + "  {},\n" // optimized empty object
-                + "  [],\n" // optimized empty array
-                + "  \"\",\n"
-                + "  \" \",\n"
-                + "  null,\n"
-                + "  -1,\n"
-                + "  -1.0\n"
+                + "    {\n"
+                + "        \"foo\": \"\uD83D\uDCA9\",\n"
+                + "        \"baz\": true,\n"
+                + "        \"bam\": false,\n"
+                + "        \"boo\": 10\n"
+                + "    },\n"
+                + "    10,\n"
+                + "    true,\n"
+                + "    false,\n"
+                + "    {},\n" // optimized empty object
+                + "    [],\n" // optimized empty array
+                + "    \"\",\n"
+                + "    \" \",\n"
+                + "    null,\n"
+                + "    -1,\n"
+                + "    -1.0\n"
                 + "]"));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeTest.java
@@ -177,7 +177,8 @@ public class NodeTest {
 
     @Test
     public void prettyPrintsJson() {
-        assertThat(Node.prettyPrintJson(Node.parse("{\"foo\": true}")), equalTo(String.format("{%n  \"foo\": true%n}")));
+        assertThat(Node.prettyPrintJson(Node.parse("{\"foo\": true}")),
+                   equalTo(String.format("{%n    \"foo\": true%n}")));
     }
 
     @Test


### PR DESCRIPTION
This commit adds support for an `ast` command in the CLI to convert 0 or
more Smithy models into a JSON AST. This can be used to more easily
combine multiple models or for simply testing parser implementations.
This change also updates the default indentation for JSON pretty
printing to use 4 spaces instead of 2 since that's what is used
throughout the Smithy specification.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
