### PR TITLE
Make CodeWriter expressions configurable

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -41,23 +41,23 @@ final class CodeFormatter {
         formatters.put(identifier, formatter);
     }
 
-    String format(Object content, String indent, CodeWriter writer, Object... args) {
+    String format(char expressionStart, Object content, String indent, CodeWriter writer, Object... args) {
         String expression = String.valueOf(content);
 
         // Simple case of no arguments and no expressions.
-        if (args.length == 0 && expression.indexOf('$') == -1) {
+        if (args.length == 0 && expression.indexOf(expressionStart) == -1) {
             return expression;
         }
 
-        return parse(new State(content, indent, writer, args));
+        return parse(expressionStart, new State(content, indent, writer, args));
     }
 
-    private String parse(State state) {
+    private String parse(char expressionStart, State state) {
         while (!state.eof()) {
             char c = state.c();
             state.next();
-            if (c == '$') {
-                parseArgumentWrapper(state);
+            if (c == expressionStart) {
+                parseArgumentWrapper(expressionStart, state);
             } else {
                 state.result.append(c);
             }
@@ -74,15 +74,15 @@ final class CodeFormatter {
         return state.result.toString();
     }
 
-    private void parseArgumentWrapper(State state) {
+    private void parseArgumentWrapper(char expressionStart, State state) {
         if (state.eof()) {
             throw new IllegalArgumentException("Invalid format string: " + state);
         }
 
         char c = state.c();
-        if (c == '$') {
+        if (c == expressionStart) {
             // $$ -> $
-            state.result.append('$');
+            state.result.append(expressionStart);
             state.next();
         } else if (c == '{') {
             parseBracedArgument(state);

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
@@ -34,7 +34,7 @@ public class CodeFormatterTest {
     @Test
     public void formatsDollarLiterals() {
         CodeFormatter formatter = new CodeFormatter();
-        String result = formatter.format("hello $$", "", createWriter());
+        String result = formatter.format('$', "hello $$", "", createWriter());
 
         assertThat(result, equalTo("hello $"));
     }
@@ -43,7 +43,7 @@ public class CodeFormatterTest {
     public void formatsRelativeLiterals() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello $L", "", createWriter(), "there");
+        String result = formatter.format('$', "hello $L", "", createWriter(), "there");
 
         assertThat(result, equalTo("hello there"));
     }
@@ -52,7 +52,7 @@ public class CodeFormatterTest {
     public void formatsRelativeLiteralsInBraces() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello ${L}", "", createWriter(), "there");
+        String result = formatter.format('$', "hello ${L}", "", createWriter(), "there");
 
         assertThat(result, equalTo("hello there"));
     }
@@ -61,7 +61,7 @@ public class CodeFormatterTest {
     public void requiresTextAfterOpeningBrace() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
-            formatter.format("hello ${", "", createWriter(), "there");
+            formatter.format('$', "hello ${", "", createWriter(), "there");
         });
     }
 
@@ -70,7 +70,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello ${L .", "", createWriter(), "there");
+            formatter.format('$', "hello ${L .", "", createWriter(), "there");
         });
     }
 
@@ -78,7 +78,7 @@ public class CodeFormatterTest {
     public void formatsMultipleRelativeLiterals() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello $L, $L", "", createWriter(), "there", "guy");
+        String result = formatter.format('$', "hello $L, $L", "", createWriter(), "there", "guy");
 
         assertThat(result, equalTo("hello there, guy"));
     }
@@ -87,7 +87,7 @@ public class CodeFormatterTest {
     public void formatsMultipleRelativeLiteralsInBraces() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello ${L}, ${L}", "", createWriter(), "there", "guy");
+        String result = formatter.format('$', "hello ${L}, ${L}", "", createWriter(), "there", "guy");
 
         assertThat(result, equalTo("hello there, guy"));
     }
@@ -97,7 +97,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $L", "", createWriter(), "a", "b", "c");
+            formatter.format('$', "hello $L", "", createWriter(), "a", "b", "c");
         });
     }
 
@@ -106,7 +106,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $L", "", createWriter());
+            formatter.format('$', "hello $L", "", createWriter());
         });
     }
 
@@ -115,7 +115,16 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $", "", createWriter());
+            formatter.format('$', "hello $", "", createWriter());
+        });
+    }
+
+    @Test
+    public void validatesThatCustomStartIsNotAtEof() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            CodeFormatter formatter = new CodeFormatter();
+            formatter.putFormatter('L', CodeFormatterTest::valueOf);
+            formatter.format('#', "hello #", "", createWriter());
         });
     }
 
