### PR TITLE
Correct timestamp format spec

### DIFF
--- a/docs/source/1.0/spec/core/protocol-traits.rst
+++ b/docs/source/1.0/spec/core/protocol-traits.rst
@@ -305,7 +305,7 @@ Smithy defines the following built-in timestamp formats:
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,
-        ``Tue, 29 Apr 2014 18:30:38 GMT``).
+        ``Tue, 29 Apr 2014 18:30:38 GMT``). NOTE: In addition to the ``IMF-fixdate`` format specified in the RFC, implementations MUST also support fractional seconds (for example, ``Sun, 02 Jan 2000 20:34:56.000 GMT``).
     * - epoch-seconds
       - Also known as Unix time, the number of seconds that have elapsed since
         00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970,

--- a/docs/source/1.0/spec/core/protocol-traits.rst
+++ b/docs/source/1.0/spec/core/protocol-traits.rst
@@ -305,7 +305,10 @@ Smithy defines the following built-in timestamp formats:
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,
-        ``Tue, 29 Apr 2014 18:30:38 GMT``). NOTE: In addition to the ``IMF-fixdate`` format specified in the RFC, implementations MUST also support fractional seconds (for example, ``Sun, 02 Jan 2000 20:34:56.000 GMT``).
+        ``Tue, 29 Apr 2014 18:30:38 GMT``). Note that in addition to the
+        ``IMF-fixdate`` format specified in the RFC, implementations MUST
+        also support optional fractional seconds (for example,
+        ``Sun, 02 Jan 2000 20:34:56.000 GMT``).
     * - epoch-seconds
       - Also known as Unix time, the number of seconds that have elapsed since
         00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970,


### PR DESCRIPTION
*Description of changes:*

The timestamp format specification is slightly incorrect–`IMF-fixdate` does not allow fractional seconds, but Smithy requires that fractional seconds are supported. This change updates the docs to reflect that change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
