### PR TITLE
Add deprecated property for OpenAPI operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/
 !smithy-build/src/test/resources/software/amazon/smithy/build
 */out/
 */*/out/
+/wrapper

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -43,6 +43,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AuthTrait;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.TitleTrait;
 import software.amazon.smithy.model.traits.Trait;
@@ -425,6 +426,10 @@ public final class OpenApiConverter {
                 String method = result.getMethod();
                 String path = result.getUri();
                 PathItem.Builder pathItem = paths.computeIfAbsent(result.getUri(), (uri) -> PathItem.builder());
+                // Mark the operation deprecated if the trait's present.
+                if (shape.hasTrait(DeprecatedTrait.class)) {
+                    result.getOperation().deprecated(true);
+                }
                 // Add security requirements to the operation.
                 addOperationSecurity(context, result.getOperation(), shape, plugin);
                 // Pass the operation through the plugin system and then build it.

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -53,6 +53,7 @@
     "/payload/{path}": {
       "put": {
         "operationId": "PutPayload",
+        "deprecated": true,
         "requestBody": {
           "content": {
             "application/octet-stream": {


### PR DESCRIPTION
The operation updated with the property in the test [already had the trait applied.](https://github.com/awslabs/smithy/blob/34d51e3f7f9c351ed0867a816e082ba3ac56cc4c/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json#L34)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
