### PR TITLE
Add @sparse trait to JsonMapsInputOutputMap

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
@@ -133,6 +133,7 @@ structure JsonMapsInputOutput {
     myMap: JsonMapsInputOutputMap,
 }
 
+@sparse
 map JsonMapsInputOutputMap {
     key: String,
     value: GreetingStruct


### PR DESCRIPTION
*Description of changes:*
Some of the protocol tests assume that this map is sparse and will attempt to insert null values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
