### PR TITLE
Add enum names  for httpApiKeyLocations

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -201,8 +201,15 @@ structure httpApiKeyAuth {
 
 @private
 @enum([
-    {value: "header"},
-    {value: "query"}])
+    {
+        name: "HEADER",
+        value: "header",
+    },
+    {
+        name: "QUERY",
+        value: "query",
+    },
+])
 string HttpApiKeyLocations
 
 /// Indicates that an operation can be called without authentication.


### PR DESCRIPTION
This updates the `HttpApiKeyLocations` shape in the prelude so that each enum entry has a name attribute defined.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
