### PR TITLE
Use title for oneOf union strategy

### DIFF
--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -195,6 +195,7 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
                     String memberName = converter.toPropertyName(member);
                     schemas.add(Schema.builder()
                             .type("object")
+                            .title(memberName)
                             .required(ListUtils.of(memberName))
                             .putProperty(memberName, createRef(member))
                             .build());

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.jsonschema.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.jsonschema.json
@@ -114,6 +114,7 @@
       "oneOf": [
         {
           "type": "object",
+          "title": "a",
           "required": [
             "a"
           ],
@@ -125,6 +126,7 @@
         },
         {
           "type": "object",
+          "title": "b",
           "required": [
             "b"
           ],

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -203,6 +203,7 @@
         "oneOf": [
           {
             "type": "object",
+            "title": "a",
             "properties": {
               "a": {
                 "type": "string"
@@ -214,6 +215,7 @@
           },
           {
             "type": "object",
+            "title": "b",
             "properties": {
               "b": {
                 "type": "string"


### PR DESCRIPTION
Use `title` to improve generated documentation for the `oneOf` union
strategy. Without `title` tools see an inlined (unnamed) object.

Fixes #483 

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.