### PR TITLE
Fix broken link in docs to protocol tests

### DIFF
--- a/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
@@ -26,7 +26,7 @@ Trait selector
 Value type
     Annotation trait.
 See
-    `Protocol tests <https://github.com/awslabs/smithy/tree/meta-protocol-and-auth/smithy-aws-protocol-tests/model>`_
+    `Protocol tests <https://github.com/awslabs/smithy/tree/1.3.0/smithy-aws-protocol-tests/model/awsJson1_0>`_
 
 .. tabs::
 

--- a/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
@@ -26,7 +26,7 @@ Trait selector
 Value type
     Annotation trait.
 See
-    `Protocol tests <https://github.com/awslabs/smithy/tree/1.3.0/smithy-aws-protocol-tests/model/awsJson1_0>`_
+    `Protocol tests <https://github.com/awslabs/smithy/tree/__smithy_version__/smithy-aws-protocol-tests/model/awsJson1_0>`_
 
 .. tabs::
 

--- a/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
@@ -26,7 +26,7 @@ Trait selector
 Value type
     Annotation trait.
 See
-    `Protocol tests <https://github.com/awslabs/smithy/tree/1.3.0/smithy-aws-protocol-tests/model/awsJson1_1>`_
+    `Protocol tests <https://github.com/awslabs/smithy/tree/__smithy_version__/smithy-aws-protocol-tests/model/awsJson1_1>`_
 
 .. tabs::
 

--- a/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
@@ -26,7 +26,7 @@ Trait selector
 Value type
     Annotation trait.
 See
-    `Protocol tests <https://github.com/awslabs/smithy/tree/meta-protocol-and-auth/smithy-aws-protocol-tests/model>`_
+    `Protocol tests <https://github.com/awslabs/smithy/tree/1.3.0/smithy-aws-protocol-tests/model/awsJson1_1>`_
 
 .. tabs::
 

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -26,7 +26,7 @@ Trait selector
 Value type
     Annotation trait.
 See
-    `Protocol tests <https://github.com/awslabs/smithy/tree/meta-protocol-and-auth/smithy-aws-protocol-tests/model>`_
+    `Protocol tests <https://github.com/awslabs/smithy/tree/1.3.0/smithy-aws-protocol-tests/model/awsQuery>`_
 
 .. tabs::
 

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -26,7 +26,7 @@ Trait selector
 Value type
     Annotation trait.
 See
-    `Protocol tests <https://github.com/awslabs/smithy/tree/1.3.0/smithy-aws-protocol-tests/model/awsQuery>`_
+    `Protocol tests <https://github.com/awslabs/smithy/tree/__smithy_version__/smithy-aws-protocol-tests/model/awsQuery>`_
 
 .. tabs::
 


### PR DESCRIPTION
*Description of changes:*
I updated the link to 1.3.0—let me know if you'd prefer master or somewhere else. Currently, the link just 404s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.