### PR TITLE
Fixup AWS REST-JSON streaming protocol test URI paths

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -111,7 +111,7 @@ apply StreamingTraitsRequireLength @httpRequestTests([
         documentation: "Serializes a blob in the HTTP payload with a required length",
         protocol: restJson1,
         method: "POST",
-        uri: "/StreamingTraits",
+        uri: "/StreamingTraitsRequireLength",
         body: "blobby blob blob",
         headers: {
             "X-Foo": "Foo",
@@ -130,7 +130,7 @@ apply StreamingTraitsRequireLength @httpRequestTests([
         documentation: "Serializes an empty blob in the HTTP payload",
         protocol: restJson1,
         method: "POST",
-        uri: "/StreamingTraits",
+        uri: "/StreamingTraitsRequireLength",
         body: "",
         headers: {
             "X-Foo": "Foo"


### PR DESCRIPTION
Fixes AWS REST-JSON protocol test for streaming with required length test operation to use correct URI path.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
