### PR TITLE
Fix gradle to not call invalid .get()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
     task sourcesJar(type: Jar) {
         metaInf.with(licenseSpec)
         from {
-            sourceSets.main.get().allJava
+            sourceSets.main.allJava
         }
         archiveClassifier = "sources"
     }


### PR DESCRIPTION
We previously failed to build ther sourcesJar when calling `publishToMavenLocal`. This is now fixed and tested by publishing all JARs to maven local.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
