### PR TITLE
Fix truncated environment variable expansions

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
@@ -115,6 +115,11 @@ final class ConfigLoader {
             while (matcher.find()) {
                 String variable = matcher.group(1);
                 String replacement = expand(node.getSourceLocation(), variable);
+                // INLINE over-matches to allow for escaping. If the over-matched first group does not start with
+                // '${', we need to prepend the first character from that group on the replacement.
+                if (!matcher.group(0).startsWith("${")) {
+                    replacement = matcher.group(0).charAt(0) + replacement;
+                }
                 matcher.appendReplacement(builder, replacement);
             }
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
@@ -120,6 +120,7 @@ public class SmithyBuildConfigTest {
     @Test
     public void expandsEnvironmentVariables() {
         System.setProperty("FOO", "Hi");
+        System.setProperty("BAR", "TagFromEnv");
         System.setProperty("NAME_KEY", "name");
         SmithyBuildConfig config = SmithyBuildConfig.load(
                 Paths.get(getResourcePath("config-with-env.json")));
@@ -129,7 +130,7 @@ public class SmithyBuildConfigTest {
         assertThat(transform.getName(), equalTo("includeShapesByTag"));
         // Did the array and string values in it expand?
         assertThat(transform.getArgs(), equalTo(Node.objectNode()
-                .withMember("tags", Node.fromStrings("Hi", "${BAZ}"))));
+                .withMember("tags", Node.fromStrings("Hi", "compoundTagFromEnv", "${BAZ}"))));
     }
 
     @Test

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/config-with-env.json
@@ -8,6 +8,7 @@
           "args": {
             "tags": [
               "${FOO}",
+              "compound${BAR}",
               "\\${BAZ}"
             ]
           }


### PR DESCRIPTION
Any environment variable expansions in smithy-build.json that did not start at the beginning of the field resulted in dropping the character that preceded the ${NAME} placeholder.

Consider the following `smithy-build.json` example, with the environment variable of `FOO` was set to `BAZ`:
```
{
    "version": "1.0",
    "projections": {
        "a": {
            "transforms": [
                {
                    "name": "includeShapesByTag",
                    "args": {
                        "tags": ["BAR${FOO}"]
                    }
                }
            ]
        }
    }
}
```
Currently, this results in the shapes with the tag `BABAZ` being included, instead of `BARBAZ` as expected.

This CR corrects the expansion behavior to assure preceding characters are included appropriately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
