### PR TITLE
Add endpoint id property to service trait

### DIFF
--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -30,6 +30,7 @@ Value type
     * :ref:`service-cloudformation-name`
     * :ref:`service-arn-namespace`
     * :ref:`service-cloudtrail-event-source`
+    * :ref:`service-endpoint-id`
 
 The following example defines an AWS service that uses the default values of
 ``cloudFormationService``, ``arnNamespace``, and ``cloudTrailEventSource``:
@@ -80,7 +81,9 @@ The following example provides explicit values for all properties:
             sdkId: "Some Value",
             cloudFormationName: "FooBaz",
             arnNamespace: "myservice",
-            cloudTrailEventSource: "myservice.amazon.aws")
+            cloudTrailEventSource: "myservice.amazon.aws",
+            endpointId: "my-endpoint"
+        )
         service FooBaz {
             version: "2018-03-17",
         }
@@ -228,6 +231,24 @@ This value SHOULD follow the convention of ``{arnNamespace}.amazonaws.com``,
 but there are some exceptions. For example, the event source for
 Amazon CloudWatch is ``monitoring.amazonaws.com``. Such services will
 need to explicitly configure the ``cloudTrailEventSource`` setting.
+
+
+.. _service-endpoint-id:
+
+``endpointId``
+==============
+
+The ``endpointId`` property is a ``string`` value that specifies which endpoint
+in a given region should be used to connect to the service. For example, most
+services in the AWS standard partition have endpoints which follow the format:
+``{endpointId}.{region}.amazonaws.com``. A service with the endpoint id
+``example`` in the region ``us-west-2`` might have the endpoint
+``example.us-west-2.amazonaws.com``. For a full listing of possible endpoints,
+check the `AWS Regions and Endpoints`_ page.
+
+This value is not unique across services and is subject to change. Therefore,
+it MUST NOT be used for client naming or for any other purpose that requires
+a unique identifier. :ref:`service-sdk-id` should be used for those purposes.
 
 
 .. _aws.api#arn-trait:
@@ -1311,3 +1332,4 @@ existing AWS services.
 .. _Amazon Resource Name (ARN): https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 .. _AWS Service Namespaces: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
 .. _CloudFormation resource type: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
+.. _AWS Regions and Endpoints:

--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -30,7 +30,7 @@ Value type
     * :ref:`service-cloudformation-name`
     * :ref:`service-arn-namespace`
     * :ref:`service-cloudtrail-event-source`
-    * :ref:`service-endpoint-id`
+    * :ref:`service-endpoint-prefix`
 
 The following example defines an AWS service that uses the default values of
 ``cloudFormationService``, ``arnNamespace``, and ``cloudTrailEventSource``:
@@ -82,7 +82,7 @@ The following example provides explicit values for all properties:
             cloudFormationName: "FooBaz",
             arnNamespace: "myservice",
             cloudTrailEventSource: "myservice.amazon.aws",
-            endpointId: "my-endpoint"
+            endpointPrefix: "my-endpoint"
         )
         service FooBaz {
             version: "2018-03-17",
@@ -233,15 +233,15 @@ Amazon CloudWatch is ``monitoring.amazonaws.com``. Such services will
 need to explicitly configure the ``cloudTrailEventSource`` setting.
 
 
-.. _service-endpoint-id:
+.. _service-endpoint-prefix:
 
-``endpointId``
+``endpointPrefix``
 ==============
 
-The ``endpointId`` property is a ``string`` value that identifies which endpoint
+The ``endpointPrefix`` property is a ``string`` value that identifies which endpoint
 in a given region should be used to connect to the service. For example, most
 services in the AWS standard partition have endpoints which follow the format:
-``{endpointId}.{region}.amazonaws.com``. A service with the endpoint id
+``{endpointPrefix}.{region}.amazonaws.com``. A service with the endpoint id
 ``example`` in the region ``us-west-2`` might have the endpoint
 ``example.us-west-2.amazonaws.com``. For a full listing of possible endpoints,
 check the `AWS Regions and Endpoints`_ page.

--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -238,7 +238,7 @@ need to explicitly configure the ``cloudTrailEventSource`` setting.
 ``endpointId``
 ==============
 
-The ``endpointId`` property is a ``string`` value that specifies which endpoint
+The ``endpointId`` property is a ``string`` value that identifies which endpoint
 in a given region should be used to connect to the service. For example, most
 services in the AWS standard partition have endpoints which follow the format:
 ``{endpointId}.{region}.amazonaws.com``. A service with the endpoint id
@@ -248,7 +248,8 @@ check the `AWS Regions and Endpoints`_ page.
 
 This value is not unique across services and is subject to change. Therefore,
 it MUST NOT be used for client naming or for any other purpose that requires
-a unique identifier. :ref:`service-sdk-id` should be used for those purposes.
+a static, unique identifier. :ref:`service-sdk-id` should be used for those
+purposes.
 
 
 .. _aws.api#arn-trait:
@@ -1332,4 +1333,4 @@ existing AWS services.
 .. _Amazon Resource Name (ARN): https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 .. _AWS Service Namespaces: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
 .. _CloudFormation resource type: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
-.. _AWS Regions and Endpoints:
+.. _AWS Regions and Endpoints: https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -41,6 +41,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     private final String arnNamespace;
     private final String sdkId;
     private final String cloudTrailEventSource;
+    private final String endpointId;
 
     private ServiceTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
@@ -49,6 +50,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         this.cloudFormationName = SmithyBuilder.requiredState("cloudFormationName", builder.cloudFormationName);
         this.cloudTrailEventSource = SmithyBuilder.requiredState(
                 "cloudTrailEventSource", builder.cloudTrailEventSource);
+        this.endpointId = SmithyBuilder.requiredState("endpointId", builder.endpointId);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -74,6 +76,9 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                     .ifPresent(builder::cloudFormationName);
             objectNode.getStringMember("cloudTrailEventSource").map(StringNode::getValue)
                     .ifPresent(builder::cloudTrailEventSource);
+            objectNode.getStringMember("endpointId")
+                    .map(StringNode::getValue)
+                    .ifPresent(builder::endpointId);
             return builder.build(target);
         }
     }
