### PR TITLE
Prevent parsing overly deep Node values

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -72,6 +72,9 @@ import software.amazon.smithy.utils.StringUtils;
 
 final class IdlModelParser {
 
+    /** Only allow nesting up to 250 arrays/objects in node values. */
+    private static final int MAX_NESTING_LEVEL = 250;
+
     private static final String PUT_KEY = "put";
     private static final String CREATE_KEY = "create";
     private static final String READ_KEY = "read";
@@ -111,6 +114,7 @@ final class IdlModelParser {
     private String namespace;
     private String definedVersion;
     private TraitEntry pendingDocumentationComment;
+    private int nestingLevel;
 
     /** Map of shape aliases to their targets. */
     private final Map<String, ShapeId> useShapes = new HashMap<>();
@@ -909,5 +913,15 @@ final class IdlModelParser {
 
     int position() {
         return position;
+    }
+
+    void increaseNestingLevel() {
+        if (++nestingLevel >= MAX_NESTING_LEVEL) {
+            throw syntax("Node value nesting too deep");
+        }
+    }
+
+    void decreaseNestingLevel() {
+        nestingLevel--;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlNodeParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlNodeParser.java
@@ -104,6 +104,7 @@ final class IdlNodeParser {
     }
 
     static ObjectNode parseObjectNode(IdlModelParser parser) {
+        parser.increaseNestingLevel();
         SourceLocation location = parser.currentLocation();
         Map<StringNode, Node> entries = new LinkedHashMap<>();
         parser.expect('{');
@@ -132,6 +133,7 @@ final class IdlNodeParser {
         }
 
         parser.expect('}');
+        parser.decreaseNestingLevel();
         return new ObjectNode(entries, location);
     }
 
@@ -144,6 +146,7 @@ final class IdlNodeParser {
     }
 
     private static ArrayNode parseArrayNode(IdlModelParser parser) {
+        parser.increaseNestingLevel();
         SourceLocation location = parser.currentLocation();
         List<Node> items = new ArrayList<>();
         parser.expect('[');
@@ -166,6 +169,7 @@ final class IdlNodeParser {
         }
 
         parser.expect(']');
+        parser.decreaseNestingLevel();
         return new ArrayNode(items, location);
     }
 }


### PR DESCRIPTION
This commit updates the IDL parser to detect overly nested Node values
and throw a syntax exception when the stack gets too deep. This prevents
stack overflows and guards against a pathological case.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
