### PR TITLE
Fix Access-Control-Expose-Headers

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ final class AddIntegrations implements ApiGatewayMapper {
         IntegrationTraitIndex index = IntegrationTraitIndex.of(context.getModel());
         return index.getIntegrationTrait(context.getService(), shape)
                 .map(trait -> operation.toBuilder()
-                        .putExtension(EXTENSION_NAME, createIntegration(context, shape, trait))
+                        .putExtension(EXTENSION_NAME, createIntegration(context, operation, shape, trait))
                         .build())
                 .orElseGet(() -> {
                     LOGGER.warning("No API Gateway integration trait found for " + shape.getId());
@@ -84,6 +84,7 @@ final class AddIntegrations implements ApiGatewayMapper {
 
     private ObjectNode createIntegration(
             Context<? extends Trait> context,
+            OperationObject operationObject,
             OperationShape shape,
             Trait integration
     ) {
@@ -91,7 +92,7 @@ final class AddIntegrations implements ApiGatewayMapper {
         return context.getService().getTrait(CorsTrait.class)
                 .map(cors -> {
                     LOGGER.fine(() -> String.format("Adding CORS to `%s` operation responses", shape.getId()));
-                    return updateIntegrationWithCors(context, shape, integrationObject, cors);
+                    return updateIntegrationWithCors(context, operationObject, shape, integrationObject, cors);
                 })
                 .orElse(integrationObject);
     }
@@ -122,6 +123,7 @@ final class AddIntegrations implements ApiGatewayMapper {
 
     private ObjectNode updateIntegrationWithCors(
             Context<? extends Trait> context,
+            OperationObject operationObject,
             OperationShape shape,
             ObjectNode integrationNode,
             CorsTrait cors
@@ -141,7 +143,7 @@ final class AddIntegrations implements ApiGatewayMapper {
 
         LOGGER.finer(() -> String.format("Adding the following CORS headers to the API Gateway integration of %s: %s",
                                          shape.getId(), corsHeaders));
-        Set<String> deducedHeaders = CorsHeader.deduceOperationHeaders(context, shape, cors);
+        Set<String> deducedHeaders = CorsHeader.deduceOperationResponseHeaders(context, operationObject, shape, cors);
         LOGGER.fine(() -> String.format("Detected the following headers for operation %s: %s",
                                         shape.getId(), deducedHeaders));
 

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayMapper.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayMapper.java
@@ -113,6 +113,18 @@ public interface ApiGatewayMapper extends OpenApiMapper {
             }
 
             @Override
+            public OperationObject postProcessOperation(
+                    Context<? extends Trait> context,
+                    OperationShape shape,
+                    OperationObject operation,
+                    String httpMethodName, String path
+            ) {
+                return matchesApiType(context)
+                       ? delegate.postProcessOperation(context, shape, operation, httpMethodName, path)
+                       : operation;
+            }
+
+            @Override
             public PathItem updatePathItem(Context<? extends Trait> context, String path, PathItem pathItem) {
                 return matchesApiType(context)
                        ? delegate.updatePathItem(context, path, pathItem)

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CorsHeader.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CorsHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import software.amazon.smithy.model.traits.CorsTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.SecuritySchemeConverter;
+import software.amazon.smithy.openapi.model.OperationObject;
+import software.amazon.smithy.openapi.model.ResponseObject;
 
 enum CorsHeader {
 
@@ -43,8 +45,9 @@ enum CorsHeader {
         return headerName;
     }
 
-    static <T extends Trait> Set<String> deduceOperationHeaders(
+    static <T extends Trait> Set<String> deduceOperationResponseHeaders(
             Context<T> context,
+            OperationObject operationObject,
             OperationShape shape,
             CorsTrait cors
     ) {
@@ -56,6 +59,11 @@ enum CorsHeader {
 
         for (SecuritySchemeConverter<? extends Trait> converter : context.getSecuritySchemeConverters()) {
             result.addAll(getSecuritySchemeResponseHeaders(context, converter));
+        }
+
+        // Include all headers found in the generated OpenAPI response.
+        for (ResponseObject responseObject : operationObject.getResponses().values()) {
+            result.addAll(responseObject.getHeaders().keySet());
         }
 
         return result;

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-explicit-options.openapi.json
@@ -63,7 +63,8 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'"
+                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Hd'"
               }
             }
           }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -199,7 +199,7 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Access-Control-Expose-Headers": "'X-Service-Output-Metadata'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Foo-Header,X-Service-Output-Metadata'",
                 "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'"
               }
             }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
@@ -199,7 +199,7 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Access-Control-Expose-Headers": "'X-Service-Output-Metadata'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Foo-Header,X-Service-Output-Metadata'",
                 "method.response.header.Access-Control-Allow-Origin": "'https://www.example.com'"
               }
             }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-custom-gateway-response-headers.openapi.json
@@ -63,7 +63,8 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'"
+                "method.response.header.Access-Control-Allow-Origin": "'https://foo.com'",
+                "method.response.header.Access-Control-Expose-Headers": "'X-Hd'"
               }
             }
           }


### PR DESCRIPTION
This commit ensures that Access-Control-Expose-Headers is correctly
populated based on all of the headers used in an operation, including
any headers that might be  added manually during the OpenAPI conversion
independent of a Smithy shape.

I added a new ApiGatewayMapper method called postProcessOperation to
allow transformations to better control when they are applied, in
particular, transforms sometimes need to occur on an operation after the
things that the operation contains have been transformed. This was not
previously possible even with the ordering semantics that already exist.
This change was necessary in order to ensure that the correct CORs
headers are added to operations based on all of the transforms applied
to the operation, and it makes it easier to separate CORS headers from
modeled headers when constructing Access-Control-Expose-Headers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