@@ -132,6 +137,20 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         return cloudTrailEventSource;
     }
 
+    /**
+     * Returns the endpoint id for the service.
+     *
+     * This value is not unique across service and it can change at any time.
+     * Therefore it MUST NOT be used to generate class names, namespaces, or
+     * for any other purpose that requires a static, unique identifier. The
+     * sdkId property should be used for those purposes.
+     *
+     * @return Returns the aws sdk endpoint identifier.
+     */
+    public String getEndpointId() {
+        return endpointId;
+    }
+
     @Deprecated
     public Optional<String> getAbbreviation() {
         return Optional.empty();
@@ -144,7 +163,8 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .sourceLocation(getSourceLocation())
                 .cloudFormationName(cloudFormationName)
                 .arnNamespace(arnNamespace)
-                .cloudTrailEventSource(cloudTrailEventSource);
+                .cloudTrailEventSource(cloudTrailEventSource)
+                .endpointId(endpointId);
     }
 
     @Override
@@ -153,7 +173,8 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .withMember("sdkId", Node.from(sdkId))
                 .withMember("arnNamespace", Node.from(getArnNamespace()))
                 .withMember("cloudFormationName", Node.from(getCloudFormationName()))
-                .withMember("cloudTrailEventSource", Node.from(getCloudTrailEventSource()));
+                .withMember("cloudTrailEventSource", Node.from(getCloudTrailEventSource()))
+                .withMember("endpointId", Node.from(getEndpointId()));
     }
 
     /** Builder for {@link ServiceTrait}. */
@@ -162,11 +183,16 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         private String cloudFormationName;
         private String arnNamespace;
         private String cloudTrailEventSource;
+        private String endpointId;
 
         private Builder() {}
 
         @Override
         public ServiceTrait build() {
+            if (endpointId == null) {
+                endpointId(arnNamespace);
+            }
+
             return new ServiceTrait(this);
         }
 
@@ -182,6 +208,10 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
 
             if (cloudTrailEventSource == null) {
                 cloudTrailEventSource = arnNamespace + ".amazonaws.com";
+            }
+
+            if (endpointId == null) {
+                endpointId(arnNamespace);
             }
 
             return new ServiceTrait(this);
