### PR TITLE
Improve ValidationEvent's NodeMapper support

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/ProjectionResultTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/ProjectionResultTest.java
@@ -31,7 +31,7 @@ public class ProjectionResultTest {
                 .addEvent(ValidationEvent.builder()
                         .message("foo")
                         .severity(Severity.ERROR)
-                        .eventId("abc")
+                        .id("abc")
                         .build())
                 .build().isBroken());
     }
@@ -44,7 +44,7 @@ public class ProjectionResultTest {
                 .addEvent(ValidationEvent.builder()
                         .message("foo")
                         .severity(Severity.DANGER)
-                        .eventId("abc")
+                        .id("abc")
                         .build())
                 .build().isBroken());
     }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildResultTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildResultTest.java
@@ -37,7 +37,7 @@ public class SmithyBuildResultTest {
                         .addEvent(ValidationEvent.builder()
                                           .message("foo")
                                           .severity(Severity.ERROR)
-                                          .eventId("abc")
+                                          .id("abc")
                                           .build())
                         .build())
                 .build().anyBroken());

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AbstractDiffEvaluator.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AbstractDiffEvaluator.java
@@ -75,6 +75,6 @@ public abstract class AbstractDiffEvaluator implements DiffEvaluator {
     }
 
     private ValidationEvent createEvent(ValidationEvent.Builder builder) {
-        return builder.eventId(getEventId()).build();
+        return builder.id(getEventId()).build();
     }
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedEntityBinding.java
@@ -65,7 +65,7 @@ public final class AddedEntityBinding extends AbstractDiffEvaluator {
                 "%s binding of `%s` was added to the %s shape, `%s`",
                 descriptor, addedShape, entity.getType(), entity.getId());
         return ValidationEvent.builder()
