### PR TITLE
Add Content-Length required header to request protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/documents.smithy
@@ -33,6 +33,9 @@ apply PutAndGetInlineDocuments @httpRequestTests([
               }""",
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/json"},
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             inlineDocument: {
                 foo: "bar"

--- a/smithy-aws-protocol-tests/model/awsJson1_1/kitchen-sink.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/kitchen-sink.smithy
@@ -13,6 +13,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes string shapes",
         body: "{\"String\":\"abc xyz\"}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             String: "abc xyz",
         },
@@ -25,6 +28,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes string shapes with jsonvalue trait",
         body: "{\"JsonValue\":\"{\\\"string\\\":\\\"value\\\",\\\"number\\\":1234.5,\\\"boolTrue\\\":true,\\\"boolFalse\\\":false,\\\"array\\\":[1,2,3,4],\\\"object\\\":{\\\"key\\\":\\\"value\\\"},\\\"null\\\":null}\"}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             JsonValue: "{\"string\":\"value\",\"number\":1234.5,\"boolTrue\":true,\"boolFalse\":false,\"array\":[1,2,3,4],\"object\":{\"key\":\"value\"},\"null\":null}",
         },
@@ -37,6 +43,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes integer shapes",
         body: "{\"Integer\":1234}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Integer: 1234,
         },
@@ -49,6 +58,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes long shapes",
         body: "{\"Long\":999999999999}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Long: 999999999999,
         },
@@ -61,6 +73,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes float shapes",
         body: "{\"Float\":1234.5}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Float: 1234.5,
         },
@@ -73,6 +88,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes double shapes",
         body: "{\"Double\":1234.5}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Double: 1234.5,
         },
@@ -85,6 +103,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes blob shapes",
         body: "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Blob: "binary-value",
         },
@@ -97,6 +118,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes boolean shapes (true)",
         body: "{\"Boolean\":true}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Boolean: true,
         },
@@ -109,6 +133,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes boolean shapes (false)",
         body: "{\"Boolean\":false}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Boolean: false,
         },
@@ -121,6 +148,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes",
         body: "{\"Timestamp\":946845296}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Timestamp: 946845296,
         },
@@ -133,6 +163,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes with iso8601 timestampFormat",
         body: "{\"Iso8601Timestamp\":\"2000-01-02T20:34:56Z\"}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             Iso8601Timestamp: 946845296,
         },
@@ -145,6 +178,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes with httpdate timestampFormat",
         body: "{\"HttpdateTimestamp\":\"Sun, 02 Jan 2000 20:34:56 GMT\"}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             HttpdateTimestamp: 946845296,
         },
@@ -157,6 +193,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes with unixTimestamp timestampFormat",
         body: "{\"UnixTimestamp\":946845296}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             UnixTimestamp: 946845296,
         },
@@ -169,6 +208,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list shapes",
         body: "{\"ListOfStrings\":[\"abc\",\"mno\",\"xyz\"]}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             ListOfStrings: [
                 "abc",
@@ -185,6 +227,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes empty list shapes",
         body: "{\"ListOfStrings\":[]}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             ListOfStrings: [],
         },
@@ -197,6 +242,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list of map shapes",
         body: "{\"ListOfMapsOfStrings\":[{\"foo\":\"bar\"},{\"abc\":\"xyz\"},{\"red\":\"blue\"}]}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             ListOfMapsOfStrings: [
                 {
@@ -219,6 +267,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list of structure shapes",
         body: "{\"ListOfStructs\":[{\"Value\":\"abc\"},{\"Value\":\"mno\"},{\"Value\":\"xyz\"}]}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             ListOfStructs: [
                 {
@@ -241,6 +292,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list of recursive structure shapes",
         body: "{\"RecursiveList\":[{\"RecursiveList\":[{\"RecursiveList\":[{\"Integer\":123}]}]}]}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             RecursiveList: [
                 {
@@ -265,6 +319,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map shapes",
         body: "{\"MapOfStrings\":{\"abc\":\"xyz\",\"mno\":\"hjk\"}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             MapOfStrings: {
                 abc: "xyz",
@@ -280,6 +337,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes empty map shapes",
         body: "{\"MapOfStrings\":{}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             MapOfStrings: {},
         },
@@ -292,6 +352,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map of list shapes",
         body: "{\"MapOfListsOfStrings\":{\"abc\":[\"abc\",\"xyz\"],\"mno\":[\"xyz\",\"abc\"]}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             MapOfListsOfStrings: {
                 abc: [
@@ -313,6 +376,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map of structure shapes",
         body: "{\"MapOfStructs\":{\"key1\":{\"Value\":\"value-1\"},\"key2\":{\"Value\":\"value-2\"}}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             MapOfStructs: {
                 key1: {
@@ -332,6 +398,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map of recursive structure shapes",
         body: "{\"RecursiveMap\":{\"key1\":{\"RecursiveMap\":{\"key2\":{\"RecursiveMap\":{\"key3\":{\"Boolean\":false}}}}}}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             RecursiveMap: {
                 key1: {
@@ -356,6 +425,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes structure shapes",
         body: "{\"SimpleStruct\":{\"Value\":\"abc\"}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             SimpleStruct: {
                 Value: "abc",
@@ -370,6 +442,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes structure members with locationName traits",
         body: "{\"StructWithLocationName\":{\"RenamedMember\":\"some-value\"}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             StructWithLocationName: {
                 Value: "some-value",
@@ -384,6 +459,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes empty structure shapes",
         body: "{\"SimpleStruct\":{}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             SimpleStruct: {},
         },
@@ -396,6 +474,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes structure which have no members",
         body: "{\"EmptyStruct\":{}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             EmptyStruct: {},
         },
@@ -408,6 +489,9 @@ use smithy.test#httpResponseTests
         documentation: "Serializes recursive structure shapes",
         body: "{\"String\":\"top-value\",\"Boolean\":false,\"RecursiveStruct\":{\"String\":\"nested-value\",\"Boolean\":true,\"RecursiveList\":[{\"String\":\"string-only\"},{\"RecursiveStruct\":{\"MapOfStrings\":{\"color\":\"red\",\"size\":\"large\"}}}]}}",
         bodyMediaType: "application/json",
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             String: "top-value",
             Boolean: false,

--- a/smithy-aws-protocol-tests/model/awsQuery/input.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input.smithy
@@ -24,6 +24,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -44,6 +47,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -64,6 +70,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -82,6 +91,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -100,6 +112,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -118,6 +133,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -136,6 +154,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -176,6 +197,9 @@ apply QueryTimestamps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=QueryTimestamps
               &Version=2020-01-08
@@ -220,6 +244,9 @@ apply NestedStructures @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=NestedStructures
               &Version=2020-01-08
@@ -265,6 +292,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
@@ -280,6 +310,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08

--- a/smithy-aws-protocol-tests/model/ec2Query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input.smithy
@@ -25,6 +25,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -45,6 +48,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -65,6 +71,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -83,6 +92,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -101,6 +113,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -119,6 +134,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -137,6 +155,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -155,6 +176,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -173,6 +197,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -191,6 +218,9 @@ apply SimpleInputParams @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=SimpleInputParams
               &Version=2020-01-08
@@ -241,6 +271,9 @@ apply QueryTimestamps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=QueryTimestamps
               &Version=2020-01-08
@@ -285,6 +318,9 @@ apply NestedStructures @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=NestedStructures
               &Version=2020-01-08
@@ -330,6 +366,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08
@@ -345,6 +384,9 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: """
               Action=QueryIdempotencyTokenAutoFill
               &Version=2020-01-08

--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -31,6 +31,9 @@ apply HttpPayloadTraits @httpRequestTests([
         headers: {
             "X-Foo": "Foo"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             foo: "Foo",
             blob: "blobby blob blob"
@@ -110,6 +113,9 @@ apply HttpPayloadTraitsWithMediaType @httpRequestTests([
             "X-Foo": "Foo",
             "Content-Type": "text/plain"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             foo: "Foo",
             blob: "blobby blob blob"
@@ -170,6 +176,9 @@ apply HttpPayloadWithStructure @httpRequestTests([
         headers: {
             "Content-Type": "application/json"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             nested: {
                 greeting: "hello",

--- a/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
@@ -31,6 +31,9 @@ apply HttpPayloadTraits @httpRequestTests([
         headers: {
             "X-Foo": "Foo"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             foo: "Foo",
             blob: "blobby blob blob"
@@ -110,6 +113,9 @@ apply HttpPayloadTraitsWithMediaType @httpRequestTests([
             "X-Foo": "Foo",
             "Content-Type": "text/plain"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             foo: "Foo",
             blob: "blobby blob blob"
@@ -171,6 +177,9 @@ apply HttpPayloadWithStructure @httpRequestTests([
         headers: {
             "Content-Type": "application/xml"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             nested: {
                 greeting: "hello",
@@ -236,6 +245,9 @@ apply HttpPayloadWithXmlName @httpRequestTests([
         headers: {
             "Content-Type": "application/xml"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             nested: {
                 name: "Phreddy"
@@ -296,6 +308,9 @@ apply HttpPayloadWithXmlNamespace @httpRequestTests([
         headers: {
             "Content-Type": "application/xml"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             nested: {
                 name: "Phreddy"
@@ -359,6 +374,9 @@ apply HttpPayloadWithXmlNamespaceAndPrefix @httpRequestTests([
         headers: {
             "Content-Type": "application/xml"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             nested: {
                 name: "Phreddy"


### PR DESCRIPTION
Adds Content-Length as an expected header to be serialized in AWS protocol requests for structured and blob payloads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
