### PR TITLE
Emit events when traits are changed

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
@@ -101,6 +101,29 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                             changedShape.getNewShape().getType(),
                             Node.prettyPrintJson(oldTrait.toNode()),
                             Node.prettyPrintJson(newTrait.toNode()))));
+                } else if (oldTrait == null) {
+                    events.add(note(changedShape.getNewShape(), newTrait, String.format(
+                            "The `%s` trait was added to the `%s` %s shape: %s",
+                            traitName,
+                            changedShape.getNewShape().getId(),
+                            changedShape.getNewShape().getType(),
+                            Node.prettyPrintJson(newTrait.toNode()))));
+                } else if (newTrait == null) {
+                    events.add(warning(changedShape.getNewShape(), String.format(
+                            "The `%s` trait was removed from the `%s` %s shape. The removed trait value was: %s",
+                            traitName,
+                            changedShape.getNewShape().getId(),
+                            changedShape.getNewShape().getType(),
+                            Node.prettyPrintJson(oldTrait.toNode()))));
+                } else {
+                    events.add(note(changedShape.getNewShape(), newTrait, String.format(
+                            "The `%s` trait was changed on the `%s` %s shape. The old trait value was: %s. "
+                            + "The new trait value is: %s",
+                            traitName,
+                            changedShape.getNewShape().getId(),
+                            changedShape.getNewShape().getType(),
+                            Node.prettyPrintJson(oldTrait.toNode()),
+                            Node.prettyPrintJson(newTrait.toNode()))));
                 }
             });
         });

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
@@ -103,7 +103,7 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                             Node.prettyPrintJson(newTrait.toNode()))));
                 } else if (oldTrait == null) {
                     events.add(note(changedShape.getNewShape(), newTrait, String.format(
-                            "The `%s` trait was added to the `%s` %s shape: %s",
+                            "The `%s` trait was added to the `%s` %s shape with the value: %s",
                             traitName,
                             changedShape.getNewShape().getId(),
                             changedShape.getNewShape().getType(),

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
@@ -49,7 +49,7 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
-        assertThat(TestHelper.findEvents(events, Severity.NOTE).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSeverity(), equalTo(Severity.NOTE));
     }
 
     @Test

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -123,7 +123,7 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.WARNING).count(), equalTo(1L));
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.NOTE).count(), equalTo(2L));
 
-        assertThat(messages, hasItem("The `smithy.example#c` trait was added to the `smithy.example#Foo` string shape: \"foo\""));
+        assertThat(messages, hasItem("The `smithy.example#c` trait was added to the `smithy.example#Foo` string shape with the value: \"foo\""));
         assertThat(messages, hasItem("The `smithy.example#a` trait was removed from the `smithy.example#Foo` string shape. The removed trait value was: {}"));
         assertThat(messages, hasItem("The `smithy.example#b` trait was changed on the `smithy.example#Foo` string shape. The old trait value was: \"hello\". The new trait value is: \"hello!\""));
     }

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-test-a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-test-a.smithy
@@ -1,0 +1,14 @@
+namespace smithy.example
+
+@a
+@b("hello")
+string Foo
+
+@trait
+structure a {}
+
+@trait
+string b
+
+@trait
+string c

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-test-b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-test-b.smithy
@@ -1,0 +1,14 @@
+namespace smithy.example
+
+@b("hello!")
+@c("foo")
+string Foo
+
+@trait
+structure a {}
+
+@trait
+string b
+
+@trait
+string c


### PR DESCRIPTION
Smithy-diff previously did not emit validation events when a trait was
added, removed, or changed unless the trait was marked with one of a few
special tags. This commit updates smithy-diff to emit a NOTE when a
trait is added or changed and a WARNING when a trait is removed. This
helps ensure that all trait changes are caught by smithy-diff, while
still allowing more granular control through the tags.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
