### PR TITLE
Fix endpointPrefix documentation formatting

### DIFF
--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -236,7 +236,7 @@ need to explicitly configure the ``cloudTrailEventSource`` setting.
 .. _service-endpoint-prefix:
 
 ``endpointPrefix``
-==============
+==================
 
 The ``endpointPrefix`` property is a ``string`` value that identifies which endpoint
 in a given region should be used to connect to the service. For example, most


### PR DESCRIPTION
Fixes formatting for endpointPrefix documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