@@ -123,7 +132,16 @@ public class CodeFormatterTest {
     public void formatsPositionalLiterals() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello $1L", "", createWriter(), "there");
+        String result = formatter.format('$', "hello $1L", "", createWriter(), "there");
+
+        assertThat(result, equalTo("hello there"));
+    }
+
+    @Test
+    public void formatsPositionalLiteralsWithCustomStart() {
+        CodeFormatter formatter = new CodeFormatter();
+        formatter.putFormatter('L', CodeFormatterTest::valueOf);
+        String result = formatter.format('#', "hello #1L", "", createWriter(), "there");
 
         assertThat(result, equalTo("hello there"));
     }
@@ -132,7 +150,7 @@ public class CodeFormatterTest {
     public void formatsMultiplePositionalLiterals() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello $1L, $2L. $2L? You $1L?", "", createWriter(), "there", "guy");
+        String result = formatter.format('$', "hello $1L, $2L. $2L? You $1L?", "", createWriter(), "there", "guy");
 
         assertThat(result, equalTo("hello there, guy. guy? You there?"));
     }
@@ -141,7 +159,7 @@ public class CodeFormatterTest {
     public void formatsMultiplePositionalLiteralsInBraces() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("hello ${1L}, ${2L}. ${2L}? You ${1L}?", "", createWriter(), "there", "guy");
+        String result = formatter.format('$', "hello ${1L}, ${2L}. ${2L}? You ${1L}?", "", createWriter(), "there", "guy");
 
         assertThat(result, equalTo("hello there, guy. guy? You there?"));
     }
@@ -150,7 +168,7 @@ public class CodeFormatterTest {
     public void formatsMultipleDigitPositionalLiterals() {
         CodeFormatter formatter = new CodeFormatter();
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
-        String result = formatter.format("$1L $2L $3L $4L $5L $6L $7L $8L $9L $10L $11L", "", createWriter(),
+        String result = formatter.format('$', "$1L $2L $3L $4L $5L $6L $7L $8L $9L $10L $11L", "", createWriter(),
                                          "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11");
 
         assertThat(result, equalTo("1 2 3 4 5 6 7 8 9 10 11"));
@@ -161,7 +179,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $1L", "", createWriter());
+            formatter.format('$', "hello $1L", "", createWriter());
         });
     }
 
@@ -170,7 +188,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $0L", "", createWriter(), "a");
+            formatter.format('$', "hello $0L", "", createWriter(), "a");
         });
     }
 
@@ -179,7 +197,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $2", "", createWriter());
+            formatter.format('$', "hello $2", "", createWriter());
         });
     }
 
@@ -188,7 +206,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $2L $3L", "", createWriter(), "a", "b", "c", "d");
+            formatter.format('$', "hello $2L $3L", "", createWriter(), "a", "b", "c", "d");
         });
     }
 
@@ -197,7 +215,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $1L, $L", "", createWriter(), "there");
+            formatter.format('$', "hello $1L, $L", "", createWriter(), "there");
         });
     }
 
@@ -206,7 +224,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $L, $1L", "", createWriter(), "there");
+            formatter.format('$', "hello $L, $1L", "", createWriter(), "there");
         });
     }
 
@@ -217,7 +235,7 @@ public class CodeFormatterTest {
         CodeWriter writer = createWriter();
         writer.putContext("a", "a");
         writer.putContext("abc_def", "b");
-        String result = formatter.format("$a:L $abc_def:L", "", writer);
+        String result = formatter.format('$', "$a:L $abc_def:L", "", writer);
 
         assertThat(result, equalTo("a b"));
     }
