### PR TITLE
Optimize validation event aggregation

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
@@ -95,14 +95,17 @@ final class ModelValidator {
         List<ValidatorDefinition> assembledValidatorDefinitions = assembleValidatorDefinitions();
         assembleValidators(assembledValidatorDefinitions);
 
-        events.addAll(validators
+        List<ValidationEvent> result = validators
                 .parallelStream()
                 .flatMap(validator -> validator.validate(model).stream())
                 .map(this::suppressEvent)
                 .filter(ModelValidator::filterPrelude)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
 
-        return events;
+        // Add in events encountered while building up validators and suppressions.
+        result.addAll(events);
+
+        return result;
     }
 
     private static boolean filterPrelude(ValidationEvent event) {


### PR DESCRIPTION
When validating massive models, this line was causing out of memory
errors because it required keeping two copies of a validation events in
memory at once (one to aggregate and then one to copy into the result).
This change instead just uses a single list to aggregate the result, and
then mutates that list to add in any other events encountered while
building up validators.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
