### PR TITLE
Add missing javadoc @return

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/trace/TraceFile.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/trace/TraceFile.java
@@ -74,6 +74,7 @@ public final class TraceFile implements ToNode, ToSmithyBuilder<TraceFile> {
      * Converts ObjectNode into TraceFile.
      *
      * @param value an ObjectNode that represents the entire trace file.
+     * @return TraceFile produced from an ObjectNode.
      */
     public static TraceFile fromNode(Node value) {
         ObjectNode node = value.expectObjectNode();


### PR DESCRIPTION
Add missing javadoc @return statement for TraceFile `fromNode` method.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
