### PR TITLE
Add tags and deprecated to waiters

### DIFF
--- a/docs/source/1.0/spec/waiters.rst
+++ b/docs/source/1.0/spec/waiters.rst
@@ -265,6 +265,16 @@ has entered into a desired state.
       - The maximum amount of time in seconds to delay between each retry.
         This value defaults to ``120`` if not specified (2 minutes). If
         specified, this value MUST be greater than or equal to 1.
+    * - ``deprecated``
+      - ``boolean``
+      - Indicates if the waiter is considered deprecated. A waiter SHOULD
+        be marked as deprecated if it has been replaced by another waiter or
+        if it is no longer needed (for example, if a resource changes from
+        eventually consistent to strongly consistent).
+    * - ``tags``
+      - ``[string]``
+      - A list of tags associated with the waiter that allow waiters to be
+        categorized and grouped.
 
 
 .. _waiter-acceptor:

--- a/smithy-waiters/src/main/resources/META-INF/smithy/waiters.smithy
+++ b/smithy-waiters/src/main/resources/META-INF/smithy/waiters.smithy
@@ -32,6 +32,16 @@ structure Waiter {
     /// This value defaults to 120 if not specified (or, 2 minutes). If
     /// specified, this value MUST be greater than or equal to 1.
     maxDelay: WaiterDelay,
+
+    /// Indicates if the waiter is considered deprecated. A waiter SHOULD
+    /// be marked as deprecated if it has been replaced by another waiter or
+    /// if it is no longer needed (for example, if a resource changes from
+    /// eventually consistent to strongly consistent).
+    deprecated: PrimitiveBoolean,
+
+    /// A list of tags associated with the waiter that allow waiters to be
+    /// categorized and grouped.
+    tags: NonEmptyStringList,
 }
 
 @box
@@ -150,3 +160,12 @@ structure PathMatcher {
 ])
 @private
 string PathComparator
+
+@private
+list NonEmptyStringList {
+    member: NonEmptyString,
+}
+
+@private
+@length(min: 1)
+string NonEmptyString

--- a/smithy-waiters/src/test/resources/software/amazon/smithy/waiters/errorfiles/valid-waiters.smithy
+++ b/smithy-waiters/src/test/resources/software/amazon/smithy/waiters/errorfiles/valid-waiters.smithy
@@ -97,6 +97,8 @@ use smithy.waiters#waitable
         ]
     },
     F: {
+        "deprecated": true,
+        "tags": ["A", "B"],
         "acceptors": [
             {
                 "state": "success",


### PR DESCRIPTION
We allow tags and deprecated on enum definitions, so I think it makes
sense on waiters too. Deprecated is particularly timely because of S3
recently making PUT, GET, LIST, etc strongly consistent.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
