### PR TITLE
Update REST-JSON protocol test implicit request body case

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -94,7 +94,7 @@ apply EmptyInputAndEmptyOutput @httpResponseTests([
         documentation: "Empty output serializes no payload",
         protocol: restJson1,
         code: 200,
-        body: "{}",
+        body: "",
         bodyMediaType: "application/json"
     },
 ])


### PR DESCRIPTION
Updates the restJson1 protocol test to not expect `{}` as the request body. Instead the test expects no/empty request body. This matches the AWS SDK's expectation of REST-JSON with no input parameters when no document or payload binding are modeled on the input shape.

https://github.com/aws/aws-sdk-go-v2/blob/master/models/protocol_tests/input/rest-json.json#L724-L737

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
