### PR TITLE
Add missing deprecated member to enum definition

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -435,6 +435,9 @@ structure EnumDefinition {
 
     /// Applies a list of tags to the enum constant.
     tags: NonEmptyStringList,
+
+    /// Whether the enum value should be considered deprecated.
+    deprecated: PrimitiveBoolean,
 }
 
 /// The optional name or label of the enum constant value.

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/enum-can-be-deprecated-and-tagged.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/enum-can-be-deprecated-and-tagged.smithy
@@ -1,0 +1,32 @@
+namespace smithy.example
+
+// This example is taken from the specification to ensure that
+// enums can be defined as specified.
+@enum([
+    {
+        value: "t2.nano",
+        name: "T2_NANO",
+        documentation: """
+            T2 instances are Burstable Performance
+            Instances that provide a baseline level of CPU
+            performance with the ability to burst above the
+            baseline.""",
+        tags: ["ebsOnly"]
+    },
+    {
+        value: "t2.micro",
+        name: "T2_MICRO",
+        documentation: """
+            T2 instances are Burstable Performance
+            Instances that provide a baseline level of CPU
+            performance with the ability to burst above the
+            baseline.""",
+        tags: ["ebsOnly"]
+    },
+    {
+        value: "m256.mega",
+        name: "M256_MEGA",
+        deprecated: true
+    }
+])
+string MyString


### PR DESCRIPTION
This previously worked, but it would warn about the additional member.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