@@ -229,7 +247,7 @@ public class CodeFormatterTest {
         CodeWriter writer = createWriter();
         writer.putContext("a", "a");
         writer.putContext("abc_def", "b");
-        String result = formatter.format("${a:L} ${abc_def:L}", "", writer);
+        String result = formatter.format('$', "${a:L} ${abc_def:L}", "", writer);
 
         assertThat(result, equalTo("a b"));
     }
@@ -239,7 +257,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $abc foo", "", createWriter());
+            formatter.format('$', "hello $abc foo", "", createWriter());
         });
     }
 
@@ -248,7 +266,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("hello $abc:", "", createWriter());
+            formatter.format('$', "hello $abc:", "", createWriter());
         });
     }
 
@@ -260,8 +278,8 @@ public class CodeFormatterTest {
         CodeWriter writer = createWriter();
         writer.putContext("foo.baz#Bar$bam", "hello");
         writer.putContext("foo_baz", "hello");
-        assertThat(formatter.format("$foo.baz#Bar$bam:L", "", writer), equalTo("hello"));
-        assertThat(formatter.format("$foo_baz:L", "", writer), equalTo("hello"));
+        assertThat(formatter.format('$', "$foo.baz#Bar$bam:L", "", writer), equalTo("hello"));
+        assertThat(formatter.format('$', "$foo_baz:L", "", writer), equalTo("hello"));
     }
 
     @Test
@@ -269,7 +287,7 @@ public class CodeFormatterTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
             formatter.putFormatter('L', CodeFormatterTest::valueOf);
-            formatter.format("$nope!:L", "", createWriter());
+            formatter.format('$', "$nope!:L", "", createWriter());
         });
     }
 
@@ -301,7 +319,7 @@ public class CodeFormatterTest {
     public void ensuresFormatterIsValid() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             CodeFormatter formatter = new CodeFormatter();
-            formatter.format("$L", "", createWriter(), "hi");
+            formatter.format('$', "$L", "", createWriter(), "hi");
         });
     }
 
@@ -311,7 +329,7 @@ public class CodeFormatterTest {
         formatter.putFormatter('L', CodeFormatterTest::valueOf);
         CodeWriter writer = createWriter();
 
-        assertThat(formatter.format("${L@hello}", "", writer, "default"), equalTo("default"));
+        assertThat(formatter.format('$', "${L@hello}", "", writer, "default"), equalTo("default"));
     }
 
     @Test

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -634,4 +634,40 @@ public class CodeWriterTest {
 
         assertThat(result, equalTo("[\n    hi\n]\n"));
     }
+
+    @Test
+    public void canSetCustomExpressionStartChar() {
+        CodeWriter writer = new CodeWriter();
+        writer.pushState();
+        writer.setExpressionStart('#');
+        writer.write("Hi, #L", "1");
+        writer.write("Hi, ##L");
+        writer.write("Hi, $L");
+        writer.write("Hi, $$L");
+        writer.popState();
+        writer.write("Hi, #L");
+        writer.write("Hi, ##L");
+        writer.write("Hi, $L", "2");
+        writer.write("Hi, $$L");
+        String result = writer.toString();
+
+        assertThat(result, equalTo("Hi, 1\n"
+                                   + "Hi, #L\n"
+                                   + "Hi, $L\n"
+                                   + "Hi, $$L\n"
+                                   + "Hi, #L\n"
+                                   + "Hi, ##L\n"
+                                   + "Hi, 2\n"
+                                   + "Hi, $L\n"));
+    }
+
+    @Test
+    public void expressionStartCannotBeSpace() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CodeWriter().setExpressionStart(' '));
+    }
+
+    @Test
+    public void expressionStartCannotBeNewline() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CodeWriter().setExpressionStart('\n'));
+    }
 }


### PR DESCRIPTION
CodeWriter can now configure the character used to start expressions in
the current state, making it easier to generate code for language that
give syntactic meaning to CodeWriter's default expression character,
'$'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
