### PR TITLE
Improve dulplicate member handling

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-list-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-list-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Duplicate shape definition for `com.foo#List$member` found at | Model
+[ERROR] -: Parse error at line 5, column 11 near `: `: Duplicate member of com.foo#List: 'member' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-map-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-map-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Parse error at line 5, column 8 near `: `: Unexpected member of com.foo#Map: 'key' | Model
+[ERROR] -: Parse error at line 5, column 8 near `: `: Duplicate member of com.foo#Map: 'key' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-set-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-set-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Duplicate shape definition for `com.foo#Set$member` found at | Model
+[ERROR] -: Parse error at line 5, column 11 near `: `: Duplicate member of com.foo#Set: 'member' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-structure-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-structure-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Duplicate shape definition for `com.foo#Struct$foo` found at | Model
+[ERROR] -: Parse error at line 5, column 8 near `: `: Duplicate member of com.foo#Struct: 'foo' | Model


### PR DESCRIPTION
This commit simplifies how we detect and report on duplicate members in
aggregate shapes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
