### PR TITLE
Update quick start guide to produce buildable model

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -428,6 +428,68 @@ Let's define the operation used to "read" a ``City``.
             }
         }
 
+And define the operation used to "read" a ``Forecast``.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        @readonly
+        operation GetForecast {
+            input: GetForecastInput,
+            output: GetForecastOutput
+        }
+
+        // "cityId" provides the only identifier for the resource since
+        // a Forecast doesn't have its own.
+        structure GetForecastInput {
+            @required
+            cityId: CityId,
+        }
+
+        structure GetForecastOutput {
+            chanceOfRain: Float
+        }
+
+    .. code-tab:: json
+
+        {
+            "smithy": "1.0",
+            "shapes": {
+                "example.weather#GetForecast": {
+                    "type": "operation",
+                    "input": {
+                        "target": "example.weather#GetForecastInput"
+                    },
+                    "output": {
+                        "target": "example.weather#GetForecastOutput"
+                    },
+                    "traits": {
+                        "smithy.api#readonly": true
+                    }
+                },
+                "example.weather#GetForecastInput": {
+                    "type": "structure",
+                    "members": {
+                        "cityId": {
+                            "target": "example.weather#CityId",
+                            "traits": {
+                                "smithy.api#required": true
+                            }
+                        }
+                    }
+                },
+                "example.weather#GetForecastOutput": {
+                    "type": "structure",
+                    "members": {
+                        "chanceOfRain": {
+                            "target": "smithy.api#Float"
+                        }
+                    }
+                }
+            }
+        }
+
 .. admonition:: Review
     :class: tip
 


### PR DESCRIPTION
Adds example operations and structures missing from quick start guide.

Fixes #460 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
