### PR TITLE
Add javadoc example and unit test for composing set via CodeWriter.on…

### DIFF
--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
@@ -113,18 +113,4 @@ public class CodegenWriterTest {
         assertThat(writer.getImportContainer().imports, hasKey("MyString"));
         assertThat(writer.getImportContainer().imports.get("MyString"), equalTo("java.lang.String"));
     }
-
-    @Test
-    public void canComposeSetWithSection() {
-        String testSection = "testSection";
-        MyWriter writer = new MyWriter("foo");
-
-        writer.onSection(testSection, text -> writer.write(text + "1, "));
-        writer.onSection(testSection, text -> writer.write(text + "2, "));
-        writer.onSection(testSection, text -> writer.write(text + "3"));
-
-        writer.write("[${L@testSection}]", "");
-
-        assertThat(writer.toString(), equalTo("[1, 2, 3]"));
-    }
 }

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/writer/CodegenWriterTest.java
@@ -113,4 +113,18 @@ public class CodegenWriterTest {
         assertThat(writer.getImportContainer().imports, hasKey("MyString"));
         assertThat(writer.getImportContainer().imports.get("MyString"), equalTo("java.lang.String"));
     }
+
+    @Test
+    public void canComposeSetWithSection() {
+        String testSection = "testSection";
+        MyWriter writer = new MyWriter("foo");
+
+        writer.onSection(testSection, text -> writer.write(text + "1, "));
+        writer.onSection(testSection, text -> writer.write(text + "2, "));
+        writer.onSection(testSection, text -> writer.write(text + "3"));
+
+        writer.write("[${L@testSection}]", "");
+
+        assertThat(writer.toString(), equalTo("[1, 2, 3]"));
+    }
 }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -358,9 +358,9 @@ import java.util.regex.Pattern;
  *
  * <pre>{@code
  * CodeWriter writer = new CodeWriter();
- * writer.onSection("example", text -> writer2.write(text + "1, "));
- * writer.onSection("example", text -> writer2.write(text + "2, "));
- * writer.onSection("example", text -> writer2.write(text + "3"));
+ * writer.onSection("example", text -> writer.write(text + "1, "));
+ * writer.onSection("example", text -> writer.write(text + "2, "));
+ * writer.onSection("example", text -> writer.write(text + "3"));
  * writer.write("[${L@example}]", "");
  * System.out.println(writer.toString());
  * // Outputs: "[1, 2, 3]\n"

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -353,6 +353,18 @@ import java.util.regex.Pattern;
  * System.out.println(writer.toString());
  * // Outputs: "Leading text...Intercepted: foo...Trailing text...\n"
  * }</pre>
+ *
+ * Inline sections are useful for composing sets or lists from any code with access to {@code CodeWriter}:
+ *
+ * <pre>{@code
+ * CodeWriter writer = new CodeWriter();
+ * writer.onSection("example", text -> writer2.write(text + "1, "));
+ * writer.onSection("example", text -> writer2.write(text + "2, "));
+ * writer.onSection("example", text -> writer2.write(text + "3"));
+ * writer.write("[${L@example}]", "");
+ * System.out.println(writer.toString());
+ * // Outputs: "[1, 2, 3]\n"
+ * }</pre>
  */
 public class CodeWriter {
     private static final Pattern LINES = Pattern.compile("\\r?\\n");

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -682,4 +682,18 @@ public class CodeWriterTest {
 
         assertThat(writer.toString(), equalTo("HELLO!\nGOODBYE!\n"));
     }
+
+    @Test
+    public void canComposeSetWithSection() {
+        String testSection = "testSection";
+        CodeWriter writer = new CodeWriter();
+
+        writer.onSection(testSection, text -> writer.write(text + "1, "));
+        writer.onSection(testSection, text -> writer.write(text + "2, "));
+        writer.onSection(testSection, text -> writer.write(text + "3"));
+
+        writer.write("[${L@testSection}]", "");
+
+        assertThat(writer.toString(), equalTo("[1, 2, 3]\n"));
+    }
 }


### PR DESCRIPTION
…Section() and inline section notation.

*Issue #, if available:* N/A

Based on slack discussion, added javadoc to demonstrate generating a list using inline sections with an accompanying unit test.  Happy to remove the unit test of deemed redundant.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
