### PR TITLE
Fix an issue with double forward reference

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-1.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/apply-use-1.smithy
@@ -7,3 +7,9 @@ apply Foo @bar("hi")
 
 // This applies smithy.example.b#baz to smithy.example#Foo
 apply Foo @baz("hi")
+
+// This applies smithy.api#deprecated to smithy.example#Foo
+apply Foo @deprecated
+
+// This applies smithy.api#sensitive to smithy.example#Foo
+apply Foo @smithy.api#sensitive


### PR DESCRIPTION
This commit fixes an issue where resolving a forward reference could
throw a ConcurrentModificationException when the resolution would
need to create another forward reference. For example, when applying
a trait to a shape defined in another file without importing the trait
or using its fully qualified shape ID, as done when applying a prelude
trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
