### PR TITLE
Fix xmlns + attr ser test

### DIFF
--- a/smithy-aws-protocol-tests/model/restXmlWithNamespace/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXmlWithNamespace/main.smithy
@@ -134,13 +134,13 @@ structure SimpleScalarPropertiesInputOutput {
     longValue: Long,
     floatValue: Float,
 
+    @xmlNamespace(prefix: "xsi", uri: "https://example.com")
     Nested: NestedWithNamespace,
 
     @xmlName("DoubleDribble")
     doubleValue: Double,
 }
 
-@xmlNamespace(prefix: "xsi", uri: "https://example.com")
 structure NestedWithNamespace {
     @xmlAttribute
     @xmlName("xsi:someName")


### PR DESCRIPTION
This fixes a test intended to exercise behavior of serializing an xml
namespace and namespaced attribute on a nested member. Previously the
member's xml namespace trait was applied to the target shape rather
than the member shape.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
