### PR TITLE
Resolve all imports relative to their config

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -43,7 +43,6 @@ public final class SmithyBuild {
     public static final String VERSION = "1.0";
 
     SmithyBuildConfig config;
-    Path importBasePath;
     Path outputDirectory;
     Function<String, Optional<ProjectionTransformer>> transformFactory;
     Function<String, Optional<SmithyBuildPlugin>> pluginFactory;
@@ -170,7 +169,6 @@ public final class SmithyBuild {
      */
     public SmithyBuild config(SmithyBuildConfig config) {
         this.config = config;
-        config.getImportBasePath().ifPresent(this::importBasePath);
         return this;
     }
 
@@ -197,14 +195,8 @@ public final class SmithyBuild {
         return this;
     }
 
-    /**
-     * Sets the base path for where imports are found.
-     *
-     * @param importBasePath Base path to look for imports.
-     * @return Returns the builder.
-     */
+    @Deprecated
     public SmithyBuild importBasePath(Path importBasePath) {
-        this.importBasePath = importBasePath;
         return this;
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
@@ -25,11 +25,12 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * ProjectionConfig stored in a {@link SmithyBuildConfig}.
  */
-public final class ProjectionConfig {
+public final class ProjectionConfig implements ToSmithyBuilder<ProjectionConfig> {
     private final boolean isAbstract;
     private final List<String> imports;
     private final List<TransformConfig> transforms;
@@ -48,6 +49,15 @@ public final class ProjectionConfig {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder()
+                .imports(imports)
+                .plugins(plugins)
+                .transforms(transforms)
+                .setAbstract(isAbstract);
     }
 
     /**
@@ -79,6 +89,8 @@ public final class ProjectionConfig {
     public List<String> getImports() {
         return imports;
     }
+
+
 
     /**
      * Builds a {@link ProjectionConfig}.

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -45,12 +45,10 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     private final String outputDirectory;
     private final Map<String, ProjectionConfig> projections;
     private final Map<String, ObjectNode> plugins;
-    private final Path importBasePath;
 
     private SmithyBuildConfig(Builder builder) {
         SmithyBuilder.requiredState("version", builder.version);
         version = builder.version;
-        importBasePath = builder.importBasePath;
         outputDirectory = builder.outputDirectory;
         imports = ListUtils.copyOf(builder.imports);
         projections = MapUtils.copyOf(builder.projections);
@@ -110,14 +108,12 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
+        return builder()
                 .version(version)
                 .outputDirectory(outputDirectory)
                 .imports(imports)
                 .projections(projections)
                 .plugins(plugins);
-        builder.importBasePath = importBasePath;
-        return builder;
     }
 
     /**
@@ -168,15 +164,6 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
-     * Gets the base path of where the config file was loaded from.
-     *
-     * @return Returns the optionally present base path.
-     */
-    public Optional<Path> getImportBasePath() {
-        return Optional.ofNullable(importBasePath);
-    }
-
-    /**
      * Builder used to create a {@link SmithyBuildConfig}.
      */
     public static final class Builder implements SmithyBuilder<SmithyBuildConfig> {
@@ -185,7 +172,6 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         private final Map<String, ObjectNode> plugins = new LinkedHashMap<>();
         private String version;
         private String outputDirectory;
-        private Path importBasePath;
 
         Builder() {}
 
@@ -212,7 +198,6 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
          * @return Returns the updated builder.
          */
         public Builder load(Path config) {
-            importBasePath = config.getParent();
             return merge(ConfigLoader.load(config));
         }
 
@@ -228,9 +213,6 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
             imports.addAll(config.getImports());
             projections.putAll(config.getProjections());
             plugins.putAll(config.getPlugins());
-            if (config.importBasePath != null) {
-                importBasePath = config.importBasePath;
-            }
             return this;
         }
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -50,6 +50,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
@@ -197,6 +198,7 @@ public class SmithyBuildTest {
     public void loadsImports() throws Exception {
         SmithyBuildConfig config = SmithyBuildConfig.builder()
                 .load(Paths.get(getClass().getResource("imports/smithy-build.json").toURI()))
+                .load(Paths.get(getClass().getResource("otherimports/smithy-build.json").toURI()))
                 .outputDirectory(outputDirectory.toString())
                 .build();
         SmithyBuild builder = new SmithyBuild(config);
@@ -210,6 +212,10 @@ public class SmithyBuildTest {
                            .getTrait(SensitiveTrait.class).isPresent());
         assertFalse(resultA.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).isPresent());
+        assertTrue(resultA.getShape(ShapeId.from("com.foo#String")).get()
+                .getTrait(TagsTrait.class).isPresent());
+        assertThat(resultA.getShape(ShapeId.from("com.foo#String")).get()
+                .getTrait(TagsTrait.class).get().getValues().get(0), equalTo("multi-import"));
 
         assertTrue(resultB.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(SensitiveTrait.class).isPresent());
@@ -217,6 +223,10 @@ public class SmithyBuildTest {
                            .getTrait(DocumentationTrait.class).isPresent());
         assertThat(resultB.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).get().getValue(), equalTo("b.json"));
+        assertTrue(resultB.getShape(ShapeId.from("com.foo#String")).get()
+                .getTrait(TagsTrait.class).isPresent());
+        assertThat(resultB.getShape(ShapeId.from("com.foo#String")).get()
+                .getTrait(TagsTrait.class).get().getValues().get(0), equalTo("multi-import"));
 
         assertTrue(resultC.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(SensitiveTrait.class).isPresent());
@@ -224,6 +234,10 @@ public class SmithyBuildTest {
                            .getTrait(DocumentationTrait.class).isPresent());
         assertThat(resultC.getShape(ShapeId.from("com.foo#String")).get()
                            .getTrait(DocumentationTrait.class).get().getValue(), equalTo("c.json"));
+        assertTrue(resultC.getShape(ShapeId.from("com.foo#String")).get()
+                .getTrait(TagsTrait.class).isPresent());
+        assertThat(resultC.getShape(ShapeId.from("com.foo#String")).get()
+                .getTrait(TagsTrait.class).get().getValues().get(0), equalTo("multi-import"));
     }
 
     @Test

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/otherimports/d.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/otherimports/d.json
@@ -1,0 +1,11 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "com.foo#String": {
+            "type": "apply",
+            "traits": {
+                "smithy.api#tags": ["multi-import"]
+            }
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/otherimports/smithy-build.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/otherimports/smithy-build.json
@@ -1,0 +1,4 @@
+{
+    "version": "1.0",
+    "imports": ["d.json"]
+}


### PR DESCRIPTION
*Description of changes:*

This resolves all imports relative to the config file they're defined in. Previously it would resolve relative to the location of the last config file loaded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
