### PR TITLE
Allow customAuthType defaulting to be disabled

### DIFF
--- a/docs/source/1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source/1.0/spec/aws/amazon-apigateway.rst
@@ -123,7 +123,8 @@ An *authorizer* definition is a structure that supports the following members:
       - The ``authType`` of the authorizer. This value is used in APIGateway
         exports as ``x-amazon-apigateway-authtype``. This value is set to
         ``custom`` by default, or ``awsSigv4`` if your scheme is
-        :ref:`aws.auth#sigv4 <aws.auth#sigv4-trait>`.
+        :ref:`aws.auth#sigv4 <aws.auth#sigv4-trait>`. Set the value to an empty
+        string to disable defaulting to ``custom``.
     * - uri
       - ``string``
       - Specifies the authorizer's Uniform Resource Identifier

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
@@ -113,6 +113,28 @@ public class AddAuthorizersTest {
     }
 
     @Test
+    public void emptyCustomAuthTypeNotSet() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("empty-custom-auth-type-authorizer.json"))
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("ns.foo#SomeService"));
+        OpenApi result = OpenApiConverter.create()
+                .config(config)
+                .classLoader(getClass().getClassLoader())
+                .convert(model);
+        SecurityScheme apiKey = result.getComponents().getSecuritySchemes().get("api_key");
+
+        assertThat(apiKey.getType(), equalTo("apiKey"));
+        assertThat(apiKey.getName().get(), equalTo("x-api-key"));
+        assertThat(apiKey.getIn().get(), equalTo("header"));
+        assertFalse(apiKey.getExtension("x-amazon-apigateway-authtype").isPresent());
+        assertFalse(apiKey.getExtension("x-amazon-apigateway-authorizer").isPresent());
+    }
+
+    @Test
     public void resolvesEffectiveAuthorizersForEachOperation() {
         Model model = Model.assembler()
                 .discoverModels(getClass().getClassLoader())

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/empty-custom-auth-type-authorizer.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/empty-custom-auth-type-authorizer.json
@@ -1,0 +1,23 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "ns.foo#SomeService": {
+      "type": "service",
+      "version": "2018-03-17",
+      "traits": {
+        "aws.protocols#restJson1": {},
+        "smithy.api#httpApiKeyAuth": {
+          "name": "x-api-key",
+          "in": "header"
+        },
+        "aws.apigateway#authorizer": "api_key",
+        "aws.apigateway#authorizers": {
+          "api_key": {
+            "scheme": "smithy.api#httpApiKeyAuth",
+            "customAuthType": ""
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allow the setting of an empty `customAuthType` to indicate that the `x-amazon-apigateway-authtype` extension should not be set to "custom". This is done to handle the current defaulting behavior instead of adding a flag. This is necessary to enable API Gateway's built-in API key validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
