### PR TITLE
Add nullability metadata to Smithy

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/package-info.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,14 +13,8 @@
  * permissions and limitations under the License.
  */
 
-description = "This module is a library used to validate Smithy models, create filtered " +
-        "projections of a model, and generate build artifacts."
-extra["displayName"] = "Smithy :: Build"
-extra["moduleName"] = "software.amazon.smithy.build"
-
-dependencies {
-    api(project(":smithy-utils"))
-    api(project(":smithy-model"))
-
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
-}
+/**
+ * Defines integration points for Smithy code generators.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package software.amazon.smithy.build;


### PR DESCRIPTION
Description of changes: This is a preliminary PR to introduce nullability metadata to Smithy APIs.  The primary value for the submitter is better interop with Kotlin, however there are other benefits as well.  This PR is not conclusive because:
* It's unclear to me which (if any) parameters allow nulls
* If this is the best nullability annotation library to use with Smithy

What I'm looking for in this PR is a go-ahead that this change is generally beneficial and that the nullability metadata implementation is acceptable.

### Testing Done

Before change, depend on public Smithy dependency and create a class that subclasses from SmithyBuildPlugin.  Observe IDE generated code:

```kotlin
import software.amazon.smithy.build.PluginContext
import software.amazon.smithy.build.SmithyBuildPlugin

class MySmithyPlugin : SmithyBuildPlugin {
    override fun getName(): String {
        TODO("Not yet implemented")
    }

    override fun execute(context: PluginContext?) {
        TODO("Not yet implemented")
    }

}
```

Notice that `context: PluginContext?` means that I must deal with the null case, even though it's not going to be passed from Smithy.

After change, generate jar locally, create new project that depends on local jar `smithy-buld-1.0.6.jar`, produce the same class in Kotlin:

```kotlin
import software.amazon.smithy.build.PluginContext
import software.amazon.smithy.build.SmithyBuildPlugin

class MySmithyPlugin : SmithyBuildPlugin {
    override fun getName(): String {
        TODO("Not yet implemented")
    }

    override fun execute(p0: PluginContext) {
        TODO("Not yet implemented")
    }
}
```

Notice `p0: PluginContext`, now I do not have to deal with the null case.  This same benefit is carried to all method parameters specific to the `software.amazon.smithy.build` package, but not children.  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
