### PR TITLE
Fix casing of passthroughBehavior in openapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Smithy Changelog
 
+## 1.0.7 (TBD)
+
+### Bug Fixes
+
+* Fixed a bug where `passthroughBehavior` was misspelled as `passThroughBehavior`
+  in APIGateway OpenAPI output for integrations and mock integrations.
+
 ## 1.0.6 (2020-06-24)
 
 ### Features

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
@@ -32,6 +32,7 @@
                     },
                     "cacheNamespace": "cache namespace",
                     "cacheKeyParameters": [],
+                    "passThroughBehavior": "never",
                     "responses": {
                         "2\\d{2}": {
                             "statusCode": "200",
@@ -112,6 +113,7 @@
                         "integration.request.path.stage": "method.request.querystring.version",
                         "integration.request.querystring.provider": "method.request.querystring.vendor"
                     },
+                    "passThroughBehavior": "when_no_match",
                     "responses": {
                         "2\\d{2}": {
                             "statusCode": "200",

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
@@ -76,6 +76,7 @@
             "application/xml": "#set ($root=$input.path('$')) <stage>$root.name</stage> ",
             "application/json": "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }"
           },
+          "passthroughBehavior": "never",
           "responses": {
             "302": {
               "statusCode": "302",
@@ -169,6 +170,7 @@
             "application/xml": "#set ($root=$input.path('$')) <stage>$root.name</stage> ",
             "application/json": "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }"
           },
+          "passthroughBehavior": "when_no_match",
           "responses": {
             "302": {
               "statusCode": "302",


### PR DESCRIPTION
This fixes a bug where "passthroughBehavior" was misspelled as "passThroughBehavior" in the apigateway openapi output.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
