### PR TITLE
Remove extra word in authorizers documentation.

### DIFF
--- a/docs/source/1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source/1.0/spec/aws/amazon-apigateway.rst
@@ -114,7 +114,7 @@ An *authorizer* definition is a structure that supports the following members:
     * - type
       - ``string``
       - The type of the authorizer. If specifying information beyond the
-        scheme, this value is required. The he value must be "token", for an
+        scheme, this value is required. The value must be "token", for an
         authorizer with the caller identity embedded in an authorization token,
         or "request", for an authorizer with the caller identity contained in
         request parameters.


### PR DESCRIPTION
Remove extra word in authorizers documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