@@ -234,6 +264,17 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
          */
         public Builder cloudTrailEventSource(String cloudTrailEventSource) {
             this.cloudTrailEventSource = cloudTrailEventSource;
+            return this;
+        }
+
+        /**
+         * Set the endpoint id used to construct client endpoints.
+         *
+         * @param endpointId The endpoint id of the service.
+         * @return Returns the builder.
+         */
+        public Builder endpointId(String endpointId) {
+            this.endpointId = endpointId;
             return this;
         }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -140,7 +140,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     /**
      * Returns the endpoint id for the service.
      *
-     * This value is not unique across service and it can change at any time.
+     * This value is not unique across services and it can change at any time.
      * Therefore it MUST NOT be used to generate class names, namespaces, or
      * for any other purpose that requires a static, unique identifier. The
      * sdkId property should be used for those purposes.

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -41,7 +41,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     private final String arnNamespace;
     private final String sdkId;
     private final String cloudTrailEventSource;
-    private final String endpointId;
+    private final String endpointPrefix;
 
     private ServiceTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
@@ -50,7 +50,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         this.cloudFormationName = SmithyBuilder.requiredState("cloudFormationName", builder.cloudFormationName);
         this.cloudTrailEventSource = SmithyBuilder.requiredState(
                 "cloudTrailEventSource", builder.cloudTrailEventSource);
-        this.endpointId = SmithyBuilder.requiredState("endpointId", builder.endpointId);
+        this.endpointPrefix = SmithyBuilder.requiredState("endpointPrefix", builder.endpointPrefix);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -76,9 +76,9 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                     .ifPresent(builder::cloudFormationName);
             objectNode.getStringMember("cloudTrailEventSource").map(StringNode::getValue)
                     .ifPresent(builder::cloudTrailEventSource);
-            objectNode.getStringMember("endpointId")
+            objectNode.getStringMember("endpointPrefix")
                     .map(StringNode::getValue)
-                    .ifPresent(builder::endpointId);
+                    .ifPresent(builder::endpointPrefix);
             return builder.build(target);
         }
     }
@@ -138,17 +138,17 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     }
 
     /**
-     * Returns the endpoint id for the service.
+     * Returns the endpoint prefix for the service.
      *
      * This value is not unique across services and it can change at any time.
      * Therefore it MUST NOT be used to generate class names, namespaces, or
      * for any other purpose that requires a static, unique identifier. The
      * sdkId property should be used for those purposes.
      *
-     * @return Returns the aws sdk endpoint identifier.
+     * @return Returns the aws sdk endpoint prefix.
      */
-    public String getEndpointId() {
-        return endpointId;
+    public String getEndpointPrefix() {
+        return endpointPrefix;
     }
 
     @Deprecated
@@ -164,7 +164,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .cloudFormationName(cloudFormationName)
                 .arnNamespace(arnNamespace)
                 .cloudTrailEventSource(cloudTrailEventSource)
-                .endpointId(endpointId);
+                .endpointPrefix(endpointPrefix);
     }
 
     @Override
@@ -174,7 +174,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .withMember("arnNamespace", Node.from(getArnNamespace()))
                 .withMember("cloudFormationName", Node.from(getCloudFormationName()))
                 .withMember("cloudTrailEventSource", Node.from(getCloudTrailEventSource()))
-                .withMember("endpointId", Node.from(getEndpointId()));
+                .withMember("endpointPrefix", Node.from(getEndpointPrefix()));
     }
 
     /** Builder for {@link ServiceTrait}. */
@@ -183,14 +183,14 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         private String cloudFormationName;
         private String arnNamespace;
         private String cloudTrailEventSource;
