### PR TITLE
Add validation for bad syntactic shape ID

### DIFF
--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -612,6 +612,17 @@ shape IDs inside of strings, and this difference is inconsequential in the
 resolved to a string that contains a fully-qualified shape ID when parsing
 the model.
 
+.. rubric:: Validation
+
+When a syntactic shape ID is found that does not target an actual shape in
+the fully loaded semantic model, an implementation SHOULD emit a DANGER
+:ref:`validation event <validation>` with an ID of `SyntacticShapeIdTarget`.
+This validation brings attention to the broken reference and helps to ensure
+that modelers do not unintentionally use a syntactic shape ID when they should
+have used a string. A DANGER severity is used so that the validation can be
+:ref:`suppressed <suppression-definition>` in the rare cases that the broken
+reference can be ignored.
+
 
 Defining shapes
 ===============

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-bad-syntactic-shape-ids.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-bad-syntactic-shape-ids.errors
@@ -1,0 +1,1 @@
+[DANGER] -: Syntactic shape ID `GET` does not resolve to a valid shape ID: `smithy.example#GET`. Did you mean to quote this string? Are you missing a model file? | SyntacticShapeIdTarget

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-bad-syntactic-shape-ids.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-bad-syntactic-shape-ids.smithy
@@ -1,0 +1,4 @@
+namespace smithy.example
+
+@http(method: GET, uri: "/") // <- Use "GET" not GET!
+operation Foo {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/bottom-up.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/bottom-up.smithy
@@ -18,7 +18,6 @@ operation Resource1Operation {}
 resource Resource1_2 {}
 
 resource Resource1_1 {
-    type: resource,
     operations: [Resource1_1_Operation],
     resources: [Resource1_1_1, Resource1_1_2]
 }


### PR DESCRIPTION
Smithy will now emit a DANGER event when a syntactic shape ID is found that
does not resolve to a valid shape. This should help detect invalid
models during model validation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
