### PR TITLE
Fix TopologicalIndex

### DIFF
--- a/smithy-codegen-core/src/test/resources/software/amazon/smithy/codegen/core/topological-recursion.smithy
+++ b/smithy-codegen-core/src/test/resources/software/amazon/smithy/codegen/core/topological-recursion.smithy
@@ -1,0 +1,40 @@
+namespace smithy.example
+
+service Example {
+    version: "1.0.0",
+    operations: [GetFoo]
+}
+
+operation GetFoo {
+    input: GetFooInput
+}
+
+structure GetFooInput {
+    foo: User
+}
+
+structure User {
+    recursiveUser: User,
+    recursiveList: UsersList,
+    recursiveMap: UsersMap,
+    notRecursive: NonRecursiveList,
+}
+
+list UsersList {
+    member: User
+}
+
+map UsersMap {
+    key: MyString,
+    value: User
+}
+
+list NonRecursiveList {
+    member: NonRecursive,
+}
+
+structure NonRecursive {
+    foo: MyString
+}
+
+string MyString

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/PathFinder.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.selector;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -114,7 +113,7 @@ public final class PathFinder {
         return searchFromShapeToSet(startingShape, candidates);
     }
 
-    private List<Path> searchFromShapeToSet(ToShapeId startingShape, Set<Shape> candidates) {
+    private List<Path> searchFromShapeToSet(ToShapeId startingShape, Collection<Shape> candidates) {
         Shape shape = model.getShape(startingShape.toShapeId()).orElse(null);
         if (shape == null || candidates.isEmpty()) {
             return ListUtils.of();
@@ -124,17 +123,15 @@ public final class PathFinder {
     }
 
     /**
-     * Finds all of the possible paths from the {@code startingShape} to the
-     * the {@code targetShape}.
+     * Finds all of the possible paths from the {@code startingShape} to
+     * any of the provided shapes in {@code targetShapes}.
      *
      * @param startingShape Starting shape to find the paths from.
-     * @param targetShape The shape to try to find a path to.
+     * @param targetShapes The shapes to try to find a path to.
      * @return Returns the list of matching paths.
      */
-    public List<Path> search(ToShapeId startingShape, ToShapeId targetShape) {
-        return searchFromShapeToSet(
-                startingShape,
-                model.getShape(targetShape.toShapeId()).map(Collections::singleton).orElse(Collections.emptySet()));
+    public List<Path> search(ToShapeId startingShape, Collection<Shape> targetShapes) {
+        return searchFromShapeToSet(startingShape, targetShapes);
     }
 
     /**

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/PathFinderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/PathFinderTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -161,7 +162,7 @@ public class PathFinderTest {
                 .build();
         Model model = Model.builder().addShapes(struct).build();
         PathFinder finder = PathFinder.create(model);
-        List<PathFinder.Path> paths = finder.search(struct.getId(), struct.getId());
+        List<PathFinder.Path> paths = finder.search(struct.getId(), Collections.singleton(struct));
 
         assertThat(paths, hasSize(1));
         assertThat(paths.get(0), hasSize(2));


### PR DESCRIPTION
This commit fixes a bug in TopologicalIndex where some forms of
recursion weren't detected, which resulted in a stack overflow. This was
because directly recursive shapes were found, but transitively recursive
shapes were not (shapes that are recursive on themselves, but enter into
a cycle because they reference recursive shapes). To address this,
TopologicalIndex was rewritten to just implement a DFS rather than try
to reuse PathFinder.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
