### PR TITLE
PREFIX_HEADERS location support in HttpBindingIndex.determineTimestampFormat

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -242,6 +242,7 @@ public final class HttpBindingIndex implements KnowledgeIndex {
                 .orElseGet(() -> {
                     // Determine the format based on the location.
                     switch (location) {
+                        case PREFIX_HEADERS:
                         case HEADER:
                             return TimestampFormatTrait.Format.HTTP_DATE;
                         case QUERY:

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.pattern.UriPattern;
 import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -327,6 +328,28 @@ public class HttpBindingIndexTest {
         assertThat(index.determineTimestampFormat(
                 member, HttpBinding.Location.HEADER, TimestampFormatTrait.Format.EPOCH_SECONDS),
                    equalTo(TimestampFormatTrait.Format.HTTP_DATE));
+    }
+
+    @Test
+    public void prefixHeadersLocationUsesHttpDateTimestampFormat() {
+        MemberShape key = MemberShape.builder()
+                .id("foo.bar#Baz$key")
+                .target("smithy.api#String")
+                .build();
+        MemberShape value = MemberShape.builder()
+                .id("foo.bar#Baz$value")
+                .target("smithy.api#Timestamp")
+                .build();
+        Model model = Model.assembler()
+                .addShape(value)
+                .addShape(MapShape.builder().addMember(key).addMember(value).id("foo.bar#Baz").build())
+                .assemble()
+                .unwrap();
+        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+
+        assertThat(index.determineTimestampFormat(
+                value, HttpBinding.Location.PREFIX_HEADERS, TimestampFormatTrait.Format.EPOCH_SECONDS),
+                equalTo(TimestampFormatTrait.Format.HTTP_DATE));
     }
 
     @Test


### PR DESCRIPTION
Adds support for correctly returning HTTP_DATE timestamp format when PREFIX_HEADERS location is passed to determineTimestampFormat.