### PR TITLE
More windows fixes

### DIFF
--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-    id "software.amazon.smithy" version "0.5.0"
+    id "software.amazon.smithy" version "0.5.1"
 }
 
 description = "Defines protocol tests for AWS HTTP protocols."

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/AstCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/AstCommandTest.java
@@ -54,7 +54,7 @@ public class AstCommandTest {
     @Test
     public void failsOnUnknownTrait() {
         CliError e = Assertions.assertThrows(CliError.class, () -> {
-            String model = getClass().getResource("unknown-trait.smithy").getPath();
+            String model = Paths.get(getClass().getResource("unknown-trait.smithy").toURI()).toString();
             SmithyCli.create().run("ast", model);
         });
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -349,10 +349,11 @@ public class ModelAssemblerTest {
                 .assemble()
                 .unwrap();
 
+        String expectedPath = Paths.get(getClass().getResource("main.json").toURI()).toString();
         assertThat(model.getShape(ShapeId.from("example.namespace#String")).get().getSourceLocation(),
-                is(new SourceLocation(getClass().getResource("main.json").toString().replace("file:", ""), 4, 37)));
+                is(new SourceLocation(expectedPath, 4, 37)));
         assertThat(model.getShape(ShapeId.from("example.namespace#TaggedUnion$foo")).get().getSourceLocation(),
-                is(new SourceLocation(getClass().getResource("main.json").toString().replace("file:", ""), 69, 24)));
+                is(new SourceLocation(expectedPath, 69, 24)));
     }
 
     @Test


### PR DESCRIPTION
This change adds various fixes to Smithy and tests so that they now work on Windows. We'll need to configure our tests to automatically run on Windows to ensure there are no regressions here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
