### PR TITLE
Add protocol tests for httpResponseCode

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -1,0 +1,37 @@
+// This file defines test cases that test HTTP response code bindings.
+// See: https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#httpresponsecode-trait
+
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpResponseTests
+
+@idempotent
+@http(uri: "/HttpResponseCode", method: "PUT")
+operation HttpResponseCode {
+    output: HttpResponseCodeOutput
+}
+
+structure HttpResponseCodeOutput {
+    @httpResponseCode
+    Status: Integer
+}
+
+apply HttpResponseCode @httpResponseTests([
+    {
+        id: "RestJsonHttpResponseCode",
+        documentation: "Binds the http response code to an output structure.",
+        protocol: restJson1,
+        code: 201,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        "body": "",
+        "bodyMediaType": "json",
+        params: {
+            Status: 201,
+        }
+    }
+])

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -47,6 +47,9 @@ service RestJson {
         HttpPayloadTraitsWithMediaType,
         HttpPayloadWithStructure,
 
+        // @httpResponseCode tests
+        HttpResponseCode,
+
         // @streaming tests
         StreamingTraits,
         StreamingTraitsRequireLength,

--- a/smithy-aws-protocol-tests/model/restXml/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-response-code.smithy
@@ -1,0 +1,37 @@
+// This file defines test cases that test HTTP response code bindings.
+// See: https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#httpresponsecode-trait
+
+$version: "1.0"
+
+namespace aws.protocoltests.restxml
+
+use aws.protocols#restXml
+use smithy.test#httpResponseTests
+
+@idempotent
+@http(uri: "/HttpResponseCode", method: "PUT")
+operation HttpResponseCode {
+    output: HttpResponseCodeOutput
+}
+
+structure HttpResponseCodeOutput {
+    @httpResponseCode
+    Status: Integer
+}
+
+apply HttpResponseCode @httpResponseTests([
+    {
+        id: "RestXmlHttpResponseCode",
+        documentation: "Binds the http response code to an output structure.",
+        protocol: restXml,
+        code: 201,
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        "body": "",
+        "bodyMediaType": "application/xml",
+        params: {
+            Status: 201,
+        }
+    }
+])

--- a/smithy-aws-protocol-tests/model/restXml/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/main.smithy
@@ -51,6 +51,9 @@ service RestXml {
         HttpPayloadWithXmlNamespace,
         HttpPayloadWithXmlNamespaceAndPrefix,
 
+        // @httpResponseCode tests
+        HttpResponseCode,
+
         // Output tests
         XmlEmptyBlobs,
 

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
@@ -27,6 +27,7 @@
                         "smithy.api#httpPayload",
                         "smithy.api#httpPrefixHeaders",
                         "smithy.api#httpQuery",
+                        "smithy.api#httpResponseCode",
                         "smithy.api#jsonName",
                         "smithy.api#timestampFormat"
                     ]
@@ -64,6 +65,7 @@
                         "smithy.api#httpPayload",
                         "smithy.api#httpPrefixHeaders",
                         "smithy.api#httpQuery",
+                        "smithy.api#httpResponseCode",
                         "smithy.api#xmlAttribute",
                         "smithy.api#xmlFlattened",
                         "smithy.api#xmlName",


### PR DESCRIPTION
*Description of changes:*

This adds protocol tests for `httpResponseCode` in the aws protocol tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
