### PR TITLE
Optimize reverse neighbors for memory

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborProvider.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborProvider.java
@@ -127,7 +127,7 @@ public interface NeighborProvider {
         // Note: this method previously needed lots of intermediate representations
         // stored in memory to create a Map<ShapeId, List<RelationShip>> that contains
         // only unique relationships. It was done using Stream, distinct, and groupingBy.
-        // however, when trying to load ridiculously large models, that approach consume
+        // However, when trying to load ridiculously large models, that approach consumes
         // tons of heap. This approach allocates as little as possible (I think), but
         // does require creating an ArrayList copy of a Set each time neighbors are returned.
         Map<ShapeId, Set<Relationship>> targetedFrom = new HashMap<>();


### PR DESCRIPTION
This method previously needed lots of intermediate representations
stored in memory to create a Map<ShapeId, List<RelationShip>> that
contains only unique relationships. It was done using Stream,
distinct, and groupingBy. However, when trying to load ridiculously
large models, that approach consume tons of heap. This approach
allocates as little as possible (I think), but does require creating
an ArrayList copy of a Set each time neighbors are returned.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
