### PR TITLE
Adds restxml protocol test around xml preamble, CDATA, escaped characters

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -59,7 +59,49 @@ apply SimpleScalarProperties @httpRequestTests([
             floatValue: 5.5,
             doubleValue: 6.5,
         }
-    }
+    },
+    {
+        id: "SimpleScalarPropertiesWithEscapedCharacter",
+        documentation: "Serializes string with escaping",
+        protocol: restXml,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>&lt;string&gt;</stringValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "<string>",
+        }
+    },
+    {
+        id: "SimpleScalarPropertiesWithWhiteSpace",
+        documentation: "Serializes string containing white space",
+        protocol: restXml,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>string with white    space</stringValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "string with white    space",
+        }
+    },
 ])
 
 apply SimpleScalarProperties @httpResponseTests([
@@ -101,7 +143,7 @@ apply SimpleScalarProperties @httpResponseTests([
     },
     {
         id: "SimpleScalarPropertiesWithEscapedCharacter",
-        documentation: "Serializes escaped string",
+        documentation: "Serializes string with escaping",
         protocol: restXml,
         code: 200,
         body: """
@@ -140,6 +182,27 @@ apply SimpleScalarProperties @httpResponseTests([
         params: {
             foo: "Foo",
             stringValue: "string",
+        }
+    },
+    {
+        id: "SimpleScalarPropertiesWithWhiteSpace",
+        documentation: "Serializes string containing white space",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <?xml version = "1.0" encoding = "UTF-8"?>
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>string with white    space</stringValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "string with white    space",
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -98,6 +98,49 @@ apply SimpleScalarProperties @httpResponseTests([
             floatValue: 5.5,
             doubleValue: 6.5,
         }
+    },
+    {
+        id: "SimpleScalarPropertiesWithEscapedCharacter",
+        documentation: "Serializes escaped string",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>&lt;string&gt;</stringValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "<string>",
+        }
+    },
+    {
+        id: "SimpleScalarPropertiesWithXMLPreamble",
+        documentation: "Serializes simple scalar properties with xml preamble, comments and CDATA",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <?xml version = "1.0" encoding = "UTF-8"?>
+              <SimpleScalarPropertiesInputOutput>
+                  <![CDATA[characters representing CDATA]]>
+                  <stringValue>string</stringValue>
+                  <!--xml comment-->
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "string",
+        }
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/document-xml-attributes.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-xml-attributes.smithy
@@ -36,7 +36,27 @@ apply XmlAttributes @httpRequestTests([
             foo: "hi",
             attr: "test"
         }
-    }
+    },
+    {
+        id: "XmlAttributesWithEscaping",
+        documentation: "Serializes XML attributes with escaped characters on the synthesized document",
+        protocol: restXml,
+        method: "PUT",
+        uri: "/XmlAttributes",
+        body: """
+              <XmlAttributesInputOutput test="&lt;test&amp;mock&gt;">
+                  <foo>hi</foo>
+              </XmlAttributesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            foo: "hi",
+            attr: "<test&mock>"
+        }
+    },
 ])
 
 apply XmlAttributes @httpResponseTests([


### PR DESCRIPTION
*Description of changes:*
1. Adds few protocol test for rest xml deserializers to check behavior with xml preamble, comments, CDATA, white space, characters that need to be escaped are present in xml response body. 
2. Adds test cases for white space, character escaping when serializing into xml request body.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
