### PR TITLE
Add tests for writing in sections.  

### DIFF
--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
@@ -113,34 +113,4 @@ public class CodegenWriterTest {
         assertThat(writer.getImportContainer().imports, hasKey("MyString"));
         assertThat(writer.getImportContainer().imports.get("MyString"), equalTo("java.lang.String"));
     }
-
-    @Test
-    public void sectionWithWrite() {
-        String testSection = "TEST_SECTION";
-        MyWriter writer = new MyWriter("foo");
-
-        writer.onSection(testSection, text -> {
-            writer.write(text + "addition");
-        });
-
-        writer.pushState(testSection);
-        writer.popState();
-
-        assertThat(writer.toString(), equalTo("addition\n"));
-    }
-
-    @Test
-    public void sectionWithWriteInline() {
-        String testSection = "TEST_SECTION";
-        MyWriter writer = new MyWriter("foo");
-
-        writer.onSection(testSection, text -> {
-            writer.writeInline(text + "inline addition");
-        });
-
-        writer.pushState(testSection);
-        writer.popState();
-
-        assertThat(writer.toString(), equalTo("inline addition\n"));
-    }
 }

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
@@ -113,4 +113,34 @@ public class CodegenWriterTest {
         assertThat(writer.getImportContainer().imports, hasKey("MyString"));
         assertThat(writer.getImportContainer().imports.get("MyString"), equalTo("java.lang.String"));
     }
+
+    @Test
+    public void sectionWithWrite() {
+        String testSection = "TEST_SECTION";
+        MyWriter writer = new MyWriter("foo");
+
+        writer.onSection(testSection, text -> {
+            writer.write(text + "addition");
+        });
+
+        writer.pushState(testSection);
+        writer.popState();
+
+        assertThat(writer.toString(), equalTo("addition\n"));
+    }
+
+    @Test
+    public void sectionWithWriteInline() {
+        String testSection = "TEST_SECTION";
+        MyWriter writer = new MyWriter("foo");
+
+        writer.onSection(testSection, text -> {
+            writer.writeInline(text + "inline addition");
+        });
+
+        writer.pushState(testSection);
+        writer.popState();
+
+        assertThat(writer.toString(), equalTo("inline addition\n"));
+    }
 }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -667,10 +667,10 @@ public class CodeWriter {
 
         // Remove the trailing newline, if present, since it gets added in the
         // final call to writeOptional.
-        if (builder != null
-                && builder.length() > 0
-                && builder.charAt(builder.length() - 1) == currentState.newline) {
-            builder.delete(builder.length() - 1, builder.length());
+        if (builder != null && builder.length() > 0) {
+            if (builder.charAt(builder.length() - 1) == currentState.newline) {
+                builder.delete(builder.length() - 1, builder.length());
+            }
             result = builder.toString();
         }
 

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -696,4 +696,33 @@ public class CodeWriterTest {
 
         assertThat(writer.toString(), equalTo("[1, 2, 3]\n"));
     }
+
+    public void sectionWithWrite() {
+        String testSection = "TEST_SECTION";
+        CodeWriter writer = new CodeWriter();
+
+        writer.onSection(testSection, text -> {
+            writer.write(text + "addition");
+        });
+
+        writer.pushState(testSection);
+        writer.popState();
+
+        assertThat(writer.toString(), equalTo("addition\n"));
+    }
+
+    @Test
+    public void sectionWithWriteInline() {
+        String testSection = "TEST_SECTION";
+        CodeWriter writer = new CodeWriter();
+
+        writer.onSection(testSection, text -> {
+            writer.writeInline(text + "inline addition");
+        });
+
+        writer.pushState(testSection);
+        writer.popState();
+
+        assertThat(writer.toString(), equalTo("inline addition\n"));
+    }
 }


### PR DESCRIPTION
The inline test is failing due to  (what I believe to be) a bug.

*Issue #, if available:* N/A

*Description of changes:*

I have code that requires multiple integrations to all contribute a string to the same line in codegen output.  I use `CodeWriter.writeInLine()` but this produces no change in the codegen output.  This PR captures the bug.

I've added another test which passes which exercises `CodeWriter.write()` in addition to the breaking test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
