### PR TITLE
Allow setting customAuthType without type

### DIFF
--- a/docs/source/1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source/1.0/spec/aws/amazon-apigateway.rst
@@ -114,10 +114,10 @@ An *authorizer* definition is a structure that supports the following members:
     * - type
       - ``string``
       - The type of the authorizer. If specifying information beyond the
-        scheme, this value is required. The value must be "token", for an
-        authorizer with the caller identity embedded in an authorization token,
-        or "request", for an authorizer with the caller identity contained in
-        request parameters.
+        scheme or customAuthType, this value is required. The value must be
+        "token", for an authorizer with the caller identity embedded in an
+        authorization token, or "request", for an authorizer with the caller
+        identity contained in request parameters.
     * - customAuthType
       - ``string``
       - The ``authType`` of the authorizer. This value is used in APIGateway

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
@@ -111,7 +111,7 @@ public class AddAuthorizersTest {
         assertThat(sigV4.getName().get(), equalTo("Authorization"));
         assertThat(sigV4.getIn().get(), equalTo("header"));
         assertThat(sigV4.getExtension("x-amazon-apigateway-authtype").get(), equalTo(Node.from("myCustomType")));
-        assertTrue(sigV4.getExtension("x-amazon-apigateway-authorizer").isPresent());
+        assertFalse(sigV4.getExtension("x-amazon-apigateway-authorizer").isPresent());
     }
 
     @Test

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/custom-auth-type-authorizer.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/custom-auth-type-authorizer.json
@@ -13,7 +13,6 @@
                 "aws.apigateway#authorizers": {
                     "sigv4": {
                         "scheme": "aws.auth#sigv4",
-                        "type": "request",
                         "customAuthType": "myCustomType"
                     }
                 }


### PR DESCRIPTION
There are valid use cases on an `@aws.apigateway#authorizors` entry for setting the `customAuthType` property without setting its `type` property. This enables that use case while still not defaulting the client extension to "custom" if the `type` is not set.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
