### PR TITLE
Maintain order of operations and resources

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.model.shapes;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import software.amazon.smithy.utils.SetUtils;
 
@@ -28,11 +28,10 @@ public abstract class EntityShape extends Shape {
     private final Set<ShapeId> resources;
     private final Set<ShapeId> operations;
 
-    @SuppressWarnings("unchecked")
-    EntityShape(Builder builder) {
+    EntityShape(Builder<?, ?> builder) {
         super(builder, false);
-        resources = SetUtils.copyOf(builder.resources);
-        operations = SetUtils.copyOf(builder.operations);
+        resources = SetUtils.orderedCopyOf(builder.resources);
+        operations = SetUtils.orderedCopyOf(builder.operations);
     }
 
     /**
@@ -79,11 +78,12 @@ public abstract class EntityShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
+    @SuppressWarnings("rawtypes")
     public abstract static class Builder<B extends Builder, S extends EntityShape>
             extends AbstractShapeBuilder<B, S> {
 
-        private final Set<ShapeId> resources = new HashSet<>();
-        private final Set<ShapeId> operations = new HashSet<>();
+        private final Set<ShapeId> resources = new LinkedHashSet<>();
+        private final Set<ShapeId> operations = new LinkedHashSet<>();
 
         @SuppressWarnings("unchecked")
         public B operations(Collection<ShapeId> ids) {
@@ -98,7 +98,6 @@ public abstract class EntityShape extends Shape {
             return (B) this;
         }
 
-        @SuppressWarnings("unchecked")
         public B addOperation(String id) {
             return addOperation(ShapeId.from(id));
         }
@@ -128,7 +127,6 @@ public abstract class EntityShape extends Shape {
             return (B) this;
         }
 
-        @SuppressWarnings("unchecked")
         public B addResource(String id) {
             return addResource(ShapeId.from(id));
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
@@ -15,14 +15,14 @@
 
 package software.amazon.smithy.model.shapes;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Abstract classes shared by structure and union shapes.
@@ -41,7 +41,7 @@ abstract class NamedMembersShape extends Shape {
 
         // Copy the members to make them immutable and ensure that each
         // member has a valid ID that is prefixed with the shape ID.
-        members = Collections.unmodifiableMap(new LinkedHashMap<>(builder.members));
+        members = MapUtils.orderedCopyOf(builder.members);
 
         members.forEach((key, value) -> {
             ShapeId expected = getId().withMember(key);
@@ -71,7 +71,7 @@ abstract class NamedMembersShape extends Shape {
     public List<String> getMemberNames() {
         List<String> names = memberNames;
         if (names == null) {
-            names = Collections.unmodifiableList(new ArrayList<>(members.keySet()));
+            names = ListUtils.copyOf(members.keySet());
             memberNames = names;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -19,10 +19,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -42,14 +44,14 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
 
     private ResourceShape(Builder builder) {
         super(builder);
-        identifiers = Collections.unmodifiableMap(new LinkedHashMap<>(builder.identifiers));
+        identifiers = MapUtils.orderedCopyOf(builder.identifiers);
         put = builder.put;
         create = builder.create;
         read = builder.read;
         update = builder.update;
         delete = builder.delete;
         list = builder.list;
-        collectionOperations = SetUtils.copyOf(builder.collectionOperations);
+        collectionOperations = SetUtils.orderedCopyOf(builder.collectionOperations);
 
         // Compute all operations bound to the resource.
         allOperations.addAll(getOperations());
@@ -201,13 +203,13 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
      */
     public static final class Builder extends EntityShape.Builder<Builder, ResourceShape> {
         private final Map<String, ShapeId> identifiers = new LinkedHashMap<>();
+        private final Set<ShapeId> collectionOperations = new LinkedHashSet<>();
         private ShapeId put;
         private ShapeId create;
         private ShapeId read;
         private ShapeId update;
         private ShapeId delete;
         private ShapeId list;
-        private final Set<ShapeId> collectionOperations = new HashSet<>();
 
         @Override
         public ResourceShape build() {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EntityShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EntityShapeTest.java
@@ -1,0 +1,47 @@
+package software.amazon.smithy.model.shapes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class EntityShapeTest {
+    @Test
+    public void operationsAreOrdered() {
+        ServiceShape.Builder builder = ServiceShape.builder()
+                .id("com.foo#Bar")
+                .version("1");
+
+        List<ShapeId> operations = new ArrayList<>(20);
+        for (int i = 0; i < 20; i++) {
+            OperationShape operation = OperationShape.builder().id("com.foo#Op" + i).build();
+            operations.add(operation.getId());
+            builder.addOperation(operation);
+        }
+
+        ServiceShape service = builder.build();
+
+        assertThat(ListUtils.copyOf(service.getAllOperations()), equalTo(operations));
+    }
+
+    @Test
+    public void resourcesAreOrdered() {
+        ServiceShape.Builder builder = ServiceShape.builder()
+                .id("com.foo#Bar")
+                .version("1");
+
+        List<ShapeId> resources = new ArrayList<>(20);
+        for (int i = 0; i < 20; i++) {
+            ResourceShape resource = ResourceShape.builder().id("com.foo#Resource" + i).build();
+            resources.add(resource.getId());
+            builder.addResource(resource);
+        }
+
+        ServiceShape service = builder.build();
+
+        assertThat(ListUtils.copyOf(service.getResources()), equalTo(resources));
+    }
+}

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/MapUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/MapUtils.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.utils;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -39,6 +40,18 @@ public final class MapUtils {
      */
     public static <K, V> Map<K, V>  copyOf(Map<? extends K, ? extends V> map) {
         return map.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(map));
+    }
+
+    /**
+     * Creates an ordered immutable copy of the given map.
+     *
+     * @param map The map to make an immutable copy of
+     * @param <K> the Map's key type
+     * @param <V> the Map's value type
+     * @return An ordered immutable Map copy that maintains the order of the original.
+     */
+    public static <K, V> Map<K, V>  orderedCopyOf(Map<? extends K, ? extends V> map) {
+        return map.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(new LinkedHashMap<>(map));
     }
 
     /**

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/SetUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/SetUtils.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.utils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -37,6 +38,17 @@ public final class SetUtils {
      */
     public static <T> Set<T> copyOf(Collection<? extends T> values) {
         return values.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(new HashSet<>(values));
+    }
+
+    /**
+     * Creates an ordered immutable copy of the given set.
+     *
+     * @param values The collection to make an immutable set of.
+     * @param <T> the Set's value type.
+     * @return An ordered immutable Set copy that maintains the order of the original.
+     */
+    public static <T> Set<T> orderedCopyOf(Collection<? extends T> values) {
+        return values.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(new LinkedHashSet<>(values));
     }
 
     /**

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/MapUtilsTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/MapUtilsTest.java
@@ -18,10 +18,12 @@ package software.amazon.smithy.utils;
 import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,21 @@ public class MapUtilsTest {
     @Test
     public void copyOfIsSame() {
         assertThat(MapUtils.copyOf(Collections.singletonMap("1", "A")), hasEntry("1", "A"));
+    }
+
+    @Test
+    public void orderedCopyOfEmptyIsEmpty() {
+        assertThat(MapUtils.orderedCopyOf(Collections.emptyMap()), anEmptyMap());
+    }
+
+    @Test
+    public void orderedCopyOfIsSame() {
+        Map<String, String> input = new LinkedHashMap<>();
+        input.put("a", "aa");
+        input.put("b", "bb");
+        Map<String, String> copy = MapUtils.copyOf(input);
+
+        assertThat(ListUtils.copyOf(input.entrySet()), equalTo(ListUtils.copyOf(copy.entrySet())));
     }
 
     @Test

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/SetUtilsTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/SetUtilsTest.java
@@ -19,8 +19,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +34,23 @@ public class SetUtilsTest {
     }
 
     @Test
+    public void orderedCopyOfEmptyIsEmpty() {
+        assertThat(SetUtils.orderedCopyOf(Collections.emptyList()), empty());
+    }
+
+    @Test
     public void copyOfIsSame() {
         assertThat(SetUtils.copyOf(Collections.singletonList("Jason")), contains("Jason"));
+    }
+
+    @Test
+    public void orderedCopyOfIsSame() {
+        Set<String> input = new LinkedHashSet<>();
+        input.add("A");
+        input.add("B");
+        Set<String> copy = SetUtils.orderedCopyOf(input);
+
+        assertThat(ListUtils.copyOf(input), equalTo(ListUtils.copyOf(copy)));
     }
 
     @Test


### PR DESCRIPTION
This commit updates service and operation shapes to maintain the order
in which operations and resources are defined in a Smithy model. Note
that resource lifecycle operation order is not maintained since those
are named operations that don't have any particular order in a model
like a list of operations, collectionOperations, or resources do.

To achieve this, I added a couple new helper methods to make copies of
Maps and Sets that maintains order.

Closes #591