### PR TITLE
Set 'security' to empty list for unauthed ops

### DIFF
--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.json
@@ -13,6 +13,9 @@
                 },
                 {
                     "target": "smithy.example#Operation3"
+                },
+                {
+                    "target": "smithy.example#UnauthenticatedOperation"
                 }
             ],
             "traits": {
@@ -58,6 +61,16 @@
                     "smithy.api#httpBasicAuth",
                     "aws.auth#sigv4"
                 ]
+            }
+        },
+        "smithy.example#UnauthenticatedOperation": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/4",
+                    "method": "GET"
+                },
+                "smithy.api#auth": []
             }
         }
     }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
@@ -47,6 +47,17 @@
           }
         ]
       }
+    },
+    "/4": {
+      "get": {
+        "operationId": "UnauthenticatedOperation",
+        "responses": {
+          "200": {
+            "description": "UnauthenticatedOperation response"
+          }
+        },
+        "security": []
+      }
     }
   },
   "components": {


### PR DESCRIPTION
This ensures that if an operation explicitly removes authentication,
"security" is set to an empty list as opposed to simply being unset
as unset will result in the operation inheriting global configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