-                .eventId(eventId)
+                .id(eventId)
                 .severity(Severity.NOTE)
                 .shape(entity)
                 .message(message)

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedMetadata.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedMetadata.java
@@ -30,7 +30,7 @@ public final class AddedMetadata extends AbstractDiffEvaluator {
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.addedMetadata()
                 .map(metadata -> ValidationEvent.builder()
-                        .eventId(getEventId())
+                        .id(getEventId())
                         .severity(Severity.NOTE)
                         .sourceLocation(metadata.getRight().getSourceLocation())
                         .message(String.format(

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationInputOutput.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationInputOutput.java
@@ -68,7 +68,7 @@ public final class AddedOperationInputOutput implements DiffEvaluator {
             if (struct.getAllMembers().values().stream().noneMatch(MemberShape::isRequired)) {
                 // This is a backward compatible change.
                 return ValidationEvent.builder()
-                        .eventId(eventId)
+                        .id(eventId)
                         .severity(Severity.NOTE)
                         .shape(operation)
                         .message(String.format(
@@ -79,7 +79,7 @@ public final class AddedOperationInputOutput implements DiffEvaluator {
 
             // This is a breaking change!
             return ValidationEvent.builder()
-                    .eventId(eventId)
+                    .id(eventId)
                     .severity(Severity.ERROR)
                     .shape(operation)
                     .message(String.format(

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedTraitDefinition.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedTraitDefinition.java
@@ -31,7 +31,7 @@ public final class AddedTraitDefinition extends AbstractDiffEvaluator {
         return differences.addedShapes()
                 .filter(shape -> shape.hasTrait(TraitDefinition.class))
                 .map(shape -> ValidationEvent.builder()
-                        .eventId(getEventId())
+                        .id(getEventId())
                         .severity(Severity.NOTE)
                         .shape(shape)
                         .message(String.format("Trait definition `%s` was added", shape.getId()))

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberTarget.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberTarget.java
@@ -50,7 +50,7 @@ public final class ChangedMemberTarget extends AbstractDiffEvaluator {
 
         return ValidationEvent.builder()
                 .severity(severity)
-                .eventId(getEventId())
+                .id(getEventId())
                 .shape(change.getNewShape())
                 .message(createMessage(change, oldTarget, newTarget))
                 .build();

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMetadata.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMetadata.java
@@ -30,7 +30,7 @@ public final class ChangedMetadata extends AbstractDiffEvaluator {
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.changedMetadata()
                 .map(metadata -> ValidationEvent.builder()
-                        .eventId(getEventId())
+                        .id(getEventId())
                         .severity(Severity.WARNING)
                         .sourceLocation(metadata)
                         .message(String.format(

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -65,7 +65,7 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
                 "%s binding of `%s` was removed from %s shape, `%s`",
                 descriptor, removedShape, entity.getType(), entity.getId());
         return ValidationEvent.builder()
-                .eventId(eventId)
+                .id(eventId)
                 .severity(Severity.ERROR)
                 .shape(entity)
                 .message(message)

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedMetadata.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedMetadata.java
@@ -30,7 +30,7 @@ public final class RemovedMetadata extends AbstractDiffEvaluator {
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.removedMetadata()
                 .map(metadata -> ValidationEvent.builder()
-                        .eventId(getEventId())
+                        .id(getEventId())
                         .severity(Severity.DANGER)
                         .sourceLocation(metadata.getRight().getSourceLocation())
                         .message(String.format(

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinition.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinition.java
@@ -31,7 +31,7 @@ public final class RemovedTraitDefinition extends AbstractDiffEvaluator {
         return differences.removedShapes()
                 .filter(shape -> shape.hasTrait(TraitDefinition.class))
                 .map(shape -> ValidationEvent.builder()
-                        .eventId(getEventId())
+                        .id(getEventId())
                         .severity(Severity.ERROR)
                         .shape(shape)
                         .message(String.format("Trait definition `%s` was removed", shape.getId()))

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/TestHelper.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/TestHelper.java
@@ -24,7 +24,7 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class TestHelper {
     public static List<ValidationEvent> findEvents(List<ValidationEvent> events, String eventId) {
         return events.stream()
-                .filter(event -> event.getEventId().equals(eventId))
+                .filter(event -> event.getId().equals(eventId))
                 .collect(Collectors.toList());
     }
 

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/InputOutputStructureReuseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/InputOutputStructureReuseValidator.java
@@ -128,7 +128,7 @@ public final class InputOutputStructureReuseValidator extends AbstractValidator 
 
     private ValidationEvent emit(Model model, ShapeId shape, String message) {
         ValidationEvent.Builder builder = ValidationEvent.builder()
-                .eventId(getName())
+                .id(getName())
                 .severity(Severity.DANGER)
                 .message(message)
                 .shapeId(shape);

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/ReservedWordsValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/ReservedWordsValidator.java
@@ -166,7 +166,7 @@ public final class ReservedWordsValidator extends AbstractValidator {
         private ValidationEvent emit(Shape shape, String word, String reason) {
             return ValidationEvent.builder()
                     .severity(Severity.DANGER)
-                    .eventId(ValidatorService.determineValidatorName(ReservedWordsValidator.class))
+                    .id(ValidatorService.determineValidatorName(ReservedWordsValidator.class))
                     .shape(shape)
                     .message(format("The word `%s` is reserved. %s", word, reason))
                     .build();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -189,7 +189,7 @@ final class IdlModelParser extends SimpleParser {
                 onVersion(value);
             } else {
                 visitor.onError(ValidationEvent.builder()
-                        .eventId(Validator.MODEL_ERROR)
+                        .id(Validator.MODEL_ERROR)
                         .sourceLocation(value)
                         .severity(Severity.WARNING)
                         .message(format("Unknown control statement `%s` with value `%s", key, Node.printJson(value)))

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderVisitor.java
@@ -320,7 +320,7 @@ final class LoaderVisitor {
         if (Prelude.isImmutablePublicPreludeShape(target)) {
             onError(ValidationEvent.builder()
                     .severity(Severity.ERROR)
-                    .eventId(Validator.MODEL_ERROR)
+                    .id(Validator.MODEL_ERROR)
                     .sourceLocation(sourceLocation)
                     .shapeId(target)
                     .message(String.format(
@@ -358,7 +358,7 @@ final class LoaderVisitor {
             metadata.put(key, mergedArray);
         } else if (!metadata.get(key).equals(value)) {
             onError(ValidationEvent.builder()
-                    .eventId(Validator.MODEL_ERROR)
+                    .id(Validator.MODEL_ERROR)
                     .severity(Severity.ERROR)
                     .sourceLocation(value)
                     .message(format(
@@ -507,7 +507,7 @@ final class LoaderVisitor {
     private void emitErrorsForEachInvalidTraitTarget(ShapeId target, List<PendingTrait> pendingTraits) {
         for (PendingTrait pendingTrait : pendingTraits) {
             onError(ValidationEvent.builder()
-                    .eventId(Validator.MODEL_ERROR)
+                    .id(Validator.MODEL_ERROR)
                     .severity(Severity.ERROR)
                     .sourceLocation(pendingTrait.value.getSourceLocation())
                     .message(format("Trait `%s` applied to unknown shape `%s`",
@@ -618,7 +618,7 @@ final class LoaderVisitor {
 
     private void onDuplicateTrait(ShapeId target, ShapeId traitName, FromSourceLocation previous, Node duplicate) {
         onError(ValidationEvent.builder()
-                .eventId(Validator.MODEL_ERROR)
+                .id(Validator.MODEL_ERROR)
                 .severity(Severity.ERROR)
                 .sourceLocation(duplicate.getSourceLocation())
                 .shapeId(target)
@@ -635,7 +635,7 @@ final class LoaderVisitor {
 
         // Fail if the trait cannot be resolved.
         onError(ValidationEvent.builder()
-                .eventId(Validator.MODEL_ERROR)
+                .id(Validator.MODEL_ERROR)
                 .severity(severity)
                 .sourceLocation(trait.value.getSourceLocation())
                 .shapeId(shapeBuilder.getId())

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
@@ -151,7 +151,7 @@ final class ModelValidator {
     private ValidationEvent unknownValidatorError(String name, SourceLocation location) {
         return ValidationEvent.builder()
                 // Per the spec, the eventID is "UnknownValidator_<validatorName>".
-                .eventId("UnknownValidator_" + name)
+                .id("UnknownValidator_" + name)
                 .severity(Severity.WARNING)
                 .sourceLocation(location)
                 .message("Unable to locate a validator named `" + name + "`")
@@ -199,9 +199,9 @@ final class ModelValidator {
     private String resolveReason(ValidationEvent event) {
         return event.getShapeId()
                 .flatMap(model::getShape)
-                .flatMap(shape -> matchSuppression(shape, event.getEventId()))
+                .flatMap(shape -> matchSuppression(shape, event.getId()))
                 // This is always evaluated if a reason hasn't been found.
-                .orElseGet(() -> matchWildcardNamespaceSuppressions(event.getEventId()));
+                .orElseGet(() -> matchWildcardNamespaceSuppressions(event.getId()));
     }
 
     private Optional<String> matchSuppression(Shape shape, String eventId) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
@@ -74,7 +74,7 @@ final class ValidatorDefinition {
             } else {
                 // Modify the event by changing the id, severity, or message.
                 ValidationEvent.Builder builder = event.toBuilder();
-                builder.eventId(id != null ? id : event.getEventId());
+                builder.id(id != null ? id : event.getId());
                 builder.severity(severity != null ? severity : event.getSeverity());
                 if (message != null) {
                     builder.message(message.replace("{super}", event.getMessage()));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorFromDefinitionFactory.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorFromDefinitionFactory.java
@@ -45,7 +45,7 @@ final class ValidatorFromDefinitionFactory {
         } catch (RuntimeException e) {
             return ValidatedResult.fromErrors(ListUtils.of(
                     ValidationEvent.builder()
-                            .eventId(Validator.MODEL_ERROR)
+                            .id(Validator.MODEL_ERROR)
                             .sourceLocation(definition.sourceLocation)
                             .severity(Severity.ERROR)
                             .message(format("Error creating `%s` validator: %s", definition.name, e.getMessage()))

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/AbstractValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/AbstractValidator.java
@@ -66,6 +66,6 @@ public abstract class AbstractValidator implements Validator {
     }
 
     private ValidationEvent createEvent(ValidationEvent.Builder builder) {
-        return builder.eventId(getName()).build();
+        return builder.id(getName()).build();
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatter.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatter.java
@@ -53,7 +53,7 @@ public final class ContextualValidationEventFormatter implements ValidationEvent
         formatter.format("%s: %s (%s)%n",
                          event.getSeverity(),
                          event.getShapeId().map(ShapeId::toString).orElse("-"),
-                         event.getEventId());
+                         event.getId());
 
         if (event.getSourceLocation() != SourceLocation.NONE) {
             String humanReadableFilename = getHumanReadableFilename(event.getSourceLocation());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/LineValidationEventFormatter.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/LineValidationEventFormatter.java
@@ -35,7 +35,7 @@ public final class LineValidationEventFormatter implements ValidationEventFormat
                 event.getSeverity(),
                 event.getShapeId().map(ShapeId::toString).orElse("-"),
                 message,
-                event.getEventId(),
+                event.getId(),
                 event.getSourceLocation().getFilename(),
                 event.getSourceLocation().getLine(),
                 event.getSourceLocation().getColumn());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -360,7 +360,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     private ValidationEvent event(String message, Severity severity, SourceLocation sourceLocation) {
         return ValidationEvent.builder()
-                .eventId(eventId)
+                .id(eventId)
                 .severity(severity)
                 .sourceLocation(sourceLocation)
                 .shapeId(eventShapeId)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
@@ -56,7 +56,7 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
         this.sourceLocation = SmithyBuilder.requiredState("sourceLocation", builder.sourceLocation);
         this.message = SmithyBuilder.requiredState("message", builder.message);
         this.severity = SmithyBuilder.requiredState("severity", builder.severity);
-        this.eventId = SmithyBuilder.requiredState("eventId", builder.eventId);
+        this.eventId = SmithyBuilder.requiredState("id", builder.eventId);
         this.shapeId = builder.shapeId;
         this.suppressionReason = builder.suppressionReason;
     }
@@ -85,7 +85,7 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
     public static ValidationEvent fromSourceException(SourceException exception, String prefix) {
         // Get the message without source location since it's in the event.
         return ValidationEvent.builder()
-                .eventId(MODEL_ERROR)
+                .id(MODEL_ERROR)
                 .severity(ERROR)
                 .message(prefix + exception.getMessageWithoutLocation())
                 .sourceLocation(exception.getSourceLocation())
@@ -160,7 +160,7 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
     @Override
     public Node toNode() {
         return Node.objectNodeBuilder()
-                .withMember("id", Node.from(getEventId()))
+                .withMember("id", Node.from(getId()))
                 .withMember("severity", Node.from(getSeverity().toString()))
                 .withOptionalMember("shapeId", getShapeId().map(Object::toString).map(Node::from))
                 .withMember("message", Node.from(getMessage()))
@@ -198,8 +198,20 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
      * <p>The validation event identifier can be used to suppress events.
      *
      * @return Returns the event ID.
+     * @deprecated Use the {@code getId()} method to match the node format.
      */
     public String getEventId() {
+        return getId();
+    }
+
+    /**
+     * Returns the identifier of the validation event.
+     *
+     * <p>The validation event identifier can be used to suppress events.
+     *
+     * @return Returns the event ID.
+     */
+    public String getId() {
         return eventId;
     }
 
@@ -263,8 +275,19 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
          *
          * @param eventId Event ID.
          * @return Returns the builder.
+         * @deprecated Use the {@code id(String eventId)} setter to match the node format.
          */
         public Builder eventId(final String eventId) {
+            return id(eventId);
+        }
+
+        /**
+         * Sets the required event ID of the event.
+         *
+         * @param eventId Event ID.
+         * @return Returns the builder.
+         */
+        public Builder id(final String eventId) {
             this.eventId = Objects.requireNonNull(eventId);
             return this;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/linters/EmitNoneSelectorValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/linters/EmitNoneSelectorValidator.java
@@ -82,7 +82,7 @@ public final class EmitNoneSelectorValidator extends AbstractValidator {
 
         if (shapes.isEmpty()) {
             return ListUtils.of(ValidationEvent.builder()
-                    .eventId(getName())
+                    .id(getName())
                     .severity(Severity.DANGER)
                     .message("Expected at least one shape to match selector: " + config.getSelector())
                     .build());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCase.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCase.java
@@ -128,7 +128,7 @@ public final class SmithyTestCase {
 
         String comparedMessage = expected.getMessage().replace("\n", "\\n");
         return expected.getSeverity() == actual.getSeverity()
-               && expected.getEventId().equals(actual.getEventId())
+               && expected.getId().equals(actual.getId())
                && expected.getShapeId().equals(actual.getShapeId())
                // Normalize new lines.
                && normalizedActualMessage.startsWith(comparedMessage);
@@ -162,7 +162,7 @@ public final class SmithyTestCase {
         ValidationEvent.Builder builder = ValidationEvent.builder()
                 .severity(Severity.fromString(matcher.group("severity")).get())
                 .sourceLocation(location)
-                .eventId(matcher.group("id"))
+                .id(matcher.group("id"))
                 .message(matcher.group("message"));
 
         // A shape ID of "-" means no shape.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceValidator.java
@@ -104,7 +104,7 @@ public final class ServiceValidator extends AbstractValidator {
         String declaration = severity == Severity.DANGER || severity == Severity.ERROR ? "must" : "should";
 
         return ValidationEvent.builder()
-                .eventId(getName())
+                .id(getName())
                 .severity(severity)
                 .shape(subject)
                 .message(String.format(

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -132,7 +132,7 @@ public class ModelAssemblerTest {
     @Test
     public void addsExplicitValidators() {
         ValidationEvent event = ValidationEvent.builder()
-                .severity(Severity.ERROR).eventId("Foo").message("bar").build();
+                .severity(Severity.ERROR).id("Foo").message("bar").build();
         String document = "{\"smithy\": \"" + Model.MODEL_VERSION + "\"}";
         ValidatedResult<Model> result = new ModelAssembler()
                 .addUnparsedModel(SourceLocation.NONE.getFilename(), document)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelValidatorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelValidatorTest.java
@@ -35,7 +35,7 @@ public class ModelValidatorTest {
     @Test
     public void addsExplicitValidators() {
         ValidationEvent event = ValidationEvent.builder()
-                .severity(Severity.ERROR).eventId("Foo").message("bar").build();
+                .severity(Severity.ERROR).id("Foo").message("bar").build();
         String document = "{\"smithy\": \"1.0\"}";
         ValidatedResult<Model> result = new ModelAssembler()
                 .addUnparsedModel("[N/A]", document)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
@@ -35,7 +35,7 @@ public class ValidatorDefinitionTest {
                                ? Optional.of(
                                        model -> model.shapes()
                                                .map(shape -> ValidationEvent.builder()
-                                                       .eventId(name)
+                                                       .id(name)
                                                        .shape(shape)
                                                        .severity(Severity.WARNING)
                                                        .message("Hello!")
@@ -48,12 +48,12 @@ public class ValidatorDefinitionTest {
                 .getValidationEvents();
 
         assertThat(events, not(empty()));
-        Assertions.assertEquals(2, events.stream().filter(e -> e.getEventId().equals("hello")).count());
-        Assertions.assertEquals(4, events.stream().filter(e -> e.getEventId().equals("custom")).count());
+        Assertions.assertEquals(2, events.stream().filter(e -> e.getId().equals("hello")).count());
+        Assertions.assertEquals(4, events.stream().filter(e -> e.getId().equals("custom")).count());
 
         // Ensure that template expansion works.
         for (ValidationEvent event : events) {
-            if (event.getEventId().equals("custom")) {
+            if (event.getId().equals("custom")) {
                 assertThat(event.getMessage(), equalTo("Test Hello!"));
             }
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatterTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatterTest.java
@@ -22,7 +22,7 @@ public class ContextualValidationEventFormatterTest {
 
         Shape shape = model.expectShape(ShapeId.from("example.smithy#Foo"));
         ValidationEvent event = ValidationEvent.builder()
-                .eventId("foo")
+                .id("foo")
                 .severity(Severity.ERROR)
                 .message("This is the message")
                 .shape(shape)
@@ -43,7 +43,7 @@ public class ContextualValidationEventFormatterTest {
     @Test
     public void doesNotLoadSourceLocationNone() {
         ValidationEvent event = ValidationEvent.builder()
-                .eventId("foo")
+                .id("foo")
                 .severity(Severity.ERROR)
                 .message("This is the message")
                 .sourceLocation(SourceLocation.NONE)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/ValidationEventTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/ValidationEventTest.java
@@ -35,7 +35,7 @@ public class ValidationEventTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ValidationEvent.builder()
                     .severity(Severity.ERROR)
-                    .eventId("foo")
+                    .id("foo")
                     .build();
         });
     }
@@ -45,13 +45,13 @@ public class ValidationEventTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ValidationEvent.builder()
                     .message("test")
-                    .eventId("foo")
+                    .id("foo")
                     .build();
         });
     }
 
     @Test
-    public void requiresEventId() {
+    public void requiresId() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ValidationEvent.builder()
                     .severity(Severity.ERROR)
@@ -66,7 +66,7 @@ public class ValidationEventTest {
             ValidationEvent.builder()
                     .severity(Severity.ERROR)
                     .message("test")
-                    .eventId("foo")
+                    .id("foo")
                     .suppressionReason("Some reason")
                     .build();
         });
@@ -79,13 +79,13 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(id)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .build();
 
         assertThat(event.getSeverity(), equalTo(Severity.SUPPRESSED));
         assertThat(event.getMessage(), equalTo("The message"));
-        assertThat(event.getEventId(), equalTo("abc.foo"));
+        assertThat(event.getId(), equalTo("abc.foo"));
         assertThat(event.getSuppressionReason().get(), equalTo("my reason"));
         assertThat(event.getShapeId().get(), is(id));
         assertThat(event.getSeverity(), is(Severity.SUPPRESSED));
@@ -98,7 +98,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.ERROR)
                 .shape(stringShape)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .build();
 
         assertThat(event.getSourceLocation(), is(stringShape.getSourceLocation()));
@@ -111,7 +111,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(id)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .build();
 
@@ -124,7 +124,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#baz"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .build();
         ValidationEvent other = event.toBuilder().build();
@@ -138,7 +138,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .build();
 
         assertEquals(a, a);
@@ -150,7 +150,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .build();
 
         assertNotEquals(a, "test");
@@ -162,7 +162,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .build();
         ValidationEvent b = a.toBuilder().message("other message").build();
 
@@ -176,7 +176,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .build();
         ValidationEvent b = a.toBuilder().severity(Severity.ERROR).build();
 
@@ -190,7 +190,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .sourceLocation(SourceLocation.none())
                 .build();
@@ -206,7 +206,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .sourceLocation(SourceLocation.none())
                 .build();
@@ -222,11 +222,11 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .sourceLocation(SourceLocation.none())
                 .build();
-        ValidationEvent b = a.toBuilder().eventId("other.id").build();
+        ValidationEvent b = a.toBuilder().id("other.id").build();
 
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
@@ -238,7 +238,7 @@ public class ValidationEventTest {
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
                 .shapeId(ShapeId.from("ns.foo#bar"))
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .suppressionReason("my reason")
                 .sourceLocation(SourceLocation.none())
                 .build();
@@ -253,7 +253,7 @@ public class ValidationEventTest {
         ValidationEvent a = ValidationEvent.builder()
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .build();
 
         assertEquals(a.toString(), "[SUPPRESSED] -: The message | abc.foo N/A:0:0");
@@ -264,7 +264,7 @@ public class ValidationEventTest {
         ValidationEvent a = ValidationEvent.builder()
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .shapeId(ShapeId.from("ns.foo#baz"))
                 .build();
 
@@ -276,7 +276,7 @@ public class ValidationEventTest {
         ValidationEvent a = ValidationEvent.builder()
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .shapeId(ShapeId.from("ns.foo#baz"))
                 .sourceLocation(new SourceLocation("file", 1, 2))
                 .build();
@@ -289,7 +289,7 @@ public class ValidationEventTest {
         ValidationEvent a = ValidationEvent.builder()
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .shapeId(ShapeId.from("ns.foo#baz"))
                 .suppressionReason("Foo baz bar")
                 .sourceLocation(new SourceLocation("file", 1, 2))
@@ -303,7 +303,7 @@ public class ValidationEventTest {
         ValidationEvent a = ValidationEvent.builder()
                 .message("The message")
                 .severity(Severity.SUPPRESSED)
-                .eventId("abc.foo")
+                .id("abc.foo")
                 .shapeId(ShapeId.from("ns.foo#baz"))
                 .sourceLocation(new SourceLocation("file", 1, 2))
                 .build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCaseTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCaseTest.java
@@ -50,7 +50,7 @@ public class SmithyTestCaseTest {
     @Test
     public void matchesMessageUsingPrefix() {
         ValidationEvent actual = ValidationEvent.builder()
-                .eventId("FooBar")
+                .id("FooBar")
                 .severity(Severity.DANGER)
                 .message("This is a test")
                 .build();
@@ -65,7 +65,7 @@ public class SmithyTestCaseTest {
     @Test
     public void failsWhenMessageDoesNotMatchPrefix() {
         ValidationEvent actual = ValidationEvent.builder()
-                .eventId("FooBar")
+                .id("FooBar")
                 .severity(Severity.DANGER)
                 .message("Not a test")
                 .build();
@@ -80,7 +80,7 @@ public class SmithyTestCaseTest {
     @Test
     public void matchesOnShapeId() {
         ValidationEvent actual = ValidationEvent.builder()
-                .eventId("FooBar")
+                .id("FooBar")
                 .severity(Severity.DANGER)
                 .message("abc")
                 .shapeId(ShapeId.from("foo.baz#Bar"))
@@ -95,7 +95,7 @@ public class SmithyTestCaseTest {
     @Test
     public void failsWhenShapeIdDoesNotMatch() {
         ValidationEvent actual = ValidationEvent.builder()
-                .eventId("FooBar")
+                .id("FooBar")
                 .severity(Severity.DANGER)
                 .message("abc")
                 .shapeId(ShapeId.from("foo.baz#Bar"))
@@ -111,13 +111,13 @@ public class SmithyTestCaseTest {
     @Test
     public void newlinesAreBetweenEventsWhenFormatting() {
         ValidationEvent e1 = ValidationEvent.builder()
-                .eventId("FooBar")
+                .id("FooBar")
                 .severity(Severity.DANGER)
                 .message("a")
                 .shapeId(ShapeId.from("foo.baz#Bar"))
                 .build();
         ValidationEvent e2 = ValidationEvent.builder()
-                .eventId("FooBar")
+                .id("FooBar")
                 .severity(Severity.DANGER)
                 .message("b")
                 .shapeId(ShapeId.from("foo.baz#Bar"))


### PR DESCRIPTION
This commit adds `id` related get and set methods to the `ValidationEvent`
class and its `Builder`, respectively, that match its `toNode` format.
This makes it so `ValidationEvents` can be loaded with a `NodeMapper`.
The `eventId` methods have been deprecated and replaced in use.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
