### PR TITLE
Add exact documents and document type docs

### DIFF
--- a/docs/source/1.0/spec/core/protocol-traits.rst
+++ b/docs/source/1.0/spec/core/protocol-traits.rst
@@ -232,6 +232,11 @@ The following example defines a video/quicktime blob:
         @mediaType("video/quicktime")
         blob VideoData
 
+.. seealso::
+
+    Refer to the :ref:`exactDocument-trait` for information on how to
+    embed nested documents inside of ``string`` and ``blob`` shapes.
+
 
 .. _timestampFormat-trait:
 

--- a/docs/source/1.0/spec/core/shapes.rst
+++ b/docs/source/1.0/spec/core/shapes.rst
@@ -285,7 +285,7 @@ Shapes that are simple types are defined using the following grammar:
       - Represents an instant in time with no UTC offset or timezone. The
         serialization of a timestamp is determined by a
         :ref:`protocol <protocolDefinition-trait>`.
-    * - document
+    * - :ref:`document <document-type>`
       - A protocol-specific untyped value.
 
 The following example defines a shape for each simple type in the
@@ -394,16 +394,33 @@ by tooling to represent a timestamp.
 Document types
 ==============
 
-A document type represents a protocol-specific untyped value. Documents
-are useful when interacting with data that has no predefined schema,
-uses a schema language that is not compatible with Smithy, or if the schema
-that defines the data is specified and versioned outside of the
+A document type represents protocol-agnostic open content that is accessed
+like JSON data. Open content is useful for modeling unstructured data that
+has no schema, data that can't be modeled using rigid types, or data that has
+a schema that evolves outside of the purview of a Smithy model.
+
+.. rubric:: Inline document serialization
+
+Document types are *inline documents* because they are serialized using the
+same format as their surroundings and require no additional encoding or
+escaping. The serialization format of an inline document is an implementation
+detail; changing the protocol of a service SHOULD NOT change the features and
+functionality of a document type abstraction used in code generated from a
 Smithy model.
 
-.. note::
+Documents can also be defined using the :ref:`exactDocument-trait`. This
+trait indicates that a ``blob`` or ``string`` shape contains a nested document
+that can be lazily parsed into a document abstraction.
 
-    * Not all protocols support document types
-    * The serialization format of a document is protocol-specific.
+.. rubric:: Code generation and implementation
+
+Smithy implementations that generate code for document types MUST provide
+structured access to documents through JSON-like abstractions, allowing
+developers to interact with documents as lists, maps, strings, numbers,
+booleans, and nulls. Additional functionality is allowed, though the
+aforementioned access patterns are required. Implementations MUST NOT provide
+access to the underlying bytes of an inline document because its serialization
+format is an implementation detail.
 
 
 .. _aggregate-types:

--- a/smithy-aws-protocol-tests/model/awsJson1_1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/documents.smithy
@@ -60,3 +60,63 @@ apply PutAndGetInlineDocuments @httpResponseTests([
         }
     }
 ])
+
+/// This example serializes an exact document in JSON input and output.
+operation PutAndGetExactDocuments {
+    input: PutAndGetExactDocumentsInputOutput,
+    output: PutAndGetExactDocumentsInputOutput
+}
+
+structure PutAndGetExactDocumentsInputOutput {
+    jsonValue: JsonDocument,
+    binaryDocument: SomeBinaryDocument,
+}
+
+@exactDocument
+@mediaType("application/json")
+string JsonDocument
+
+@exactDocument
+@mediaType("application/x-foo")
+blob SomeBinaryDocument
+
+apply PutAndGetExactDocuments @httpRequestTests([
+    {
+        id: "PutAndGetExactDocumentsInput",
+        documentation: "Serializes exact documents in a JSON request.",
+        protocol: awsJson1_1,
+        method: "POST",
+        uri: "/",
+        body: """
+              {
+                  "jsonValue": "[\"hi\"]",
+                  "binaryDocument": "e30K"
+              }""",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            jsonValue: "{}",
+            binaryDocument: "{}",
+        }
+    }
+])
+
+apply PutAndGetExactDocuments @httpResponseTests([
+    {
+        id: "PutAndGetExactDocumentsOutput",
+        documentation: "Serializes exact documents in a JSON response.",
+        protocol: awsJson1_1,
+        code: 200,
+        body: """
+            {
+                "jsonValue": "[\"hi\"]",
+                "binaryDocument": "e30K"
+            }""",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            jsonValue: "[\"hi\"]",
+            binaryDocument: "{}",
+        }
+    }
+])

--- a/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
@@ -23,7 +23,8 @@ service JsonProtocol {
         EmptyOperation,
         KitchenSinkOperation,
         OperationWithOptionalInputOutput,
-        PutAndGetInlineDocuments
+        PutAndGetInlineDocuments,
+        PutAndGetExactDocuments,
     ],
 }
 

