### PR TITLE
Fix xmlName value in protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restXmlWithNamespace/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXmlWithNamespace/main.smithy
@@ -143,6 +143,6 @@ structure SimpleScalarPropertiesInputOutput {
 @xmlNamespace(prefix: "xsi", uri: "https://example.com")
 structure NestedWithNamespace {
     @xmlAttribute
-    @xmlName("someName")
+    @xmlName("xsi:someName")
     attrField: String,
 }


### PR DESCRIPTION
This test is supposed to mimic s3, whose value for the equivalent trait is `xsi:type`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
