### PR TITLE
Fix IDL ABNF production

### DIFF
--- a/docs/source/1.0/spec/core/lexical-structure.rst
+++ b/docs/source/1.0/spec/core/lexical-structure.rst
@@ -44,10 +44,7 @@ Smithy IDL ABNF
 The Smithy IDL is defined by the following ABNF:
 
 .. productionlist:: smithy
-    idl:`ws`
-       :/ `control_section`
-       :/ `metadata_section`
-       :/ `shape_section`
+    idl:`ws` `control_section` `metadata_section` `shape_section`
 
 
 -------------


### PR DESCRIPTION
The previous production grammar implied that you could only specify one
of the fixed sections at a time. This update now properly specifies that
each section follows the other, and each subsection then has optional
productions inside of them, meaning they can actually be omitted in an
IDL model file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
