### PR TITLE
Add transformer that removes trait definitions

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -862,6 +862,54 @@ key is not in the provided ``keys`` list.
             }
         }
 
+.. _removeTraitDefinitions-transform:
+
+removeTraitDefinitions
+----------------------
+
+Removes trait definitions from the model, but leaves the instances of traits
+intact on any shapes.
+
+You can *export* trait definitions by applying specific tags to the trait
+definition and adding the list of export tags in the ``exportTagged`` argument.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - exportTagged
+      - ``[string]``
+      - The set of tags that, if found on a trait definition, forces the trait
+        to be retained in the transformed model.
+
+The following example removes trait definitions but keeps the instances of the
+trait intact on shapes in the model:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "removeTraitDefinitions",
+                            "args": {
+                                "exportTagged": [
+                                    "export-tag1",
+                                    "another-export-tag"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
 
 .. _removeUnusedShapes-transform:
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveTraitDefinitions.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveTraitDefinitions.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TraitDefinition;
+import software.amazon.smithy.model.transform.ModelTransformer;
+
+/**
+ * {@code removeTraitShapes} removes all trait definitions from a model,
+ * but leaves if the trait definition contains any of the provided
+ * {@code tags}.
+ *
+ * <p>This transformer will not remove prelude trait definitions.
+ */
+public final class RemoveTraitDefinitions extends BackwardCompatHelper<RemoveTraitDefinitions.Config> {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoveTraitDefinitions.class.getName());
+
+    /**
+     * {@code removeTraitShapes} configuration settings.
+     */
+    public static final class Config {
+
+        private Set<String> exportTagged = Collections.emptySet();
+
+        /**
+         * You can <em>export</em> trait definitions by applying specific tags
+         * to the trait definition and adding the list of export tags as an
+         * argument to the transformer.
+         *
+         * @param exportByTags Tags that cause trait definitions to be
+         *                     exported.
+         */
+        public void setExportTagged(Set<String> exportByTags) {
+            this.exportTagged = exportByTags;
+        }
+
+        /**
+         * Gets the set of tags that are used to export trait definitions.
+         *
+         * @return the tags that are used to export trait definitions.
+         */
+        public Set<String> getExportTagged() {
+            return exportTagged;
+        }
+    }
+
+    @Override
+    String getBackwardCompatibleNameMapping() {
+        return "removeTraitDefinitions";
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Model model = context.getModel();
+        ModelTransformer transformer = context.getTransformer();
+
+        Model modelWithoutTraitDefinitions = transformer.getModelWithoutTraitShapes(model);
+
+        // If no export tags have been configured, we can return the scrubbed model directly.
+        if (config.getExportTagged().isEmpty()) {
+            return modelWithoutTraitDefinitions;
+        }
+
+        Predicate<Shape> keepTraitDefsByTag = trait -> config.getExportTagged().stream().anyMatch(trait::hasTag);
+        Model.Builder builder = modelWithoutTraitDefinitions.toBuilder();
+
+        // Add trait definitions back to scrubbed model.
+        model.shapes()
+                .filter(shape -> shape.getTrait(TraitDefinition.class).isPresent())
+                .filter(keepTraitDefsByTag)
+                .forEach(builder::addShape);
+
+        return builder.build();
+    }
+
+    @Override
+    public String getName() {
+        return "removeTraitDefinitions";
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RemoveTraitDefinitionsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RemoveTraitDefinitionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class RemoveTraitDefinitionsTest {
+
+    @Test
+    public void removesAllTraitDefinitions() throws Exception {
+        Model model = Model.assembler()
+                .addImport(Paths.get(getClass().getResource("remove-trait-definitions.json").toURI()))
+                .assemble()
+                .unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("exportTagged", Node.arrayNode()))
+                .build();
+        Model result = new RemoveTraitDefinitions().transform(context);
+        Shape baz = result.getShape(ShapeId.from("ns.foo#baz")).get();
+
+        // Trait definitions are removed.
+        assertFalse(result.getTraitDefinition(ShapeId.from("ns.foo#bar")).isPresent());
+        assertFalse(result.getShape(ShapeId.from("ns.foo#bar")).isPresent());
+        // Instance of trait on shape is retained.
+        assertTrue(baz.hasTrait("ns.foo#bar"));
+    }
+
+    @Test
+    public void retainsTaggedTraitDefinitions() throws Exception {
+        Model model = Model.assembler()
+                .addImport(Paths.get(getClass().getResource("retain-tagged-trait-definitions.json").toURI()))
+                .assemble()
+                .unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("exportTagged", Node.fromStrings("export")))
+                .build();
+        Model result = new RemoveTraitDefinitions().transform(context);
+        Shape baz = result.getShape(ShapeId.from("ns.foo#baz")).get();
+        Shape garply = result.getShape(ShapeId.from("ns.foo#garply")).get();
+
+        // Definition for trait "export" tag should be retained.
+        assertTrue(result.getTraitDefinition(ShapeId.from("ns.foo#bar")).isPresent());
+        assertTrue(result.getShape(ShapeId.from("ns.foo#bar")).isPresent());
+        // Instance of trait on shape is retained.
+        assertTrue(baz.hasTrait("ns.foo#bar"));
+
+        // Definition for trait without "export" tag should be removed.
+        assertFalse(result.getTraitDefinition(ShapeId.from("ns.foo#qux")).isPresent());
+        assertFalse(result.getShape(ShapeId.from("ns.foo#qux")).isPresent());
+        // Instance of trait on shape is retained.
+        assertTrue(garply.hasTrait("ns.foo#qux"));
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/remove-trait-definitions.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/remove-trait-definitions.json
@@ -1,0 +1,27 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "ns.foo#bar": {
+      "type": "structure",
+      "members": {
+        "member": {
+          "target": "ns.foo#BarTraitShapeMember"
+        }
+      },
+      "traits": {
+        "smithy.api#trait": {}
+      }
+    },
+    "ns.foo#baz": {
+      "type": "string",
+      "traits": {
+        "ns.foo#bar": {
+          "member": "baz"
+        }
+      }
+    },
+    "ns.foo#BarTraitShapeMember": {
+      "type": "string"
+    }
+  }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/retain-tagged-trait-definitions.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/retain-tagged-trait-definitions.json
@@ -1,0 +1,52 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "ns.foo#bar": {
+      "type": "structure",
+      "members": {
+        "member": {
+          "target": "ns.foo#BarTraitShapeMember"
+        }
+      },
+      "traits": {
+        "smithy.api#trait": {},
+        "smithy.api#tags": [
+          "export"
+        ]
+      }
+    },
+    "ns.foo#baz": {
+      "type": "string",
+      "traits": {
+        "ns.foo#bar": {
+          "member": "baz"
+        }
+      }
+    },
+    "ns.foo#BarTraitShapeMember": {
+      "type": "string"
+    },
+    "ns.foo#qux": {
+      "type": "structure",
+      "members": {
+        "member": {
+          "target": "ns.foo#BarTraitShapeMember"
+        }
+      },
+      "traits": {
+        "smithy.api#trait": {},
+        "smithy.api#tags": [
+          "corge"
+        ]
+      }
+    },
+    "ns.foo#garply": {
+      "type": "string",
+      "traits": {
+        "ns.foo#qux": {
+          "member": "baz"
+        }
+      }
+    }
+  }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -370,7 +370,7 @@ public final class ModelTransformer {
      *
      * <p>This can be useful when serializing a Smithy model to a format that
      * does not include trait definitions and the shapes used by trait definitions
-     * would have no meaning (e.g., Swagger).
+     * would have no meaning (e.g., OpenAPI).
      *
      * @param model Model to transform.
      * @return Returns the transformed model.base.
@@ -386,13 +386,13 @@ public final class ModelTransformer {
      *
      * <p>This can be useful when serializing a Smithy model to a format that
      * does not include trait definitions and the shapes used by trait definitions
-     * would have no meaning (e.g., Swagger).
+     * would have no meaning (e.g., OpenAPI).
      *
      * @param model Model to transform.
      * @param keepFilter Predicate function that accepts an trait shape (that
      *  has the {@link TraitDefinition} trait) and returns true to remove the
-     *  definition or false to keep the definition in the model.base.
-     * @return Returns the transformed model.base.
+     *  definition or false to keep the definition in the model.
+     * @return Returns the transformed model.
      */
     public Model scrubTraitDefinitions(Model model, Predicate<Shape> keepFilter) {
         return new ScrubTraitDefinitions().transform(this, model, keepFilter);
@@ -416,7 +416,7 @@ public final class ModelTransformer {
      * @param model Model that contains shapes.
      * @param keepFilter Predicate function that accepts a trait shape (that
      *  has the {@link TraitDefinition} trait) and returns true to remove the
-     *  definition or false to keep the definition in the model.base.
+     *  definition or false to keep the definition in the model.
      * @return Returns a model that contains matching shapes.
      */
     public Model getModelWithoutTraitShapes(Model model, Predicate<Shape> keepFilter) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -376,7 +376,26 @@ public final class ModelTransformer {
      * @return Returns the transformed model.base.
      */
     public Model scrubTraitDefinitions(Model model) {
-        return new ScrubTraitDefinitions().transform(this, model);
+        return scrubTraitDefinitions(model, FunctionalUtils.alwaysTrue());
+    }
+
+    /**
+     * Removes trait definitions from a model and all shapes that are
+     * only connected to the graph either directly or transitively by a
+     * trait definition shape.
+     *
+     * <p>This can be useful when serializing a Smithy model to a format that
+     * does not include trait definitions and the shapes used by trait definitions
+     * would have no meaning (e.g., Swagger).
+     *
+     * @param model Model to transform.
+     * @param keepFilter Predicate function that accepts an trait shape (that
+     *  has the {@link TraitDefinition} trait) and returns true to remove the
+     *  definition or false to keep the definition in the model.base.
+     * @return Returns the transformed model.base.
+     */
+    public Model scrubTraitDefinitions(Model model, Predicate<Shape> keepFilter) {
+        return new ScrubTraitDefinitions().transform(this, model, keepFilter);
     }
 
     /**
@@ -387,6 +406,20 @@ public final class ModelTransformer {
      * @return Returns a model that contains matching shapes.
      */
     public Model getModelWithoutTraitShapes(Model model) {
+        return getModelWithoutTraitShapes(model, FunctionalUtils.alwaysTrue());
+    }
+
+    /**
+     * Gets all shapes from a model where shapes that define traits or shapes
+     * that are only used as part of a trait definition have been removed.
+     *
+     * @param model Model that contains shapes.
+     * @param keepFilter Predicate function that accepts a trait shape (that
+     *  has the {@link TraitDefinition} trait) and returns true to remove the
+     *  definition or false to keep the definition in the model.base.
+     * @return Returns a model that contains matching shapes.
+     */
+    public Model getModelWithoutTraitShapes(Model model, Predicate<Shape> keepFilter) {
         Model.Builder builder = Model.builder();
 
         // ScrubTraitDefinitions is used to removed traits and trait shapes.
@@ -395,7 +428,7 @@ public final class ModelTransformer {
         // a model is created by getting all shape IDs from the modified
         // model, grabbing shapes from the original model, and building a new
         // Model.
-        scrubTraitDefinitions(model).shapes()
+        scrubTraitDefinitions(model, keepFilter).shapes()
                 .map(Shape::getId)
                 .map(model::getShape)
                 .map(Optional::get)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
@@ -37,7 +37,7 @@ import software.amazon.smithy.utils.FunctionalUtils;
  *
  * <p>This can be useful when serializing a Smithy model to a format that
  * does not include trait definitions and the shapes used by trait definitions
- * would have no meaning (e.g., Swagger).
+ * would have no meaning (e.g., OpenAPI).
  *
  * <p>TODO: Should there be an option to only remove private traits?
  *

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ScrubTraitDefinitionsTest.java
@@ -18,9 +18,11 @@ package software.amazon.smithy.model.transform;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class ScrubTraitDefinitionsTest {
@@ -43,6 +45,51 @@ public class ScrubTraitDefinitionsTest {
         assertThat(result.getShape(ShapeId.from("ns.foo#IpsumString")), Matchers.not(Optional.empty()));
         assertThat(result.getShape(ShapeId.from("ns.foo#IpsumList")), Matchers.not(Optional.empty()));
         assertThat(result.getShape(ShapeId.from("ns.foo#KeepStructure")), Matchers.not(Optional.empty()));
+
+        // Make sure public prelude shapes weren't removed.
+        assertThat(result.getShape(ShapeId.from("smithy.api#String")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Blob")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Boolean")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Byte")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Short")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Integer")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Long")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Float")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Double")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#BigInteger")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#BigDecimal")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("smithy.api#Timestamp")), Matchers.not(Optional.empty()));
+
+        // Make sure public prelude trait definition shapes were removed.
+        assertThat(result.getShape(ShapeId.from("smithy.api#length")), Matchers.is(Optional.empty()));
+    }
+
+    @Test
+    public void retainsSelectTraitDefinitions() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("scrub-trait-def.json"))
+                .assemble()
+                .unwrap();
+
+        Predicate<Shape> keepFilter = shape -> !shape.getId().equals(ShapeId.from("ns.foo#bam"));
+
+        ModelTransformer transformer = ModelTransformer.create();
+        Model result = transformer.scrubTraitDefinitions(model, keepFilter);
+
+        assertThat(result.getShape(ShapeId.from("ns.foo#FooStructure")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#BarString")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#BarStringList")), Matchers.is(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#ComplexRemoved")), Matchers.is(Optional.empty()));
+
+        assertThat(result.getShape(ShapeId.from("ns.foo#IpsumString")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#IpsumList")), Matchers.not(Optional.empty()));
+        assertThat(result.getShape(ShapeId.from("ns.foo#KeepStructure")), Matchers.not(Optional.empty()));
+
+        // Make sure trait definitions that should be retained weren't removed.
+        assertThat(result.getShape(ShapeId.from("ns.foo#bam")), Matchers.not(Optional.empty()));
+
+        // Make sure other trait definitions were removed.
+        assertThat(result.getShape(ShapeId.from("ns.foo#baz")), Matchers.is(Optional.empty()));
 
         // Make sure public prelude shapes weren't removed.
         assertThat(result.getShape(ShapeId.from("smithy.api#String")), Matchers.not(Optional.empty()));

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/test-model.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/test-model.json
@@ -24,7 +24,9 @@
                 }
             ],
             "traits": {
-                "smithy.api#readonly": {}
+                "smithy.api#readonly": {},
+                "ns.foo#MyTrait": {},
+                "ns.foo#MyOtherTrait": {}
             }
         },
         "ns.foo#MyOperationInput": {
@@ -37,6 +39,18 @@
             "type": "structure",
             "traits": {
                 "smithy.api#error": "client"
+            }
+        },
+        "ns.foo#MyTrait": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {}
+            }
+        },
+        "ns.foo#MyOtherTrait": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {}
             }
         }
     }


### PR DESCRIPTION
This CR adds a transformer that removes trait definitions.  This enables sharing models where the trait versions may vary.  When consuming models produced by this plugin, it is necessary to assure that the requisite traits sources are imported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
