### PR TITLE
Set OpenAPI requestBody to required if necessary

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/payloads.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/payloads.openapi.json
@@ -15,7 +15,8 @@
                 "$ref": "#/components/schemas/FooOperationPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -300,6 +300,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         });
         RequestBodyObject requestBodyObject = RequestBodyObject.builder()
                 .putContent(Objects.requireNonNull(mediaTypeRange), mediaTypeObject)
+                .required(binding.getMember().isRequired())
                 .build();
         return Optional.of(requestBodyObject);
     }
@@ -325,8 +326,18 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
                 .schema(Schema.builder().ref(pointer).build())
                 .build();
 
+        // If any of the top level bindings are required, then the body itself must be required.
+        boolean required = false;
+        for (HttpBinding binding : bindings) {
+            if (binding.getMember().isRequired()) {
+                required = true;
+                break;
+            }
+        }
+
         return Optional.of(RequestBodyObject.builder()
                 .putContent(mediaType, mediaTypeObject)
+                .required(required)
                 .build());
     }
 

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service-integer.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service-integer.openapi.json
@@ -15,7 +15,8 @@
                 "$ref": "#/components/schemas/CreateDocumentRequestContent"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {
@@ -61,7 +62,8 @@
                 "$ref": "#/components/schemas/PutPayloadInputPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {
@@ -147,8 +149,14 @@
           "stringDateTime": {
             "type": "string",
             "format": "date-time"
+          },
+          "required": {
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "required"
+        ]
       },
       "CreateDocumentResponseContent": {
         "type": "object",

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json
@@ -75,7 +75,8 @@
                 "body": {
                     "target": "example.rest#Blob",
                     "traits": {
-                        "smithy.api#httpPayload": {}
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
                     }
                 }
             }
@@ -142,6 +143,12 @@
                 },
                 "stringDateTime": {
                     "target": "example.rest#StringDateTime"
+                },
+                "required": {
+                    "target": "example.rest#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
                 }
             }
         },

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -15,7 +15,8 @@
                 "$ref": "#/components/schemas/CreateDocumentRequestContent"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {
@@ -61,7 +62,8 @@
                 "$ref": "#/components/schemas/PutPayloadInputPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {
@@ -147,8 +149,14 @@
           "stringDateTime": {
             "type": "string",
             "format": "date-time"
+          },
+          "required": {
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "required"
+        ]
       },
       "CreateDocumentResponseContent": {
         "type": "object",


### PR DESCRIPTION
*Description of changes:*

This updates the OpenAPI conversion to set an operation's `requestBody` as required if the operation has an `httpPayload` member and that member is required or if the operation has no `httpPayload` member but does have a required member bound to the document.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.