### PR TITLE
Fix AWS Query/Ec2Query response XML tag names

### DIFF
--- a/smithy-aws-protocol-tests/model/awsQuery/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-lists.smithy
@@ -140,12 +140,12 @@ apply XmlEmptyLists @httpResponseTests([
         protocol: awsQuery,
         code: 200,
         body: """
-              <XmlListsResponse xmlns="https://example.com/">
-                  <XmlListsResult>
+              <XmlEmptyListsResponse xmlns="https://example.com/">
+                  <XmlEmptyListsResult>
                       <stringList/>
                       <stringSet></stringSet>
-                  </XmlListsResult>
-              </XmlListsResponse>
+                  </XmlEmptyListsResult>
+              </XmlEmptyListsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-maps.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-maps.smithy
@@ -70,12 +70,12 @@ apply XmlEmptyMaps @httpResponseTests([
         protocol: awsQuery,
         code: 200,
         body: """
-              <XmlMapsResponse xmlns="https://example.com/">
-                  <XmlMapsResult>
+              <XmlEmptyMapsResponse xmlns="https://example.com/">
+                  <XmlEmptyMapsResult>
                       <myMap>
                       </myMap>
-                  </XmlMapsResult>
-              </XmlMapsResponse>
+                  </XmlEmptyMapsResult>
+              </XmlEmptyMapsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -91,11 +91,11 @@ apply XmlEmptyMaps @httpResponseTests([
         protocol: awsQuery,
         code: 200,
         body: """
-              <XmlMapsResponse xmlns="https://example.com/">
-                  <XmlMapsResult>
+              <XmlEmptyMapsResponse xmlns="https://example.com/">
+                  <XmlEmptyMapsResult>
                       <myMap/>
-                  </XmlMapsResult>
-              </XmlMapsResponse>
+                  </XmlEmptyMapsResult>
+              </XmlEmptyMapsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -114,11 +114,11 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: awsQuery,
         code: 200,
         body: """
-              <XmlBlobsResponse xmlns="https://example.com/">
-                  <XmlBlobsResult>
+              <XmlEmptyBlobsResponse xmlns="https://example.com/">
+                  <XmlEmptyBlobsResult>
                       <data></data>
-                  </XmlBlobsResult>
-              </XmlBlobsResponse>
+                  </XmlEmptyBlobsResult>
+              </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -134,11 +134,11 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: awsQuery,
         code: 200,
         body: """
-              <XmlBlobsResponse xmlns="https://example.com/">
-                  <XmlBlobsResult>
+              <XmlEmptyBlobsResponse xmlns="https://example.com/">
+                  <XmlEmptyBlobsResult>
                       <data/>
-                  </XmlBlobsResult>
-              </XmlBlobsResponse>
+                  </XmlEmptyBlobsResult>
+              </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
@@ -140,10 +140,10 @@ apply XmlEmptyLists @httpResponseTests([
         protocol: ec2Query,
         code: 200,
         body: """
-              <XmlListsResponse xmlns="https://example.com/">
+              <XmlEmptyListsResponse xmlns="https://example.com/">
                 <stringList/>
                 <stringSet></stringSet>
-              </XmlListsResponse>
+              </XmlEmptyListsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -116,10 +116,10 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: ec2Query,
         code: 200,
         body: """
-              <XmlBlobsResponse xmlns="https://example.com/">
+              <XmlEmptyBlobsResponse xmlns="https://example.com/">
                   <data></data>
                   <RequestId>requestid</RequestId>
-              </XmlBlobsResponse>
+              </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -135,10 +135,10 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: ec2Query,
         code: 200,
         body: """
-              <XmlBlobsResponse xmlns="https://example.com/">
+              <XmlEmptyBlobsResponse xmlns="https://example.com/">
                   <data/>
                   <RequestId>requestid</RequestId>
-              </XmlBlobsResponse>
+              </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
