### PR TITLE
Add addTrait method to ModelAssembler

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -517,9 +517,9 @@ public final class ModelAssembler {
 
         shapes.forEach(visitor::onShape);
         metadata.forEach(visitor::onMetadata);
-        pendingTraits.forEach(pendingTrait -> {
+        for (PendingTrait pendingTrait : pendingTraits) {
             visitor.onTrait(pendingTrait.id, pendingTrait.trait);
-        });
+        }
 
         for (Model model : mergeModels) {
             mergeModelIntoVisitor(model, visitor);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -40,6 +40,8 @@ import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.AbstractShapeBuilder;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -113,6 +115,7 @@ public final class ModelAssembler {
     private final List<Node> documentNodes = new ArrayList<>();
     private final List<Model> mergeModels = new ArrayList<>();
     private final List<AbstractShapeBuilder<?, ?>> shapes = new ArrayList<>();
+    private final List<PendingTrait> pendingTraits = new ArrayList<>();
     private final Map<String, Node> metadata = new HashMap<>();
     private final Map<String, Object> properties = new HashMap<>();
     private boolean disablePrelude;
@@ -142,6 +145,7 @@ public final class ModelAssembler {
         assembler.documentNodes.addAll(documentNodes);
         assembler.mergeModels.addAll(mergeModels);
         assembler.shapes.addAll(shapes);
+        assembler.pendingTraits.addAll(pendingTraits);
         assembler.metadata.putAll(metadata);
         assembler.disablePrelude = disablePrelude;
         assembler.properties.putAll(properties);
@@ -173,6 +177,7 @@ public final class ModelAssembler {
      */
     public ModelAssembler reset() {
         shapes.clear();
+        pendingTraits.clear();
         metadata.clear();
         mergeModels.clear();
         inputStreamModels.clear();
@@ -366,6 +371,19 @@ public final class ModelAssembler {
     }
 
     /**
+     * Explicitly adds a trait to a shape in the assembled model.
+     *
+     * @param target Shape to add the trait to.
+     * @param trait Trait to add.
+     * @return Returns the assembler.
+     */
+    public ModelAssembler addTrait(ShapeId target, Trait trait) {
+        PendingTrait pendingTrait = new PendingTrait(target, trait);
+        this.pendingTraits.add(pendingTrait);
+        return this;
+    }
+
+    /**
      * Merges a loaded model into the model assembler.
      *
      * @param model Model to merge in.
@@ -499,6 +517,9 @@ public final class ModelAssembler {
 
         shapes.forEach(visitor::onShape);
         metadata.forEach(visitor::onMetadata);
+        pendingTraits.forEach(pendingTrait -> {
+            visitor.onTrait(pendingTrait.id, pendingTrait.trait);
+        });
 
         for (Model model : mergeModels) {
             mergeModelIntoVisitor(model, visitor);
@@ -545,5 +566,16 @@ public final class ModelAssembler {
         List<Validator> copiedValidators = new ArrayList<>(validatorFactory.loadBuiltinValidators());
         copiedValidators.addAll(validators);
         return copiedValidators;
+    }
+
+    private static final class PendingTrait {
+        final ShapeId id;
+        final Trait trait;
+
+        // A pending trait that's already created.
+        PendingTrait(ShapeId id, Trait trait) {
+            this.id = id;
+            this.trait = trait;
+        }
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -58,8 +58,6 @@ import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.SuppressTrait;
-import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -95,21 +93,16 @@ public class ModelAssemblerTest {
     @Test
     public void addsExplicitTraits() {
         StringShape shape = StringShape.builder().id("ns.foo#Bar").build();
-
-        Node node = Node.fromStrings("validator");
-        TraitFactory provider = TraitFactory.createServiceFactory();
-        Optional<Trait> trait = provider.createTrait(
-                ShapeId.from("smithy.api#suppress"), shape.toShapeId(), node);
-
-        SuppressTrait suppress = (SuppressTrait) trait.get();
+        SuppressTrait trait = SuppressTrait.builder().build();
         ValidatedResult<Model> result = new ModelAssembler()
                 .addShape(shape)
-                .addTrait(shape.toShapeId(), suppress)
+                .addTrait(shape.toShapeId(), trait)
                 .assemble();
 
         assertThat(result.getValidationEvents(), empty());
         Shape resultShape = result.unwrap().getShape(ShapeId.from("ns.foo#Bar")).get();
         assertTrue(resultShape.findTrait("smithy.api#suppress").isPresent());
+        assertTrue(resultShape.getTrait(SuppressTrait.class).isPresent());
     }
 
     @Test


### PR DESCRIPTION
This CR adds an `addTrait` method to the model assembler, allowing for a resolved trait to be added to a target shape within the model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
