### PR TITLE
Fix multiline doc comment parsing on members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Bug Fixes
 
 * Fixed a bug where `passthroughBehavior` was misspelled as `passThroughBehavior`
-  in APIGateway OpenAPI output for integrations and mock integrations.
+  in APIGateway OpenAPI output for integrations and mock integrations. ([#495](https://github.com/awslabs/smithy/pull/495))
+* Fixed a bug where only the last line in a multiline doc comment on a
+  member would be successfully parsed. ([#498](https://github.com/awslabs/smithy/pull/498))
 
 ## 1.0.6 (2020-06-24)
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -658,6 +658,7 @@ final class IdlModelParser extends SimpleParser {
         int start = position();
         consumeRemainingCharactersOnLine();
         br();
+        sp();
         return StringUtils.stripEnd(sliceFrom(start), " \t\r\n");
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -29,6 +29,8 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.StringTrait;
 import software.amazon.smithy.model.validation.ValidatedResultException;
 
 public class IdlModelLoaderTest {
@@ -115,5 +117,18 @@ public class IdlModelLoaderTest {
         });
 
         assertThat(e.getMessage(), containsString("Parser exceeded the maximum allowed depth of"));
+    }
+
+    @Test
+    public void handlesMultilineDocComments() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("multiline-comments.smithy"))
+                .assemble()
+                .unwrap();
+
+        Shape shape = model.expectShape(ShapeId.from("smithy.example#MyStruct$myMember"));
+        String docs = shape.getTrait(DocumentationTrait.class).map(StringTrait::getValue).orElse("");
+
+        assertThat(docs, equalTo("This is the first line.\nThis is the second line."));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/multiline-comments.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/multiline-comments.smithy
@@ -1,0 +1,7 @@
+namespace smithy.example
+
+structure MyStruct {
+    /// This is the first line.
+    /// This is the second line.
+    myMember: String
+}


### PR DESCRIPTION
This fixes an issue where multiline doc comments would not work on
members due to the parser only consuming to the end of the current
line and then checking for the forward slashes. Since there will
usually be indentation here for members, the parsing ended too early.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.