### PR TITLE
Clarify timestamp formats

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -504,7 +504,8 @@ Serialization rules:
 * string values with a :ref:`mediaType-trait` are base64 encoded.
 * timestamp values are serialized using the ``http-date``
   format as defined in the ``IMF-fixdate`` production of
-  :rfc:`7231#section-7.1.1.1`.
+  :rfc:`7231#section-7.1.1.1`. The :ref:`timestampFormat-trait` MAY be used
+  to use a custom serialization format.
 
 .. note::
 
@@ -606,7 +607,8 @@ Serialization rules:
 
 - boolean is serialized as ``true`` or ``false``.
 - timestamp values are serialized as an :rfc:`3339` string
-  (e.g., ``1990-12-31T23:59:60Z``).
+  (e.g., ``1985-04-12T23:20:50.52Z``). The :ref:`timestampFormat-trait` MAY
+  be used to use a custom serialization format.
 - Unless the label is greedy, "/" MUST be percent encoded.
 
 
@@ -791,7 +793,9 @@ Serialization rules:
 * boolean values are serialized as ``true`` or ``false``.
 * blob values are base64 encoded when serialized in the query string.
 * timestamp values are serialized as an :rfc:`3339`
-  ``date-time`` string (e.g., ``1990-12-31T23:59:60Z``).
+  ``date-time`` string (e.g., ``1985-04-12T23:20:50.52Z``). The
+  :ref:`timestampFormat-trait` MAY be used to use a custom serialization
+  format.
 * :ref:`list` members are serialized by adding multiple query string parameters
   to the query string using the same name. For example, given a member bound
   to ``foo`` that targets a list of strings with a value of ``["a", "b"]``,

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -2322,8 +2322,8 @@ target from traits and how their values are defined in
       - number | string
       - If a number is provided, it represents Unix epoch seconds with optional
         millisecond precision. If a string is provided, it MUST be a valid
-        :rfc:`3339` string with optional millisecond precision and no
-        UTC offset (for example, ``1990-12-31T23:59:60Z``).
+        :rfc:`3339` string with no UTC offset and optional fractional
+        precision (for example, ``1985-04-12T23:20:50.52Z``).
     * - list and set
       - array
       - Each value in the array MUST be compatible with the targeted member.

--- a/docs/source/1.0/spec/core/protocol-traits.rst
+++ b/docs/source/1.0/spec/core/protocol-traits.rst
@@ -300,7 +300,8 @@ Smithy defines the following built-in timestamp formats:
     * - date-time
       - Date time as defined by the ``date-time`` production in
         `RFC3339 section 5.6 <https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14>`_
-        with no UTC offset (for example, ``1985-04-12T23:20:50.52Z``).
+        with no UTC offset and optional fractional precision (for example,
+        ``1985-04-12T23:20:50.52Z``).
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,
@@ -308,7 +309,7 @@ Smithy defines the following built-in timestamp formats:
     * - epoch-seconds
       - Also known as Unix time, the number of seconds that have elapsed since
         00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970,
-        with decimal precision (for example, ``1515531081.1234``).
+        with optional fractional precision (for example, ``1515531081.1234``).
 
 .. rubric:: Resolving timestamp formats
 


### PR DESCRIPTION
Clarifies that the timestampFormat trait can override the default
formats used in HTTP binding traits, and that fractional precision is
optional.

Closes #521

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
