### PR TITLE
Fix media type handling of unions as payloads

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -382,7 +382,7 @@ public final class HttpBindingIndex implements KnowledgeIndex {
                     break;
                 } else if (StreamingTrait.isEventStream(target)) {
                     return eventStreamContentType;
-                } else if (target.isDocumentShape() || target.isStructureShape()) {
+                } else if (target.isDocumentShape() || target.isStructureShape() || target.isUnionShape()) {
                     // Document type and structure targets are always the document content-type.
                     return documentContentType;
                 } else if (target.getTrait(MediaTypeTrait.class).isPresent()) {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -409,6 +409,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             ResponseObject.Builder responseBuilder,
             Shape operationOrError
     ) {
+        Objects.requireNonNull(mediaType, "Unable to determine response media type for " + operationOrError);
+
         // API Gateway validation requires that in-line schemas must be objects
         // or arrays. These schemas are synthesized as references so that
         // any schemas with string types will pass validation.

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -407,4 +407,20 @@ public class OpenApiConverterTest {
 
         Node.assertEquals(result, expectedNode);
     }
+
+    @Test
+    public void convertsUnions() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("union-test.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Example"));
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("union-test.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/union-test.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/union-test.openapi.json
@@ -1,0 +1,63 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Example",
+        "version": "2020-09-11"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "GetItem",
+                "responses": {
+                    "200": {
+                        "description": "GetItem 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ItemResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Foo": {
+                "type": "object"
+            },
+            "ItemResponse": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "Foo",
+                        "properties": {
+                            "Foo": {
+                                "$ref": "#/components/schemas/Foo"
+                            }
+                        },
+                        "required": [
+                            "Foo"
+                        ]
+                    }
+                ]
+            }
+        },
+        "securitySchemes": {
+            "aws.auth.sigv4": {
+                "type": "apiKey",
+                "description": "AWS Signature Version 4 authentication",
+                "name": "Authorization",
+                "in": "header",
+                "x-amazon-apigateway-authtype": "awsSigv4"
+            }
+        }
+    },
+    "security": [
+        {
+            "aws.auth.sigv4": []
+        }
+    ]
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/union-test.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/union-test.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use aws.api#service
+use aws.auth#sigv4
+use aws.protocols#restJson1
+
+@title("Example")
+@service(sdkId: "Example")
+@sigv4(name: "Example")
+@restJson1
+service Example {
+    version: "2020-09-11",
+    operations: [GetItem],
+}
+
+@http(uri: "/", method: "GET")
+@readonly
+operation GetItem {
+    input: GetItemRequest,
+    output: GetItemResponse,
+}
+
+structure GetItemRequest {}
+
+structure GetItemResponse {
+    @httpPayload
+    item: ItemResponse
+}
+
+union ItemResponse {
+    Foo: Foo,
+}
+
+structure Foo {}


### PR DESCRIPTION
We had a case where if a union shape is marked with the httpPayload
trait, we wouldn't resolve a proper mediaType. This caused an NPE. The
code that determines the media type has been updated to treat unions
like structures, and a more helpful message was added in case a media
type can't be resolved at some point in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
