### PR TITLE
Disallow problematic identifiers

### DIFF
--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -216,6 +216,12 @@ The Smithy IDL is defined by the following ABNF:
     trait_structure_kvp :`node_object_key` `ws` ":" `ws` `node_value`
     apply_statement :"apply" `ws` `shape_id` `ws` `trait` `br`
 
+.. rubric:: Shape ID
+
+.. seealso::
+
+    Refer to :ref:`shape-id` for the ABNF grammar of shape IDs.
+
 
 .. _comments:
 

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -445,7 +445,9 @@ Shape IDs are formally defined by the following ABNF:
     root_shape_id          :`absolute_root_shape_id` / `identifier`
     absolute_root_shape_id :`namespace` "#" `identifier`
     namespace              :`identifier` *("." `identifier`)
-    identifier             :(ALPHA / "_") *(ALPHA / DIGIT / "_")
+    identifier             :identifier_start *identifier_chars
+    identifier_start       :*"_" ALPHA
+    identifier_chars       :ALPHA / DIGIT / "_"
     shape_id_member        :"$" `identifier`
 
 .. rubric:: Best practices for defining shape names

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -941,7 +941,8 @@ public class SelectorTest {
                 "${\nfoo\n}\n",
                 "${a}",
                 "${a_b_c}",
-                "${_}");
+                "${_a}",
+                "${__a}");
 
         for (String expr : exprs) {
             Selector.parse(expr);
@@ -956,7 +957,9 @@ public class SelectorTest {
                 "${}",
                 "$}",
                 "${a",
-                "${*}");
+                "${*}",
+                "${_}",
+                "${__}");
 
         for (String expr : exprs) {
             Assertions.assertThrows(SelectorSyntaxException.class, () -> Selector.parse(expr));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeIdTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeIdTest.java
@@ -170,7 +170,6 @@ public class ShapeIdTest {
                 { "Mixed.case#name", false},
                 { "_foo.baz#name", false},
                 { "__foo.baz#name", false},
-                { "a._.b#name", false},
 
                 // invalid namespaces
                 { "#name", true},
@@ -179,6 +178,8 @@ public class ShapeIdTest {
                 { ".name.space#name", true},
                 { "name-space#name", true},
                 { "1namespace.foo#name", true},
+                { "a._.b#name", true},
+                { "a.____.b#name", true},
 
                 // valid shape names
                 { "ns.foo#shapename", false},

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/invalid-unquoted-shape-id.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/invalid-unquoted-shape-id.smithy
@@ -1,5 +1,5 @@
 // Parse error at line 3, column 19 near `#\n`: Expected a valid identifier character, but found '#'
 
-metadata abc = __$#
+metadata abc = aa$#
 
 namespace foo.baz

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/shape-name-syntax2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/shape-name-syntax2.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 11 near `%I`: Expected a valid identifier character, but found '%'
+namespace com.foo
+
+structure %Invalid {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/shape-name-syntax3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/shape-name-syntax3.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 12 near ` `: Expected a valid identifier character, but found ' '
+namespace com.foo
+
+structure _ {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/use/use-invalid-namespace.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/use/use-invalid-namespace.smithy
@@ -3,4 +3,4 @@ $version: "1.0"
 
 namespace smithy.example
 
-use _$#Bar
+use a$#Bar


### PR DESCRIPTION
These newly disallowed identifiers were never actually supported in
practice and are problematic on multiple levels:

1. An identifier like `_` or `__` are bad names that don't help users understand an API.
2. Identifiers like `_` are problematic for languages like Rust that use this character for pattern matching.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
