### PR TITLE
Make structure order part of the contract

### DIFF
--- a/docs/source/1.0/spec/core/shapes.rst
+++ b/docs/source/1.0/spec/core/shapes.rst
@@ -809,6 +809,12 @@ Traits can be applied to structure members:
             }
         }
 
+New members added to existing structures SHOULD be added to the end of the
+structure. This ensures that programming languages that require a specific
+data structure layout or alignment for code generated from Smithy models are
+able to maintain backward compatibility.
+
+
 .. _union:
 
 Union
@@ -860,6 +866,11 @@ The following example defines a union shape with several members:
                 }
             }
         }
+
+New members added to existing unions SHOULD be added to the end of the
+union. This ensures that programming languages that require a specific
+data structure layout or alignment for code generated from Smithy models are
+able to maintain backward compatibility.
 
 
 .. _default-values:

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberOrder.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberOrder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.smithy.diff.ChangedShape;
+import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Creates a DANGER event when a structure or union member is added
+ * anywhere other than the end of the previous definition or the
+ * member order is changed.
+ */
+public final class ChangedMemberOrder extends AbstractDiffEvaluator {
+    @Override
+    public List<ValidationEvent> evaluate(Differences differences) {
+        Stream<ChangedShape<?>> changes = Stream.concat(
+                differences.changedShapes(StructureShape.class),
+                differences.changedShapes(UnionShape.class));
+
+        return changes
+                .filter(diff -> isUnordered(diff.getOldShape().members(), diff.getNewShape().members()))
+                .map(diff -> danger(diff.getNewShape(), String.format(
+                        "%s shape members were reordered. This can cause ABI compatibility issues in languages "
+                        + "like C, C++, and Rust where the layout and alignment of a data structure matters.",
+                        diff.getOldShape().getType())))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isUnordered(Collection<MemberShape> a, Collection<MemberShape> b) {
+        Iterator<MemberShape> aIter = a.iterator();
+        Iterator<MemberShape> bIter = b.iterator();
+
+        while (aIter.hasNext()) {
+            // If members were removed, then this check is satisfied (though there are
+            // other backward incompatible changes that other evaluators will detect).
+            if (!bIter.hasNext()) {
+                break;
+            }
+
+            String oldMember = aIter.next().getMemberName();
+            String newMember = bIter.next().getMemberName();
+            if (!oldMember.equals(newMember)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
+++ b/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
@@ -6,6 +6,7 @@ software.amazon.smithy.diff.evaluators.AddedShape
 software.amazon.smithy.diff.evaluators.AddedTraitDefinition
 software.amazon.smithy.diff.evaluators.ChangedEnumTrait
 software.amazon.smithy.diff.evaluators.ChangedLengthTrait
+software.amazon.smithy.diff.evaluators.ChangedMemberOrder
 software.amazon.smithy.diff.evaluators.ChangedMemberTarget
 software.amazon.smithy.diff.evaluators.ChangedMetadata
 software.amazon.smithy.diff.evaluators.ChangedOperationInput

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedMemberOrderTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedMemberOrderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.diff.ModelDiff;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class ChangedMemberOrderTest {
+    @Test
+    public void detectsOrderChanges() {
+        Shape shape1 = StringShape.builder().id("foo.baz#String").build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#Struct$member1").target(shape1).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#Struct$member2").target(shape1).build();
+        StructureShape oldStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .addMember(member2)
+                .build();
+
+        StructureShape newStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member2)
+                .addMember(member1)
+                .build();
+
+        Model modelA = Model.assembler().addShapes(shape1, oldStruct).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, newStruct).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberOrder").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, oldStruct.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.DANGER).size(), equalTo(1));
+    }
+
+    @Test
+    public void detectsOrderInsertionChanges() {
+        Shape shape1 = StringShape.builder().id("foo.baz#String").build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#Struct$member1").target(shape1).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#Struct$member2").target(shape1).build();
+        StructureShape oldStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .addMember(member2)
+                .build();
+
+        MemberShape member3 = MemberShape.builder().id("foo.baz#Struct$member3").target(shape1).build();
+        StructureShape newStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .addMember(member3)
+                .addMember(member2)
+                .build();
+
+        Model modelA = Model.assembler().addShapes(shape1, oldStruct).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, newStruct).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberOrder").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, oldStruct.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.DANGER).size(), equalTo(1));
+    }
+
+    @Test
+    public void detectsCompatibleChanges() {
+        Shape shape1 = StringShape.builder().id("foo.baz#String").build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#Struct$member1").target(shape1).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#Struct$member2").target(shape1).build();
+        StructureShape oldStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .addMember(member2)
+                .build();
+
+        MemberShape member3 = MemberShape.builder().id("foo.baz#Struct$member3").target(shape1).build();
+        StructureShape newStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .addMember(member2)
+                .addMember(member3)
+                .build();
+
+        Model modelA = Model.assembler().addShapes(shape1, oldStruct).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, newStruct).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberOrder"), empty());
+    }
+
+    // Ignore the fact that a member was removed.
+    @Test
+    public void ignoresOtherBreakingChanges() {
+        Shape shape1 = StringShape.builder().id("foo.baz#String").build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#Struct$member1").target(shape1).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#Struct$member2").target(shape1).build();
+        StructureShape oldStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .addMember(member2)
+                .build();
+
+        StructureShape newStruct = StructureShape.builder()
+                .id("foo.baz#Struct")
+                .addMember(member1)
+                .build();
+
+        Model modelA = Model.assembler().addShapes(shape1, oldStruct).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, newStruct).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberOrder"), empty());
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -83,10 +84,10 @@ final class LoaderVisitor {
     private final List<ForwardReferenceResolver> forwardReferenceResolvers = new ArrayList<>();
 
     /** Shapes that have yet to be built. */
-    private final Map<ShapeId, AbstractShapeBuilder> pendingShapes = new HashMap<>();
+    private final Map<ShapeId, AbstractShapeBuilder> pendingShapes = new LinkedHashMap<>();
 
     /** Built shapes to add to the Model. Keys are not allowed to conflict with pendingShapes. */
-    private final Map<ShapeId, Shape> builtShapes = new HashMap<>();
+    private final Map<ShapeId, Shape> builtShapes = new LinkedHashMap<>();
 
     /** Built trait definitions. */
     private final Map<ShapeId, TraitDefinition> builtTraitDefinitions = new HashMap<>();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/ObjectNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/ObjectNode.java
@@ -19,7 +19,6 @@ import static java.lang.String.format;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -221,7 +220,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
     public Map<String, Node> getStringMap() {
         Map<String, Node> map = stringMap;
         if (map == null) {
-            map = new HashMap<>(nodeMap.size());
+            map = new LinkedHashMap<>(nodeMap.size());
             for (Map.Entry<StringNode, Node> entry : nodeMap.entrySet()) {
                 map.put(entry.getKey().getValue(), entry.getValue());
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -250,8 +250,6 @@ public final class ModelSerializer {
             ObjectNode result = createTypedNode(shape);
             result = result.withMember("members", members.entrySet().stream()
                     .map(entry -> Pair.of(entry.getKey(), entry.getValue().accept(this)))
-                    // Sort by key to ensure a consistent member order.
-                    .sorted(Comparator.comparing(Pair::getLeft))
                     .collect(ObjectNode.collectStringKeys(Pair::getLeft, Pair::getRight)));
             return withTraits(shape, result);
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/ObjectNodeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/ObjectNodeTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -96,6 +97,19 @@ public class ObjectNodeTest {
         assertTrue(node.containsMember("foo"));
         assertTrue(node.containsMember("baz"));
         assertTrue(node.containsMember("bam"));
+    }
+
+    @Test
+    public void membersAreOrdered() {
+        ObjectNode node = ObjectNode.objectNodeBuilder()
+                .withMember("foo", "bar")
+                .withMember("baz", true)
+                .withMember("bam", false)
+                .build();
+
+        assertThat(node.getMembers().values(),
+                   contains(node.expectMember("foo"), node.expectMember("baz"), node.expectBooleanMember("bam")));
+        assertThat(node.getStringMap().keySet(), contains("foo", "baz", "bam"));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
@@ -16,7 +16,10 @@
 package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
@@ -74,5 +77,25 @@ public class StructureShapeTest {
                 .build();
 
         assertThat(shape.members(), hasSize(2));
+        // Members are ordered.
+        assertThat(shape.members(), contains(shape.getMember("foo").get(), shape.getMember("baz").get()));
+        assertThat(shape.getAllMembers().keySet(), contains("foo", "baz"));
+    }
+
+    @Test
+    public void memberOrderMattersForEqualComparison() {
+        StructureShape a = StructureShape.builder()
+                .id("ns.foo#bar")
+                .addMember("foo", ShapeId.from("ns.foo#bam"))
+                .addMember("baz", ShapeId.from("ns.foo#bam"))
+                .build();
+
+        StructureShape b = StructureShape.builder()
+                .id("ns.foo#bar")
+                .addMember("baz", ShapeId.from("ns.foo#bam"))
+                .addMember("foo", ShapeId.from("ns.foo#bam"))
+                .build();
+
+        assertThat(a, not(equalTo(b)));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/main-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/main-test.json
@@ -115,14 +115,14 @@
         "example.weather#GetCityOutput": {
             "type": "structure",
             "members": {
-                "coordinates": {
-                    "target": "example.weather#CityCoordinates",
+                "name": {
+                    "target": "smithy.api#String",
                     "traits": {
                         "smithy.api#required": {}
                     }
                 },
-                "name": {
-                    "target": "smithy.api#String",
+                "coordinates": {
+                    "target": "example.weather#CityCoordinates",
                     "traits": {
                         "smithy.api#required": {}
                     }
@@ -183,13 +183,13 @@
                         "smithy.api#required": {}
                     }
                 },
-                "high": {
+                "low": {
                     "target": "smithy.api#Integer",
                     "traits": {
                         "smithy.api#required": {}
                     }
                 },
-                "low": {
+                "high": {
                     "target": "smithy.api#Integer",
                     "traits": {
                         "smithy.api#required": {}
@@ -208,8 +208,8 @@
             "traits": {
                 "smithy.api#paginated": {
                     "inputToken": "nextToken",
-                    "items": "items",
                     "outputToken": "nextToken",
+                    "items": "items",
                     "pageSize": "pageSize"
                 },
                 "smithy.api#readonly": {}
@@ -232,14 +232,14 @@
         "example.weather#ListCitiesOutput": {
             "type": "structure",
             "members": {
+                "nextToken": {
+                    "target": "smithy.api#String"
+                },
                 "items": {
                     "target": "example.weather#CitySummaries",
                     "traits": {
                         "smithy.api#required": {}
                     }
-                },
-                "nextToken": {
-                    "target": "smithy.api#String"
                 }
             }
         },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/structures.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/structures.json
@@ -47,42 +47,42 @@
         "com.foo#I": {
             "type": "structure",
             "members": {
-                "baz": {
-                    "target": "com.foo#H"
-                },
                 "foo": {
                     "target": "com.foo#E"
+                },
+                "baz": {
+                    "target": "com.foo#H"
                 }
             }
         },
         "com.foo#J": {
             "type": "structure",
             "members": {
-                "baz": {
-                    "target": "com.foo#H"
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {}
                     }
+                },
+                "baz": {
+                    "target": "com.foo#H"
                 }
             }
         },
         "com.foo#K": {
             "type": "structure",
             "members": {
-                "baz": {
-                    "target": "com.foo#H",
-                    "traits": {
-                        "smithy.api#deprecated": {}
-                    }
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {},
                         "smithy.api#since": "2.0"
+                    }
+                },
+                "baz": {
+                    "target": "com.foo#H",
+                    "traits": {
+                        "smithy.api#deprecated": {}
                     }
                 }
             }
@@ -90,17 +90,17 @@
         "com.foo#L": {
             "type": "structure",
             "members": {
-                "baz": {
-                    "target": "com.foo#H",
-                    "traits": {
-                        "smithy.api#deprecated": {}
-                    }
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {},
                         "smithy.api#since": "2.0"
+                    }
+                },
+                "baz": {
+                    "target": "com.foo#H",
+                    "traits": {
+                        "smithy.api#deprecated": {}
                     }
                 }
             }
@@ -108,17 +108,17 @@
         "com.foo#M": {
             "type": "structure",
             "members": {
-                "baz": {
-                    "target": "com.foo#H",
-                    "traits": {
-                        "smithy.api#deprecated": {}
-                    }
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {},
                         "smithy.api#since": "2.0"
+                    }
+                },
+                "baz": {
+                    "target": "com.foo#H",
+                    "traits": {
+                        "smithy.api#deprecated": {}
                     }
                 }
             },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/unions.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/unions.json
@@ -75,42 +75,42 @@
         "com.foo#I": {
             "type": "union",
             "members": {
-                "baz": {
-                    "target": "com.foo#H"
-                },
                 "foo": {
                     "target": "com.foo#E"
+                },
+                "baz": {
+                    "target": "com.foo#H"
                 }
             }
         },
         "com.foo#J": {
             "type": "union",
             "members": {
-                "baz": {
-                    "target": "com.foo#H"
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {}
                     }
+                },
+                "baz": {
+                    "target": "com.foo#H"
                 }
             }
         },
         "com.foo#K": {
             "type": "union",
             "members": {
-                "baz": {
-                    "target": "com.foo#H",
-                    "traits": {
-                        "smithy.api#deprecated": {}
-                    }
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {},
                         "smithy.api#since": "2.0"
+                    }
+                },
+                "baz": {
+                    "target": "com.foo#H",
+                    "traits": {
+                        "smithy.api#deprecated": {}
                     }
                 }
             }
@@ -118,17 +118,17 @@
         "com.foo#L": {
             "type": "union",
             "members": {
-                "baz": {
-                    "target": "com.foo#H",
-                    "traits": {
-                        "smithy.api#deprecated": {}
-                    }
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {},
                         "smithy.api#since": "2.0"
+                    }
+                },
+                "baz": {
+                    "target": "com.foo#H",
+                    "traits": {
+                        "smithy.api#deprecated": {}
                     }
                 }
             }
@@ -136,17 +136,17 @@
         "com.foo#M": {
             "type": "union",
             "members": {
-                "baz": {
-                    "target": "com.foo#H",
-                    "traits": {
-                        "smithy.api#deprecated": {}
-                    }
-                },
                 "foo": {
                     "target": "com.foo#E",
                     "traits": {
                         "smithy.api#deprecated": {},
                         "smithy.api#since": "2.0"
+                    }
+                },
+                "baz": {
+                    "target": "com.foo#H",
+                    "traits": {
+                        "smithy.api#deprecated": {}
                     }
                 }
             },


### PR DESCRIPTION
This change updates Smithy to make the order of structure members part
of the contract of structures and unions. We previously sorted these
members automatically. However, languages like C, C++, Rust and others
require the order of structures to be consistent, and new fields added
to the end to maintain ABI compatibility. This change adds that language
to the spec, updates the semantic model to use insertion order, updates
equality checks to ensure that members have the same order, and adds a
diff evaluator to detect a violation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
