### PR TITLE
Refer to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -65,4 +65,4 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/smithy/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/awslabs/smithy/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ service ExampleService {
 
 Find out more about building artifacts of your Smithy model in the [Building
 Smithy Models][building] guide. For more examples, see the
-[examples directory](https://github.com/awslabs/smithy-gradle-plugin/tree/master/examples)
+[examples directory](https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples)
 of the Smithy Gradle Plugin repository.
 
 # License

--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -355,6 +355,6 @@ Complete Examples
 For several complete examples, see the `examples directory`_ of the Smithy
 Gradle plugin repository.
 
-.. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/master/examples
+.. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples
 .. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin/
 .. _Gradle: https://gradle.org/

--- a/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
@@ -332,7 +332,7 @@ Protocol compliance tests
 -------------------------
 
 A full compliance test suite is provided and SHALL be considered a normative
-reference: https://github.com/awslabs/smithy/tree/master/smithy-aws-protocol-tests/model/awsJson1_1
+reference: https://github.com/awslabs/smithy/tree/main/smithy-aws-protocol-tests/model/awsJson1_1
 
 These compliance tests define a model that is used to define test cases and
 the expected serialized HTTP requests and responses for each case.

--- a/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
@@ -373,7 +373,7 @@ Protocol compliance tests
 -------------------------
 
 A full compliance test suite is provided and SHALL be considered a normative
-reference: https://github.com/awslabs/smithy/tree/master/smithy-aws-protocol-tests/model/restXml
+reference: https://github.com/awslabs/smithy/tree/main/smithy-aws-protocol-tests/model/restXml
 
 These compliance tests define a model that is used to define test cases and
 the expected serialized HTTP requests and responses for each case.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1249,7 +1249,7 @@ Finally, the complete ``weather.smithy`` model should look like:
             }
         }
 
-.. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/master/examples
+.. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples
 .. _Tagged union: https://en.wikipedia.org/wiki/Tagged_union
 .. _Smithy Gradle Plugin: https://github.com/awslabs/smithy-gradle-plugin/
 .. _gradle installed: https://gradle.org/install/

--- a/smithy-build/README.md
+++ b/smithy-build/README.md
@@ -5,4 +5,4 @@ projections of a model, and generate build artifacts.
 
 
 - [Online documentation](https://awslabs.github.io/smithy/guides/building-models/build-config.html)
-- [Documentation source](https://github.com/awslabs/smithy/blob/master/docs/source/guides/building-models/build-config.rst)
+- [Documentation source](https://github.com/awslabs/smithy/blob/main/docs/source/guides/building-models/build-config.rst)


### PR DESCRIPTION
This PR updates references to the branch so that `main` can be used the default branch on this repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
