### PR TITLE
Clarify the semantic model

### DIFF
--- a/docs/source/1.0/spec/core/traits.rst
+++ b/docs/source/1.0/spec/core/traits.rst
@@ -59,6 +59,8 @@ current namespace in exactly the same same way as
     the :ref:`documentation-trait` as "Documentation").
 
 
+.. _apply-statement:
+
 Apply statement
 ===============
 


### PR DESCRIPTION
This commit intends to clarify the differences between the IDL and JSON AST by defining the "semantic model" (as originally defined by Martin Fowler in [Domain Specific Languages](https://martinfowler.com/dslCatalog/semanticModel.html). Basically features that are present in the IDL that aren't present in the JSON AST (like control statements) aren't actually part of the semantic model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
