### PR TITLE
Fix protocol tests for sparse traits

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
@@ -3,7 +3,8 @@ $version: "1.0"
 namespace aws.protocoltests.json
 
 use aws.protocols#awsJson1_1
-use aws.protocoltests.shared#StringList
+use aws.protocoltests.shared#SparseStringList
+use aws.protocoltests.shared#SparseStringMap
 use aws.protocoltests.shared#StringMap
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
@@ -28,16 +29,16 @@ use smithy.test#httpResponseTests
         protocol: awsJson1_1,
         body: """
             {
-                "stringMap": {
+                "sparseStringMap": {
                     "foo": null
                 }
             }""",
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/x-amz-json-1.1"},
         params: {
-          stringMap: {
-              "foo": null
-          }
+            "sparseStringMap": {
+                "foo": null
+            }
         },
         method: "POST",
         uri: "/",
@@ -48,14 +49,16 @@ use smithy.test#httpResponseTests
         protocol: awsJson1_1,
         body: """
             {
-                "stringList": [
+                "sparseStringList": [
                     null
                 ]
             }""",
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/x-amz-json-1.1"},
         params: {
-          stringList: [null]
+            "sparseStringList": [
+                null
+            ]
         },
         method: "POST",
         uri: "/",
@@ -82,16 +85,16 @@ use smithy.test#httpResponseTests
         code: 200,
         body: """
             {
-                "stringMap": {
+                "sparseStringMap": {
                     "foo": null
                 }
             }""",
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/x-amz-json-1.1"},
         params: {
-          stringMap: {
-              "foo": null
-          }
+            "sparseStringMap": {
+                "foo": null
+            }
         },
     },
     {
@@ -101,14 +104,16 @@ use smithy.test#httpResponseTests
         code: 200,
         body: """
             {
-                "stringList": [
+                "sparseStringList": [
                     null
                 ]
             }""",
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/x-amz-json-1.1"},
         params: {
-          stringList: [null]
+            "sparseStringList": [
+                null
+            ]
         },
     }
 ])
@@ -119,6 +124,6 @@ operation NullOperation {
 
 structure NullOperationInputOutput {
     string: String,
-    stringList: StringList,
-    stringMap: StringMap,
+    sparseStringList: SparseStringList,
+    sparseStringMap: SparseStringMap,
 }

--- a/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
@@ -12,6 +12,7 @@ use aws.protocoltests.shared#GreetingList
 use aws.protocoltests.shared#IntegerList
 use aws.protocoltests.shared#NestedStringList
 use aws.protocoltests.shared#StringList
+use aws.protocoltests.shared#SparseStringList
 use aws.protocoltests.shared#StringSet
 use aws.protocoltests.shared#TimestampList
 use smithy.test#httpRequestTests
@@ -158,14 +159,15 @@ apply JsonLists @httpRequestTests([
           uri: "/JsonLists",
           body: """
                 {
-                    "stringList": [
-                        null
+                    "sparseStringList": [
+                        null,
+                        "hi"
                     ]
                 }""",
           bodyMediaType: "application/json",
           headers: {"Content-Type": "application/json"},
           params: {
-              stringList: [null]
+              sparseStringList: [null, "hi"]
           }
     }
 ])
