### PR TITLE
Improve diff evaluation of changed member targets

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/ChangedShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/ChangedShape.java
@@ -39,7 +39,7 @@ public final class ChangedShape<S extends Shape> implements FromSourceLocation {
     private final S newShape;
     private final Map<ShapeId, Pair<Trait, Trait>> traitDiff;
 
-    ChangedShape(S oldShape, S newShape) {
+    public ChangedShape(S oldShape, S newShape) {
         this.oldShape = oldShape;
         this.newShape = newShape;
         traitDiff = Collections.unmodifiableMap(findTraitDifferences(oldShape, newShape));

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberTarget.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,26 +15,47 @@
 
 package software.amazon.smithy.diff.evaluators;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.SimpleShape;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Checks for changes in the shapes targeted by a member.
  *
  * <p>If the shape targeted by the member changes from a simple shape to
- * a simple shape of the same type with the same traits, then the emitted
- * event is a WARNING. All other changes are ERROR events.
+ * a simple shape of the same type with the same traits, or a list or set
+ * that has a member that targets the shame exact shape and has the same
+ * traits, then the emitted event is a WARNING. If an enum trait is
+ * found on the old or newly targeted shape, then the event is an ERROR,
+ * because enum traits typically materialize as named types in codegen.
+ * All other changes are ERROR events.
  */
 public final class ChangedMemberTarget extends AbstractDiffEvaluator {
+
+    /**
+     * These traits are traits that are known to significantly influence
+     * code generation. Right now it just contains the enum trait, but
+     * other traits could be added in the future as needed.
+     */
+    private static final Set<ShapeId> SIGNIFICANT_CODEGEN_TRAITS = SetUtils.of(EnumTrait.ID);
+
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.changedShapes(MemberShape.class)
@@ -46,13 +67,21 @@ public final class ChangedMemberTarget extends AbstractDiffEvaluator {
     private ValidationEvent createChangeEvent(Differences differences, ChangedShape<MemberShape> change) {
         Shape oldTarget = getShapeTarget(differences.getOldModel(), change.getOldShape().getTarget());
         Shape newTarget = getShapeTarget(differences.getNewModel(), change.getNewShape().getTarget());
-        Severity severity = areShapesCompatible(oldTarget, newTarget) ? Severity.WARNING : Severity.ERROR;
+        List<String> issues = areShapesCompatible(oldTarget, newTarget);
+        Severity severity = issues.isEmpty() ? Severity.WARNING : Severity.ERROR;
+
+        String message = createSimpleMessage(change, oldTarget, newTarget);
+        if (severity == Severity.WARNING) {
+            message += "This was determined backward compatible.";
+        } else {
+            message += String.join(". ", issues) + ".";
+        }
 
         return ValidationEvent.builder()
                 .severity(severity)
                 .id(getEventId())
                 .shape(change.getNewShape())
-                .message(createMessage(change, oldTarget, newTarget))
+                .message(message)
                 .build();
     }
 
@@ -60,24 +89,92 @@ public final class ChangedMemberTarget extends AbstractDiffEvaluator {
         return model.getShape(id).orElse(null);
     }
 
-    private boolean areShapesCompatible(Shape oldShape, Shape newShape) {
+    private static List<String> areShapesCompatible(Shape oldShape, Shape newShape) {
         if (oldShape == null || newShape == null) {
-            return false;
+            return ListUtils.of();
         }
 
-        return oldShape.getType() == newShape.getType()
-               && oldShape instanceof SimpleShape
-               && newShape instanceof SimpleShape
-               && oldShape.getAllTraits().equals(newShape.getAllTraits());
+        if (oldShape.getType() != newShape.getType()) {
+            return ListUtils.of(String.format("The type of the targeted shape changed from %s to %s",
+                                              oldShape.getType(), newShape.getType()));
+        }
+
+        if (!(oldShape instanceof SimpleShape || oldShape instanceof CollectionShape)) {
+            return ListUtils.of(String.format("The name of a %s is significant", oldShape.getType()));
+        }
+
+        List<String> results = new ArrayList<>();
+        for (ShapeId significantCodegenTrait : SIGNIFICANT_CODEGEN_TRAITS) {
+            if (oldShape.hasTrait(significantCodegenTrait)) {
+                results.add(String.format("The `%s` trait was found on the target, so the name of the targeted "
+                                          + "shape matters for codegen",
+                                          significantCodegenTrait));
+            }
+        }
+
+        if (!oldShape.getAllTraits().equals(newShape.getAllTraits())) {
+            results.add(createTraitDiffMessage(oldShape, newShape));
+        }
+
+        if (oldShape instanceof CollectionShape) {
+            MemberShape oldMember = ((CollectionShape) oldShape).getMember();
+            MemberShape newMember = ((CollectionShape) newShape).getMember();
+            if (!oldMember.getTarget().equals(newMember.getTarget())) {
+                results.add(String.format("Both the old and new shapes are a %s, but the old shape targeted "
+                                          + "`%s` while the new shape targets `%s`",
+                                          oldShape.getType(),
+                                          oldMember.getTarget(),
+                                          newMember.getTarget()));
+            } else if (!oldMember.getAllTraits().equals(newMember.getAllTraits())) {
+                results.add(String.format("Both the old and new shapes are a %s, but their members have "
+                                          + "differing traits. %s",
+                                          oldShape.getType(),
+                                          createTraitDiffMessage(oldMember, newMember)));
+            }
+        }
+
+        return results;
     }
 
-    private String createMessage(ChangedShape<MemberShape> change, Shape oldTarget, Shape newTarget) {
+    private static String createSimpleMessage(ChangedShape<MemberShape> change, Shape oldTarget, Shape newTarget) {
         return String.format(
-                "The shape targeted by the member `%s` changed from `%s`, a %s, to `%s`, a %s.",
+                "The shape targeted by the member `%s` changed from `%s` (%s) to `%s` (%s). ",
                 change.getShapeId(),
                 change.getOldShape().getTarget(),
-                oldTarget,
+                oldTarget.getType(),
                 change.getNewShape().getTarget(),
-                newTarget);
+                newTarget.getType());
+    }
+
+    private static String createTraitDiffMessage(Shape oldShape, Shape newShape) {
+        StringJoiner joiner = new StringJoiner(". ");
+        ChangedShape<Shape> targetChange = new ChangedShape<>(oldShape, newShape);
+
+        Set<ShapeId> removedTraits = targetChange.removedTraits()
+                .map(Trait::toShapeId)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        if (!removedTraits.isEmpty()) {
+            joiner.add("The targeted shape no longer has the the following traits: " + removedTraits);
+        }
+
+        Set<ShapeId> addedTraits = targetChange.addedTraits()
+                .map(Trait::toShapeId)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        if (!addedTraits.isEmpty()) {
+            joiner.add("The newly targeted shape now has the following additional traits: " + addedTraits);
+        }
+
+        // Only select the traits that exist in both placed but changed.
+        Set<ShapeId> changedTraits = new TreeSet<>(targetChange.getTraitDifferences().keySet());
+        changedTraits.removeAll(addedTraits);
+        changedTraits.removeAll(removedTraits);
+
+        if (!changedTraits.isEmpty()) {
+            joiner.add("The newly targeted shape has traits that differ from the previous shape: " + changedTraits);
+        }
+
+        return joiner.toString();
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedMemberTargetTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedMemberTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -26,7 +26,12 @@ import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.EnumDefinition;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -49,7 +54,28 @@ public class ChangedMemberTargetTest {
     }
 
     @Test
-    public void detectsCompatibleTypeChanges() {
+    public void detectsIncompatibleTargetChanges() {
+        Shape shape1 = StructureShape.builder().id("foo.baz#Shape1").build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#List$member").target(shape1.getId()).build();
+        ListShape list1 = ListShape.builder().id("foo.baz#List").member(member1).build();
+        Shape shape2 = StructureShape.builder().id("foo.baz#Shape2").build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#List$member").target(shape2.getId()).build();
+        ListShape list2 = ListShape.builder().id("foo.baz#List").member(member2).build();
+        Model modelA = Model.assembler().addShapes(shape1, shape2, member1, list1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, shape2, member2, list2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, member2.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `foo.baz#List$member` changed from "
+                           + "`foo.baz#Shape1` (structure) to `foo.baz#Shape2` (structure). The name of a "
+                           + "structure is significant."));
+    }
+
+    @Test
+    public void detectsCompatibleChanges() {
         StringShape shape1 = StringShape.builder().id("foo.baz#String1").build();
         MemberShape member1 = MemberShape.builder().id("foo.baz#List$member").target(shape1.getId()).build();
         ListShape list1 = ListShape.builder().id("foo.baz#List").member(member1).build();
@@ -63,5 +89,194 @@ public class ChangedMemberTargetTest {
         assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, member2.getId()).size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, Severity.WARNING).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `foo.baz#List$member` changed from "
+                           + "`foo.baz#String1` (string) to `foo.baz#String2` (string). "
+                           + "This was determined backward compatible."));
+    }
+
+    @Test
+    public void detectsIncompatibleEnumTraitTargetChange() {
+        EnumTrait enumTrait = EnumTrait.builder()
+                .addEnum(EnumDefinition.builder().name("FOO").value("foo").build())
+                .build();
+
+        StringShape shape1 = StringShape.builder().id("foo.baz#String1").addTrait(enumTrait).build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#List$member").target(shape1.getId()).build();
+        ListShape list1 = ListShape.builder().id("foo.baz#List").member(member1).build();
+
+        StringShape shape2 = StringShape.builder().id("foo.baz#String2").addTrait(enumTrait).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#List$member").target(shape2.getId()).build();
+        ListShape list2 = ListShape.builder().id("foo.baz#List").member(member2).build();
+
+        Model modelA = Model.assembler().addShapes(shape1, shape2, member1, list1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, shape2, member2, list2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, member2.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `foo.baz#List$member` changed from `foo.baz#String1` "
+                           + "(string) to `foo.baz#String2` (string). The `smithy.api#enum` trait was found on the "
+                           + "target, so the name of the targeted shape matters for codegen."));
+    }
+
+    @Test
+    public void detectsTraitRemovalOnMemberTarget() {
+        EnumTrait enumTrait = EnumTrait.builder()
+                .addEnum(EnumDefinition.builder().name("FOO").value("foo").build())
+                .build();
+
+        StringShape shape1 = StringShape.builder().id("foo.baz#String1").addTrait(enumTrait).build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#List$member").target(shape1.getId()).build();
+        ListShape list1 = ListShape.builder().id("foo.baz#List").member(member1).build();
+
+        StringShape shape2 = StringShape.builder().id("foo.baz#String2").build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#List$member").target(shape2.getId()).build();
+        ListShape list2 = ListShape.builder().id("foo.baz#List").member(member2).build();
+
+        Model modelA = Model.assembler().addShapes(shape1, shape2, member1, list1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, shape2, member2, list2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, member2.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `foo.baz#List$member` changed from "
+                           + "`foo.baz#String1` (string) to `foo.baz#String2` (string). The `smithy.api#enum` trait "
+                           + "was found on the target, so the name of the targeted shape matters for codegen. "
+                           + "The targeted shape no longer has the the following traits: [smithy.api#enum]."));
+    }
+
+    @Test
+    public void detectsTraitAddedToMemberTarget() {
+                StringShape shape1 = StringShape.builder().id("foo.baz#String1").build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#List$member").target(shape1.getId()).build();
+        ListShape list1 = ListShape.builder().id("foo.baz#List").member(member1).build();
+
+        StringShape shape2 = StringShape.builder().id("foo.baz#String2").addTrait(new SensitiveTrait()).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#List$member").target(shape2.getId()).build();
+        ListShape list2 = ListShape.builder().id("foo.baz#List").member(member2).build();
+
+        Model modelA = Model.assembler().addShapes(shape1, shape2, member1, list1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, shape2, member2, list2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, member2.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `foo.baz#List$member` changed from `foo.baz#String1` "
+                           + "(string) to `foo.baz#String2` (string). The newly targeted shape now has the "
+                           + "following additional traits: [smithy.api#sensitive]."));
+    }
+
+    @Test
+    public void detectsTraitChangedOnMemberTarget() {
+        StringShape shape1 = StringShape.builder().id("foo.baz#String1").addTrait(new DocumentationTrait("a")).build();
+        MemberShape member1 = MemberShape.builder().id("foo.baz#List$member").target(shape1.getId()).build();
+        ListShape list1 = ListShape.builder().id("foo.baz#List").member(member1).build();
+
+        StringShape shape2 = StringShape.builder().id("foo.baz#String2").addTrait(new DocumentationTrait("b")).build();
+        MemberShape member2 = MemberShape.builder().id("foo.baz#List$member").target(shape2.getId()).build();
+        ListShape list2 = ListShape.builder().id("foo.baz#List").member(member2).build();
+
+        Model modelA = Model.assembler().addShapes(shape1, shape2, member1, list1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(shape1, shape2, member2, list2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, member2.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `foo.baz#List$member` changed from `foo.baz#String1` "
+                           + "(string) to `foo.baz#String2` (string). The newly targeted shape has traits that "
+                           + "differ from the previous shape: [smithy.api#documentation]."));
+    }
+
+    @Test
+    public void detectsAcceptableListMemberChangesInNestedTargets() {
+        Model modelA = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-valid-nested1-a.smithy"))
+                .assemble()
+                .unwrap();
+        Model modelB = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-valid-nested1-b.smithy"))
+                .assemble()
+                .unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.WARNING).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `smithy.example#A$member` changed from "
+                           + "`smithy.example#B1` (list) to `smithy.example#B2` (list). This was determined "
+                           + "backward compatible."));
+    }
+
+    @Test
+    public void detectsAcceptableSetMemberChangesInNestedTargets() {
+        Model modelA = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-valid-nested2-a.smithy"))
+                .assemble()
+                .unwrap();
+        Model modelB = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-valid-nested2-b.smithy"))
+                .assemble()
+                .unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.WARNING).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").get(0).getMessage(),
+                   equalTo("The shape targeted by the member `smithy.example#A$member` changed from "
+                           + "`smithy.example#B1` (set) to `smithy.example#B2` (set). This was determined "
+                           + "backward compatible."));
+    }
+
+    @Test
+    public void detectsInvalidListMemberChangesInNestedTargets() {
+        Model modelA = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-invalid-nested1-a.smithy"))
+                .assemble()
+                .unwrap();
+        Model modelB = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-invalid-nested1-b.smithy"))
+                .assemble()
+                .unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        ValidationEvent event = TestHelper.findEvents(events, "ChangedMemberTarget").get(0);
+        assertThat(event.getSeverity(), equalTo(Severity.ERROR));
+        assertThat(event.getMessage(),
+                   equalTo("The shape targeted by the member `smithy.example#A$member` changed from "
+                           + "`smithy.example#B1` (list) to `smithy.example#B2` (list). Both the old and new "
+                           + "shapes are a list, but their members have differing traits. The newly targeted "
+                           + "shape now has the following additional traits: [smithy.api#sensitive]."));
+    }
+
+    @Test
+    public void detectsInvalidListMemberTargetChange() {
+        Model modelA = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-invalid-nested2-a.smithy"))
+                .assemble()
+                .unwrap();
+        Model modelB = Model.assembler()
+                .addImport(getClass().getResource("changed-member-target-invalid-nested2-b.smithy"))
+                .assemble()
+                .unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedMemberTarget").size(), equalTo(1));
+        ValidationEvent event = TestHelper.findEvents(events, "ChangedMemberTarget").get(0);
+        assertThat(event.getSeverity(), equalTo(Severity.ERROR));
+        assertThat(event.getMessage(),
+                   equalTo("The shape targeted by the member `smithy.example#A$member` changed from "
+                           + "`smithy.example#B1` (list) to `smithy.example#B2` (list). Both the old and new "
+                           + "shapes are a list, but the old shape targeted `smithy.example#MyString` while "
+                           + "the new shape targets `smithy.example#MyString2`."));
     }
 }

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested1-a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested1-a.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+list A {
+    member: B1
+}
+
+list B1 {
+    member: MyString
+}
+
+string MyString

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested1-b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested1-b.smithy
@@ -1,0 +1,13 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+list A {
+    member: B2
+}
+
+list B2 {
+    @sensitive
+    member: MyString
+}
+
+string MyString

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested2-a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested2-a.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+list A {
+    member: B1
+}
+
+list B1 {
+    member: MyString
+}
+
+string MyString

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested2-b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-invalid-nested2-b.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+list A {
+    member: B2
+}
+
+list B2 {
+    member: MyString2
+}
+
+string MyString2

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested1-a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested1-a.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+list A {
+    member: B1
+}
+
+list B1 {
+    member: MyString
+}
+
+string MyString

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested1-b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested1-b.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+list A {
+    member: B2
+}
+
+list B2 {
+    member: MyString
+}
+
+string MyString

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested2-a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested2-a.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+set A {
+    member: B1
+}
+
+set B1 {
+    member: MyString
+}
+
+string MyString

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested2-b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/changed-member-target-valid-nested2-b.smithy
@@ -1,0 +1,12 @@
+// See ChangedMemberTargetTest
+namespace smithy.example
+
+set A {
+    member: B2
+}
+
+set B2 {
+    member: MyString
+}
+
+string MyString


### PR DESCRIPTION
The diff evaluator that detects changed members now contains much more
information when an incompatibility is detected. It also allows for some
new kinds of differences that are inconsequential (like a member that
targets a list that is exactly like the old list).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
