### PR TITLE
Remove old style guide namespace guidance

### DIFF
--- a/docs/source/1.0/guides/style-guide.rst
+++ b/docs/source/1.0/guides/style-guide.rst
@@ -61,13 +61,6 @@ New lines are represented using ``Line Feed``, ``U+000A``.
 All files SHOULD end with a new line.
 
 
-One namespace per file
-----------------------
-
-Source model files SHOULD include only a single namespace. Multiple namespaces
-MAY appear when representing a model as a single build artifact.
-
-
 Model file structure
 ====================
 


### PR DESCRIPTION
We used to allow multiple namespaces in a single IDL file, but removed
this feature prior to 1.0. This change just removes a left-over
recommendation that suggests using a single namespace per/file (which is
now a requirement).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
