### PR TITLE
Clarify matching allStringEquals on empty array

### DIFF
--- a/docs/source/1.0/spec/waiters.rst
+++ b/docs/source/1.0/spec/waiters.rst
@@ -571,8 +571,9 @@ comparator can be set to any of the following values:
         corresponding boolean value.
       - ``boolean``
     * - allStringEquals
-      - Matches if the return value of a JMESPath expression is an array and
-        every value in the array is a string that equals an expected string.
+      - Matches if the return value of a JMESPath expression is an array that
+        contains at least one value, and every value in the array is a string
+        that equals an expected string.
       - ``array`` of ``string``
     * - anyStringEquals
       - Matches if the return value of a JMESPath expression is an array and


### PR DESCRIPTION
Clarify that empty arrays do not match allStringEquals.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
