### PR TITLE
Fix httpPrefixHeaders selector

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -689,11 +689,9 @@ Trait selector
     .. code-block:: none
 
         structure > member
-        :test(> map > member[id|member=value] > :test(
-            boolean, number, string, timestamp,
-            collection > member > :test(boolean, number, string, timestamp)))
+        :test(> map > member[id|member=value] > :test(string, collection > member > string))
 
-    *Structure member that targets a map of specific simple types or a map of lists/sets of specific simple types*
+    *Structure member that targets a map of strings, or a map of list/set of strings*
 Value type
     ``string`` value that defines the prefix to prepend to each header field
     name stored in the targeted map member. For example, given a prefix value

--- a/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
@@ -83,10 +83,42 @@ structure HttpPrefixHeadersInputOutput {
     foo: String,
 
     @httpPrefixHeaders("X-Foo-")
-    fooMap: FooPrefixHeaders,
+    fooMap: StringMap,
 }
 
-map FooPrefixHeaders {
+map StringMap {
     key: String,
     value: String,
+}
+
+/// Clients that perform this test extract all headers from the response.
+@readonly
+@http(uri: "/HttpPrefixHeadersResponse", method: "GET")
+operation HttpPrefixHeadersResponse  {
+    output: HttpPrefixHeadersResponseOutput
+}
+
+apply HttpPrefixHeadersResponse @httpResponseTests([
+    {
+        id: "HttpPrefixHeadersResponse",
+        documentation: "(de)serializes all response headers",
+        protocol: restJson1,
+        code: 200,
+        body: "",
+        headers: {
+            "X-Foo": "Foo",
+            "Hello": "Hello"
+        },
+        params: {
+            prefixHeaders: {
+                "X-Foo": "Foo",
+                "Hello": "Hello"
+            }
+        }
+    },
+])
+
+structure HttpPrefixHeadersResponseOutput {
+    @httpPrefixHeaders("")
+    prefixHeaders: StringMap,
 }

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -40,6 +40,7 @@ service RestJson {
 
         // @httpPrefixHeaders tests
         HttpPrefixHeaders,
+        HttpPrefixHeadersResponse,
 
         // @httpPayload tests
         HttpPayloadTraits,

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -556,9 +556,7 @@ string httpHeader
 /// Binds a map of key-value pairs to prefixed HTTP headers.
 @trait(selector: """
         structure > member
-        :test(> map > member[id|member=value] > :test(
-              boolean, number, string, timestamp,
-              collection > member > :test(boolean, number, string, timestamp)))""",
+        :test(> map > member[id|member=value] > :test(string, collection > member > string))""",
         structurallyExclusive: "member",
         conflicts: [httpLabel, httpQuery, httpHeader, httpPayload])
 @tags(["diff.error.const"])


### PR DESCRIPTION
The httpPrefixHeaders trait actually only supports string values in the
map (or a list/set of strings). A compliance test was added to test
extracting all headers with no prefix.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
