### PR TITLE
Add validation for payloadFormatVersion with HTTP APIs

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -129,8 +129,9 @@ final class AddIntegrations implements ApiGatewayMapper {
         // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration.html
         // If the payloadFormatVersion has not been set on an integration and the apiGatewayType has been set to "HTTP",
         // the conversion fails.
-        if (!trait.getPayloadFormatVersion().isPresent() && context.getConfig().getExtensions(ApiGatewayConfig.class)
-                .getApiGatewayType().equals(ApiGatewayConfig.ApiType.HTTP)) {
+        ApiGatewayConfig.ApiType apiType = context.getConfig().getExtensions(ApiGatewayConfig.class)
+                .getApiGatewayType();
+        if (!trait.getPayloadFormatVersion().isPresent() && apiType.equals(ApiGatewayConfig.ApiType.HTTP)) {
             throw new OpenApiException("When using the HTTP apiGatewayType, a payloadFormatVersion must be set on the"
                     + " integration applied to the operation: " + operation.getId());
         }

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -132,8 +132,8 @@ final class AddIntegrations implements ApiGatewayMapper {
         ApiGatewayConfig.ApiType apiType = context.getConfig().getExtensions(ApiGatewayConfig.class)
                 .getApiGatewayType();
         if (!trait.getPayloadFormatVersion().isPresent() && apiType.equals(ApiGatewayConfig.ApiType.HTTP)) {
-            throw new OpenApiException("When using the HTTP apiGatewayType, a payloadFormatVersion must be set on the"
-                    + " integration applied to the operation: " + operation.getId());
+            throw new OpenApiException("When the 'apiGatewayType' OpenAPI conversion setting is 'HTTP', a "
+                    + "'payloadFormatVersion' must be set on the aws.apigateway#integration trait.");
         }
     }
 

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrationsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrationsTest.java
@@ -78,7 +78,7 @@ public class AddIntegrationsTest {
             OpenApiConverter.create().config(config).convertToNode(model);
         });
 
-        assertThat(thrown.getMessage(), containsString("a payloadFormatVersion must be set on the integration"
-                    + " applied to the operation:"));
+        assertThat(thrown.getMessage(), containsString("When the 'apiGatewayType' OpenAPI conversion setting is"
+                + " 'HTTP', a 'payloadFormatVersion' must be set on the aws.apigateway#integration trait."));
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrationsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrationsTest.java
@@ -17,8 +17,8 @@ package software.amazon.smithy.aws.apigateway.openapi;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
@@ -64,22 +64,21 @@ public class AddIntegrationsTest {
 
     @Test
     public void throwsOnInvalidIntegrationTraitForHttpApi() {
-        Model model = Model.assembler(getClass().getClassLoader())
-                .discoverModels(getClass().getClassLoader())
-                .addImport(getClass().getResource("invalid-integration-for-http-api.json"))
-                .assemble()
-                .unwrap();
-        OpenApiConfig config = new OpenApiConfig();
-        config.setService(ShapeId.from("smithy.example#Service"));
-        ApiGatewayConfig apiGatewayConfig = new ApiGatewayConfig();
-        apiGatewayConfig.setApiGatewayType(ApiGatewayConfig.ApiType.HTTP);
-        config.putExtensions(apiGatewayConfig);
-        try {
+        OpenApiException thrown = assertThrows(OpenApiException.class, () -> {
+            Model model = Model.assembler(getClass().getClassLoader())
+                    .discoverModels(getClass().getClassLoader())
+                    .addImport(getClass().getResource("invalid-integration-for-http-api.json"))
+                    .assemble()
+                    .unwrap();
+            OpenApiConfig config = new OpenApiConfig();
+            config.setService(ShapeId.from("smithy.example#Service"));
+            ApiGatewayConfig apiGatewayConfig = new ApiGatewayConfig();
+            apiGatewayConfig.setApiGatewayType(ApiGatewayConfig.ApiType.HTTP);
+            config.putExtensions(apiGatewayConfig);
             OpenApiConverter.create().config(config).convertToNode(model);
-            Assertions.fail("Expected to throw");
-        } catch (OpenApiException e) {
-            assertThat(e.getMessage(), containsString("a payloadFormatVersion must be set on the integration"
+        });
+
+        assertThat(thrown.getMessage(), containsString("a payloadFormatVersion must be set on the integration"
                     + " applied to the operation:"));
-        }
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.json
@@ -28,7 +28,8 @@
                     "type": "aws_proxy",
                     "credentials": "arn:aws:iam::123456789012:role/{serviceName}{operationName}LambdaRole",
                     "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:{serviceName}{operationName}/invocations",
-                    "httpMethod": "POST"
+                    "httpMethod": "POST",
+                    "payloadFormatVersion": "1.0"
                 }
             }
         },

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -36,6 +36,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceListPayloads/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServiceListPayloadsLambdaRole",
           "responses": {
             "default": {
@@ -137,6 +138,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceDeletePayload/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServiceDeletePayloadLambdaRole",
           "responses": {
             "default": {
@@ -194,6 +196,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceGetPayload/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServiceGetPayloadLambdaRole",
           "responses": {
             "default": {
@@ -336,6 +339,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServicePutPayload/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServicePutPayloadLambdaRole",
           "responses": {
             "default": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
@@ -36,6 +36,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceListPayloads/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServiceListPayloadsLambdaRole",
           "responses": {
             "default": {
@@ -137,6 +138,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceDeletePayload/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServiceDeletePayloadLambdaRole",
           "responses": {
             "default": {
@@ -194,6 +196,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServiceGetPayload/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServiceGetPayloadLambdaRole",
           "responses": {
             "default": {
@@ -336,6 +339,7 @@
           "type": "aws_proxy",
           "uri": "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:MyServicePutPayload/invocations",
           "httpMethod": "POST",
+          "payloadFormatVersion": "1.0",
           "credentials": "arn:aws:iam::123456789012:role/MyServicePutPayloadLambdaRole",
           "responses": {
             "default": {

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/invalid-integration-for-http-api.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/invalid-integration-for-http-api.json
@@ -1,0 +1,145 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "smithy.example#Service": {
+      "type": "service",
+      "version": "2018-03-17",
+      "operations": [
+        {
+          "target": "smithy.example#Operation1"
+        }
+      ],
+      "traits": {
+        "aws.protocols#restJson1": {},
+        "aws.api#service": {
+          "sdkId": "Some Value"
+        },
+        "aws.apigateway#integration": {
+          "type": "aws",
+          "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:012345678901:function:HelloWorld/invocations",
+          "httpMethod": "POST",
+          "credentials": "arn:aws:iam::012345678901:role/apigateway-invoke-lambda-exec-role",
+          "requestTemplates": {
+            "application/json": "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+            "application/xml": "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+          },
+          "requestParameters": {
+            "integration.request.path.stage": "method.request.querystring.version",
+            "integration.request.querystring.provider": "method.request.querystring.vendor"
+          },
+          "cacheNamespace": "cache namespace",
+          "cacheKeyParameters": [],
+          "passThroughBehavior": "never",
+          "responses": {
+            "2\\d{2}": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.requestId": "integration.response.header.cid"
+              },
+              "responseTemplates": {
+                "application/json": "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
+                "application/xml": "#set ($root=$input.path('$')) <stage>$root.name</stage> "
+              }
+            },
+            "302": {
+              "statusCode": "302",
+              "responseParameters": {
+                "method.response.header.Location": "integration.response.body.redirect.url"
+              }
+            },
+            "default": {
+              "statusCode": "400",
+              "responseParameters": {
+                "method.response.header.test-method-response-header": "'static value'"
+              }
+            }
+          }
+        }
+      }
+    },
+    "smithy.example#Operation1": {
+      "type": "operation",
+      "input": {
+        "target": "smithy.example#OperationInput"
+      },
+      "output": {
+        "target": "smithy.example#OperationOutput"
+      },
+      "errors": [
+        {
+          "target": "smithy.example#Default"
+        },
+        {
+          "target": "smithy.example#Redirect"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/1"
+        }
+      }
+    },
+    "smithy.example#Default": {
+      "type": "structure",
+      "members": {
+        "testMethodResponseHeader": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpHeader": "test-method-response-header"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "smithy.example#Redirect": {
+      "type": "structure",
+      "members": {
+        "location": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpHeader": "Location"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 302,
+        "smithy.api#suppress": ["HttpResponseCodeSemantics"]
+      }
+    },
+    "smithy.example#OperationInput": {
+      "type": "structure",
+      "members": {
+        "vendor": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#httpQuery": "vendor",
+            "smithy.api#required": {}
+          }
+        },
+        "version": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#httpQuery": "version",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "smithy.example#OperationOutput": {
+      "type": "structure",
+      "members": {
+        "requestId": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpHeader": "requestId"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
HTTP APIs on API Gateway [require](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration.html) that the `payloadFormatVersion` is set, either to `1.0` or `2.0`.  This CR adds validation to ensure that when converting to OpenAPI for use with API Gateway, the `aws.apigateway#integration` trait must have this property set when used with an HTTP API.  Use with an HTTP API is indicated by setting the `apiGatewayType` to `HTTP` when configuring the `openapi` plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
