### PR TITLE
Make internal a trait and not just a tag

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -74,9 +74,9 @@ The following is an example ``smithy-build.json`` configuration:
                             }
                         },
                         {
-                            "name": "excludeTraitsByTag",
+                            "name": "excludeShapesByTrait",
                             "args": {
-                                "tags": ["internal"]
+                                "trait": "internal"
                             }
                         }
                     ],
@@ -285,6 +285,47 @@ the :ref:`tags trait <tags-trait>`.
 .. note::
 
     This transformer does not remove shapes from the prelude.
+
+
+.. _excludeShapesByTrait-transform:
+
+excludeShapesByTrait
+--------------------
+
+Removes shapes if they are marked with a specific trait.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - trait
+      - ``string``
+      - The :ref:`shape ID <shape-id>` of a trait. If this trait is found on
+        a shape, the shape is removed from the model. Relative shape IDs are
+        assumed to be in the ``smithy.api`` prelude namespace.
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "excludeShapesByTrait",
+                            "args": {
+                                "trait": "internal"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
 
 
 .. _includeShapesByTag-transform:

--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -76,7 +76,7 @@ The following is an example ``smithy-build.json`` configuration:
                         {
                             "name": "excludeShapesByTrait",
                             "args": {
-                                "trait": "internal"
+                                "traits": ["internal"]
                             }
                         }
                     ],
@@ -292,7 +292,7 @@ the :ref:`tags trait <tags-trait>`.
 excludeShapesByTrait
 --------------------
 
-Removes shapes if they are marked with a specific trait.
+Removes shapes if they are marked with one or more specific traits.
 
 .. list-table::
     :header-rows: 1
@@ -301,11 +301,12 @@ Removes shapes if they are marked with a specific trait.
     * - Property
       - Type
       - Description
-    * - trait
-      - ``string``
-      - The :ref:`shape ID <shape-id>` of a trait. If this trait is found on
-        a shape, the shape is removed from the model. Relative shape IDs are
-        assumed to be in the ``smithy.api`` prelude namespace.
+    * - traits
+      - ``[string]``
+      - A list of trait :ref:`shape IDs <shape-id>`. If any of these traits
+        are found on a shape, the shape is removed from the model. Relative
+        shape IDs are assumed to be in the ``smithy.api``
+        :ref:`prelude <prelude>` namespace.
 
 .. tabs::
 
@@ -319,7 +320,7 @@ Removes shapes if they are marked with a specific trait.
                         {
                             "name": "excludeShapesByTrait",
                             "args": {
-                                "trait": "internal"
+                                "traits": ["internal"]
                             }
                         }
                     ]

--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -246,9 +246,9 @@ projection. For example:
                             }
                         },
                         {
-                            "name": "excludeTraitsByTag",
+                            "name": "excludeShapesByTrait",
                             "args": {
-                                "tags": ["internal"]
+                                "trait": "internal"
                             }
                         },
                         {

--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -248,7 +248,7 @@ projection. For example:
                         {
                             "name": "excludeShapesByTrait",
                             "args": {
-                                "trait": "internal"
+                                "traits": ["internal"]
                             }
                         },
                         {

--- a/docs/source/1.0/spec/core/documentation-traits.rst
+++ b/docs/source/1.0/spec/core/documentation-traits.rst
@@ -264,6 +264,38 @@ Value type
         }
 
 
+.. _internal-trait:
+
+------------------
+``internal`` trait
+------------------
+
+Summary
+    Shapes marked with the internal trait are meant only for internal use.
+    Tooling can use the ``internal`` trait to filter out shapes from models
+    that are not intended for external customers.
+Trait selector
+    ``*``
+Value type
+    Annotation trait
+
+As an example, a service team may wish to use a version of a model that
+includes features that are only available to internal customers within the
+same company, whereas clients for external customers could be built from a
+filtered version of the model.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        structure MyStructure {
+            foo: String,
+
+            @internal
+            bar: String,
+        }
+
+
 .. _sensitive-trait:
 
 -------------------

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -1336,7 +1336,7 @@ members.
         name: smithy.api#String,
 
         @length(min: 0)
-        @tags(["internal"])
+        @tags(["private-beta"])
         age: smithy.api#Integer,
     }
 

