### PR TITLE
Fix putProperty doc example

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -432,7 +432,7 @@ public final class ModelAssembler {
      *
      * <pre>{@code
      * ModelAssembler assembler = Model.assembler();
-     * assembler.putLoaderVisitorSetting(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
+     * assembler.putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
      * }</pre>
      *
      * @param setting Name of the property to put.


### PR DESCRIPTION
Fix documentation example on putProperty for ModelAssembler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
