### PR TITLE
Create empty manifest when no source models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ subprojects {
         test {
             testLogging {
                 events = ["passed", "skipped", "failed"]
+                exceptionFormat = "full"
             }
         }
     }

--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -1134,7 +1134,8 @@ The ``sources`` plugin copies the source models and creates a manifest.
 When building the ``source`` projection, the models that were used to build the
 model are copied over literally. When a JAR is used as a source model, the
 Smithy models contained within the JAR are copied as a source model while the
-JAR itself is not copied.
+JAR itself is not copied. If there are no source models, an empty manifest is
+created.
 
 When applying a projection, a new model file is created that contains only
 the shapes, trait definitions, and metadata that were defined in a source

--- a/smithy-build/src/main/java/software/amazon/smithy/build/plugins/SourcesPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/plugins/SourcesPlugin.java
@@ -88,14 +88,15 @@ public final class SourcesPlugin implements SmithyBuildPlugin {
             projectSources(context);
         }
 
+        String manifest = "";
         if (names.isEmpty()) {
-            LOGGER.info(String.format("Skipping `%s` manifest because no Smithy sources found", projectionName));
+            LOGGER.info(String.format("Writing empty `%s` manifest because no Smithy sources found", projectionName));
         } else {
             LOGGER.fine(() -> String.format("Writing `%s` manifest", projectionName));
             // Normalize filenames to Unix style.
-            String manifest = names.stream().map(name -> name.replace("\\", "/")).collect(Collectors.joining("\n"));
-            context.getFileManifest().writeFile("manifest", manifest + "\n");
+            manifest = names.stream().map(name -> name.replace("\\", "/")).collect(Collectors.joining("\n"));
         }
+        context.getFileManifest().writeFile("manifest", manifest + "\n");
     }
 
     private static List<String> copySources(PluginContext context) {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
