### PR TITLE
Require non-empty aws.auth#sigv4 name

### DIFF
--- a/docs/source/1.0/spec/aws/aws-auth.rst
+++ b/docs/source/1.0/spec/aws/aws-auth.rst
@@ -36,9 +36,9 @@ Trait value
         * - name
           - ``string``
           - **Required**. The signature version 4 service signing name to use
-            in the `credential scope`_ when signing requests. This value
-            SHOULD match the ``arnNamespace`` property of the
-            :ref:`aws.api#service-trait`.
+            in the `credential scope`_ when signing requests. This value MUST
+            NOT be empty. This value SHOULD match the ``arnNamespace`` property
+            of the :ref:`aws.api#service-trait`.
 
 .. tabs::
 

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.json
@@ -8,6 +8,9 @@
                     "target": "smithy.api#String",
                     "traits": {
                         "smithy.api#required": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
                         "smithy.api#documentation": "The signature version 4 service signing name to use in the credential scope when signing requests. This value SHOULD match the `arnNamespace` property of the `aws.api#service-trait`.",
                         "smithy.api#externalDocumentation": {
                             "Reference": "https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html"

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/auth/sigv4-empty-name.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/auth/sigv4-empty-name.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#InvalidService: Error validating trait `aws.auth#sigv4`.name: String value provided for `aws.auth#sigv4$name` must be >= 1 characters, but the provided value is only 0 characters. | TraitValue

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/auth/sigv4-empty-name.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/auth/sigv4-empty-name.smithy
@@ -1,0 +1,8 @@
+namespace smithy.example
+
+use aws.auth#sigv4
+
+@sigv4(name: "")
+service InvalidService {
+    version: "2020-07-02"
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