--- a/smithy-aws-protocol-tests/model/restJson1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/documents.smithy
@@ -126,3 +126,246 @@ apply InlineDocumentAsPayload @httpResponseTests([
         }
     }
 ])
+
+@mediaType("application/json")
+@exactDocument
+string JsonDocument
+
+@mediaType("application/x-foo")
+@exactDocument
+string SomeBinaryDocument
+
+/// This example serializes exact documents in HTTP headers.
+@readonly
+@http(uri: "/ExactDocumentInHeader", method: "GET")
+operation ExactDocumentInHeader {
+    input: ExactDocumentInHeaderInputOutput,
+    output: ExactDocumentInHeaderInputOutput
+}
+
+structure ExactDocumentInHeaderInputOutput {
+    @httpHeader("X-JSON")
+    documentValue: JsonDocument,
+}
+
+apply ExactDocumentInHeader @httpRequestTests([
+    {
+        id: "ExactDocumentInHeaderInput",
+        documentation: "Serializes an exact document in a base64 encoded header.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/ExactDocumentInHeader",
+        headers: {
+            "X-JSON": "eyJncmVldGluZyI6ImhlbGxvIn0="
+        },
+        params: {
+            documentValue: "{\"greeting\": \"hello\"}"
+        }
+    }
+])
+
+apply ExactDocumentInHeader @httpResponseTests([
+    {
+        id: "ExactDocumentInHeaderInputOutput",
+        documentation: "Serializes an exact document in a base64 encoded header.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "X-JSON": "eyJncmVldGluZyI6ImhlbGxvIn0="
+        },
+        params: {
+            documentValue: "{\"greeting\": \"hello\"}"
+        }
+    }
+])
+
+/// This example serializes an exact document in a HTTP query string parameter.
+@readonly
+@http(uri: "/ExactDocumentInQuery", method: "GET")
+operation ExactDocumentInQuery {
+    input: ExactDocumentInQueryInput
+}
+
+structure ExactDocumentInQueryInput {
+    @httpQuery("json")
+    documentValue: JsonDocument,
+
+    @httpQuery("ion")
+    binaryValue: SomeBinaryDocument,
+}
+
+apply ExactDocumentInQuery @httpRequestTests([
+    {
+        id: "ExactDocumentInQueryInput",
+        documentation: "Serializes an exact document in a HTTP query string parameter using percent-encoding.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/ExactDocumentInQuery",
+        queryParams: [
+            "json=%7B%22greeting%22%3A+%22hello%22%7D",
+            "ion=e30K",
+        ],
+        params: {
+            documentValue: "{\"greeting\": \"hello\"}",
+            binaryValue: "{}",
+        }
+    }
+])
+
+/// This example serializes exact documents nested inside of request and response payloads.
+@idempotent
+@http(uri: "/ExactDocumentInPayload", method: "PUT")
+operation ExactDocumentInPayload {
+    input: ExactDocumentInPayloadInputOutput,
+    output: ExactDocumentInPayloadInputOutput
+}
+
+structure ExactDocumentInPayloadInputOutput {
+    json: JsonDocument,
+    binaryValue: SomeBinaryDocument,
+}
+
+apply ExactDocumentInPayload @httpRequestTests([
+    {
+        id: "ExactDocumentInPayloadInput",
+        documentation: "Serializes an exact document within the payload of a JSON request.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/ExactDocumentInPayload",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: """
+              {
+                  "json": "{\"greeting\": \"hello\"}",
+                  "ion": "e30K"
+              }""",
+        bodyMediaType: "application/json",
+        params: {
+            json: "{\"greeting\": \"hello\"}",
+            binaryValue: "{}"
+        }
+    }
+])
+
+apply ExactDocumentInPayload @httpResponseTests([
+    {
+        id: "ExactDocumentInPayloadOutput",
+        documentation: "Serializes an exact document within the payload of a JSON response.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: """
+              {
+                  "json": "{\"greeting\": \"hello\"}",
+                  "ion": "e30K"
+              }""",
+        bodyMediaType: "application/json",
+        params: {
+            json: "{\"greeting\": \"hello\"}",
+            binaryValue: "{}"
+        }
+    }
+])
+
+/// This example serializes an exact string document as the payload of a request and response.
+@idempotent
+@http(uri: "/ExactStringDocumentAsPayload", method: "PUT")
+operation ExactStringDocumentAsPayload {
+    input: ExactStringDocumentAsPayloadInputOutput,
+    output: ExactStringDocumentAsPayloadInputOutput
+}
+
+structure ExactStringDocumentAsPayloadInputOutput {
+    @httpPayload
+    json: JsonDocument
+}
+
+apply ExactStringDocumentAsPayload @httpRequestTests([
+    {
+        id: "ExactStringDocumentAsPayloadInput",
+        documentation: "Serializes an exact string document as the payload of a request.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/ExactStringDocumentAsPayload",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: """
+              {"greeting": "hello"}""",
+        bodyMediaType: "application/json",
+        params: {
+            json: "{\"greeting\": \"hello\"}"
+        }
+    }
+])
+
+apply ExactStringDocumentAsPayload @httpResponseTests([
+    {
+        id: "ExactStringDocumentAsPayloadOutput",
+        documentation: "Serializes an exact string document as the payload of a response.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: """
+              {"greeting": "hello"}""",
+        bodyMediaType: "application/json",
+        params: {
+            json: "{\"greeting\": \"hello\"}"
+        }
+    }
+])
+
+/// This example serializes an exact blob document as the payload of a request and response.
+@idempotent
+@http(uri: "/ExactBlobDocumentAsPayload", method: "PUT")
+operation ExactBlobDocumentAsPayload {
+    input: ExactBlobDocumentAsPayloadInputOutput,
+    output: ExactBlobDocumentAsPayloadInputOutput
+}
+
+structure ExactBlobDocumentAsPayloadInputOutput {
+    @httpPayload
+    binaryValue: SomeBinaryDocument
+}
+
+apply ExactBlobDocumentAsPayload @httpRequestTests([
+    {
+        id: "ExactBlobDocumentAsPayloadInput",
+        documentation: "Serializes an exact blob document as the payload of a request.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/ExactBlobDocumentAsPayload",
+        headers: {
+            // The Content-Type is inherited from the mediaType trait.
+            "Content-Type": "application/x-foo"
+        },
+        body: "{}",
+        bodyMediaType: "application/json",
+        params: {
+            binaryValue: "{}"
+        }
+    }
+])
+
+apply ExactBlobDocumentAsPayload @httpResponseTests([
+    {
+        id: "ExactBlobDocumentAsPayloadOutput",
+        documentation: "Serializes an exact string document as the payload of a response.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            // The Content-Type is inherited from the mediaType trait.
+            "Content-Type": "application/x-foo"
+        },
+        body: "{}",
+        bodyMediaType: "application/json",
+        params: {
+            binaryValue: "{}"
+        }
+    }
+])

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -60,5 +60,10 @@ service RestJson {
         // Documents
         InlineDocument,
         InlineDocumentAsPayload,
+        ExactDocumentInHeader,
+        ExactDocumentInQuery,
+        ExactDocumentInPayload,
+        ExactStringDocumentAsPayload,
+        ExactBlobDocumentAsPayload,
     ]
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
@@ -47,6 +47,7 @@ import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.EventHeaderTrait;
 import software.amazon.smithy.model.traits.EventPayloadTrait;
+import software.amazon.smithy.model.traits.ExactDocumentTrait;
 import software.amazon.smithy.model.traits.ExamplesTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.model.traits.HostLabelTrait;
@@ -157,6 +158,7 @@ public final class Prelude {
             EventHeaderTrait.ID,
             EventPayloadTrait.ID,
             ExamplesTrait.ID,
+            ExactDocumentTrait.ID,
             ExternalDocumentationTrait.ID,
             HostLabelTrait.ID,
             HttpChecksumRequiredTrait.ID,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExactDocumentTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExactDocumentTrait.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Indicates that a string or blob contains an exact document.
+ */
+public class ExactDocumentTrait extends AnnotationTrait {
+
+    public static final ShapeId ID = ShapeId.from("smithy.api#exactDocument");
+
+    public ExactDocumentTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public ExactDocumentTrait() {
+        this(Node.objectNode());
+    }
+
+    public static final class Provider extends AnnotationTrait.Provider<ExactDocumentTrait> {
+        public Provider() {
+            super(ID, ExactDocumentTrait::new);
+        }
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -25,6 +25,7 @@ software.amazon.smithy.model.traits.IdRefTrait$Provider
 software.amazon.smithy.model.traits.JsonNameTrait$Provider
 software.amazon.smithy.model.traits.LengthTrait$Provider
 software.amazon.smithy.model.traits.MediaTypeTrait$Provider
+software.amazon.smithy.model.traits.ExactDocumentTrait$Provider
 software.amazon.smithy.model.traits.NoReplaceTrait$Provider
 software.amazon.smithy.model.traits.PaginatedTrait$Provider
 software.amazon.smithy.model.traits.PatternTrait$Provider

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude-traits.smithy
@@ -256,6 +256,11 @@ string NonEmptyString
 @trait(selector: "resource:test(-[put]->)")
 structure noReplace {}
 
+/// Indicates that a blob or string shape contains an exact document.
+@trait(selector: ":is(blob, string)[trait|mediaType]", conflicts: [streaming])
+@tags(["diff.error.const"])
+structure exactDocument {}
+
 /// Describes the contents of a blob shape using a media type as defined by
 /// RFC 6838 (e.g., "video/quicktime").
 @trait(selector: ":is(blob, string)")


### PR DESCRIPTION
This change adds the idea of "exact" documents as a general purpose way of embedding structured data inside of blobs and strings. Furthermore, this change adds more documentation about inline document types.