### PR TITLE
TraceFile create abstractions

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/DefinitionsProvider.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/DefinitionsProvider.java
@@ -35,9 +35,10 @@ public class DefinitionsProvider extends SymbolProviderDecorator {
     public Symbol toSymbol(Shape shape) {
         Symbol symbol = provider.toSymbol(shape);
         if (!isArtifactDefinitionsFilled) {
-            symbol.toBuilder().putProperty(TraceFile.DEFINITIONS_TEXT,definitions);
+            symbol = symbol.toBuilder().putProperty(TraceFile.DEFINITIONS_TEXT, definitions).build();
             isArtifactDefinitionsFilled = true;
         }
         return symbol;
     }
+
 }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/DefinitionsProvider.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/DefinitionsProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import software.amazon.smithy.model.shapes.Shape;
+
+public class DefinitionsProvider extends SymbolProviderDecorator {
+    protected ArtifactDefinitions definitions;
+    private boolean isArtifactDefinitionsFilled = false;
+
+    /**
+     * Constructor for {@link SymbolProviderDecorator}.
+     *
+     * @param provider The {@link SymbolProvider} to be decorated.
+     */
+    public DefinitionsProvider(SymbolProvider provider, ArtifactDefinitions definitions) {
+        super(provider);
+        this.definitions = definitions;
+    }
+
+    @Override
+    public Symbol toSymbol(Shape shape) {
+        Symbol symbol = provider.toSymbol(shape);
+        if (!isArtifactDefinitionsFilled) {
+            symbol.toBuilder().putProperty(TraceFile.DEFINITIONS_TEXT,definitions);
+            isArtifactDefinitionsFilled = true;
+        }
+        return symbol;
+    }
+}

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolProviderDecorator.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolProviderDecorator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+
+public class SymbolProviderDecorator implements SymbolProvider {
+    protected SymbolProvider provider;
+
+    /**
+     * Constructor for {@link SymbolProviderDecorator}.
+     *
+     * @param provider The {@link SymbolProvider} to be decorated.
+     */
+    public SymbolProviderDecorator(SymbolProvider provider) {
+        this.provider = provider;
+    }
+
+    /**
+     * Gets the symbol to define for the given shape.
+     *
+     * <p>A "symbol" represents the qualified name of a type in a target
+     * programming language.
+     *
+     * <ul>
+     *     <li>When given a structure, union, resource, or service shape,
+     *     this method should provide the namespace and name of the type to
+     *     generate.</li>
+     *     <li>When given a simple type like a string, number, or timestamp,
+     *     this method should return the language-specific type of the
+     *     shape.</li>
+     *     <li>When given a member shape, this method should return the
+     *     language specific type to use as the target of the member.</li>
+     *     <li>When given a list, set, or map, this method should return the
+     *     language specific type to use for the shape (e.g., a map shape for
+     *     a Python code generator might return "dict".</li>
+     * </ul>
+     *
+     * @param shape Shape to get the class name of.
+     * @return Returns the generated class name.
+     */
+    @Override
+    public Symbol toSymbol(Shape shape) {
+        Symbol symbol = provider.toSymbol(shape);
+        return symbol;
+    }
+
+    /**
+     * Converts a member shape to a member/property name of a containing
+     * data structure.
+     *
+     * <p>The default implementation will return the member name of
+     * the provided shape ID and should be overridden if necessary.
+     *
+     * @param shape Shape to convert.
+     * @return Returns the converted member name.
+     */
+    @Override
+    public String toMemberName(MemberShape shape) {
+        return provider.toMemberName(shape);
+    }
+
+}

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TraceProvider.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TraceProvider.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import java.util.UUID;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.EnumTrait;
+
+public class TraceProvider extends SymbolProviderDecorator {
+    private TraceFile.Builder traceFileBuilder = TraceFile.builder();;
+
+    private boolean isMetadataFilled = false;
+    private boolean isDefinitionsFilled = false;
+
+    /**
+     * Constructor for {@link SymbolProviderDecorator}.
+     *
+     * @param provider The {@link SymbolProvider} to be decorated.
+     */
+    public TraceProvider(SymbolProvider provider) {
+        super(provider);
+    }
+
+    @Override
+    public Symbol toSymbol(Shape shape) {
+        Symbol symbol = provider.toSymbol(shape);
+
+        if (!Prelude.isPreludeShape(shape.getId())) {
+            //if metadata hasn't been filled yet
+            if (!isMetadataFilled) {
+                //if a language specific code generator has added an artifact property to our symbol
+                if (symbol.getProperty(TraceFile.ARTIFACT_TEXT).isPresent()) {
+                    traceFileBuilder.artifact(
+                            symbol.expectProperty(TraceFile.ARTIFACT_TEXT, ArtifactMetadata.class));
+                }
+                //use default ArtifactMetadata construction
+                else {
+                    traceFileBuilder.artifact(fillArtifactMetadata(symbol));
+                }
+                isMetadataFilled = true;
+            }
+
+            //if a language specific code generator has added a definitions property to our symbol
+            if (!isDefinitionsFilled && symbol.getProperty(TraceFile.DEFINITIONS_TEXT).isPresent()) {
+                traceFileBuilder.definitions(
+                        symbol.expectProperty(TraceFile.DEFINITIONS_TEXT, ArtifactDefinitions.class));
+                isDefinitionsFilled = true;
+            }
+
+            //filling the ShapeLink for this symbol
+            ShapeLink link;
+            //if a language specific code generator has added a ShapeLink property to our symbol
+            if (symbol.getProperty(TraceFile.SHAPES_TEXT).isPresent()) {
+                link = symbol.expectProperty(TraceFile.SHAPES_TEXT, ShapeLink.class);
+            }
+            else {
+                link = getShapeLink(symbol);
+            }
+            traceFileBuilder.addShapeLink(shape.getId(),link);
+        }
+        return symbol;
+    }
+
+    public TraceFile getTraceFile() {
+        return traceFileBuilder.build();
+    }
+
+    /**
+     * Fills ArtifactMetadata with a type and timestamp based on symbol, and a temporary UUID for version and
+     * id to be replaced once the version and id for the generated code are known.
+     *
+     * @param symbol Symbol to extract metadata from.
+     */
+    public static ArtifactMetadata fillArtifactMetadata(Symbol symbol) {
+        //temporarily set id and version as a UUID, this should be changed later once the version is known
+        String tempIdVersion = UUID.randomUUID().toString();
+        return ArtifactMetadata.builder()
+                .version(tempIdVersion)
+                .id(tempIdVersion)
+                .type(getArtifactMetadataType(symbol))
+                .setTimestampAsNow()
+                .build();
+    }
+
+    /**
+     * Gets the language type for ArtifactMetadata from the file extension of the source file of a symbol.
+     * Language specific code generators can implement their own version of this.
+     *
+     * @param symbol Symbol to extract type from.
+     * @return String with the type of language.
+     */
+    public static String getArtifactMetadataType(Symbol symbol) {
+        String type = "";
+        String[] split = symbol.getDefinitionFile().split("\\.");
+        String extension = split[split.length - 1].toLowerCase();
+        switch (extension) {
+            case "ts":
+                type = "TypeScript";
+                break;
+            case "go":
+                type = "Go";
+                break;
+            case "py":
+                type = "Python";
+                break;
+            case "java":
+                type = "Java";
+                break;
+            case "c":
+                type = "C";
+                break;
+            case "rs":
+                type = "Rust";
+                break;
+            default:
+                type = "unrecognized type";
+                break;
+        }
+        return type;
+    }
+
+    /**
+     * Extracts a {@link ShapeId} from a {@link Symbol} and creates a {@link ShapeLink} using all default mappings
+     * defined in this class. The created ShapeLink has a type, id, and file.
+     *
+     * @param symbol The {@link Symbol} to extract information from for the {@link TraceFile}'s shapes map.
+     */
+    public static ShapeLink getShapeLink(Symbol symbol) {
+        //set ShapeLink's file
+        ShapeLink.Builder builder = ShapeLink.builder()
+                .type(getShapeLinkType(symbol))
+                .id(getShapeLinkId(symbol))
+                .file(getShapeLinkFile(symbol));
+
+        return builder.build();
+    }
+
+    /**
+     * Provides a default mapping from a {@link Symbol} to an Id.
+     *
+     * @param symbol {@link Symbol} to extract an id from.
+     * @return String that contains the extracted id.
+     */
+    public static String getShapeLinkId(Symbol symbol) {
+        return symbol.toString()
+                .replace(".", "")
+                .replace(symbol.getNamespaceDelimiter(), ".");
+    }
+
+    /**
+     * Provides a default mapping from a symbol to type where default type values are "FIELD","ENUM", and "METHOD".
+     *
+     * @param symbol The symbol to extract a type from.
+     * @return String that contains the extracted type.
+     */
+    public static String getShapeLinkType(Symbol symbol) {
+        String type = "FIELD";
+        for (Object object : symbol.getProperties().keySet()) {
+            if (object.getClass().equals(EnumTrait.class)) {
+                type = "ENUM";
+            } else if (object.getClass().equals(Symbol.class)) {
+                type = "METHOD";
+            }
+        }
+        return type;
+    }
+
+    /**
+     * Provides a default mapping from a symbol to a ShapeLink's file.
+     *
+     * @param symbol The symbol to extract a file from.
+     * @return String that contains the extracted file.
+     */
+    public static String getShapeLinkFile(Symbol symbol) {
+        return symbol.getDefinitionFile();
+    }
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/DefinitionsProviderTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/DefinitionsProviderTest.java
@@ -1,0 +1,54 @@
+package software.amazon.smithy.codegen.core;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StringShape;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class DefinitionsProviderTest {
+    @Test
+    void assertToSymbolAddsDefinitionsToTraceFile() {
+        Map<String, String> tagMap = new HashMap<>();
+        tagMap.put("tag1", "tag1val");
+        tagMap.put("tag2", "tag2val");
+
+        Map<String, String> typeMap = new HashMap<>();
+        tagMap.put("t1", "t1val");
+        tagMap.put("t2", "t2val");
+
+        ArtifactDefinitions definitions = ArtifactDefinitions.builder()
+                .tags(tagMap)
+                .types(typeMap)
+                .build();
+
+        TraceProvider traceProvider = new TraceProvider(
+                new DefinitionsProvider(new TraceProviderTest.SymbolProviderTestHelper(), definitions));
+
+        //adding shapes to our TraceFile so that it can build
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("service-with-shapeids.smithy"))
+                .assemble()
+                .unwrap();
+
+        for (Shape shape : model.toSet()) {
+            traceProvider.toSymbol(shape);
+        }
+
+        //verifying the resulting trace file can be written and parsed without exceptions
+        Node node = traceProvider.getTraceFile().toNode();
+        TraceFile traceFile = TraceFile.fromNode((node));
+
+        //checking that the definitions component of our trace file is what it should be
+        assertThat(traceFile.getArtifactDefinitions().get().getTags(), equalTo(tagMap));
+        assertThat(traceFile.getArtifactDefinitions().get().getTypes(), equalTo(typeMap));
+    }
+
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/DefinitionsProviderTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/DefinitionsProviderTest.java
@@ -1,14 +1,11 @@
 package software.amazon.smithy.codegen.core;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.StringShape;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -21,8 +18,8 @@ class DefinitionsProviderTest {
         tagMap.put("tag2", "tag2val");
 
         Map<String, String> typeMap = new HashMap<>();
-        tagMap.put("t1", "t1val");
-        tagMap.put("t2", "t2val");
+        typeMap.put("t1", "t1val");
+        typeMap.put("t2", "t2val");
 
         ArtifactDefinitions definitions = ArtifactDefinitions.builder()
                 .tags(tagMap)

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/TraceProviderTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/TraceProviderTest.java
@@ -1,0 +1,91 @@
+package software.amazon.smithy.codegen.core;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.EnumDefinition;
+import software.amazon.smithy.model.traits.EnumTrait;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+
+class TraceProviderTest {
+
+    @Test
+    void assertToSymbolCreatesTraceFileWithRequiredFields() {
+        TraceProvider traceProvider = new TraceProvider(new SymbolProviderTestHelper());
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("service-with-shapeids.smithy"))
+                .assemble()
+                .unwrap();
+
+        for (Shape shape : model.toSet()) {
+            traceProvider.toSymbol(shape);
+        }
+
+        //verifying that it can be written and parsed without exception
+        Node node = traceProvider.getTraceFile().toNode();
+        TraceFile traceFile = TraceFile.fromNode((node));
+
+        //verifying TraceFile ArtifactMetadata contains the correct type
+        assertThat(traceFile.getArtifactMetadata().getType(), equalTo("TypeScript"));
+
+        model.toSet().parallelStream().forEach(shape -> {
+            if(!Prelude.isPreludeShape(shape)) { //ignoring everything in smithy.api
+                ShapeId x = shape.getId();
+                assertThat(traceFile.getShapes(), hasKey(x));
+                assertThat(traceFile.getShapes().get(x).get(0).getType(), equalTo("FIELD"));
+                assertThat(traceFile.getShapes().get(x).get(0).getFile().get(), equalTo("namespace.ts"));
+            }
+        });
+    }
+
+    @Test
+    void assertGetShapeLinkCreatesShapeLinkFromSymbol() {
+        Symbol symbol = Symbol.builder()
+                .definitionFile("my_name.py")
+                .namespace("namespace/name", "/")
+                .name("baz")
+                .build();
+
+        ShapeLink link = TraceProvider.getShapeLink(symbol);
+        assertThat(link.getId(), equalTo("namespace.name.baz"));
+        assertThat(link.getType(), equalTo("FIELD"));
+        assertThat(link.getFile().get(), equalTo("my_name.py"));
+    }
+
+    @Test
+    void assertFillArtifactMetadataGeneratesCorrectMetadata() {
+        Symbol symbol = Symbol.builder()
+                .definitionFile("my_name.py")
+                .namespace("namespace/name", "/")
+                .name("baz")
+                .build();
+
+        ArtifactMetadata metadata = TraceProvider.fillArtifactMetadata(symbol);
+        assertThat(metadata.getType(), equalTo("Python"));
+        assertThat(Instant.parse(metadata.getTimestamp()), is(Instant.class));
+        assertThat(UUID.fromString(metadata.getId()), is(UUID.class));
+    }
+
+    //mock class that substitutes for language-specific symbol provider
+    static class SymbolProviderTestHelper implements SymbolProvider {
+        @Override
+        public Symbol toSymbol(Shape shape) {
+            return Symbol.builder().putProperty("shape", shape)
+                    .name("boolean")
+                    .namespace("namespace", "/")
+                    .definitionFile("namespace.ts").build();
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:* Smithy lacks ability to automatically generate trace file during codegen.

*Description of changes:* Provide abstractions to automatically produce a trace file during codegen.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
