### PR TITLE
Fix missing word in RemoveUnusedShapes docs

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RemoveUnusedShapes.java
@@ -42,7 +42,7 @@ public final class RemoveUnusedShapes extends BackwardCompatHelper<RemoveUnusedS
         /**
          * You can <em>export</em> shapes that are not connected to any service
          * shape by applying specific tags to the shape and adding the list of
-         * export tags an argument to the transformer.
+         * export tags as an argument to the transformer.
          *
          * @param exportByTags Tags that cause shapes to be exported.
          */


### PR DESCRIPTION
Adds missing word in docs for RemoveUnusedShapes transformer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