--- a/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
+++ b/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.json
@@ -11,9 +11,8 @@
                 "smithy.api#externalDocumentation": {
                     "Developer Guide": "https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-api-key-source.html"
                 },
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.apigateway#authorizers": {
@@ -29,9 +28,8 @@
                     "selector": "service"
                 },
                 "smithy.api#documentation": "A list of API Gateway authorizers to augment the service's declared authentication mechanisms.",
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.apigateway#AuthorizerDefinition": {
@@ -104,9 +102,8 @@
                     "selector": ":test(service, resource, operation)"
                 },
                 "smithy.api#documentation": "Attaches an authorizer to a service, resource, or operation.",
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.apigateway#requestValidator": {
@@ -116,9 +113,8 @@
                     "selector": ":test(service, operation)"
                 },
                 "smithy.api#documentation": "Selects which request validation strategy to use. One of: 'full', 'params-only', 'body-only'",
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.apigateway#integration": {
@@ -187,9 +183,8 @@
                     ]
                 },
                 "smithy.api#documentation": "Defines an API Gateway integration.",
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.apigateway#mockIntegration": {
@@ -216,9 +211,8 @@
                     ]
                 },
                 "smithy.api#documentation": "Defines an API Gateway mock integration.",
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.apigateway#IntegrationType": {

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.json
@@ -56,9 +56,8 @@
                 },
                 "smithy.api#authDefinition": {},
                 "smithy.api#documentation": "Configures an Amazon Cognito User Pools auth scheme.",
