### PR TITLE
Register RemoveTraitDefinitions transformer

### DIFF
--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -4,6 +4,7 @@ software.amazon.smithy.build.transforms.ExcludeShapesByTrait
 software.amazon.smithy.build.transforms.ExcludeTags
 software.amazon.smithy.build.transforms.ExcludeTraits
 software.amazon.smithy.build.transforms.ExcludeTraitsByTag
+software.amazon.smithy.build.transforms.FlattenNamespaces
 software.amazon.smithy.build.transforms.IncludeMetadata
 software.amazon.smithy.build.transforms.IncludeNamespaces
 software.amazon.smithy.build.transforms.IncludeServices
@@ -13,4 +14,3 @@ software.amazon.smithy.build.transforms.IncludeTraits
 software.amazon.smithy.build.transforms.IncludeTraitsByTag
 software.amazon.smithy.build.transforms.RemoveTraitDefinitions
 software.amazon.smithy.build.transforms.RemoveUnusedShapes
-software.amazon.smithy.build.transforms.FlattenNamespaces

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -11,5 +11,6 @@ software.amazon.smithy.build.transforms.IncludeShapesByTag
 software.amazon.smithy.build.transforms.IncludeTags
 software.amazon.smithy.build.transforms.IncludeTraits
 software.amazon.smithy.build.transforms.IncludeTraitsByTag
+software.amazon.smithy.build.transforms.RemoveTraitDefinitions
 software.amazon.smithy.build.transforms.RemoveUnusedShapes
 software.amazon.smithy.build.transforms.FlattenNamespaces


### PR DESCRIPTION
Registers the RemoveTraitDefinitions transformer.

Fixes the error of ```Unable to find a transform for 'removeTraitDefinitions' in the 'foo' projection.``` when trying to use this transformer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
