### PR TITLE
Fix greedy label param names in OpenAPI

### DIFF
--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -27,7 +27,8 @@ public class AwsRestJson1ProtocolTest {
             "adds-header-mediatype-format.json",
             "supports-payloads.json",
             "aws-rest-json-uses-jsonname.json",
-            "synthesizes-contents.json"
+            "synthesizes-contents.json",
+            "greedy-labels.json"
     })
 
     public void testProtocolResult(String smithy) {

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels.json
@@ -1,0 +1,48 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#Service": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "smithy.example#Operation"
+                }
+            ],
+            "traits": {
+                "aws.protocols#restJson1": {}
+            }
+        },
+        "smithy.example#Operation": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.example#OperationInput"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/{foo}/{baz+}",
+                    "method": "POST"
+                }
+            }
+        },
+        "smithy.example#OperationInput": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpLabel": {}
+                    }
+                },
+                "baz": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpLabel": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels.openapi.json
@@ -1,0 +1,37 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Service",
+        "version": "2006-03-01"
+    },
+    "paths": {
+        "/{foo}/{baz+}": {
+            "post": {
+                "operationId": "Operation",
+                "parameters": [
+                    {
+                        "name": "foo",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "baz+",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Operation response"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Services like API Gateway that use "greedy" labels require that bath
the segment and the corresponding parameter name contain a "+". We
previously included the "+" in the URI label but not in the parameter
name.