-        private String endpointId;
+        private String endpointPrefix;
 
         private Builder() {}
 
         @Override
         public ServiceTrait build() {
-            if (endpointId == null) {
-                endpointId(arnNamespace);
+            if (endpointPrefix == null) {
+                endpointPrefix(arnNamespace);
             }
 
             return new ServiceTrait(this);
@@ -210,8 +210,8 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 cloudTrailEventSource = arnNamespace + ".amazonaws.com";
             }
 
-            if (endpointId == null) {
-                endpointId(arnNamespace);
+            if (endpointPrefix == null) {
+                endpointPrefix(arnNamespace);
             }
 
             return new ServiceTrait(this);
@@ -268,13 +268,13 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         }
 
         /**
-         * Set the endpoint id used to construct client endpoints.
+         * Set the endpoint prefix used to construct client endpoints.
          *
-         * @param endpointId The endpoint id of the service.
+         * @param endpointPrefix The endpoint prefix of the service.
          * @return Returns the builder.
          */
-        public Builder endpointId(String endpointId) {
-            this.endpointId = endpointId;
+        public Builder endpointPrefix(String endpointPrefix) {
+            this.endpointPrefix = endpointPrefix;
             return this;
         }
 

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
@@ -48,7 +48,7 @@
                 "cloudTrailEventSource": {
                     "target": "smithy.api#String"
                 },
-                "endpointId": {
+                "endpointPrefix": {
                     "target": "smithy.api#String"
                 }
             },

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.json
@@ -47,6 +47,9 @@
                 },
                 "cloudTrailEventSource": {
                     "target": "smithy.api#String"
+                },
+                "endpointId": {
+                    "target": "smithy.api#String"
                 }
             },
             "traits": {

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
@@ -45,14 +45,14 @@ public class ServiceTraitTest {
         assertThat(serviceTrait.getCloudFormationName(), equalTo("Foo"));
         assertThat(serviceTrait.getArnNamespace(), equalTo("foo"));
         assertThat(serviceTrait.getCloudTrailEventSource(), equalTo("foo.amazonaws.com"));
-        assertThat(serviceTrait.getEndpointId(), equalTo("foo"));
+        assertThat(serviceTrait.getEndpointPrefix(), equalTo("foo"));
         assertThat(serviceTrait.toBuilder().build(), equalTo(serviceTrait));
     }
 
     @Test
     public void loadsTraitWithOptionalValues() {
         Node node = Node.parse("{\"sdkId\": \"Foo\", \"arnNamespace\": \"service\", \"cloudFormationName\": \"Baz\", "
-                        + "\"endpointId\": \"endpoint-id\"}");
+                        + "\"endpointPrefix\": \"endpoint-prefix\"}");
         TraitFactory provider = TraitFactory.createServiceFactory();
         Optional<Trait> trait = provider.createTrait(ServiceTrait.ID, ShapeId.from("ns.foo#foo"), node);
 
@@ -62,7 +62,7 @@ public class ServiceTraitTest {
         assertThat(serviceTrait.getSdkId(), equalTo("Foo"));
         assertThat(serviceTrait.getArnNamespace(), equalTo("service"));
         assertThat(serviceTrait.getCloudFormationName(), equalTo("Baz"));
-        assertThat(serviceTrait.getEndpointId(), equalTo("endpoint-id"));
+        assertThat(serviceTrait.getEndpointPrefix(), equalTo("endpoint-prefix"));
     }
 
     @Test
@@ -97,6 +97,6 @@ public class ServiceTraitTest {
         assertThat(trait.getSdkId(), equalTo("Some Value"));
         assertThat(trait.getCloudFormationName(), equalTo("SomeService"));
         assertThat(trait.getArnNamespace(), equalTo("service"));
-        assertThat(trait.getEndpointId(), equalTo("some-service"));
+        assertThat(trait.getEndpointPrefix(), equalTo("some-service"));
     }
 }

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
@@ -45,12 +45,14 @@ public class ServiceTraitTest {
         assertThat(serviceTrait.getCloudFormationName(), equalTo("Foo"));
         assertThat(serviceTrait.getArnNamespace(), equalTo("foo"));
         assertThat(serviceTrait.getCloudTrailEventSource(), equalTo("foo.amazonaws.com"));
+        assertThat(serviceTrait.getEndpointId(), equalTo("foo"));
         assertThat(serviceTrait.toBuilder().build(), equalTo(serviceTrait));
     }
 
     @Test
     public void loadsTraitWithOptionalValues() {
-        Node node = Node.parse("{\"sdkId\": \"Foo\", \"arnNamespace\": \"service\", \"cloudFormationName\": \"Baz\"}");
+        Node node = Node.parse("{\"sdkId\": \"Foo\", \"arnNamespace\": \"service\", \"cloudFormationName\": \"Baz\", "
+                        + "\"endpointId\": \"endpoint-id\"}");
         TraitFactory provider = TraitFactory.createServiceFactory();
         Optional<Trait> trait = provider.createTrait(ServiceTrait.ID, ShapeId.from("ns.foo#foo"), node);
 
@@ -60,6 +62,7 @@ public class ServiceTraitTest {
         assertThat(serviceTrait.getSdkId(), equalTo("Foo"));
         assertThat(serviceTrait.getArnNamespace(), equalTo("service"));
         assertThat(serviceTrait.getCloudFormationName(), equalTo("Baz"));
+        assertThat(serviceTrait.getEndpointId(), equalTo("endpoint-id"));
     }
 
     @Test
@@ -94,5 +97,6 @@ public class ServiceTraitTest {
         assertThat(trait.getSdkId(), equalTo("Some Value"));
         assertThat(trait.getCloudFormationName(), equalTo("SomeService"));
         assertThat(trait.getArnNamespace(), equalTo("service"));
+        assertThat(trait.getEndpointId(), equalTo("some-service"));
     }
 }

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/test-model.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/test-model.json
@@ -33,7 +33,7 @@
                     "sdkId": "Some Value",
                     "arnNamespace": "service",
                     "cloudFormationName": "SomeService",
-                    "endpointId": "some-service"
+                    "endpointPrefix": "some-service"
                 }
             }
         },

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/test-model.json
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/test-model.json
@@ -32,7 +32,8 @@
                 "aws.api#service": {
                     "sdkId": "Some Value",
                     "arnNamespace": "service",
-                    "cloudFormationName": "SomeService"
+                    "cloudFormationName": "SomeService",
+                    "endpointId": "some-service"
                 }
             }
         },


### PR DESCRIPTION
*Description of changes:*

This adds the endpointId property to the AWS service trait so that
endpoints may be constructed when given a region.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.