### PR TITLE
Add payloadFormatVersion to API Gateway Integration trait.

### DIFF
--- a/docs/source/1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source/1.0/spec/aws/amazon-apigateway.rst
@@ -397,6 +397,11 @@ following members:
     * - cacheNamespace
       - ``string``
       - An API-specific tag group of related cached parameters.
+    * - payloadFormatVersion
+      - ``string``
+      - Specifies the format of the payload sent to an integration. Required for HTTP APIs. For HTTP APIs,
+        supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the
+        only supported value.
     * - cacheKeyParameters
       - ``list<string>``
       - A list of request parameter names whose values are to be cached.

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
@@ -33,6 +33,7 @@
                     "cacheNamespace": "cache namespace",
                     "cacheKeyParameters": [],
                     "passThroughBehavior": "never",
+                    "payloadFormatVersion": "1.0",
                     "responses": {
                         "2\\d{2}": {
                             "statusCode": "200",

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
@@ -68,6 +68,7 @@
           "httpMethod": "POST",
           "credentials": "arn:aws:iam::012345678901:role/apigateway-invoke-lambda-exec-role",
           "cacheNamespace": "cache namespace",
+          "payloadFormatVersion": "1.0",
           "requestParameters": {
             "integration.request.querystring.provider": "method.request.querystring.vendor",
             "integration.request.path.stage": "method.request.querystring.version"

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -56,6 +56,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
     private final String connectionId;
     private final String connectionType;
     private final String cacheNamespace;
+    private final String payloadFormatVersion;
     private final List<String> cacheKeyParameters;
     private final Map<String, String> requestParameters;
     private final Map<String, String> requestTemplates;
@@ -73,6 +74,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         connectionId = builder.connectionId;
         connectionType = builder.connectionType;
         cacheNamespace = builder.cacheNamespace;
+        payloadFormatVersion = builder.payloadFormatVersion;
         cacheKeyParameters = ListUtils.copyOf(builder.cacheKeyParameters);
         requestParameters = MapUtils.copyOf(builder.requestParameters);
         requestTemplates = MapUtils.copyOf(builder.requestTemplates);
@@ -213,6 +215,15 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
     }
 
     /**
+     * Gets the payload format version. Only used in HTTP APIs.
+     *
+     * @return Returns the optionally present cache namespace.
+     */
+    public Optional<String> getPayloadFormatVersion() {
+        return Optional.ofNullable(payloadFormatVersion);
+    }
+
+    /**
      * A list of request parameters whose values are to be cached.
      *
      * @return Returns the cache key parameters.
@@ -341,6 +352,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
                 .connectionId(connectionId)
                 .connectionType(connectionType)
                 .cacheNamespace(cacheNamespace)
+                .payloadFormatVersion(payloadFormatVersion)
                 .requestParameters(requestParameters)
                 .requestTemplates(requestTemplates)
                 .responses(responses)
@@ -358,6 +370,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         private String connectionId;
         private String connectionType;
         private String cacheNamespace;
+        private String payloadFormatVersion;
         private final List<String> cacheKeyParameters = new ArrayList<>();
         private final Map<String, String> requestParameters = new HashMap<>();
         private final Map<String, String> requestTemplates = new HashMap<>();
@@ -491,6 +504,17 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
          */
         public Builder cacheNamespace(String cacheNamespace) {
             this.cacheNamespace = cacheNamespace;
+            return this;
+        }
+
+        /**
+         * Sets the payload format version. Required for HTTP APIs.
+         *
+         * @param payloadFormatVersion Payload format version to set.
+         * @return Returns the builder.
+         */
+        public Builder payloadFormatVersion(String payloadFormatVersion) {
+            this.payloadFormatVersion = payloadFormatVersion;
             return this;
         }
 

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -217,7 +217,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
     /**
      * Gets the payload format version. Only used in HTTP APIs.
      *
-     * @return Returns the optionally present cache namespace.
+     * @return Returns the optional payload format version.
      */
     public Optional<String> getPayloadFormatVersion() {
         return Optional.ofNullable(payloadFormatVersion);

--- a/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -163,6 +163,9 @@
                 "cacheNamespace": {
                     "target": "smithy.api#String"
                 },
+                "payloadFormatVersion": {
+                    "target": "smithy.api#String"
+                },
                 "cacheKeyParameters": {
                     "target": "aws.apigateway#StringList"
                 },

--- a/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitTest.java
+++ b/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitTest.java
@@ -34,6 +34,7 @@ public class IntegrationTraitTest {
                 .connectionType("xyz")
                 .contentHandling("CONVERT_TO_TEXT")
                 .credentials("abc")
+                .payloadFormatVersion("1.0")
                 .passThroughBehavior("when_no_templates")
                 .putRequestParameter("x", "y")
                 .build();


### PR DESCRIPTION
Currently, when converting the Smithy model to API Gateway for HTTP APIs, it fails because it doesn't configure the `payloadFormatVersion`. This change adds the payload format version to the IntegrationTrait.

The payload format version specifies the format of the data that API Gateway sends to an integration, and how API Gateway interprets the response. If you create an integration for HTTP APIs programmatically, you **must** specify a payloadFormatVersion. The supported values are 1.0 and 2.0.

*Issue #, if available:* No issue #

*Description of changes:* See commit message above. Added the payloadFormatVersion that is required as document here: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
