### PR TITLE
Preprocess documentation to inject lib version

### DIFF
--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -151,12 +151,12 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:1.0.3")
+            implementation("software.amazon.smithy:smithy-model:__smithy_version__")
 
             // These are just examples of dependencies. This model has a dependency on
             // a "common" model package and uses the external AWS traits.
             implementation("com.foo.baz:foo-model-internal-common:1.0.0")
-            implementation("software.amazon.smithy:smithy-aws-traits:1.0.3")
+            implementation("software.amazon.smithy:smithy-aws-traits:__smithy_version__")
         }
 
 
@@ -193,7 +193,7 @@ build that uses the "external" projection.
                 mavenCentral()
             }
             dependencies {
-                classpath("software.amazon.smithy:smithy-aws-traits:1.0.3")
+                classpath("software.amazon.smithy:smithy-aws-traits:__smithy_version__")
 
                 // Take a dependency on the internal model package. This
                 // dependency *must* be a buildscript only dependency to ensure
@@ -217,12 +217,12 @@ build that uses the "external" projection.
         }
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:1.0.3")
+            implementation("software.amazon.smithy:smithy-model:__smithy_version__")
 
             // Any dependencies that the projected model needs must be (re)declared
             // here. For example, let's assume that the smithy-aws-traits package is
             // needed in the projected model too.
-            implementation("software.amazon.smithy:smithy-aws-traits:1.0.3")
+            implementation("software.amazon.smithy:smithy-aws-traits:__smithy_version__")
         }
 
 
@@ -345,7 +345,7 @@ The above Smithy plugin also requires a ``buildscript`` dependency in
 
                 // This dependency is required in order to apply the "openapi"
                 // plugin in smithy-build.json
-                classpath("software.amazon.smithy:smithy-openapi:1.0.3")
+                classpath("software.amazon.smithy:smithy-openapi:__smithy_version__")
             }
         }
 

--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -116,7 +116,7 @@ specification from a Smithy model using a buildscript dependency:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:1.0.3")
+            classpath("software.amazon.smithy:smithy-openapi:__smithy_version__")
         }
     }
 
@@ -142,7 +142,7 @@ that builds an OpenAPI specification from a service for the
 
 .. important::
 
-    A buildscript dependency on "software.amazon.smithy:smithy-openapi:1.0.3" is
+    A buildscript dependency on "software.amazon.smithy:smithy-openapi:__smithy_version__" is
     required in order for smithy-build to map the "openapi" plugin name to the
     correct Java library implementation.
 
@@ -634,7 +634,7 @@ dependency on ``software.amazon.smithy:smithy-aws-apigateway-openapi``.
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:1.0.3")
+            classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:__smithy_version__")
         }
     }
 
@@ -1073,7 +1073,7 @@ shows how to install ``software.amazon.smithy:smithy-openapi`` through Gradle:
 
     buildscript {
         dependencies {
-            classpath("software.amazon.smithy:smithy-openapi:1.0.3")
+            classpath("software.amazon.smithy:smithy-openapi:__smithy_version__")
         }
     }
 

--- a/docs/source/1.0/guides/model-linters.rst
+++ b/docs/source/1.0/guides/model-linters.rst
@@ -27,8 +27,8 @@ to a ``build.gradle.kts`` file:
     .. code-tab:: kotlin
 
         dependencies {
-            implementation("software.amazon.smithy:smithy-model:1.0.3")
-            implementation("software.amazon.smithy:smithy-linters:1.0.3")
+            implementation("software.amazon.smithy:smithy-model:__smithy_version__")
+            implementation("software.amazon.smithy:smithy-linters:__smithy_version__")
         }
 
 After the dependency is added and available on the Java classpath, validators

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -167,5 +167,25 @@ texinfo_documents = [
 
 html_favicon = "../themes/smithy/static/favicon.png"
 
+
+# Load the version number from ../VERSION
+def __load_version():
+    with open('../../VERSION', 'r') as file:
+        return file.read().replace('\n', '')
+
+# We use the __smithy_version__ placeholder in documentation to represent
+# the current Smithy library version number. This is found and replaced
+# using a source-read pre-processor so that the generated documentation
+# always references the current VERSION.
+smithy_version = __load_version()
+smithy_version_placeholder = "__smithy_version__"
+
+
 def setup(sphinx):
     sphinx.add_lexer("smithy", SmithyLexer(startinline=True))
+    sphinx.connect('source-read', source_read_handler)
+    print("Finding and replacing '" + smithy_version_placeholder + "' with '" + smithy_version + "'")
+
+# Rewrites __smithy_version__ to the version found in ../VERSION
+def source_read_handler(app, docname, source):
+    source[0] = source[0].replace(smithy_version_placeholder, smithy_version)


### PR DESCRIPTION
The library version of Smithy can now be injected anywhere into the
Sphinx documentation using a __smithy_version__ placeholder string. This
string is found and replaced using a source-read event pre-processor,
and it is replaced with the contents of the VERSION file at the root of
the project.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
