### PR TITLE
Allow pagination tokens to be maps

### DIFF
--- a/docs/source/1.0/spec/core/behavior-traits.rst
+++ b/docs/source/1.0/spec/core/behavior-traits.rst
@@ -194,7 +194,8 @@ The ``paginated`` trait is a structure that contains the following members:
       - The name of the operation input member that contains a continuation
         token. When this value is provided as input, the service returns
         results from where the previous response left off. This input member
-        MUST NOT be marked as ``required`` and MUST target a string shape.
+        MUST NOT be marked as ``required`` and SHOULD target a string shape.
+        It can, but SHOULD NOT target a map shape.
 
         When contained within a service, a paginated operation MUST either
         configure ``inputToken`` on the operation itself or inherit it from
@@ -206,8 +207,8 @@ The ``paginated`` trait is a structure that contains the following members:
         it indicates that there are more results to retrieve. To get the next
         page of results, the client passes the received output continuation
         token to the input continuation token of the next request. This
-        output member MUST NOT be marked as ``required`` and MUST target a
-        string shape.
+        output member MUST NOT be marked as ``required`` and SHOULD target a
+        string shape. It can, but SHOULD NOT target a map shape.
 
         When contained within a service, a paginated operation MUST either
         configure ``outputToken`` on the operation itself or inherit it from

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.errors
@@ -1,9 +1,9 @@
 [ERROR] ns.foo#Invalid1: paginated operations require an input | PaginatedTrait
 [ERROR] ns.foo#Invalid2: paginated trait `inputToken` targets a member `nextToken` that does not exist | PaginatedTrait
 [ERROR] ns.foo#Invalid2: paginated trait `outputToken` targets a member `nextToken` that does not exist | PaginatedTrait
-[ERROR] ns.foo#Invalid3: paginated trait `inputToken` member `InputNotString` targets a integer shape, but must target one of the following: [`string`] | PaginatedTrait
+[ERROR] ns.foo#Invalid3: paginated trait `inputToken` member `InputNotString` targets a integer shape, but must target one of the following: [`map`, `string`] | PaginatedTrait
 [ERROR] ns.foo#Invalid3: paginated trait `items` targets a member `items` that does not exist | PaginatedTrait
-[ERROR] ns.foo#Invalid3: paginated trait `outputToken` member `OutputNotString` targets a integer shape, but must target one of the following: [`string`] | PaginatedTrait
+[ERROR] ns.foo#Invalid3: paginated trait `outputToken` member `OutputNotString` targets a integer shape, but must target one of the following: [`map`, `string`] | PaginatedTrait
 [ERROR] ns.foo#Invalid4: paginated trait `inputToken` member `nextToken` must not be required | PaginatedTrait
 [ERROR] ns.foo#Invalid4: paginated trait `outputToken` member `nextToken` must not be required | PaginatedTrait
 [WARNING] ns.foo#Invalid4: paginated trait `pageSize` member `pageSize` should not be required | PaginatedTrait
@@ -22,3 +22,5 @@
 [WARNING] ns.foo#DeeplyNestedOutputOperation: paginated trait `outputToken` contains a path with more than two parts, which can make your API cumbersome to use | PaginatedTrait
 [ERROR] ns.foo#InvalidNestedInput: paginated trait `inputToken` does not allow path values | PaginatedTrait
 [ERROR] ns.foo#InvalidNestedInput: paginated trait `pageSize` does not allow path values | PaginatedTrait
+[DANGER] ns.foo#MapTokens: paginated trait `inputToken` member `MapTokenInputOutput` targets a map shape, but this is not recommended. One of [`string`] SHOULD be targeted. | PaginatedTrait
+[DANGER] ns.foo#MapTokens: paginated trait `outputToken` member `MapTokenInputOutput` targets a map shape, but this is not recommended. One of [`string`] SHOULD be targeted. | PaginatedTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated-trait-test.json
@@ -52,6 +52,9 @@
                 },
                 {
                     "target": "ns.foo#InvalidNestedInput"
+                },
+                {
+                    "target": "ns.foo#MapTokens"
                 }
             ]
         },
@@ -588,6 +591,39 @@
                 "items": {
                     "target": "ns.foo#StringList"
                 }
+            }
+        },
+        "ns.foo#MapTokens": {
+            "type": "operation",
+            "input": {
+                "target": "ns.foo#MapTokenInputOutput"
+            },
+            "output": {
+                "target": "ns.foo#MapTokenInputOutput"
+            },
+            "traits": {
+                "smithy.api#readonly": {},
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken"
+                }
+            }
+        },
+        "ns.foo#MapTokenInputOutput": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "ns.foo#StringMap"
+                }
+            }
+        },
+        "ns.foo#StringMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
             }
         }
     }


### PR DESCRIPTION
This relaxes the constraints of pagination tokens to allow maps. This is intended to enable existing services in the wild and is not recommended for future services, so a DANGER validation event is emitted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
