### PR TITLE
fix rest-xml protocol test for Invalid greeting error 

### DIFF
--- a/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
@@ -349,7 +349,7 @@ serialized in the response.
             <Type>Sender</Type>
             <Code>InvalidGreeting</Code>
             <Message>Hi</Message>
-            <AnotherSetting>setting</Message>
+            <AnotherSetting>setting</AnotherSetting>
         </Error>
         <RequestId>foo-id</RequestId>
     </ErrorResponse>
@@ -363,7 +363,7 @@ using this additional nested XML element.
         <Type>Sender</Type>
         <Code>InvalidGreeting</Code>
         <Message>Hi</Message>
-        <AnotherSetting>setting</Message>
+        <AnotherSetting>setting</AnotherSetting>
         <RequestId>foo-id</RequestId>
     </Error>
 

--- a/smithy-aws-protocol-tests/model/restXml/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/errors.smithy
@@ -70,7 +70,7 @@ apply InvalidGreeting @httpResponseTests([
                     <Type>Sender</Type>
                     <Code>InvalidGreeting</Code>
                     <Message>Hi</Message>
-                    <AnotherSetting>setting</Message>
+                    <AnotherSetting>setting</AnotherSetting>
                  </Error>
                  <RequestId>foo-id</RequestId>
               </ErrorResponse>


### PR DESCRIPTION
*Issue #, if available:*
Rest-XML Protocol test for Invalid greeting error is modeled with an invalid XML response. 

*Description of changes:*
This change fixes the invalid XML response, with correct xml closure tag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
