### PR TITLE
Update opinionated protocol tests to not describe optional behavior

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -83,7 +83,7 @@ apply EmptyInputAndEmptyOutput @httpRequestTests([
         protocol: restJson1,
         method: "POST",
         uri: "/EmptyInputAndEmptyOutput",
-        body: "{}",
+        body: "",
         bodyMediaType: "application/json"
     },
 ])
@@ -91,7 +91,7 @@ apply EmptyInputAndEmptyOutput @httpRequestTests([
 apply EmptyInputAndEmptyOutput @httpResponseTests([
     {
         id: "RestJsonEmptyInputAndEmptyOutput",
-        documentation: "Empty output serializes no payload",
+        documentation: "Empty output deserializes no payload",
         protocol: restJson1,
         code: 200,
         body: "",

--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -91,15 +91,15 @@ apply EmptyInputAndEmptyOutput @httpRequestTests([
 apply EmptyInputAndEmptyOutput @httpResponseTests([
     {
         id: "RestJsonEmptyInputAndEmptyOutput",
-        documentation: "Empty output deserializes no payload",
+        documentation: "Empty output serializes no payload",
         protocol: restJson1,
         code: 200,
         body: "",
         bodyMediaType: "application/json"
     },
     {
-        id: "RestJsonEmptyInputAndEmptyJSONObjectOutput",
-        documentation: "Empty output deserializes no payload",
+        id: "RestJsonEmptyInputAndEmptyJsonObjectOutput",
+        documentation: "Empty output serializes no payload",
         protocol: restJson1,
         code: 200,
         body: "{}",

--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -97,6 +97,14 @@ apply EmptyInputAndEmptyOutput @httpResponseTests([
         body: "",
         bodyMediaType: "application/json"
     },
+    {
+        id: "RestJsonEmptyInputAndEmptyOutput",
+        documentation: "Empty output deserializes no payload",
+        protocol: restJson1,
+        code: 200,
+        body: "{}",
+        bodyMediaType: "application/json"
+    },
 ])
 
 structure EmptyInputAndEmptyOutputInput {}

--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -98,7 +98,7 @@ apply EmptyInputAndEmptyOutput @httpResponseTests([
         bodyMediaType: "application/json"
     },
     {
-        id: "RestJsonEmptyInputAndEmptyOutput",
+        id: "RestJsonEmptyInputAndEmptyJSONObjectOutput",
         documentation: "Empty output deserializes no payload",
         protocol: restJson1,
         code: 200,

--- a/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
@@ -76,20 +76,6 @@ apply HttpPrefixHeaders @httpResponseTests([
             }
         }
     },
-    {
-        id: "RestJsonHttpPrefixHeadersAreNotPresent",
-        documentation: "No prefix headers are serialized because the value is empty",
-        protocol: restJson1,
-        code: 200,
-        body: "",
-        headers: {
-            "X-Foo": "Foo"
-        },
-        params: {
-            foo: "Foo",
-            fooMap: {}
-        }
-    },
 ])
 
 structure HttpPrefixHeadersInputOutput {


### PR DESCRIPTION
Removes the protocol tests for HTTP Prefix Header deserialization, deserializing to an empty map vs null value. Null vs empty map will be SDK implementation specific distinction. If there was a way to model `empty` as an expectation that would encompass both null and empty but initialized map this test would be more portable.

Updates the empty input output serialization protocol test to expect empty payload not empty JSON object as the serialized result. It doesn't look like the REST-JSON protocol should be serializing empty JSON object when no members are serialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
