### PR TITLE
Emit DANGER event for DELETE with a payload

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
@@ -57,7 +57,7 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
             "OPTIONS", new HttpMethodSemantics(true, false, false),
             "TRACE", new HttpMethodSemantics(true, false, false),
             "POST", new HttpMethodSemantics(false, null, true),
-            "DELETE", new HttpMethodSemantics(false, true, true),
+            "DELETE", new HttpMethodSemantics(false, true, false),
             "PUT", new HttpMethodSemantics(false, true, true),
             "PATCH", new HttpMethodSemantics(false, false, true));
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.errors
@@ -1,5 +1,6 @@
 [DANGER] ns.foo#K: This operation uses the `GET` method in the `http` trait, but has the following members bound to the payload: `payload` | HttpMethodSemantics
 [DANGER] ns.foo#L: This operation uses the `GET` method in the `http` trait, but has the following members bound to the document: `payload` | HttpMethodSemantics
+[DANGER] ns.foo#M: This operation uses the `DELETE` method in the `http` trait, but has the following members bound to the document: `payload` | HttpMethodSemantics
 [WARNING] ns.foo#G: This operation uses the `POST` method in the `http` trait, but is marked with the readonly trait | HttpMethodSemantics
 [WARNING] ns.foo#H: This operation uses the `DELETE` method in the `http` trait, but is not marked with the idempotent trait | HttpMethodSemantics
 [WARNING] ns.foo#I: This operation uses the `GET` method in the `http` trait, but is not marked with the readonly trait | HttpMethodSemantics

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.json
@@ -151,6 +151,27 @@
                     }
                 }
             }
+        },
+        "ns.foo#M": {
+            "type": "operation",
+            "input": {
+                "target": "ns.foo#MInput"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/M"
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "ns.foo#MInput": {
+            "type": "structure",
+            "members": {
+                "payload": {
+                    "target": "smithy.api#String"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Lots of clients don't support DELETE with a payload, and the spec calls
it out as having no defined semantics. The newly added event can be
suppressed if necessary, but this action functions as a way of essentially
"signing-off" on the risks associated with using a DELETE with a payload.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