@@ -289,25 +291,28 @@ apply JsonLists @httpResponseTests([
     },
     {
           id: "RestJsonListsSerializeNull",
-          documentation: "Serializes null values in lists",
+          documentation: "Serializes null values in sparse lists",
           protocol: restJson1,
           code: 200,
           body: """
                 {
-                    "stringList": [
-                        null
+                    "sparseStringList": [
+                        null,
+                        "hi"
                     ]
                 }""",
           bodyMediaType: "application/json",
           headers: {"Content-Type": "application/json"},
           params: {
-              stringList: [null]
+              sparseStringList: [null, "hi"]
           }
     }
 ])
 
 structure JsonListsInputOutput {
     stringList: StringList,
+
+    sparseStringList: SparseStringList,
 
     stringSet: StringSet,
 

--- a/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
@@ -7,6 +7,7 @@ namespace aws.protocoltests.restjson
 use aws.protocols#restJson1
 use aws.protocoltests.shared#FooEnumMap
 use aws.protocoltests.shared#GreetingStruct
+use aws.protocoltests.shared#SparseStringMap
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
@@ -26,7 +27,15 @@ apply JsonMaps @httpRequestTests([
         uri: "/JsonMaps",
         body: """
               {
-                  "myMap": {
+                  "denseStructMap": {
+                      "foo": {
+                          "hi": "there"
+                      },
+                      "baz": {
+                          "hi": "bye"
+                      }
+                  },
+                  "sparseStructMap": {
                       "foo": {
                           "hi": "there"
                       },
@@ -40,7 +49,15 @@ apply JsonMaps @httpRequestTests([
             "Content-Type": "application/json"
         },
         params: {
-            "myMap": {
+            "denseStructMap": {
+                "foo": {
+                    "hi": "there"
+                },
+                "baz": {
+                    "hi": "bye"
+                }
+            },
+            "sparseStructMap": {
                 "foo": {
                     "hi": "there"
                 },
@@ -52,14 +69,23 @@ apply JsonMaps @httpRequestTests([
     },
     {
         id: "RestJsonSerializesNullMapValues",
-        documentation: "Serializes null JSON map values",
+        documentation: "Serializes JSON map values in sparse maps",
         protocol: restJson1,
         method: "POST",
         uri: "/JsonMaps",
         body: """
             {
-                "myMap": {
-                    "foo": null
+                "sparseBooleanMap": {
+                    "x": null
+                },
+                "sparseNumberMap": {
+                    "x": null
+                },
+                "sparseStringMap": {
+                    "x": null
+                },
+                "sparseStructMap": {
+                    "x": null
                 }
             }""",
         bodyMediaType: "application/json",
@@ -67,11 +93,60 @@ apply JsonMaps @httpRequestTests([
             "Content-Type": "application/json"
         },
         params: {
-            myMap: {
-                "foo": null
+            "sparseBooleanMap": {
+                "x": null
+            },
+            "sparseNumberMap": {
+                "x": null
+            },
+            "sparseStringMap": {
+                "x": null
+            },
+            "sparseStructMap": {
+                "x": null
             }
         }
     },
+    {
+        id: "RestJsonSerializesZeroValuesInMaps",
+        documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonMaps",
+        body: """
+            {
+                "denseNumberMap": {
+                    "x": 0
+                },
+                "sparseNumberMap": {
+                    "x": 0
+                },
+                "denseBooleanMap": {
+                    "x": false
+                },
+                "sparseBooleanMap": {
+                    "x": false
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseNumberMap": {
+                "x": 0
+            },
+            "sparseNumberMap": {
+                "x": 0
+            },
+            "denseBooleanMap": {
+                "x": false
+            },
+            "sparseBooleanMap": {
+                "x": false
+            }
+        }
+    }
 ])
 
 apply JsonMaps @httpResponseTests([
@@ -82,26 +157,42 @@ apply JsonMaps @httpResponseTests([
         code: 200,
         body: """
               {
-                  "myMap": {
+                  "denseStructMap": {
                       "foo": {
                           "hi": "there"
                       },
                       "baz": {
                           "hi": "bye"
                       }
-                  }
+                  },
+                  "sparseStructMap": {
+                      "foo": {
+                          "hi": "there"
+                      },
+                      "baz": {
+                          "hi": "bye"
+                      }
+                 }
               }""",
         bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json"
         },
         params: {
-            myMap: {
-                foo: {
-                    hi: "there"
+            "denseStructMap": {
+                "foo": {
+                    "hi": "there"
                 },
-                baz: {
-                    hi: "bye"
+                "baz": {
+                    "hi": "bye"
+                }
+            },
+            "sparseStructMap": {
+                "foo": {
+                    "hi": "there"
+                },
+                "baz": {
+                    "hi": "bye"
                 }
             }
         }
@@ -113,8 +204,17 @@ apply JsonMaps @httpResponseTests([
         code: 200,
         body: """
             {
-                "myMap": {
-                    "foo": null
+                "sparseBooleanMap": {
+                    "x": null
+                },
+                "sparseNumberMap": {
+                    "x": null
+                },
+                "sparseStringMap": {
+                    "x": null
+                },
+                "sparseStructMap": {
+                    "x": null
                 }
             }""",
         bodyMediaType: "application/json",
@@ -122,19 +222,106 @@ apply JsonMaps @httpResponseTests([
             "Content-Type": "application/json"
         },
         params: {
-            myMap: {
-                "foo": null
+            "sparseBooleanMap": {
+                "x": null
+            },
+            "sparseNumberMap": {
+                "x": null
+            },
+            "sparseStringMap": {
+                "x": null
+            },
+            "sparseStructMap": {
+                "x": null
             }
         }
     },
+    {
+        id: "RestJsonDeserializesZeroValuesInMaps",
+        documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "denseNumberMap": {
+                    "x": 0
+                },
+                "sparseNumberMap": {
+                    "x": 0
+                },
+                "denseBooleanMap": {
+                    "x": false
+                },
+                "sparseBooleanMap": {
+                    "x": false
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseNumberMap": {
+                "x": 0
+            },
+            "sparseNumberMap": {
+                "x": 0
+            },
+            "denseBooleanMap": {
+                "x": false
+            },
+            "sparseBooleanMap": {
+                "x": false
+            }
+        }
+    }
 ])
 
 structure JsonMapsInputOutput {
-    myMap: JsonMapsInputOutputMap,
+    denseStructMap: DenseStructMap,
+    sparseStructMap: SparseStructMap,
+    denseNumberMap: DenseNumberMap,
+    denseBooleanMap: DenseBooleanMap,
+    denseStringMap: DenseStringMap,
+    sparseNumberMap: SparseNumberMap,
+    sparseBooleanMap: SparseBooleanMap,
+    sparseStringMap: SparseStringMap,
+}
+
+map DenseStructMap {
+    key: String,
+    value: GreetingStruct
 }
 
 @sparse
-map JsonMapsInputOutputMap {
+map SparseStructMap {
     key: String,
     value: GreetingStruct
+}
+
+map DenseBooleanMap {
+    key: String,
+    value: Boolean
+}
+
+map DenseNumberMap {
+    key: String,
+    value: Integer
+}
+
+map DenseStringMap {
+    key: String,
+    value: String
+}
+
+@sparse
+map SparseBooleanMap {
+    key: String,
+    value: Boolean
+}
+
+@sparse
+map SparseNumberMap {
+    key: String,
+    value: Integer
 }

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -23,11 +23,22 @@ list StringList {
     member: String,
 }
 
+@sparse
+list SparseStringList {
+    member: String
+}
+
 set StringSet {
     member: String,
 }
 
 map StringMap {
+    key: String,
+    value: String,
+}
+
+@sparse
+map SparseStringMap {
     key: String,
     value: String,
 }


### PR DESCRIPTION
We didn't update protocol tests after the sparse trait was added. This
commit updates protocol tests to take the sparse trait into account for
lists and maps.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
