### PR TITLE
Add test for map of sets to restJson protocol test.

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
@@ -286,6 +286,8 @@ structure JsonMapsInputOutput {
     sparseNumberMap: SparseNumberMap,
     sparseBooleanMap: SparseBooleanMap,
     sparseStringMap: SparseStringMap,
+    denseSetMap: DenseSetMap,
+    sparseSetMap: SparseSetMap,
 }
 
 map DenseStructMap {
@@ -324,4 +326,15 @@ map SparseBooleanMap {
 map SparseNumberMap {
     key: String,
     value: Integer
+}
+
+map DenseSetMap {
+    key: String,
+    value: aws.protocoltests.shared#StringSet
+}
+
+@sparse
+map SparseSetMap {
+    key: String,
+    value: aws.protocoltests.shared#StringSet
 }

--- a/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
@@ -8,6 +8,7 @@ use aws.protocols#restJson1
 use aws.protocoltests.shared#FooEnumMap
 use aws.protocoltests.shared#GreetingStruct
 use aws.protocoltests.shared#SparseStringMap
+use aws.protocoltests.shared#StringSet
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
@@ -146,6 +147,80 @@ apply JsonMaps @httpRequestTests([
                 "x": false
             }
         }
+    },
+    {
+        id: "RestJsonSerializesSparseSetMap",
+        documentation: "A request that contains a sparse map of sets",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonMaps",
+        body: """
+            {
+                "sparseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"]
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "sparseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    },
+    {
+        id: "RestJsonSerializesDenseSetMap",
+        documentation: "A request that contains a dense map of sets.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonMaps",
+        body: """
+            {
+                "denseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"]
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    },
+    {
+        id: "RestJsonSerializesSparseSetMapAndRetainsNull",
+        documentation: "A request that contains a sparse map of sets.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonMaps",
+        body: """
+            {
+                "sparseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"],
+                    "z": null
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "sparseSetMap": {
+                "x": [],
+                "y": ["a", "b"],
+                "z": null
+            }
+        }
     }
 ])
 
@@ -274,6 +349,104 @@ apply JsonMaps @httpResponseTests([
                 "x": false
             }
         }
+    },
+    {
+        id: "RestJsonDeserializesSparseSetMap",
+        documentation: "A response that contains a sparse map of sets",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "sparseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"]
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "sparseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    },
+    {
+        id: "RestJsonDeserializesDenseSetMap",
+        documentation: "A response that contains a dense map of sets.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "denseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"]
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    },
+    {
+        id: "RestJsonDeserializesSparseSetMapAndRetainsNull",
+        documentation: "A response that contains a sparse map of sets.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "sparseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"],
+                    "z": null
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "sparseSetMap": {
+                "x": [],
+                "y": ["a", "b"],
+                "z": null
+            }
+        }
+    },
+    {
+        id: "RestJsonDeserializesDenseSetMapAndSkipsNull",
+        documentation: """
+            Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD
+            drop the null key-value pair.""",
+        protocol: restJson1,
+        appliesTo: "client",
+        code: 200,
+        body: """
+            {
+                "denseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"],
+                    "z": null
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
     }
 ])
 
@@ -330,11 +503,11 @@ map SparseNumberMap {
 
 map DenseSetMap {
     key: String,
-    value: aws.protocoltests.shared#StringSet
+    value: StringSet
 }
 
 @sparse
 map SparseSetMap {
     key: String,
-    value: aws.protocoltests.shared#StringSet
+    value: StringSet
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds a test to exersize a nested set within a map for `restJson1` protocol.  I had implemented some serialization code but forgot about nested Sets.  Protocol tests as-is didn't catch this case.

## Testing Done

* `./gradlew test`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
