### PR TITLE
Add note about httpPayload to aws docs

### DIFF
--- a/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -33,6 +33,11 @@ Value type
 
     This protocol does not support document types.
 
+.. important::
+
+    This protocol only permits the :ref:`httpPayload-trait` to be applied to
+    members that target structures, documents, strings, blobs, or unions.
+
 .. tabs::
 
     .. code-tab:: smithy

--- a/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
@@ -56,4 +56,9 @@ See
             }
         }
 
+.. important::
+
+    This protocol only permits the :ref:`httpPayload-trait` to be applied to
+    members that target structures, documents, strings, blobs, or unions.
+
 *TODO: Add specifications, protocol examples, etc.*

--- a/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
@@ -56,4 +56,9 @@ See
             }
         }
 
+.. important::
+
+    This protocol only permits the :ref:`httpPayload-trait` to be applied to
+    members that target structures, documents, strings, blobs, or unions.
+
 *TODO: Add specifications, protocol examples, etc.*

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -62,4 +62,9 @@ See
 
     This protocol does not support document types.
 
+.. important::
+
+    This protocol only permits the :ref:`httpPayload-trait` to be applied to
+    members that target structures, documents, strings, blobs, or unions.
+
 *TODO: Add specifications, protocol examples, etc.*

--- a/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
@@ -169,6 +169,12 @@ that affect serialization:
     * - :ref:`httpPayload <httpPayload-trait>`
       - Binds a top-level input or output structure member as the payload
         of a request or response.
+
+        .. important::
+
+            This protocol only permits the :ref:`httpPayload-trait` to be applied to
+            members that target structures, documents, strings, blobs, or unions.
+
     * - :ref:`httpPrefixHeaders <httpPrefixHeaders-trait>`
       - Binds a top-level input, output, or error member to a map of
         prefixed HTTP headers.

--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -685,10 +685,11 @@ Summary
 Trait selector
     .. code-block:: none
 
-        structure > :test(member > :test(string, blob, structure, union, document))
+        structure > :test(member > :test(string, blob, structure, union, document, list, set, map))
 
     The ``httpPayload`` trait can be applied to ``structure`` members that
-    target a ``string``, ``blob``, ``structure``, ``union``, or ``document``.
+    target a ``string``, ``blob``, ``structure``, ``union``, ``document``,
+    ``set``, ``map``, or ``list``.
 Value type
     Annotation trait.
 Conflicts with
@@ -749,10 +750,10 @@ or :ref:`httpPrefixHeaders-trait`.
 
 #. When a string or blob member is referenced, the raw value is serialized
    as the body of the message.
-#. When a :ref:`structure <structure>`, :ref:`union <union>`, or
-   document type is targeted, the shape value is serialized
-   as a :ref:`protocol-specific <protocolDefinition-trait>` document that is
-   sent as the body of the message.
+#. When a :ref:`structure <structure>`, :ref:`union <union>`, :ref:`list <list>`,
+   :ref:`set <set>`, :ref:`map <map>`, or document type is targeted,
+   the shape value is serialized as a :ref:`protocol-specific <protocolDefinition-trait>`
+   document that is sent as the body of the message.
 
 
 .. _httpPrefixHeaders-trait:


### PR DESCRIPTION
*Description of changes:*

This adds a note to the aws protocol docs noting their stricter
requirements for the httpPayload trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
