### PR TITLE
Don't raise validation erros from renaming

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -150,7 +150,7 @@ public final class ModelTransformer {
             Model model,
             Map<ShapeId, ShapeId> renamed
     ) {
-        return this.renameShapes(model, renamed, Model::assembler);
+        return this.renameShapes(model, renamed, () -> Model.assembler().disableValidation());
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RenameShapes.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.utils.Pair;
 
 /**
@@ -69,9 +70,11 @@ final class RenameShapes {
         // Use visitor to traverse node and rebuild model.
         Node newModel = node.accept(new RenameShapeVisitor(toRename, renamed));
 
-        return assembler.addDocumentNode(newModel)
-                .assemble()
-                .unwrap();
+        ValidatedResult<Model> result = assembler.addDocumentNode(newModel).assemble();
+
+        // Transformers shouldn't perform validation ideally. They should only throw errors if the model
+        // can't be transformed.
+        return result.getResult().orElseGet(result::unwrap);
     }
 
     private static final class RenameShapeVisitor extends NodeVisitor.Default<Node> {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -371,5 +372,19 @@ public class RenameShapesTest {
             assertEquals(newMember.getId(), newMemberId);
         });
         assertFalse(result.getShape(containerId).isPresent());
+    }
+
+    @Test
+    public void transformationDoesntTriggerValidation() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("rename-with-resulting-errors.json"))
+                .assemble().unwrap();
+
+        Model result = ModelTransformer.create().renameShapes(model, Collections.singletonMap(
+                ShapeId.from("com.example.foo#string"), ShapeId.from("com.example#string")
+        ));
+
+        assertTrue(result.getShape(ShapeId.from("com.example#string")).isPresent());
+        assertTrue(result.getShape(ShapeId.from("com.example#String")).isPresent());
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-with-resulting-errors.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/rename-with-resulting-errors.json
@@ -1,0 +1,11 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "com.example#String": {
+            "type": "string"
+        },
+        "com.example.foo#string": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
None of the other transformers raise validation errors when
they produce a model in an invalid state, so the rename transformer
shouldn't either. With this change a tool could attempt to resolve
any issue before the model is actually used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.