### PR TITLE
Fix openapi greedy param names for API Gateway REST APIs

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -354,6 +354,26 @@ forbidGreedyLabels (``boolean``)
             }
         }
 
+.. _generate-openapi-setting-removeGreedyParameterSuffix:
+
+removeGreedyParameterSuffix (``boolean``)
+    Set to true to remove the ``+`` suffix on the parameter name. By default, greedy
+    labels will have a corresponding parameter name generated that will include
+    the ``+`` suffix. Given a label "/{foo+}", the parameter name will be "foo+".
+    If enabled, the parameter name will instead be "foo".
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "removeGreedyParameterSuffix": true
+                }
+            }
+        }
+
 .. _generate-openapi-setting-onHttpPrefixHeaders:
 
 onHttpPrefixHeaders (``string``)

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultRestConfigSettings.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultRestConfigSettings.java
@@ -22,6 +22,9 @@ import software.amazon.smithy.utils.ListUtils;
 
 /**
  * REST APIs require that name parameters for greedy labels are not suffixed with "+".
+ *  @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html">REST APIs</a>
+ *  which is counter to the default, like for
+ *  <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-http.html">HTTP APIs</a>.
  */
 final class AddDefaultRestConfigSettings implements ApiGatewayMapper {
     @Override

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultRestConfigSettings.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultRestConfigSettings.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import java.util.List;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * REST APIs require that name parameters for greedy labels are not suffixed with "+".
+ */
+final class AddDefaultRestConfigSettings implements ApiGatewayMapper {
+    @Override
+    public List<ApiGatewayConfig.ApiType> getApiTypes() {
+        return ListUtils.of(ApiGatewayConfig.ApiType.REST);
+    }
+
+    @Override
+    public void updateDefaultSettings(Model model, OpenApiConfig config) {
+        config.setRemoveGreedyParameterSuffix(true);
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayExtension.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/ApiGatewayExtension.java
@@ -27,6 +27,7 @@ public final class ApiGatewayExtension implements Smithy2OpenApiExtension {
     public List<OpenApiMapper> getOpenApiMappers() {
         return ListUtils.of(
                 ApiGatewayMapper.wrap(new AddDefaultConfigSettings()),
+                ApiGatewayMapper.wrap(new AddDefaultRestConfigSettings()),
                 ApiGatewayMapper.wrap(new AddApiKeySource()),
                 ApiGatewayMapper.wrap(new AddAuthorizers()),
                 ApiGatewayMapper.wrap(new AddBinaryTypes()),

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultRestConfigSettingsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddDefaultRestConfigSettingsTest.java
@@ -1,0 +1,40 @@
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodePointer;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.utils.IoUtils;
+
+public class AddDefaultRestConfigSettingsTest {
+    @Test
+    public void addsDefaultConfigSettings() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("greedy-labels-for-rest.json"))
+                .assemble()
+                .unwrap();
+
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        ApiGatewayConfig apiGatewayConfig = new ApiGatewayConfig();
+        apiGatewayConfig.setApiGatewayType(ApiGatewayConfig.ApiType.REST);
+        config.putExtensions(apiGatewayConfig);
+        ObjectNode result = OpenApiConverter.create().config(config).convertToNode(model);
+
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("greedy-labels-for-rest.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/greedy-labels-for-rest.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/greedy-labels-for-rest.json
@@ -1,0 +1,41 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "smithy.example#Service": {
+      "type": "service",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "smithy.example#Operation"
+        }
+      ],
+      "traits": {
+        "aws.protocols#restJson1": {}
+      }
+    },
+    "smithy.example#Operation": {
+      "type": "operation",
+      "input": {
+        "target": "smithy.example#OperationInput"
+      },
+      "traits": {
+        "smithy.api#http": {
+          "uri": "/{baz+}",
+          "method": "POST"
+        }
+      }
+    },
+    "smithy.example#OperationInput": {
+      "type": "structure",
+      "members": {
+        "baz": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpLabel": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/greedy-labels-for-rest.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/greedy-labels-for-rest.openapi.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/{baz+}": {
+      "post": {
+        "operationId": "Operation",
+        "parameters": [
+          {
+            "name": "baz",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -223,6 +223,15 @@ public class OpenApiConfig extends JsonSchemaConfig {
         return removeGreedyParameterSuffix;
     }
 
+    /**
+     * Set to true to remove the "+" suffix that is added to the generated
+     * parameter name for greedy labels.
+     *
+     * <p>By default, greedy labels will have a parameter name generated that
+     * matches the label, including the "+" suffix.</p>
+     * @param removeGreedyParameterSuffix Set to true to remove the "+" suffix
+     *                                    on generated parameter name.
+     */
     public void setRemoveGreedyParameterSuffix(boolean removeGreedyParameterSuffix) {
         this.removeGreedyParameterSuffix = removeGreedyParameterSuffix;
     }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -79,6 +79,7 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private boolean keepUnusedComponents;
     private String jsonContentType = "application/json";
     private boolean forbidGreedyLabels;
+    private boolean removeGreedyParameterSuffix;
     private HttpPrefixHeadersStrategy onHttpPrefixHeaders = HttpPrefixHeadersStrategy.FAIL;
     private boolean ignoreUnsupportedTraits;
     private Map<String, Node> substitutions = Collections.emptyMap();
@@ -216,6 +217,14 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setForbidGreedyLabels(boolean forbidGreedyLabels) {
         this.forbidGreedyLabels = forbidGreedyLabels;
+    }
+
+    public boolean getRemoveGreedyParameterSuffix() {
+        return removeGreedyParameterSuffix;
+    }
+
+    public void setRemoveGreedyParameterSuffix(boolean removeGreedyParameterSuffix) {
+        this.removeGreedyParameterSuffix = removeGreedyParameterSuffix;
     }
 
     public HttpPrefixHeadersStrategy getOnHttpPrefixHeaders() {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -141,8 +141,10 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             // Some vendors/tooling, require the "+" suffix be excluded in the generated parameter.
             // If required, the setRemoveGreedyParameterSuffix config option should be set to `true`.
             // When this option is enabled, given "/{foo+}", the parameter name will be "foo".
-            String name = (label.isGreedyLabel() && !context.getConfig().getRemoveGreedyParameterSuffix())
-                    ? label.getContent() + "+" : label.getContent();
+            String name = label.getContent();
+            if (label.isGreedyLabel() && !context.getConfig().getRemoveGreedyParameterSuffix()) {
+                name = name + "+";
+            }
 
             result.add(ModelUtils.createParameterMember(context, binding.getMember())
                     .name(name)

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -138,7 +138,11 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
 
             // Greedy labels in OpenAPI need to include the label in the generated parameter.
             // For example, given "/{foo+}", the parameter name must be "foo+".
-            String name = label.isGreedyLabel() ? label.getContent() + "+" : label.getContent();
+            // Some vendors/tooling, require the "+" suffix be excluded in the generated parameter.
+            // If required, the setRemoveGreedyParameterSuffix config option should be set to `true`.
+            // When this option is enabled, given "/{foo+}", the parameter name will be "foo".
+            String name = (label.isGreedyLabel() && !context.getConfig().getRemoveGreedyParameterSuffix())
+                    ? label.getContent() + "+" : label.getContent();
 
             result.add(ModelUtils.createParameterMember(context, binding.getMember())
                     .name(name)

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -69,4 +69,29 @@ public class AwsRestJson1ProtocolTest {
 
         Assertions.assertTrue(Node.printJson(result.toNode()).contains("application/x-amz-json-1.0"));
     }
+
+    @Test
+    public void canRemoveGreedyLabelNameParameterSuffix() {
+        String smithy = "greedy-labels-name-parameter-without-suffix.json";
+        Model model = Model.assembler()
+                .addImport(getClass().getResource(smithy))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        config.setRemoveGreedyParameterSuffix(true);
+        OpenApi result = OpenApiConverter.create()
+                .config(config)
+                .convert(model);
+        String openApiModel = smithy.replace(".json", ".openapi.json");
+        InputStream openApiStream = getClass().getResourceAsStream(openApiModel);
+
+        if (openApiStream == null) {
+            LOGGER.warning("OpenAPI model not found for test case: " + openApiModel);
+        } else {
+            Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
+            Node.assertEquals(result, expectedNode);
+        }
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels-name-parameter-without-suffix.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels-name-parameter-without-suffix.json
@@ -1,0 +1,48 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "smithy.example#Service": {
+      "type": "service",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "smithy.example#Operation"
+        }
+      ],
+      "traits": {
+        "aws.protocols#restJson1": {}
+      }
+    },
+    "smithy.example#Operation": {
+      "type": "operation",
+      "input": {
+        "target": "smithy.example#OperationInput"
+      },
+      "traits": {
+        "smithy.api#http": {
+          "uri": "/{foo}/{baz+}",
+          "method": "POST"
+        }
+      }
+    },
+    "smithy.example#OperationInput": {
+      "type": "structure",
+      "members": {
+        "foo": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpLabel": {}
+          }
+        },
+        "baz": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpLabel": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels-name-parameter-without-suffix.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/greedy-labels-name-parameter-without-suffix.openapi.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/{foo}/{baz+}": {
+      "post": {
+        "operationId": "Operation",
+        "parameters": [
+          {
+            "name": "foo",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "baz",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation response"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
For OpenAPI, "greedy" labels need a corresponding name parameter, which was added in #641.

However, some vendors/tooling, including REST APIs for API Gateway, require that the name parameter exclude the "+" suffix in the generated name parameter.

This CR adds an option to configure OpenApiConfig to remove that suffix, which is then used as the default for REST APIs in smithy-aws-apigateway-openapi.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
