### PR TITLE
Deprecate KnowledgeIndex reflection

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -82,7 +82,7 @@ final class AddAuthorizers implements ApiGatewayMapper {
         }
 
         ServiceShape service = context.getService();
-        AuthorizerIndex authorizerIndex = context.getModel().getKnowledge(AuthorizerIndex.class);
+        AuthorizerIndex authorizerIndex = AuthorizerIndex.of(context.getModel());
 
         return authorizerIndex.getAuthorizer(service, shape)
                 // Remove the original scheme authentication scheme from the operation if found.
@@ -100,7 +100,7 @@ final class AddAuthorizers implements ApiGatewayMapper {
             String path
     ) {
         ServiceShape service = context.getService();
-        AuthorizerIndex authorizerIndex = context.getModel().getKnowledge(AuthorizerIndex.class);
+        AuthorizerIndex authorizerIndex = AuthorizerIndex.of(context.getModel());
 
         // Get the resolved security schemes of the service and operation, and
         // only add security if it's different than the service.

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddBinaryTypes.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddBinaryTypes.java
@@ -71,8 +71,8 @@ final class AddBinaryTypes implements ApiGatewayMapper {
 
     private Stream<String> supportedMediaTypes(Context<? extends Trait> context) {
         Model model = context.getModel();
-        HttpBindingIndex httpBindingIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
-        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+        HttpBindingIndex httpBindingIndex = HttpBindingIndex.of(context.getModel());
+        TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
 
         // Find the media types defined on all request and response bindings.
         return topDownIndex.getContainedOperations(context.getService()).stream()

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -71,7 +71,7 @@ final class AddIntegrations implements ApiGatewayMapper {
             String httpMethod,
             String path
     ) {
-        IntegrationTraitIndex index = context.getModel().getKnowledge(IntegrationTraitIndex.class);
+        IntegrationTraitIndex index = IntegrationTraitIndex.of(context.getModel());
         return index.getIntegrationTrait(context.getService(), shape)
                 .map(trait -> operation.toBuilder()
                         .putExtension(EXTENSION_NAME, createIntegration(context, shape, trait))

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizerIndex.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizerIndex.java
@@ -71,6 +71,10 @@ public final class AuthorizerIndex implements KnowledgeIndex {
         });
     }
 
+    public static AuthorizerIndex of(Model model) {
+        return model.getKnowledge(AuthorizerIndex.class, AuthorizerIndex::new);
+    }
+
     private static String getNullableAuthorizerValue(Shape shape, String previous) {
         return shape.getTrait(AuthorizerTrait.class).map(AuthorizerTrait::getValue).orElse(previous);
     }

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTraitValidator.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTraitValidator.java
@@ -44,7 +44,7 @@ public final class AuthorizersTraitValidator extends AbstractValidator {
     }
 
     private Optional<ValidationEvent> validateService(Model model, ServiceShape service) {
-        Set<ShapeId> authSchemes = model.getKnowledge(ServiceIndex.class).getAuthSchemes(service).keySet();
+        Set<ShapeId> authSchemes = ServiceIndex.of(model).getAuthSchemes(service).keySet();
 
         // Create a comma separated string of authorizer names to schemes.
         String invalidMappings = service.getTrait(AuthorizersTrait.class)

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitIndex.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitIndex.java
@@ -33,7 +33,7 @@ import software.amazon.smithy.utils.MapUtils;
  * resource, and service shape in a model.
  */
 public final class IntegrationTraitIndex implements KnowledgeIndex {
-    private Map<ShapeId, Map<ShapeId, Trait>> traits = new HashMap<>();
+    private final Map<ShapeId, Map<ShapeId, Trait>> traits = new HashMap<>();
 
     public IntegrationTraitIndex(Model model) {
         model.shapes(ServiceShape.class).forEach(service -> {
@@ -41,6 +41,10 @@ public final class IntegrationTraitIndex implements KnowledgeIndex {
             traits.put(service.getId(), serviceMap);
             walk(model, service.getId(), service, null);
         });
+    }
+
+    public static IntegrationTraitIndex of(Model model) {
+        return model.getKnowledge(IntegrationTraitIndex.class, IntegrationTraitIndex::new);
     }
 
     /**

--- a/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/AuthorizerIndexTest.java
+++ b/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/AuthorizerIndexTest.java
@@ -18,7 +18,7 @@ public class AuthorizerIndexTest {
                 .assemble()
                 .unwrap();
 
-        AuthorizerIndex index = model.getKnowledge(AuthorizerIndex.class);
+        AuthorizerIndex index = AuthorizerIndex.of(model);
         ShapeId serviceA = ShapeId.from("smithy.example#ServiceA");
         ShapeId serviceB = ShapeId.from("smithy.example#ServiceB");
         ShapeId resourceA = ShapeId.from("smithy.example#ResourceA");

--- a/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitIndexTest.java
+++ b/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTraitIndexTest.java
@@ -31,7 +31,7 @@ public class IntegrationTraitIndexTest {
                 .assemble()
                 .unwrap();
 
-        IntegrationTraitIndex index = model.getKnowledge(IntegrationTraitIndex.class);
+        IntegrationTraitIndex index = IntegrationTraitIndex.of(model);
         ShapeId service = ShapeId.from("ns.foo#Service");
         ShapeId a = ShapeId.from("ns.foo#A");
         ShapeId b = ShapeId.from("ns.foo#B");

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndex.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndex.java
@@ -77,6 +77,10 @@ public final class ConditionKeysIndex implements KnowledgeIndex {
         });
     }
 
+    public static ConditionKeysIndex of(Model model) {
+        return model.getKnowledge(ConditionKeysIndex.class, ConditionKeysIndex::new);
+    }
+
     /**
      * Get all of the explicit and inferred condition keys used in the entire service.
      *

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysValidator.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysValidator.java
@@ -42,8 +42,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class ConditionKeysValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ConditionKeysIndex conditionIndex = model.getKnowledge(ConditionKeysIndex.class);
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        ConditionKeysIndex conditionIndex = ConditionKeysIndex.of(model);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
 
         return model.shapes(ServiceShape.class)
                 .filter(service -> service.hasTrait(ServiceTrait.class))

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndexTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndexTest.java
@@ -43,7 +43,7 @@ public class ConditionKeysIndexTest {
                 .unwrap();
         ShapeId service = ShapeId.from("smithy.example#MyService");
 
-        ConditionKeysIndex index = model.getKnowledge(ConditionKeysIndex.class);
+        ConditionKeysIndex index = ConditionKeysIndex.of(model);
         assertThat(index.getConditionKeyNames(service), containsInAnyOrder(
                 "aws:accountId", "foo:baz", "myservice:Resource1Id1", "myservice:Resource2Id2"));
         assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#Operation1")),

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
@@ -53,7 +53,7 @@ public final class ArnIndex implements KnowledgeIndex {
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight)));
 
         // Pre-compute all of the ArnTemplates in a service shape.
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         List<ServiceShape> services = model.shapes(ServiceShape.class)
                 .filter(shape -> shape.hasTrait(ServiceTrait.class))
                 .collect(Collectors.toList());
@@ -63,10 +63,14 @@ public final class ArnIndex implements KnowledgeIndex {
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight)));
 
         // Pre-compute all effective ARNs in each service.
-        IdentifierBindingIndex bindingIndex = model.getKnowledge(IdentifierBindingIndex.class);
+        IdentifierBindingIndex bindingIndex = IdentifierBindingIndex.of(model);
         for (ServiceShape service : services) {
             compileEffectiveArns(topDownIndex, bindingIndex, service);
         }
+    }
+
+    public static ArnIndex of(Model model) {
+        return model.getKnowledge(ArnIndex.class, ArnIndex::new);
     }
 
     private static String resolveServiceArn(Pair<ServiceShape, ServiceTrait> pair) {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTemplateValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTemplateValidator.java
@@ -46,7 +46,7 @@ public final class ArnTemplateValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ArnIndex arnIndex = model.getKnowledge(ArnIndex.class);
+        ArnIndex arnIndex = ArnIndex.of(model);
         return model.shapes(ServiceShape.class)
                 .flatMap(service -> Trait.flatMapStream(service, ServiceTrait.class))
                 .flatMap(pair -> validateService(model, arnIndex, pair.getLeft()))

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
@@ -58,6 +58,10 @@ public final class PlaneIndex implements KnowledgeIndex {
         });
     }
 
+    public static PlaneIndex of(Model model) {
+        return model.getKnowledge(PlaneIndex.class, PlaneIndex::new);
+    }
+
     /**
      * Checks if the given service shape is part of the control plane.
      *

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformer.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformer.java
@@ -78,7 +78,7 @@ public final class CleanClientDiscoveryTraitTransformer implements ModelTransfor
             Model model,
             Set<ShapeId> updatedServices
     ) {
-        ClientEndpointDiscoveryIndex discoveryIndex = model.getKnowledge(ClientEndpointDiscoveryIndex.class);
+        ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(model);
         Set<ShapeId> stillBoundOperations = model.shapes(ServiceShape.class)
                 // Get all endpoint discovery services
                 .filter(service -> service.hasTrait(ClientEndpointDiscoveryTrait.class))

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
@@ -41,8 +41,8 @@ public final class ClientEndpointDiscoveryIndex implements KnowledgeIndex {
     private final Map<ShapeId, Map<ShapeId, ClientEndpointDiscoveryInfo>> endpointDiscoveryInfo = new HashMap<>();
 
     public ClientEndpointDiscoveryIndex(Model model) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        OperationIndex opIndex = OperationIndex.of(model);
 
         model.shapes(ServiceShape.class)
                 .flatMap(service -> Trait.flatMapStream(service, ClientEndpointDiscoveryTrait.class))
@@ -64,6 +64,10 @@ public final class ClientEndpointDiscoveryIndex implements KnowledgeIndex {
                         }
                     }
                 });
+    }
+
+    public static ClientEndpointDiscoveryIndex of(Model model) {
+        return model.getKnowledge(ClientEndpointDiscoveryIndex.class, ClientEndpointDiscoveryIndex::new);
     }
 
     private Map<ShapeId, ClientEndpointDiscoveryInfo> getOperations(

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryValidator.java
@@ -44,8 +44,8 @@ public final class ClientEndpointDiscoveryValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ClientEndpointDiscoveryIndex discoveryIndex = model.getKnowledge(ClientEndpointDiscoveryIndex.class);
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
+        ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(model);
+        OperationIndex opIndex = OperationIndex.of(model);
 
         Map<ServiceShape, ClientEndpointDiscoveryTrait> endpointDiscoveryServices = model
                 .shapes(ServiceShape.class)

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/ProtocolHttpValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/ProtocolHttpValidator.java
@@ -34,7 +34,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class ProtocolHttpValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         return model.shapes(ServiceShape.class)
                 .flatMap(service -> validateService(service, serviceIndex).stream())
                 .collect(Collectors.toList());

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ArnIndexTest.java
@@ -107,7 +107,7 @@ public class ArnIndexTest {
                 .addImport(ArnIndexTest.class.getResource("effective-arns.json"))
                 .assemble()
                 .unwrap();
-        ArnIndex index = m.getKnowledge(ArnIndex.class);
+        ArnIndex index = ArnIndex.of(m);
         ShapeId service = ShapeId.from("ns.foo#SomeService");
 
         assertThat(index.getEffectiveOperationArn(service, ShapeId.from("ns.foo#InstanceOperation")).map(ArnTrait::getTemplate),

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/PlaneIndexTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/PlaneIndexTest.java
@@ -32,7 +32,7 @@ public class PlaneIndexTest {
                 .unwrap();
 
         ShapeId service = ShapeId.from("smithy.example#Service");
-        PlaneIndex index = model.getKnowledge(PlaneIndex.class);
+        PlaneIndex index = PlaneIndex.of(model);
         assertTrue(index.isControlPlane(service));
         assertFalse(index.isDataPlane(service));
         assertTrue(index.isPlaneDefined(service));

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndexTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndexTest.java
@@ -35,7 +35,7 @@ public class ClientEndpointDiscoveryIndexTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        ClientEndpointDiscoveryIndex discoveryIndex = result.getKnowledge(ClientEndpointDiscoveryIndex.class);
+        ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(result);
 
         ShapeId service = ShapeId.from("ns.foo#FooService");
         ShapeId operation = ShapeId.from("ns.foo#GetObject");
@@ -57,7 +57,7 @@ public class ClientEndpointDiscoveryIndexTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        ClientEndpointDiscoveryIndex discoveryIndex = result.getKnowledge(ClientEndpointDiscoveryIndex.class);
+        ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(result);
 
         ShapeId service = ShapeId.from("ns.foo#FooService");
         ShapeId operation = ShapeId.from("ns.foo#DescribeEndpoints");
@@ -73,7 +73,7 @@ public class ClientEndpointDiscoveryIndexTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        ClientEndpointDiscoveryIndex discoveryIndex = result.getKnowledge(ClientEndpointDiscoveryIndex.class);
+        ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(result);
 
         ShapeId service = ShapeId.from("ns.foo#BarService");
         ShapeId operation = ShapeId.from("ns.foo#GetObject");
@@ -89,7 +89,7 @@ public class ClientEndpointDiscoveryIndexTest {
                 .addImport(getClass().getResource("test-model.json"))
                 .assemble()
                 .unwrap();
-        ClientEndpointDiscoveryIndex discoveryIndex = result.getKnowledge(ClientEndpointDiscoveryIndex.class);
+        ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(result);
         ShapeId service = ShapeId.from("ns.foo#FooService");
         Set<ShapeId> discoveryOperations = discoveryIndex.getEndpointDiscoveryOperations(service);
 

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingPaginatedTraitValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingPaginatedTraitValidator.java
@@ -161,7 +161,7 @@ public final class MissingPaginatedTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
         return model.shapes(OperationShape.class)
                 .filter(shape -> !shape.getTrait(PaginatedTrait.class).isPresent())
                 .flatMap(shape -> validateShape(model, operationIndex, shape))

--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
@@ -128,7 +128,7 @@ public class Selectors {
     @Benchmark
     public Set<Shape> evaluateHttpBindingManually(SelectorState state) {
         Model model = state.model;
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         return model.shapes(ServiceShape.class).flatMap(service -> {
             Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
             // Stop early if there are no bindings at all in the model for any operation.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -57,6 +57,10 @@ public final class BottomUpIndex implements KnowledgeIndex {
                 serviceBindings.put(path.getEndShape().getId(), shapes);
             }
         });
+    }
+
+    public static BottomUpIndex of(Model model) {
+        return model.getKnowledge(BottomUpIndex.class, BottomUpIndex::new);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BoxIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BoxIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -47,6 +47,10 @@ public final class BoxIndex implements KnowledgeIndex {
                 s -> isBoxed(model, s),
                 (a, b) -> b,
                 () -> new HashMap<>(model.toSet().size())));
+    }
+
+    public static BoxIndex of(Model model) {
+        return model.getKnowledge(BoxIndex.class, BoxIndex::new);
     }
 
     private static boolean isBoxed(Model model, Shape shape) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public final class EventStreamIndex implements KnowledgeIndex {
     private final Map<ShapeId, EventStreamInfo> outputInfo = new HashMap<>();
 
     public EventStreamIndex(Model model) {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
 
         model.shapes(OperationShape.class).forEach(operation -> {
             operationIndex.getInput(operation).ifPresent(input -> {
@@ -53,6 +53,10 @@ public final class EventStreamIndex implements KnowledgeIndex {
                 computeEvents(model, operation, output, outputInfo);
             });
         });
+    }
+
+    public static EventStreamIndex of(Model model) {
+        return model.getKnowledge(EventStreamIndex.class, EventStreamIndex::new);
     }
 
     private void computeEvents(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamInfo.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public final class EventStreamInfo {
      * a mapping of member names to the shapes targeted by a member.
      *
      * <pre>{@code
-     * EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+     * EventStreamIndex index = EventStreamIndex.of(model);
      * EventStreamInfo info = index.getInputInfo(myShapeId);
      *
      * for (MemberShape member : info.getInitialMessageMembers()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public final class HttpBindingIndex implements KnowledgeIndex {
 
     public HttpBindingIndex(Model model) {
         this.model = model;
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex opIndex = OperationIndex.of(model);
         model.shapes(OperationShape.class).forEach(shape -> {
             if (shape.getTrait(HttpTrait.class).isPresent()) {
                 requestBindings.put(shape.getId(), computeRequestBindings(opIndex, shape));
@@ -80,6 +80,10 @@ public final class HttpBindingIndex implements KnowledgeIndex {
                 .forEach(pair -> responseBindings.put(
                         pair.getLeft().getId(),
                         createStructureBindings(pair.getLeft(), false)));
+    }
+
+    public static HttpBindingIndex of(Model model) {
+        return model.getKnowledge(HttpBindingIndex.class, HttpBindingIndex::new);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -52,8 +52,12 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
     }
 
     public IdentifierBindingIndex(Model model) {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
         model.shapes(ResourceShape.class).forEach(resource -> processResource(resource, operationIndex, model));
+    }
+
+    public static IdentifierBindingIndex of(Model model) {
+        return model.getKnowledge(IdentifierBindingIndex.class, IdentifierBindingIndex::new);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NeighborProviderIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NeighborProviderIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -43,6 +43,10 @@ public final class NeighborProviderIndex implements KnowledgeIndex {
         // Store a WeakReference to the model since the reversed provider that includes
         // traits is lazily computed.
         this.model = new WeakReference<>(model);
+    }
+
+    public static NeighborProviderIndex of(Model model) {
+        return model.getKnowledge(NeighborProviderIndex.class, NeighborProviderIndex::new);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -56,6 +56,10 @@ public final class OperationIndex implements KnowledgeIndex {
                                .map(Optional::get)
                                .collect(Collectors.toList()));
         });
+    }
+
+    public static OperationIndex of(Model model) {
+        return model.getKnowledge(OperationIndex.class, OperationIndex::new);
     }
 
     public Optional<StructureShape> getInput(ToShapeId operation) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ public final class PaginatedIndex implements KnowledgeIndex {
     private final Map<ShapeId, Map<ShapeId, PaginationInfo>> paginationInfo = new HashMap<>();
 
     public PaginatedIndex(Model model) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        OperationIndex opIndex = OperationIndex.of(model);
 
         model.shapes(ServiceShape.class).forEach(service -> {
             PaginatedTrait serviceTrait = service.getTrait(PaginatedTrait.class).orElse(null);
@@ -59,6 +59,10 @@ public final class PaginatedIndex implements KnowledgeIndex {
                     .collect(Collectors.toMap(i -> i.getOperation().getId(), Function.identity()));
             paginationInfo.put(service.getId(), Collections.unmodifiableMap(mappings));
         });
+    }
+
+    public static PaginatedIndex of(Model model) {
+        return model.getKnowledge(PaginatedIndex.class, PaginatedIndex::new);
     }
 
     private Optional<PaginationInfo> create(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/ServiceIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/ServiceIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -60,6 +60,10 @@ public final class ServiceIndex implements KnowledgeIndex {
                 .filter(shape -> shape.hasTrait(AuthDefinitionTrait.class))
                 .map(Shape::getId)
                 .collect(Collectors.toSet());
+    }
+
+    public static ServiceIndex of(Model model) {
+        return model.getKnowledge(ServiceIndex.class, ServiceIndex::new);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public final class TopDownIndex implements KnowledgeIndex {
     private final Map<ShapeId, Set<OperationShape>> operations = new HashMap<>();
 
     public TopDownIndex(Model model) {
-        NeighborProvider provider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
+        NeighborProvider provider = NeighborProviderIndex.of(model).getProvider();
         Walker walker = new Walker(provider);
 
         // Only traverse resource and operation bindings.
@@ -66,6 +66,10 @@ public final class TopDownIndex implements KnowledgeIndex {
                 resource.getId(), walker.walkShapes(resource, filter)));
         model.shapes(ServiceShape.class).forEach(resource -> findContained(
                 resource.getId(), walker.walkShapes(resource, filter)));
+    }
+
+    public static TopDownIndex of(Model model) {
+        return model.getKnowledge(TopDownIndex.class, TopDownIndex::new);
     }
 
     private void findContained(ShapeId container, Collection<Shape> shapes) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedShapes.java
@@ -54,7 +54,7 @@ public final class UnreferencedShapes {
      * @return Returns the unreferenced shapes.
      */
     public Set<Shape> compute(Model model) {
-        Walker shapeWalker = new Walker(model.getKnowledge(NeighborProviderIndex.class).getProvider());
+        Walker shapeWalker = new Walker(NeighborProviderIndex.of(model).getProvider());
 
         // Find all shapes connected to any service shape.
         Set<Shape> connected = model.shapes(ServiceShape.class)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/UnreferencedTraitDefinitions.java
@@ -48,7 +48,7 @@ public final class UnreferencedTraitDefinitions {
     }
 
     public Set<Shape> compute(Model model) {
-        Walker walker = new Walker(model.getKnowledge(NeighborProviderIndex.class).getProvider());
+        Walker walker = new Walker(NeighborProviderIndex.of(model).getProvider());
 
         // Begin with a mutable set of all trait definitions contained in the model
         Set<Shape> unused = model.getShapesWithTrait(TraitDefinition.class).stream()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/Walker.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/Walker.java
@@ -50,7 +50,7 @@ public final class Walker {
      * @param model Model to traverse.
      */
     public Walker(Model model) {
-        this(model.getKnowledge(NeighborProviderIndex.class).getProvider());
+        this(NeighborProviderIndex.of(model).getProvider());
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
@@ -67,7 +67,7 @@ public final class PathFinder {
 
     private PathFinder(Model model) {
         this.model = model;
-        this.reverseProvider = model.getKnowledge(NeighborProviderIndex.class).getReverseProvider();
+        this.reverseProvider = NeighborProviderIndex.of(model).getReverseProvider();
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
@@ -120,7 +120,7 @@ public interface Selector {
 
         private Context createContext() {
             SmithyBuilder.requiredState("model", model);
-            return new Context(model.getKnowledge(NeighborProviderIndex.class));
+            return new Context(NeighborProviderIndex.of(model));
         }
 
         /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -276,7 +276,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
     }
 
     private boolean isMemberPrimitive(MemberShape member) {
-        return !model.getKnowledge(BoxIndex.class).isBoxed(member);
+        return !BoxIndex.of(model).isBoxed(member);
     }
 
     @Override
@@ -329,7 +329,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     private List<ValidationEvent> invalidShape(Shape shape, NodeType expectedType) {
         // Boxed shapes allow null values.
-        if (allowBoxedNull && value.isNullNode() && model.getKnowledge(BoxIndex.class).isBoxed(shape)) {
+        if (allowBoxedNull && value.isNullNode() && BoxIndex.of(model).isBoxed(shape)) {
             return Collections.emptyList();
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthTraitValidator.java
@@ -44,9 +44,9 @@ public final class AuthTraitValidator extends AbstractValidator {
     }
 
     private void validateService(Model model, ServiceShape service, List<ValidationEvent> events) {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Set<ShapeId> serviceAuth = serviceIndex.getAuthSchemes(service).keySet();
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
 
         // Validate the service's @auth trait.
         validateShape(serviceAuth, service, service, events);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingsMissingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingsMissingValidator.java
@@ -39,7 +39,7 @@ public final class HttpBindingsMissingValidator extends AbstractValidator {
             return Collections.emptyList();
         }
 
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
@@ -67,7 +67,7 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
             return Collections.emptyList();
         }
 
-        HttpBindingIndex bindingIndex = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex bindingIndex = HttpBindingIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
         for (Shape shape : model.getShapesWithTrait(HttpTrait.class)) {
             shape.asOperationShape().ifPresent(operation -> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPayloadValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPayloadValidator.java
@@ -52,8 +52,8 @@ public final class HttpPayloadValidator extends AbstractValidator {
             return Collections.emptyList();
         }
 
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
-        HttpBindingIndex bindings = model.getKnowledge(HttpBindingIndex.class);
+        OperationIndex opIndex = OperationIndex.of(model);
+        HttpBindingIndex bindings = HttpBindingIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
         events.addAll(model.shapes(OperationShape.class)
                 .filter(shape -> shape.getTrait(HttpTrait.class).isPresent())

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
@@ -55,7 +55,7 @@ public final class HttpUriConflictValidator extends AbstractValidator {
     }
 
     private List<ValidationEvent> validateService(Model model, ServiceShape service) {
-        List<OperationShape> operations = model.getKnowledge(TopDownIndex.class).getContainedOperations(service)
+        List<OperationShape> operations = TopDownIndex.of(model).getContainedOperations(service)
                 .stream()
                 .filter(shape -> shape.getTrait(HttpTrait.class).isPresent())
                 .collect(Collectors.toList());
@@ -150,7 +150,7 @@ public final class HttpUriConflictValidator extends AbstractValidator {
     }
 
     private Map<String, Pattern> getLabelPatterns(Model model, OperationShape operation) {
-        return model.getKnowledge(HttpBindingIndex.class)
+        return HttpBindingIndex.of(model)
                 .getRequestBindings(operation).entrySet().stream()
                 .filter(entry -> entry.getValue().getLocation().equals(HttpBinding.Location.LABEL))
                 .flatMap(entry -> OptionalUtils.stream(entry.getValue()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -63,8 +63,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
-        TopDownIndex topDown = model.getKnowledge(TopDownIndex.class);
+        OperationIndex opIndex = OperationIndex.of(model);
+        TopDownIndex topDown = TopDownIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
 
         for (Shape shape : model.getShapesWithTrait(PaginatedTrait.class)) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -39,7 +39,7 @@ public final class PrivateAccessValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         Set<Shape> privateShapes = model.getShapesWithTrait(PrivateTrait.class);
-        NeighborProvider provider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
+        NeighborProvider provider = NeighborProviderIndex.of(model).getProvider();
         return model.shapes()
                 .filter(shape -> !(shape instanceof SimpleShape))
                 .flatMap(shape -> validateNeighbors(shape, provider.getNeighbors(shape), privateShapes))

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceIdentifierBindingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceIdentifierBindingValidator.java
@@ -47,7 +47,7 @@ public final class ResourceIdentifierBindingValidator extends AbstractValidator 
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        IdentifierBindingIndex bindingIndex = model.getKnowledge(IdentifierBindingIndex.class);
+        IdentifierBindingIndex bindingIndex = IdentifierBindingIndex.of(model);
 
         return Stream.of(
                 model.shapes(ResourceShape.class)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceValidator.java
@@ -65,7 +65,7 @@ public final class ServiceValidator extends AbstractValidator {
 
     private List<ValidationEvent> validateService(Model model, ServiceShape service) {
         // Ensure that shapes bound to the service have unique shape names.
-        Walker walker = new Walker(model.getKnowledge(NeighborProviderIndex.class).getProvider());
+        Walker walker = new Walker(NeighborProviderIndex.of(model).getProvider());
         Set<Shape> serviceClosure = walker.walkShapes(service);
         Map<String, List<ShapeId>> conflicts = ValidationUtils.findDuplicateShapeNames(serviceClosure);
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleOperationBindingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleOperationBindingValidator.java
@@ -38,7 +38,7 @@ public final class SingleOperationBindingValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleResourceBindingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/SingleResourceBindingValidator.java
@@ -37,7 +37,7 @@ public final class SingleResourceBindingValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         return model.shapes(ServiceShape.class)
                 .flatMap(shape -> validateService(topDownIndex, shape).stream())
                 .collect(Collectors.toList());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/StreamingTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/StreamingTraitValidator.java
@@ -57,7 +57,7 @@ public final class StreamingTraitValidator extends AbstractValidator {
 
     private List<ValidationEvent> validateStreamingTargets(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        NeighborProvider provider = model.getKnowledge(NeighborProviderIndex.class).getReverseProvider();
+        NeighborProvider provider = NeighborProviderIndex.of(model).getReverseProvider();
 
         // Find any containers that reference a streaming trait.
         Set<Shape> streamingStructures = model.shapes(MemberShape.class)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
@@ -53,7 +53,7 @@ public final class TargetValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        NeighborProvider neighborProvider = model.getKnowledge(NeighborProviderIndex.class).getProvider();
+        NeighborProvider neighborProvider = NeighborProviderIndex.of(model).getProvider();
         return model.shapes()
                 .flatMap(shape -> validateShape(model, shape, neighborProvider.getNeighbors(shape)))
                 .collect(Collectors.toList());

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.IntegerShape;
@@ -230,5 +231,15 @@ public class ModelTest {
 
         assertThat(shapes, hasSize(1));
         assertThat(shapes, contains(string));
+    }
+
+    /**
+     * This test ensures that the old deprecated behavior of using reflection
+     * to create a KnowledgeIndex is maintained (for now at least).
+     */
+    @Test
+    public void canCreateKnowledgeIndexUsingReflection() {
+        Model model = Model.builder().build();
+        model.getKnowledge(TopDownIndex.class);
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/BottomUpIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/BottomUpIndexTest.java
@@ -48,7 +48,7 @@ public class BottomUpIndexTest {
 
     @Test
     public void findsEntityBinding() {
-        BottomUpIndex index = model.getKnowledge(BottomUpIndex.class);
+        BottomUpIndex index = BottomUpIndex.of(model);
 
         assertThat(index.getEntityBinding(serviceId, serviceId), equalTo(Optional.empty()));
         assertThat(index.getEntityBinding(serviceId, ShapeId.from("smithy.example#ServiceOperation")).map(EntityShape::getId),
@@ -77,7 +77,7 @@ public class BottomUpIndexTest {
 
     @Test
     public void findsResourceBinding() {
-        BottomUpIndex index = model.getKnowledge(BottomUpIndex.class);
+        BottomUpIndex index = BottomUpIndex.of(model);
 
         assertThat(index.getResourceBinding(serviceId, serviceId), equalTo(Optional.empty()));
         assertThat(index.getResourceBinding(serviceId, ShapeId.from("smithy.example#ServiceOperation")).map(EntityShape::getId),
@@ -106,7 +106,7 @@ public class BottomUpIndexTest {
 
     @Test
     public void findsPathToLeafOperation() {
-        BottomUpIndex index = model.getKnowledge(BottomUpIndex.class);
+        BottomUpIndex index = BottomUpIndex.of(model);
         List<EntityShape> entities = index.getAllParents(
                 serviceId, ShapeId.from("smithy.example#Resource1_1_2_Operation"));
         List<String> ids = entities.stream()
@@ -119,7 +119,7 @@ public class BottomUpIndexTest {
 
     @Test
     public void findsPathToLeafResource() {
-        BottomUpIndex index = model.getKnowledge(BottomUpIndex.class);
+        BottomUpIndex index = BottomUpIndex.of(model);
         List<EntityShape> entities = index.getAllParents(
                 serviceId, ShapeId.from("smithy.example#Resource1_1_2"));
         List<String> ids = entities.stream()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/BoxIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/BoxIndexTest.java
@@ -16,7 +16,7 @@ public class BoxIndexTest {
     @ParameterizedTest
     @MethodSource("data")
     public void checksIfBoxed(Model model, String shapeId, boolean isBoxed) {
-        BoxIndex index = model.getKnowledge(BoxIndex.class);
+        BoxIndex index = BoxIndex.of(model);
         ShapeId targetId = ShapeId.from(shapeId);
 
         if (isBoxed && !index.isBoxed(targetId)) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/EventStreamIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/EventStreamIndexTest.java
@@ -40,21 +40,21 @@ public class EventStreamIndexTest {
 
     @Test
     public void providesEmptyOptionalWhenNotShape() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertThat(index.getInputInfo(ShapeId.from("com.foo#Missing")), equalTo(Optional.empty()));
     }
 
     @Test
     public void providesEmptyOptionalWhenNotOperation() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertThat(index.getInputInfo(ShapeId.from("smithy.api#String")), equalTo(Optional.empty()));
     }
 
     @Test
     public void providesEmptyOptionalWhenNoInput() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertThat(index.getInputInfo(ShapeId.from("example.smithy#EmptyOperation")),
                    equalTo(Optional.empty()));
@@ -62,7 +62,7 @@ public class EventStreamIndexTest {
 
     @Test
     public void providesEmptyOptionalWhenNoOutput() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertThat(index.getOutputInfo(ShapeId.from("example.smithy#EmptyOperation")),
                    equalTo(Optional.empty()));
@@ -70,7 +70,7 @@ public class EventStreamIndexTest {
 
     @Test
     public void providesEmptyOptionalWhenNoEventStreamTarget() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertThat(index.getOutputInfo(ShapeId.from("example.smithy#NotEventStreamOperation")),
                    equalTo(Optional.empty()));
@@ -78,7 +78,7 @@ public class EventStreamIndexTest {
 
     @Test
     public void returnsEventStreamInputInformation() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertThat(index.getOutputInfo(ShapeId.from("example.smithy#NotEventStreamOperation")),
                    equalTo(Optional.empty()));
@@ -86,7 +86,7 @@ public class EventStreamIndexTest {
 
     @Test
     public void returnsEventStreamOutputInformation() {
-        EventStreamIndex index = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex index = EventStreamIndex.of(model);
 
         assertTrue(index.getInputInfo(ShapeId.from("example.smithy#EventStreamOperation")).isPresent());
         assertTrue(index.getOutputInfo(ShapeId.from("example.smithy#EventStreamOperation")).isPresent());

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -56,13 +56,13 @@ public class HttpBindingIndexTest {
     @Test
     public void throwsWhenShapeIsInvalid() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            model.getKnowledge(HttpBindingIndex.class).getRequestBindings(ShapeId.from("ns.foo#Missing"));
+            HttpBindingIndex.of(model).getRequestBindings(ShapeId.from("ns.foo#Missing"));
         });
     }
 
     @Test
     public void providesResponseCode() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.getResponseCode(ShapeId.from("ns.foo#ServiceOperationNoInputOutput")), is(200));
     }
@@ -75,7 +75,7 @@ public class HttpBindingIndexTest {
                 .addTrait(new HttpErrorTrait(400, SourceLocation.NONE))
                 .build();
         Model model = Model.assembler().addShape(structure).assemble().unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.getResponseCode(ShapeId.from("ns.foo#Error")), is(400));
     }
@@ -87,14 +87,14 @@ public class HttpBindingIndexTest {
                 .addTrait(new ErrorTrait("client", SourceLocation.NONE))
                 .build();
         Model model = Model.assembler().addShape(structure).assemble().unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.getResponseCode(ShapeId.from("ns.foo#Error")), is(400));
     }
 
     @Test
     public void returnsEmptyBindingsWhenNoInputOrOutput() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.getRequestBindings(ShapeId.from("ns.foo#ServiceOperationNoInputOutput")).entrySet(), empty());
         assertThat(index.getResponseBindings(ShapeId.from("ns.foo#ServiceOperationNoInputOutput")).entrySet(), empty());
@@ -102,7 +102,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void returnsResponseMemberBindingsWithDefaults() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId id = ShapeId.from("ns.foo#ServiceOperationExplicitMembers");
         Map<String, HttpBinding> responseBindings = index.getResponseBindings(id);
 
@@ -130,7 +130,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void returnsResponseMemberBindingsWithExplicitBody() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId id = ShapeId.from("ns.foo#ServiceOperationExplicitBody");
         Map<String, HttpBinding> responseBindings = index.getResponseBindings(id);
 
@@ -154,7 +154,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void returnsErrorResponseCode() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId id = ShapeId.from("ns.foo#ErrorExplicitStatus");
 
         assertThat(index.getResponseCode(id), is(403));
@@ -162,7 +162,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void findsLabelBindings() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId id = ShapeId.from("ns.foo#WithLabels");
         Map<String, HttpBinding> bindings = index.getRequestBindings(id);
 
@@ -202,7 +202,7 @@ public class HttpBindingIndexTest {
                 .assemble()
                 .getResult()
                 .get();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         Map<String, HttpBinding> requestBindings = index.getRequestBindings(operation.getId());
 
         assertThat(requestBindings.get("bar").getLocation(), is(HttpBinding.Location.PAYLOAD));
@@ -235,7 +235,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void resolvesStructureBodyContentType() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithStructurePayload");
         Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
 
@@ -244,7 +244,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void resolvesStringBodyContentType() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId operation = ShapeId.from("ns.foo#ServiceOperationExplicitMembers");
         Optional<String> contentType = index.determineRequestContentType(operation, "application/json");
 
@@ -253,7 +253,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void resolvesBlobBodyContentType() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithBlobPayload");
         Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
 
@@ -262,7 +262,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void resolvesMediaType() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithMediaType");
         Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
 
@@ -271,7 +271,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void resolvesResponseEventStreamMediaType() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId operation = ShapeId.from("ns.foo#ServiceOperationWithEventStream");
         String expected = "application/vnd.amazon.eventstream";
         Optional<String> contentType = index.determineResponseContentType(operation, "ignore/me", expected);
@@ -281,7 +281,7 @@ public class HttpBindingIndexTest {
 
     @Test
     public void resolvesDocumentMediaType() {
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         ShapeId operation = ShapeId.from("ns.foo#ServiceOperationExplicitMembers");
         Optional<String> contentType = index.determineResponseContentType(operation, "application/json");
 
@@ -305,7 +305,7 @@ public class HttpBindingIndexTest {
                 .addShape(ListShape.builder().member(member).id("foo.bar#Baz").build())
                 .assemble()
                 .unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
         TimestampFormatTrait.Format format = index.determineTimestampFormat(
                 member, HttpBinding.Location.HEADER, TimestampFormatTrait.Format.DATE_TIME);
 
@@ -323,7 +323,7 @@ public class HttpBindingIndexTest {
                 .addShape(ListShape.builder().member(member).id("foo.bar#Baz").build())
                 .assemble()
                 .unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.determineTimestampFormat(
                 member, HttpBinding.Location.HEADER, TimestampFormatTrait.Format.EPOCH_SECONDS),
@@ -345,7 +345,7 @@ public class HttpBindingIndexTest {
                 .addShape(MapShape.builder().addMember(key).addMember(value).id("foo.bar#Baz").build())
                 .assemble()
                 .unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.determineTimestampFormat(
                 value, HttpBinding.Location.PREFIX_HEADERS, TimestampFormatTrait.Format.EPOCH_SECONDS),
@@ -363,7 +363,7 @@ public class HttpBindingIndexTest {
                 .addShape(ListShape.builder().member(member).id("foo.bar#Baz").build())
                 .assemble()
                 .unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.determineTimestampFormat(
                 member, HttpBinding.Location.QUERY, TimestampFormatTrait.Format.EPOCH_SECONDS),
@@ -384,7 +384,7 @@ public class HttpBindingIndexTest {
                 .addShape(ListShape.builder().member(member).id("foo.bar#Baz").build())
                 .assemble()
                 .unwrap();
-        HttpBindingIndex index = model.getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex index = HttpBindingIndex.of(model);
 
         assertThat(index.determineTimestampFormat(
                 member, HttpBinding.Location.DOCUMENT, TimestampFormatTrait.Format.EPOCH_SECONDS),

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndexTest.java
@@ -39,7 +39,7 @@ public class IdentifierBindingIndexTest {
     @Test
     public void returnsEmptyMapForUnknownBindings() {
         Model model = Model.builder().build();
-        IdentifierBindingIndex index = model.getKnowledge(IdentifierBindingIndex.class);
+        IdentifierBindingIndex index = IdentifierBindingIndex.of(model);
 
         assertThat(index.getOperationBindingType(ShapeId.from("ns.foo#A"), ShapeId.from("ns.foo#B")),
                    equalTo(IdentifierBindingIndex.BindingType.NONE));
@@ -64,7 +64,7 @@ public class IdentifierBindingIndexTest {
                 .addOperation(operation.getId())
                 .build();
         Model model = Model.assembler().addShapes(id, resource, operation, input).assemble().unwrap();
-        IdentifierBindingIndex index = model.getKnowledge(IdentifierBindingIndex.class);
+        IdentifierBindingIndex index = IdentifierBindingIndex.of(model);
 
         assertThat(index.getOperationBindingType(resource.getId(), operation.getId()),
                    equalTo(IdentifierBindingIndex.BindingType.INSTANCE));
@@ -102,7 +102,7 @@ public class IdentifierBindingIndexTest {
                 .addShapes(id, resource, operation, input, listOperation, createOperation)
                 .assemble()
                 .unwrap();
-        IdentifierBindingIndex index = model.getKnowledge(IdentifierBindingIndex.class);
+        IdentifierBindingIndex index = IdentifierBindingIndex.of(model);
 
         assertThat(index.getOperationBindingType(resource.getId(), operation.getId()),
                    equalTo(IdentifierBindingIndex.BindingType.COLLECTION));
@@ -136,7 +136,7 @@ public class IdentifierBindingIndexTest {
                 .addOperation(operation.getId())
                 .build();
         Model model = Model.assembler().addShapes(resource, operation, input).assemble().unwrap();
-        IdentifierBindingIndex index = model.getKnowledge(IdentifierBindingIndex.class);
+        IdentifierBindingIndex index = IdentifierBindingIndex.of(model);
 
         assertThat(index.getOperationBindingType(resource.getId(), operation.getId()),
                    equalTo(IdentifierBindingIndex.BindingType.INSTANCE));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
@@ -47,7 +47,7 @@ public class OperationIndexTest {
 
     @Test
     public void indexesEmptyOperations() {
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex opIndex = OperationIndex.of(model);
 
         assertThat(opIndex.getInput(ShapeId.from("ns.foo#A")), is(Optional.empty()));
         assertThat(opIndex.getOutput(ShapeId.from("ns.foo#A")), is(Optional.empty()));
@@ -56,7 +56,7 @@ public class OperationIndexTest {
 
     @Test
     public void indexesOperations() {
-        OperationIndex opIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex opIndex = OperationIndex.of(model);
         Shape input = model.getShape(ShapeId.from("ns.foo#Input")).get();
         Shape output = model.getShape(ShapeId.from("ns.foo#Output")).get();
         Shape error1 = model.getShape(ShapeId.from("ns.foo#Error1")).get();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/PaginatedIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/PaginatedIndexTest.java
@@ -32,7 +32,7 @@ public class PaginatedIndexTest {
                         "/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json"))
                 .assemble();
         Model model = result.getResult().get();
-        PaginatedIndex index = model.getKnowledge(PaginatedIndex.class);
+        PaginatedIndex index = PaginatedIndex.of(model);
         ShapeId service = ShapeId.from("ns.foo#Service");
 
         assertThat(index.getPaginationInfo(service, ShapeId.from("ns.foo#Valid2")).isPresent(), is(true));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/ServiceIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/ServiceIndexTest.java
@@ -54,7 +54,7 @@ public class ServiceIndexTest {
                 .addImport(getClass().getResource("service-index-loads-protocols.smithy"))
                 .assemble()
                 .unwrap();
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> protocols = serviceIndex.getProtocols(ShapeId.from("smithy.example#TestService"));
 
         assertThat(protocols, hasKey(ShapeId.from("smithy.example#fooJson")));
@@ -64,7 +64,7 @@ public class ServiceIndexTest {
 
     @Test
     public void returnsAuthSchemesOfService() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithNoAuthTrait"));
 
@@ -76,7 +76,7 @@ public class ServiceIndexTest {
 
     @Test
     public void getsAuthSchemesOfServiceWithNoAuthTrait() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithNoAuthTrait"));
 
@@ -88,7 +88,7 @@ public class ServiceIndexTest {
 
     @Test
     public void getsAuthSchemesOfServiceWithAuthTrait() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithAuthTrait"));
 
@@ -99,7 +99,7 @@ public class ServiceIndexTest {
 
     @Test
     public void getsAuthSchemesOfOperationWithNoAuthTraitAndServiceWithNoAuthTrait() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithNoAuthTrait"),
                 ShapeId.from("smithy.example#OperationWithNoAuthTrait"));
@@ -112,7 +112,7 @@ public class ServiceIndexTest {
 
     @Test
     public void getsAuthSchemesOfOperationWithNoAuthTraitAndServiceWithAuthTrait() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithAuthTrait"),
                 ShapeId.from("smithy.example#OperationWithNoAuthTrait"));
@@ -124,7 +124,7 @@ public class ServiceIndexTest {
 
     @Test
     public void getsAuthSchemesOfOperationWithAuthTrait() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithAuthTrait"),
                 ShapeId.from("smithy.example#OperationWithAuthTrait"));
@@ -135,7 +135,7 @@ public class ServiceIndexTest {
 
     @Test
     public void returnsAnEmptyCollectionWhenTheServiceDoesNotExist() {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#Invalid"),
                 ShapeId.from("smithy.example#OperationWithAuthTrait"));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/TopDownIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/TopDownIndexTest.java
@@ -37,7 +37,7 @@ public class TopDownIndexTest {
                 .build();
         ResourceShape resource = ResourceShape.builder().id("ns.foo#Resource").build();
         Model model = Model.builder().addShapes(service, resource).build();
-        TopDownIndex childIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex childIndex = TopDownIndex.of(model);
 
         assertThat(childIndex.getContainedOperations(service), empty());
         assertThat(childIndex.getContainedResources(service), contains(resource));
@@ -62,7 +62,7 @@ public class TopDownIndexTest {
         OperationShape operation = OperationShape.builder().id("ns.foo#Operation").build();
         OperationShape list = OperationShape.builder().id("ns.foo#List").build();
         Model model = Model.builder().addShapes(service, resourceA, resourceB, operation, list).build();
-        TopDownIndex childIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex childIndex = TopDownIndex.of(model);
 
         assertThat(childIndex.getContainedResources(service.getId()), containsInAnyOrder(resourceA, resourceB));
         assertThat(childIndex.getContainedOperations(service.getId()), containsInAnyOrder(operation, list));

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
@@ -41,7 +41,7 @@ import software.amazon.smithy.model.traits.Trait;
  *
  * <pre>
  * {@code
- * ResolvedTopicIndex resolvedIndex = model.getKnowledge(ResolvedTopicIndex.class);
+ * ResolvedTopicIndex resolvedIndex = ResolvedTopicIndex.of(model);
  * TopicBinding<PublishTrait> binding = resolvedIndex.getPublishBinding(myOperation).get();
  *
  * assert(binding.getTopic() instanceOf Topic);
@@ -59,8 +59,8 @@ public final class ResolvedTopicIndex implements KnowledgeIndex {
 
     public ResolvedTopicIndex(Model model) {
         // Find all the MQTT topic bindings in the model.
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
+        OperationIndex operationIndex = OperationIndex.of(model);
 
         model.shapes(OperationShape.class).forEach(operation -> {
             if (operation.hasTrait(PublishTrait.class)) {
@@ -72,6 +72,10 @@ public final class ResolvedTopicIndex implements KnowledgeIndex {
                 createSubscribeBinding(input, eventStreamIndex, operation, trait);
             }
         });
+    }
+
+    public static ResolvedTopicIndex of(Model model) {
+        return model.getKnowledge(ResolvedTopicIndex.class, ResolvedTopicIndex::new);
     }
 
     /**

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeOutputValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeOutputValidator.java
@@ -49,7 +49,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class MqttSubscribeOutputValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         return model.shapes(OperationShape.class)
                 .flatMap(shape -> Trait.flatMapStream(shape, SubscribeTrait.class))
                 .flatMap(pair -> validateOperation(model, pair.getLeft(), eventStreamIndex).stream())

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicConflictValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicConflictValidator.java
@@ -37,7 +37,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class MqttTopicConflictValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        ResolvedTopicIndex bindingIndex = model.getKnowledge(ResolvedTopicIndex.class);
+        ResolvedTopicIndex bindingIndex = ResolvedTopicIndex.of(model);
 
         // Find conflicting topic bindings for each resolved topic.
         return bindingIndex.topicBindings()

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -249,7 +249,7 @@ public final class OpenApiConverter {
     // If the derived protocol trait cannot be found on the service, an exception
     // is thrown.
     private Trait loadOrDeriveProtocolTrait(Model model, ServiceShape service) {
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Set<ShapeId> serviceProtocols = serviceIndex.getProtocols(service).keySet();
 
         if (config.getProtocol() != null) {
@@ -363,7 +363,7 @@ public final class OpenApiConverter {
             List<Smithy2OpenApiExtension> extensions
     ) {
         // Note: Using a LinkedHashSet here in case order is ever important.
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Set<Class<? extends Trait>> schemes = getTraitMapTypes(serviceIndex.getAuthSchemes(service));
 
         List<SecuritySchemeConverter<? extends Trait>> converters = extensions.stream()
@@ -417,7 +417,7 @@ public final class OpenApiConverter {
             OpenApiProtocol<T> protocolService,
             OpenApiMapper plugin
     ) {
-        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
         Map<String, PathItem.Builder> paths = new HashMap<>();
 
         // Add each operation connected to the service shape to the OpenAPI model.
@@ -498,7 +498,7 @@ public final class OpenApiConverter {
             OpenApiMapper plugin
     ) {
         ServiceShape service = context.getService();
-        ServiceIndex serviceIndex = context.getModel().getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(context.getModel());
         Map<ShapeId, Trait> serviceSchemes = serviceIndex.getEffectiveAuthSchemes(service);
         Map<ShapeId, Trait> operationSchemes = serviceIndex.getEffectiveAuthSchemes(service, shape);
 
@@ -633,7 +633,7 @@ public final class OpenApiConverter {
             OpenApiMapper plugin
     ) {
         ServiceShape service = context.getService();
-        ServiceIndex serviceIndex = context.getModel().getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(context.getModel());
 
         // Create security components for each referenced security scheme.
         for (SecuritySchemeConverter<? extends Trait> converter : context.getSecuritySchemeConverters()) {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
@@ -123,9 +123,7 @@ public interface OpenApiProtocol<T extends Trait> {
      * @return Returns the status code as a string.
      */
     default String getOperationResponseStatusCode(Context<T> context, ToShapeId operationOrError) {
-        return String.valueOf(context.getModel()
-                .getKnowledge(HttpBindingIndex.class)
-                .getResponseCode(operationOrError));
+        return String.valueOf(HttpBindingIndex.of(context.getModel()).getResponseCode(operationOrError));
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForPrefixHeaders.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/CheckForPrefixHeaders.java
@@ -50,7 +50,7 @@ public class CheckForPrefixHeaders implements OpenApiMapper {
 
     @Override
     public void before(Context<? extends Trait> context, OpenApi.Builder builder) {
-        HttpBindingIndex httpBindings = context.getModel().getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex httpBindings = HttpBindingIndex.of(context.getModel());
         context.getModel().shapes(OperationShape.class).forEach(operation -> {
             check(context, httpBindings.getRequestBindings(operation, HttpBinding.Location.PREFIX_HEADERS));
             checkForResponseHeaders(context, httpBindings, operation);

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -106,8 +106,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             String method = context.getOpenApiProtocol().getOperationMethod(context, operation);
             String uri = context.getOpenApiProtocol().getOperationUri(context, operation);
             OperationObject.Builder builder = OperationObject.builder().operationId(operation.getId().getName());
-            HttpBindingIndex bindingIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
-            EventStreamIndex eventStreamIndex = context.getModel().getKnowledge(EventStreamIndex.class);
+            HttpBindingIndex bindingIndex = HttpBindingIndex.of(context.getModel());
+            EventStreamIndex eventStreamIndex = EventStreamIndex.of(context.getModel());
             createPathParameters(context, operation).forEach(builder::addParameter);
             createQueryParameters(context, operation).forEach(builder::addParameter);
             createRequestHeaderParameters(context, operation).forEach(builder::addParameter);
@@ -119,7 +119,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
 
     private List<ParameterObject> createPathParameters(Context<T> context, OperationShape operation) {
         List<ParameterObject> result = new ArrayList<>();
-        HttpBindingIndex bindingIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex bindingIndex = HttpBindingIndex.of(context.getModel());
 
         for (HttpBinding binding : bindingIndex.getRequestBindings(operation, HttpBinding.Location.LABEL)) {
             Schema schema = createPathParameterSchema(context, binding);
@@ -163,7 +163,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     // bound to the QUERY location will generate a new ParameterObject that
     // has a location of "query".
     private List<ParameterObject> createQueryParameters(Context<T> context, OperationShape operation) {
-        HttpBindingIndex httpBindingIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex httpBindingIndex = HttpBindingIndex.of(context.getModel());
         List<ParameterObject> result = new ArrayList<>();
 
         for (HttpBinding binding : httpBindingIndex.getRequestBindings(operation, HttpBinding.Location.QUERY)) {
@@ -191,7 +191,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     }
 
     private Collection<ParameterObject> createRequestHeaderParameters(Context<T> context, OperationShape operation) {
-        List<HttpBinding> bindings = context.getModel().getKnowledge(HttpBindingIndex.class)
+        List<HttpBinding> bindings = HttpBindingIndex.of(context.getModel())
                 .getRequestBindings(operation, HttpBinding.Location.HEADER);
         return createHeaderParameters(context, bindings, MessageType.REQUEST).values();
     }
@@ -319,7 +319,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             OperationShape operation
     ) {
         Map<String, ResponseObject> result = new TreeMap<>();
-        OperationIndex operationIndex = context.getModel().getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(context.getModel());
 
         operationIndex.getOutput(operation).ifPresent(output -> {
             updateResponsesMapWithResponseStatusAndObject(
@@ -367,7 +367,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             Context<T> context,
             Shape operationOrError
     ) {
-        List<HttpBinding> bindings = context.getModel().getKnowledge(HttpBindingIndex.class)
+        List<HttpBinding> bindings = HttpBindingIndex.of(context.getModel())
                 .getResponseBindings(operationOrError, HttpBinding.Location.HEADER);
         return createHeaderParameters(context, bindings, MessageType.RESPONSE);
     }

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
@@ -47,7 +47,7 @@ abstract class ProtocolTestCaseValidator<T extends Trait> extends AbstractValida
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
 
         return Stream.concat(model.shapes(OperationShape.class), model.shapes(StructureShape.class))
                 .flatMap(operation -> Trait.flatMapStream(operation, traitClass))


### PR DESCRIPTION
This commit deprecates the old access pattern used to create a
KnowledgeIndex (`model.getKnowledge(X.class)`) in favor of using a new
convention: `X.of(model)`. KnowledgeIndex implementations are now
expected to provide a public static method named `of` that accepts a
`Model` and returns an instance of the class. The instance should be
created by calling `model.getKnowledge(Class<T>, Function<Model, T>)`
which will ensure the index is cached in the given model.

This change is the first step towards seeing if we can get full GraalVM
native image support. It also makes using a KnowledgeIndex more
ergonomic IMO, and remove reflection, which is generally a good thing.

The deprecated method will eventually be removed in a subsequent
release.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
