### PR TITLE
Use sets for OpenAPI security settings

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
@@ -18,9 +18,11 @@ package software.amazon.smithy.openapi.model;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
@@ -143,7 +145,9 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
         private final List<ServerObject> servers = new ArrayList<>();
         private Map<String, PathItem> paths = new TreeMap<>();
         private ComponentsObject components;
-        private final List<Map<String, List<String>>> security = new ArrayList<>();
+        // Use a set for security as duplicate entries are unnecessary (effectively
+        // represent an "A or A" security posture) and can cause downstream issues.
+        private final Set<Map<String, List<String>>> security = new LinkedHashSet<>();
         private final List<TagObject> tags = new ArrayList<>();
         private ExternalDocumentation externalDocs;
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OperationObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OperationObject.java
@@ -19,9 +19,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
@@ -189,7 +191,9 @@ public final class OperationObject extends Component implements ToSmithyBuilder<
         private final List<ParameterObject> parameters = new ArrayList<>();
         private final Map<String, ResponseObject> responses = new TreeMap<>();
         private final Map<String, CallbackObject> callbacks = new TreeMap<>();
-        private List<Map<String, List<String>>> security;
+        // Use a set for security as duplicate entries are unnecessary (effectively
+        // represent an "A or A" security posture) and can cause downstream issues.
+        private Set<Map<String, List<String>>> security;
         private final List<ServerObject> servers = new ArrayList<>();
         private String summary;
         private String description;
@@ -280,14 +284,14 @@ public final class OperationObject extends Component implements ToSmithyBuilder<
         }
 
         public Builder security(Collection<Map<String, List<String>>> security) {
-            this.security = new ArrayList<>();
+            this.security = new LinkedHashSet<>();
             this.security.addAll(security);
             return this;
         }
 
         public Builder addSecurity(Map<String, List<String>> security) {
             if (this.security == null) {
-                this.security = new ArrayList<>();
+                this.security = new LinkedHashSet<>();
             }
             this.security.add(security);
             return this;

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/consolidates-security-service.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/consolidates-security-service.json
@@ -1,0 +1,79 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#Service": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "smithy.example#Operation1"
+                },
+                {
+                    "target": "smithy.example#Operation2"
+                },
+                {
+                    "target": "smithy.example#Operation3"
+                },
+                {
+                    "target": "smithy.example#UnauthenticatedOperation"
+                }
+            ],
+            "traits": {
+                "aws.protocols#restJson1": {},
+                "aws.auth#sigv4": {
+                    "name": "example"
+                },
+                "smithy.api#httpBasicAuth": {},
+                "smithy.api#httpDigestAuth": {},
+                "smithy.api#auth": [
+                    "aws.auth#sigv4",
+                    "smithy.api#httpDigestAuth"
+                ]
+            }
+        },
+        "smithy.example#Operation1": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/1",
+                    "method": "GET"
+                }
+            }
+        },
+        "smithy.example#Operation2": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/2",
+                    "method": "GET"
+                },
+                "smithy.api#auth": [
+                    "smithy.api#httpBasicAuth"
+                ]
+            }
+        },
+        "smithy.example#Operation3": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/3",
+                    "method": "GET"
+                },
+                "smithy.api#auth": [
+                    "smithy.api#httpBasicAuth",
+                    "aws.auth#sigv4"
+                ]
+            }
+        },
+        "smithy.example#UnauthenticatedOperation": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/4",
+                    "method": "GET"
+                },
+                "smithy.api#auth": []
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit updates the OpenAPI document and Operation object builders
to use sets for storing their security settings instead of lists. Each
entry in these collections can be safely made unique, as duplicates would
represent an "A or A" posture. Having multiple entries can cause issues
with consuming the output document.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
