### PR TITLE
Fix bug allowing validation to be skipped

### DIFF
--- a/docs/source/1.0/spec/core/model-validation.rst
+++ b/docs/source/1.0/spec/core/model-validation.rst
@@ -179,18 +179,18 @@ Suppressions
 ------------
 
 Suppressions are used to suppress specific validation events.
-Suppressions are created using the :ref:`suppression-trait` and
+Suppressions are created using the :ref:`suppress-trait` and
 :ref:`suppressions metadata <suppressions-metadata>`.
 
 
-.. _suppression-trait:
+.. _suppress-trait:
 
-``suppression`` trait
+``suppress`` trait
 =====================
 
 Summary
-    The suppression trait is used to suppress validation events(s) for a
-    specific shape. Each value in the ``suppression`` trait is a
+    The suppress trait is used to suppress validation events(s) for a
+    specific shape. Each value in the ``suppress`` trait is a
     validation event ID to suppress for the shape.
 Trait selector
     ``*``
@@ -208,7 +208,7 @@ for the ``smithy.example#MyString`` shape:
 
         namespace smithy.example
 
-        @suppression(["Foo", "Bar"])
+        @suppress(["Foo", "Bar"])
         string MyString
 
 

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.json
@@ -165,7 +165,8 @@
             },
             "traits": {
                 "smithy.api#error": "client",
-                "smithy.api#httpError": 302
+                "smithy.api#httpError": 302,
+                "smithy.api#suppress": ["HttpResponseCodeSemantics"]
             }
         },
         "smithy.example#OperationInput": {
@@ -198,14 +199,5 @@
                 }
             }
         }
-    },
-    "metadata": {
-        "suppressions": [
-            {
-                "ids": ["HttpResponseCodeSemantics"],
-                "shapes": ["smithy.example#Redirect"],
-                "reason": "model redirect as error"
-            }
-        ]
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
@@ -166,7 +166,8 @@
             },
             "traits": {
                 "smithy.api#error": "client",
-                "smithy.api#httpError": 302
+                "smithy.api#httpError": 302,
+                "smithy.api#suppress": ["HttpResponseCodeSemantics"]
             }
         },
         "smithy.example#OperationInput": {
@@ -199,14 +200,5 @@
                 }
             }
         }
-    },
-    "metadata": {
-        "suppressions": [
-            {
-                "ids": ["HttpResponseCodeSemantics"],
-                "shapes": ["smithy.example#Redirect"],
-                "reason": "model redirect as error"
-            }
-        ]
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -477,8 +477,10 @@ public final class ModelAssembler {
         try {
             return doAssemble(visitor);
         } catch (SourceException e) {
-            visitor.onError(ValidationEvent.fromSourceException(e));
-            return visitor.onEnd();
+            ValidatedResult<Model> modelResult = visitor.onEnd();
+            List<ValidationEvent> events = new ArrayList<>(modelResult.getValidationEvents());
+            events.add(ValidationEvent.fromSourceException(e));
+            return new ValidatedResult<>(modelResult.getResult().orElse(null), events);
         }
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -481,4 +481,16 @@ public class ModelAssemblerTest {
 
         assertFalse(result.isBroken());
     }
+
+    @Test
+    public void canHandleBadSuppressions() {
+        String document = "namespace foo.baz\n"
+                + "@idempotent\n" // < this is invalid
+                + "string MyString\n";
+        ValidatedResult<Model> result = new ModelAssembler()
+                .addUnparsedModel("foo.smithy", document)
+                .putMetadata("suppressions", Node.parse("[{}]"))
+                .assemble();
+        assertTrue(result.isBroken());
+    }
 }


### PR DESCRIPTION
*Description of changes:*

This fixes a bug where any `SourceException`s rasied after the model assembler began validation would result in validation getting skipped. This was due to the fact that the assembler calls `onEnd` in its visitor before validation AND whenever it catches that class of exception. `onEnd` will cache its result, so you can't simply call `onError` and guarantee it will be in the output.

This also updates a few tests that were accidentally doing this, as well as the documentation for the `suppress` trait which incorrectly called it `suppression`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
