### PR TITLE
Fix forward reference resolution of service shapes

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/use-operations/nested.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/use-operations/nested.smithy
@@ -1,0 +1,28 @@
+namespace smithy.example.nested
+
+use smithy.example.other#Hello2
+use smithy.example.other#X
+use smithy.example.other#GetHello2
+
+operation Hello {}
+
+resource Resource {
+    // A "use" identifier.
+    identifiers: {
+        x: X,
+        s: String,
+    },
+
+    // A "use" lifecycle operation.
+    read: GetHello2,
+
+    // A "use" instance operation.
+    operations: [Hello2]
+}
+
+structure A {}
+
+structure B {}
+
+@error("client")
+structure C {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/use-operations/other.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/use-operations/other.smithy
@@ -1,0 +1,20 @@
+namespace smithy.example.other
+
+operation Hello2 {
+    input: Hello2Input,
+}
+
+structure Hello2Input {
+    @required
+    x: X,
+
+    @required
+    s: String, // this should resolve to smithy.api#String
+}
+
+string X
+
+@readonly
+operation GetHello2 {
+    input: Hello2Input,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/use-operations/service.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/use-operations/service.smithy
@@ -1,0 +1,28 @@
+namespace smithy.example
+
+use smithy.example.nested#Hello
+use smithy.example.nested#A
+use smithy.example.nested#B
+use smithy.example.nested#C
+use smithy.example.nested#Resource
+
+service Foo {
+    version: "2020-06-11",
+
+    // A "use" resource.
+    resources: [Resource],
+
+    // "use" instance operations.
+    operations: [Hello, Local]
+}
+
+operation Local {
+    // "use" input
+    input: A,
+
+    // "use" output
+    output: B,
+
+    // "use" errors
+    errors: [C]
+}


### PR DESCRIPTION
Service shapes weren't correctly using forward reference resolution in
the IDL for operation bindings and resource bindings. This is because we
were eagerly taking the value out of a StringNode that uses a syntactic
shape ID before all of the shapes are resolved. This causes the
StringNode to assume that the shape ID is in the same namespace that it
was defined in, which can be incorrect when there are `use` statements
in effect. To address this, I've updated the optionalId and
optionalIdList methods used in the IDL loader to always use a dedicated
forward reference resolution callback independent of the callback used
in other places (like trait values). Now things like identifiers,
inputs, outputs, operation, and resource bindings are all handled in a
uniform way.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