-                "smithy.api#tags": [
-                    "internal"
-                ]
+                "smithy.api#internal": {},
+                "smithy.api#tags": ["internal"]
             }
         },
         "aws.auth#StringList": {

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByTrait.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByTrait.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Removes shapes from the model if they are marked with a specific trait.
+ */
+public final class ExcludeShapesByTrait extends ConfigurableProjectionTransformer<ExcludeShapesByTrait.Config> {
+
+    public static final class Config {
+        private String trait;
+
+        /**
+         * Gets the shape ID of the trait to filter shapes by.
+         *
+         * @return Returns the trait shape ID.
+         */
+        public String getTrait() {
+            return trait;
+        }
+
+        /**
+         * Sets the shape ID of the trait to filter shapes by.
+         *
+         * @param trait The shape ID of the trait that if present causes a shape to be removed.
+         */
+        public void setTrait(String trait) {
+            this.trait = trait;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "excludeShapesByTrait";
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        // Default to smithy.api# if the given trait ID is relative.
+        ShapeId traitId = ShapeId.fromOptionalNamespace(Prelude.NAMESPACE, config.getTrait());
+
+        return context.getTransformer().removeShapesIf(context.getModel(), shape -> shape.hasTrait(traitId));
+    }
+}

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -1,5 +1,6 @@
 software.amazon.smithy.build.transforms.ExcludeMetadata
 software.amazon.smithy.build.transforms.ExcludeShapesByTag
+software.amazon.smithy.build.transforms.ExcludeShapesByTrait
 software.amazon.smithy.build.transforms.ExcludeTags
 software.amazon.smithy.build.transforms.ExcludeTraits
 software.amazon.smithy.build.transforms.ExcludeTraitsByTag

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTraitTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTraitTest.java
@@ -1,0 +1,48 @@
+package software.amazon.smithy.build.transforms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class ExcludeShapesByTraitTest {
+    @ParameterizedTest
+    @MethodSource("traitValues")
+    public void removesShapesByTrait(String trait) {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("internal-shapes.smithy"))
+                .assemble()
+                .unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("trait", Node.from(trait)))
+                .build();
+        Model result = new ExcludeShapesByTrait().transform(context);
+
+        // Structure removal also removes members.
+        assertThat(result.getShapeIds(), not(hasItem(ShapeId.from("smithy.example#InternalStructure"))));
+        assertThat(result.getShapeIds(), not(hasItem(ShapeId.from("smithy.example#InternalStructure$foo"))));
+
+        // Can remove specific members from structures.
+        assertThat(result.getShapeIds(), hasItem(ShapeId.from("smithy.example#ExternalStructure")));
+        assertThat(result.getShapeIds(), hasItem(ShapeId.from("smithy.example#ExternalStructure$external")));
+        assertThat(result.getShapeIds(), not(hasItem(ShapeId.from("smithy.example#ExternalStructure$internal"))));
+    }
+
+    public static List<String> traitValues() {
+        return Arrays.asList(
+                // Relative IDs are assumed to be in "smithy.api".
+                "internal",
+                // Absolute IDs are used as-is.
+                "smithy.api#internal"
+        );
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTraitTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTraitTest.java
@@ -23,7 +23,7 @@ public class ExcludeShapesByTraitTest {
                 .unwrap();
         TransformContext context = TransformContext.builder()
                 .model(model)
-                .settings(Node.objectNode().withMember("trait", Node.from(trait)))
+                .settings(Node.objectNode().withMember("traits", Node.fromStrings(trait)))
                 .build();
         Model result = new ExcludeShapesByTrait().transform(context);
 

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/internal-shapes.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/internal-shapes.smithy
@@ -1,0 +1,13 @@
+namespace smithy.example
+
+@internal
+structure InternalStructure {
+    foo: String,
+}
+
+structure ExternalStructure {
+    @internal
+    internal: String,
+
+    external: String,
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/InternalTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/InternalTrait.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Shapes marked with the internal trait are meant only for internal use and
+ * must not be exposed to customers.
+ */
+public final class InternalTrait extends AnnotationTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.api#internal");
+
+    public InternalTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public InternalTrait() {
+        this(Node.objectNode());
+    }
+
+    public static final class Provider extends AnnotationTrait.Provider<InternalTrait> {
+        public Provider() {
+            super(ID, InternalTrait::new);
+        }
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -22,6 +22,7 @@ software.amazon.smithy.model.traits.HttpTrait$Provider
 software.amazon.smithy.model.traits.IdempotencyTokenTrait$Provider
 software.amazon.smithy.model.traits.IdempotentTrait$Provider
 software.amazon.smithy.model.traits.IdRefTrait$Provider
+software.amazon.smithy.model.traits.InternalTrait$Provider
 software.amazon.smithy.model.traits.JsonNameTrait$Provider
 software.amazon.smithy.model.traits.LengthTrait$Provider
 software.amazon.smithy.model.traits.MediaTypeTrait$Provider

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -262,6 +262,11 @@ structure idempotent {}
        structurallyExclusive: "member")
 structure idempotencyToken {}
 
+/// Shapes marked with the internal trait are meant only for internal use and
+/// must not be exposed to customers.
+@trait
+structure internal {}
+
 /// The jsonName trait allows a serialized object property name to differ
 /// from a structure member name used in the model.
 @trait(selector: "structure > member")

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/InternalTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/InternalTraitTest.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.model.traits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class InternalTraitTest {
+
+    @Test
+    public void loadsTrait() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#internal"), ShapeId.from("ns.qux#foo"), Node.objectNode());
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(InternalTrait.class));
+        assertThat(trait.get().toNode(), equalTo(Node.objectNode()));
+    }
+}


### PR DESCRIPTION
We've been using the "internal" tag to indicate that something is
internal only and should not be exposed to external consumers of a model
(i.e., people that don't work at the same company as the service team).
The original motivation for using tags and not traits was that there are
more dimensions to filtering shapes out of models than just internal vs
external. However, the internal/external split is so common that it
makes sense to make it a trait, which is more configurable and less
based on convention. Tags can still be used for filtering things out of
models (for example, an operation could be tagged so that it is only
exposed to a particular customer).

There are other cases where we migrated away from tags and moved to
traits like the `aws.api#controlPlane` and `aws.api#dataPlane` traits.

To support this change, a SmithyBuild transform was added that removes
shapes marked as internal. Note that this does not perform tree shaking
since like other transforms, tree shaking is performed by a dedicated
transform.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
