### PR TITLE
Normalize URL filenames for better reporting

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/CompositeModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/CompositeModelFile.java
@@ -106,7 +106,7 @@ final class CompositeModelFile implements ModelFile {
                 } else if (!previous.equals(shape)) {
                     mergeEvents.add(LoaderUtils.onShapeConflict(shape.getId(), shape.getSourceLocation(),
                                                                 previous.getSourceLocation()));
-                } else {
+                } else if (!LoaderUtils.isSameLocation(shape, previous)) {
                     LOGGER.warning(() -> "Ignoring duplicate but equivalent shape definition: " + previous.getId()
                                          + " defined at " + shape.getSourceLocation() + " and "
                                          + previous.getSourceLocation());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.loader;
 
 import java.util.Collection;
 import java.util.List;
+import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -79,5 +80,19 @@ final class LoaderUtils {
                 .shapeId(id)
                 .message(String.format("Conflicting shape definition for `%s` found at `%s` and `%s`", id, a, b))
                 .build();
+    }
+
+    /**
+     * Checks if the given values are defined at the same source location,
+     * and the source location is not {@link SourceLocation#NONE}.
+     *
+     * @param a First value to check.
+     * @param b Second value to check.
+     * @return Returns true if they are the same.
+     */
+    static boolean isSameLocation(FromSourceLocation a, FromSourceLocation b) {
+        SourceLocation sa = a.getSourceLocation();
+        SourceLocation sb = b.getSourceLocation();
+        return sa != SourceLocation.NONE && sa.equals(sb);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -298,7 +298,17 @@ public final class ModelAssembler {
      */
     public ModelAssembler addImport(URL url) {
         Objects.requireNonNull(url, "The provided url to ModelAssembler#addImport was null");
-        inputStreamModels.put(url.toExternalForm(), () -> {
+
+        // Format the key used to de-dupe files.
+        String key = url.toExternalForm();
+        if (key.startsWith("jar:")) {
+            key = key.substring(4);
+        }
+        if (key.startsWith("file:")) {
+            key = key.substring(5);
+        }
+
+        inputStreamModels.put(key, () -> {
             try {
                 URLConnection connection = url.openConnection();
                 if (properties.containsKey(ModelAssembler.DISABLE_JAR_CACHE)) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -349,9 +349,9 @@ public class ModelAssemblerTest {
                 .unwrap();
 
         assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getSourceLocation(),
-                is(new SourceLocation(getClass().getResource("main.json").toString(), 4, 37)));
+                is(new SourceLocation(getClass().getResource("main.json").toString().replace("file:", ""), 4, 37)));
         assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion$foo")).get().getSourceLocation(),
-                is(new SourceLocation(getClass().getResource("main.json").toString(), 69, 24)));
+                is(new SourceLocation(getClass().getResource("main.json").toString().replace("file:", ""), 69, 24)));
     }
 
     @Test


### PR DESCRIPTION
When a URL is imported with the model assembler, it will now strip off
leading "jar:" and "file:" prefixes in order to create a normalized
de-dupe key so that imports through URLs and through Path to the same
files are de-duped. This also offers better SourceLocation reporting for
files that are imported through a URL.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
