### PR TITLE
Add methods for retrieving full paginator output token and item paths.

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.validators.PaginatedTraitValidator;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.OptionalUtils;
 
 /**
@@ -83,17 +84,17 @@ public final class PaginatedIndex implements KnowledgeIndex {
 
         MemberShape inputToken = trait.getInputToken().flatMap(input::getMember).orElse(null);
         List<MemberShape> outputTokenPath = trait.getOutputToken()
-                .flatMap(path -> PaginatedTrait.resolvePath(path, model, output))
-                .orElse(null);
+                .map(path -> PaginatedTrait.resolvePathToMember(path, model, output))
+                .orElse(ListUtils.of());
 
-        if (inputToken == null || outputTokenPath == null) {
+        if (inputToken == null || outputTokenPath.size() == 0) {
             return Optional.empty();
         }
 
         MemberShape pageSizeMember = trait.getPageSize().flatMap(input::getMember).orElse(null);
         List<MemberShape> itemsMemberPath = trait.getItems()
-                .flatMap(path -> PaginatedTrait.resolvePath(path, model, output))
-                .orElse(null);
+                .map(path -> PaginatedTrait.resolvePathToMember(path, model, output))
+                .orElse(ListUtils.of());
 
         return Optional.of(new PaginationInfo(
                 service, operation, input, output, trait,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -87,7 +87,7 @@ public final class PaginatedIndex implements KnowledgeIndex {
                 .map(path -> PaginatedTrait.resolveFullPath(path, model, output))
                 .orElse(ListUtils.of());
 
-        if (inputToken == null || outputTokenPath.size() == 0) {
+        if (inputToken == null || outputTokenPath.isEmpty()) {
             return Optional.empty();
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.knowledge;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -81,22 +82,22 @@ public final class PaginatedIndex implements KnowledgeIndex {
         }
 
         MemberShape inputToken = trait.getInputToken().flatMap(input::getMember).orElse(null);
-        MemberShape outputToken = trait.getOutputToken()
+        List<MemberShape> outputTokenPath = trait.getOutputToken()
                 .flatMap(path -> PaginatedTrait.resolvePath(path, model, output))
                 .orElse(null);
 
-        if (inputToken == null || outputToken == null) {
+        if (inputToken == null || outputTokenPath == null) {
             return Optional.empty();
         }
 
         MemberShape pageSizeMember = trait.getPageSize().flatMap(input::getMember).orElse(null);
-        MemberShape itemsMember = trait.getItems()
+        List<MemberShape> itemsMemberPath = trait.getItems()
                 .flatMap(path -> PaginatedTrait.resolvePath(path, model, output))
                 .orElse(null);
 
         return Optional.of(new PaginationInfo(
                 service, operation, input, output, trait,
-                inputToken, outputToken, pageSizeMember, itemsMember));
+                inputToken, outputTokenPath, pageSizeMember, itemsMemberPath));
     }
 
     public Optional<PaginationInfo> getPaginationInfo(ToShapeId service, ToShapeId operation) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -84,7 +84,7 @@ public final class PaginatedIndex implements KnowledgeIndex {
 
         MemberShape inputToken = trait.getInputToken().flatMap(input::getMember).orElse(null);
         List<MemberShape> outputTokenPath = trait.getOutputToken()
-                .map(path -> PaginatedTrait.resolvePathToMember(path, model, output))
+                .map(path -> PaginatedTrait.resolveFullPath(path, model, output))
                 .orElse(ListUtils.of());
 
         if (inputToken == null || outputTokenPath.size() == 0) {
@@ -93,7 +93,7 @@ public final class PaginatedIndex implements KnowledgeIndex {
 
         MemberShape pageSizeMember = trait.getPageSize().flatMap(input::getMember).orElse(null);
         List<MemberShape> itemsMemberPath = trait.getItems()
-                .map(path -> PaginatedTrait.resolvePathToMember(path, model, output))
+                .map(path -> PaginatedTrait.resolveFullPath(path, model, output))
                 .orElse(ListUtils.of());
 
         return Optional.of(new PaginationInfo(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
@@ -91,14 +91,11 @@ public final class PaginationInfo {
 
     /**
      * @return the last {@link MemberShape} of the output path.
-     * @deprecated See getOutputTokenPath.
+     *
+     * @deprecated See {@link PaginationInfo#getOutputTokenPath} to retrieve the full path.
      */
     public MemberShape getOutputTokenMember() {
-        int size = outputToken.size();
-        if (size == 0) {
-            return null;
-        }
-        return outputToken.get(size - 1);
+        return outputToken.get(outputToken.size() - 1);
     }
 
     public List<MemberShape> getOutputTokenPath() {
@@ -107,7 +104,8 @@ public final class PaginationInfo {
 
     /**
      * @return the last {@link MemberShape} of the items path.
-     * @deprecated See getItemsMemberPath
+     *
+     * @deprecated See {@link PaginationInfo#getItemsMemberPath} to retrieve the full path.
      */
     public Optional<MemberShape> getItemsMember() {
         int size = items.size();
@@ -117,8 +115,8 @@ public final class PaginationInfo {
         return Optional.ofNullable(items.get(size - 1));
     }
 
-    public Optional<List<MemberShape>> getItemsMemberPath() {
-        return Optional.ofNullable(items);
+    public List<MemberShape> getItemsMemberPath() {
+        return items;
     }
 
     public Optional<MemberShape> getPageSizeMember() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
@@ -94,10 +94,16 @@ public final class PaginationInfo {
      *
      * @deprecated See {@link PaginationInfo#getOutputTokenPath} to retrieve the full path.
      */
+    @Deprecated
     public MemberShape getOutputTokenMember() {
         return outputToken.get(outputToken.size() - 1);
     }
 
+    /**
+     * Get the resolved output path identifiers as a list of {@link MemberShape}.
+     *
+     * @return A list of {@link MemberShape}.
+     */
     public List<MemberShape> getOutputTokenPath() {
         return outputToken;
     }
@@ -107,6 +113,7 @@ public final class PaginationInfo {
      *
      * @deprecated See {@link PaginationInfo#getItemsMemberPath} to retrieve the full path.
      */
+    @Deprecated
     public Optional<MemberShape> getItemsMember() {
         int size = items.size();
         if (size == 0) {
@@ -115,6 +122,11 @@ public final class PaginationInfo {
         return Optional.ofNullable(items.get(size - 1));
     }
 
+    /**
+     * Get the resolved items path identifiers as a list of {@link MemberShape}.
+     *
+     * @return A list of {@link MemberShape}.
+     */
     public List<MemberShape> getItemsMemberPath() {
         return items;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
@@ -92,7 +92,7 @@ public final class PaginationInfo {
     /**
      * @return the last {@link MemberShape} of the output path.
      *
-     * @deprecated See {@link PaginationInfo#getOutputTokenPath} to retrieve the full path.
+     * @deprecated See {@link PaginationInfo#getOutputTokenMemberPath} to retrieve the full path.
      */
     @Deprecated
     public MemberShape getOutputTokenMember() {
@@ -104,7 +104,7 @@ public final class PaginationInfo {
      *
      * @return A list of {@link MemberShape}.
      */
-    public List<MemberShape> getOutputTokenPath() {
+    public List<MemberShape> getOutputTokenMemberPath() {
         return outputToken;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginationInfo.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.model.knowledge;
 
+import java.util.List;
 import java.util.Optional;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -33,9 +34,9 @@ public final class PaginationInfo {
     private final StructureShape output;
     private final PaginatedTrait paginatedTrait;
     private final MemberShape inputToken;
-    private final MemberShape outputToken;
+    private final List<MemberShape> outputToken;
     private final MemberShape pageSize;
-    private final MemberShape items;
+    private final List<MemberShape> items;
 
     PaginationInfo(
             ServiceShape service,
@@ -44,9 +45,9 @@ public final class PaginationInfo {
             StructureShape output,
             PaginatedTrait paginatedTrait,
             MemberShape inputToken,
-            MemberShape outputToken,
+            List<MemberShape> outputToken,
             MemberShape pageSize,
-            MemberShape items
+            List<MemberShape> items
     ) {
         this.service = service;
         this.operation = operation;
@@ -88,11 +89,35 @@ public final class PaginationInfo {
         return inputToken;
     }
 
+    /**
+     * @return the last {@link MemberShape} of the output path.
+     * @deprecated See getOutputTokenPath.
+     */
     public MemberShape getOutputTokenMember() {
+        int size = outputToken.size();
+        if (size == 0) {
+            return null;
+        }
+        return outputToken.get(size - 1);
+    }
+
+    public List<MemberShape> getOutputTokenPath() {
         return outputToken;
     }
 
+    /**
+     * @return the last {@link MemberShape} of the items path.
+     * @deprecated See getItemsMemberPath
+     */
     public Optional<MemberShape> getItemsMember() {
+        int size = items.size();
+        if (size == 0) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(items.get(size - 1));
+    }
+
+    public Optional<List<MemberShape>> getItemsMemberPath() {
         return Optional.ofNullable(items);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
@@ -93,14 +93,15 @@ public final class PaginatedTrait extends AbstractTrait implements ToSmithyBuild
      *              of an operation.
      * @return The optional member shape that the path resolves to.
      * @deprecated This method only returns the last {@link MemberShape} of an output path. To resolve each path
-     * identifier to it's respective {@link MemberShape} see {@link PaginatedTrait#resolvePathToMember}
+     * identifier to it's respective {@link MemberShape} see {@link PaginatedTrait#resolveFullPath}
      */
+    @Deprecated
     public static Optional<MemberShape> resolvePath(
             String path,
             Model model,
             StructureShape shape
     ) {
-        List<MemberShape> memberShapes = resolvePathToMember(path, model, shape);
+        List<MemberShape> memberShapes = resolveFullPath(path, model, shape);
         if (memberShapes.size() == 0) {
             return Optional.empty();
         }
@@ -120,7 +121,7 @@ public final class PaginatedTrait extends AbstractTrait implements ToSmithyBuild
      * @return The list of member shapes corresponding to each path identifier. An unresolvable path will be returned
      * as an empty list.
      */
-    public static List<MemberShape> resolvePathToMember(
+    public static List<MemberShape> resolveFullPath(
             String path,
             Model model,
             StructureShape shape

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.traits;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
@@ -90,23 +92,26 @@ public final class PaginatedTrait extends AbstractTrait implements ToSmithyBuild
      *              of an operation.
      * @return The optional member shape that the path resolves to.
      */
-    public static Optional<MemberShape> resolvePath(
+    public static Optional<List<MemberShape>> resolvePath(
             String path,
             Model model,
             StructureShape shape
     ) {
+        List<MemberShape> memberShapes = new ArrayList<>();
+
         // For each member name in the path, try to find that member in the previous structure
-        Optional<MemberShape> memberShape = Optional.empty();
+        Optional<MemberShape> memberShape;
         Optional<StructureShape> container = Optional.of(shape);
         for (String memberName: PATH_PATTERN.split(path)) {
             memberShape = container.flatMap(structure -> structure.getMember(memberName));
             if (!memberShape.isPresent()) {
                 return Optional.empty();
             }
+            memberShapes.add(memberShape.get());
             container = model.getShape(memberShape.get().getTarget())
                     .flatMap(Shape::asStructureShape);
         }
-        return memberShape;
+        return Optional.of(memberShapes);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -136,9 +136,9 @@ public final class PaginatedTraitValidator extends AbstractValidator {
 
         if (memberPath == null) {
             return service != null && validator.isRequiredToBePresent()
-                   ? Collections.singletonList(error(operation, trait, String.format(
+                    ? Collections.singletonList(error(operation, trait, String.format(
                     "%spaginated trait `%s` is not configured", prefix, validator.propertyName())))
-                   : Collections.emptyList();
+                    : Collections.emptyList();
         }
 
         if (!validator.pathsAllowed() && memberPath.contains(".")) {
@@ -184,7 +184,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         if (validator.pathsAllowed() && PATH_PATTERN.split(memberPath).length > 2) {
             events.add(warning(operation, trait, String.format(
                     "%spaginated trait `%s` contains a path with more than two parts, which can make your API "
-                        + "cumbersome to use",
+                    + "cumbersome to use",
                     prefix, validator.propertyName()
             )));
         }
@@ -228,7 +228,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         ) {
             Optional<StructureShape> outputShape = opIndex.getOutput(operation);
             return outputShape.flatMap(structureShape -> getMemberPath(opIndex, operation, trait)
-                    .flatMap(path -> PaginatedTrait.resolvePath(path, model, structureShape)));
+                    .flatMap(path -> PaginatedTrait.resolvePath(path, model, structureShape)))
+                    .map(memberShapes -> memberShapes.get(memberShapes.size() - 1));
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -228,8 +228,13 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         ) {
             Optional<StructureShape> outputShape = opIndex.getOutput(operation);
             return outputShape.flatMap(structureShape -> getMemberPath(opIndex, operation, trait)
-                    .flatMap(path -> PaginatedTrait.resolvePath(path, model, structureShape)))
-                    .map(memberShapes -> memberShapes.get(memberShapes.size() - 1));
+                    .map(path -> PaginatedTrait.resolvePathToMember(path, model, structureShape)))
+                    .flatMap(memberShapes -> {
+                        if (memberShapes.size() == 0) {
+                            return Optional.empty();
+                        }
+                        return Optional.of(memberShapes.get(memberShapes.size() - 1));
+                    });
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -228,7 +228,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         ) {
             Optional<StructureShape> outputShape = opIndex.getOutput(operation);
             return outputShape.flatMap(structureShape -> getMemberPath(opIndex, operation, trait)
-                    .map(path -> PaginatedTrait.resolvePathToMember(path, model, structureShape)))
+                    .map(path -> PaginatedTrait.resolveFullPath(path, model, structureShape)))
                     .flatMap(memberShapes -> {
                         if (memberShapes.size() == 0) {
                             return Optional.empty();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/PaginatedIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/PaginatedIndexTest.java
@@ -19,12 +19,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.CollectionUtils;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -49,8 +46,8 @@ public class PaginatedIndexTest {
         assertThat(info.getOutput().getId(), is(ShapeId.from("ns.foo#ValidOutput")));
         assertThat(info.getInputTokenMember().getMemberName(), equalTo("nextToken"));
         assertThat(info.getOutputTokenMember().getMemberName(), equalTo("nextToken"));
-        assertThat(info.getOutputTokenPath().isEmpty(), is(false));
-        assertThat(info.getOutputTokenPath().stream()
+        assertThat(info.getOutputTokenMemberPath().isEmpty(), is(false));
+        assertThat(info.getOutputTokenMemberPath().stream()
                 .map(MemberShape::getMemberName)
                 .collect(Collectors.toList()), equalTo(ListUtils.of("nextToken")));
         assertThat(info.getPageSizeMember().isPresent(), is(true));
@@ -78,8 +75,8 @@ public class PaginatedIndexTest {
 
         PaginationInfo info = optionalInfo.get();
         assertThat(info.getOutputTokenMember().getMemberName(), equalTo("nextToken"));
-        assertThat(info.getOutputTokenPath().isEmpty(), is(false));
-        assertThat(info.getOutputTokenPath().stream()
+        assertThat(info.getOutputTokenMemberPath().isEmpty(), is(false));
+        assertThat(info.getOutputTokenMemberPath().stream()
                 .map(MemberShape::getMemberName)
                 .collect(Collectors.toList()), equalTo(ListUtils.of("result", "nextToken")));
         assertThat(info.getItemsMember().isPresent(), is(true));


### PR DESCRIPTION
Adds support for retrieving the full list of MemberShape paths for the @paginated.outputToken and @paginated.items paths. Currently marked the old methods as deprecated as to better indicate the more desirable retrievers a user should use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
