### PR TITLE
Support API Gateway API key usage plans

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -1071,6 +1071,36 @@ entry:
 In the entry, ``providerARNs`` will be populated from the ``providerArns`` list
 from the trait.
 
+Amazon API Gateway API key usage plans
+======================================
+
+Smithy enables `API Gateway's API key usage plans`_ when a scheme based on the
+:ref:`httpApiKeyAuth-trait` is set and configured as :ref:`an authorizer
+<aws.apigateway#authorizers-trait>` with no ``type`` property set.
+
+The following Smithy model enables API Gateway's API key usage plans on the
+``OperationA`` operation:
+
+.. code-block:: smithy
+
+    namespace smithy.example
+
+    use aws.apigateway#authorizer
+    use aws.apigateway#authorizers
+    use aws.protocols#restJson1
+
+    @restJson1
+    @httpApiKeyAuth(name: "x-api-key", in: "header")
+    @authorizer("api_key")
+    @authorizers(api_key: {scheme: "smithy.api#httpApiKeyAuth"})
+    service Example {
+      version: "2019-06-17",
+      operations: [OperationA],
+    }
+
+    operation OperationA {}
+
+
 .. _other-traits:
 
 Other traits that influence API Gateway
@@ -1152,3 +1182,4 @@ The conversion process is highly extensible through
 .. _OpenAPI security schemes: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#securitySchemeObject
 .. _x-amazon-apigateway-authorizer: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html
 .. _Lambda authorizers: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html
+.. _API Gateway's API key usage plans: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html

--- a/docs/source/1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source/1.0/spec/aws/amazon-apigateway.rst
@@ -122,9 +122,8 @@ An *authorizer* definition is a structure that supports the following members:
       - ``string``
       - The ``authType`` of the authorizer. This value is used in APIGateway
         exports as ``x-amazon-apigateway-authtype``. This value is set to
-        ``custom`` by default, or ``awsSigv4`` if your scheme is
-        :ref:`aws.auth#sigv4 <aws.auth#sigv4-trait>`. Set the value to an empty
-        string to disable defaulting to ``custom``.
+        ``custom`` by default if ``type`` is set, or ``awsSigv4`` if your
+        scheme is :ref:`aws.auth#sigv4 <aws.auth#sigv4-trait>`.
     * - uri
       - ``string``
       - Specifies the authorizer's Uniform Resource Identifier

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.aws.apigateway.openapi;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Logger;
 import software.amazon.smithy.aws.apigateway.traits.AuthorizerDefinition;
 import software.amazon.smithy.aws.apigateway.traits.AuthorizerIndex;
@@ -29,6 +30,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
@@ -103,17 +105,42 @@ final class AddAuthorizers implements ApiGatewayMapper {
         AuthorizerIndex authorizerIndex = AuthorizerIndex.of(context.getModel());
 
         // Get the resolved security schemes of the service and operation, and
-        // only add security if it's different than the service.
+        // only add security if it's different than the service or...
         String serviceAuth = authorizerIndex.getAuthorizer(service).orElse(null);
         String operationAuth = authorizerIndex.getAuthorizer(service, shape).orElse(null);
 
-        if (operationAuth == null || Objects.equals(operationAuth, serviceAuth)) {
+        // Short circuit if we have no authorizer for the operation.
+        if (operationAuth == null) {
+            return operation;
+        }
+
+        // ...API Gateway's built-in API keys are being used. It requires the
+        // security to be specified on every operation.
+        // See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-setup-api-key-with-console.html#api-gateway-usage-plan-configure-apikey-on-method
+        if (Objects.equals(operationAuth, serviceAuth) && !usesApiGatewayApiKeys(service, operationAuth)) {
             return operation;
         }
 
         return operation.toBuilder()
                 .addSecurity(MapUtils.of(operationAuth, ListUtils.of()))
                 .build();
+    }
+
+    private boolean usesApiGatewayApiKeys(ServiceShape service, String operationAuth) {
+        // Get the authorizer for this operation if it has no "type" set,
+        // as is required for API Gateway's API keys.
+        Optional<AuthorizerDefinition> definitionOptional = service.getTrait(AuthorizersTrait.class)
+                .flatMap(authorizers -> authorizers.getAuthorizer(operationAuth)
+                        .filter(authorizer -> !authorizer.getType().isPresent()));
+
+        if (!definitionOptional.isPresent()) {
+            return false;
+        }
+        AuthorizerDefinition definition = definitionOptional.get();
+
+        // We then need to validate that the @httpApiKeyAuth trait has been set
+        // to authenticate the operation, declaring it's a built-in scheme.
+        return definition.getScheme().equals(HttpApiKeyAuthTrait.ID);
     }
 
     @Override
@@ -168,12 +195,12 @@ final class AddAuthorizers implements ApiGatewayMapper {
         SecurityScheme createdScheme = converter.createSecurityScheme(context, authTrait);
         SecurityScheme.Builder schemeBuilder = createdScheme.toBuilder();
 
-        // Allow the setting of an empty customAuthType to indicate that
-        // the extension should not be set to "custom". This is done to
-        // handle the current defaulting behavior instead of adding a flag.
+        // Do not set the client extension if there is no "type" property
+        // set on the authorizer definition. This is consistent with the
+        // "type" property support in the documentation.
         // This is necessary to enable API Gateway's built-in API key validation.
         String authType = authorizer.getCustomAuthType().orElse(DEFAULT_AUTH_TYPE);
-        if (!authType.isEmpty()) {
+        if (authorizer.getType().isPresent()) {
             schemeBuilder.putExtension(CLIENT_EXTENSION_NAME, authType);
         }
 

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/custom-auth-type-authorizer.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/custom-auth-type-authorizer.json
@@ -13,6 +13,7 @@
                 "aws.apigateway#authorizers": {
                     "sigv4": {
                         "scheme": "aws.auth#sigv4",
+                        "type": "request",
                         "customAuthType": "myCustomType"
                     }
                 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/operation-http-api-key-security.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/operation-http-api-key-security.json
@@ -1,9 +1,14 @@
 {
   "smithy": "1.0",
   "shapes": {
-    "ns.foo#SomeService": {
+    "smithy.example#Service": {
       "type": "service",
-      "version": "2018-03-17",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "smithy.example#Operation1"
+        }
+      ],
       "traits": {
         "aws.protocols#restJson1": {},
         "smithy.api#httpApiKeyAuth": {
@@ -15,6 +20,15 @@
           "api_key": {
             "scheme": "smithy.api#httpApiKeyAuth"
           }
+        }
+      }
+    },
+    "smithy.example#Operation1": {
+      "type": "operation",
+      "traits": {
+        "smithy.api#http": {
+          "uri": "/",
+          "method": "GET"
         }
       }
     }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/operation-http-api-key-security.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/operation-http-api-key-security.openapi.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "Operation1",
+        "responses": {
+          "200": {
+            "description": "Operation1 response"
+          }
+        },
+        "security": [
+          {
+            "api_key": [ ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "description": "X-Api-Key authentication",
+        "name": "x-api-key",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "api_key": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds support for enabling API Gateway's API key usage
plans. A non-custom httpApiKeyAuth based authorizer on an operation
will now be directly set on every operation in the OpenAPI document,
even if it's the same as the service level authorizer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
