### PR TITLE
Fix synthetic schema naming

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -545,7 +545,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     private String stripNonAlphaNumericCharsIfNecessary(Context<T> context, String name) {
         String alphanumericOnly = NON_ALPHA_NUMERIC.matcher(name).replaceAll("");
         if (context.getConfig().getAlphanumericOnlyRefs() && !alphanumericOnly.equals(name)) {
-            LOGGER.info("Removing non-alphanumeric characters from " + name);
+            LOGGER.info(() -> String.format("Removing non-alphanumeric characters from %s to assure compatibility with"
+                    + " vendors that only allow alphanumeric shape names.", name));
             return alphanumericOnly;
         }
         return name;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.knowledge.EventStreamInfo;
@@ -67,6 +68,7 @@ import software.amazon.smithy.openapi.model.ResponseObject;
 abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<T> {
 
     private static final String AWS_EVENT_STREAM_CONTENT_TYPE = "application/vnd.amazon.eventstream";
+    private static final Pattern NON_ALPHA_NUMERIC = Pattern.compile("[^A-Za-z0-9]");
 
     /** The type of message being created. */
     enum MessageType { REQUEST, RESPONSE, ERROR }
@@ -326,7 +328,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
 
         // Synthesize a schema for the body of the request.
         Schema schema = createDocumentSchema(context, operation, bindings, MessageType.REQUEST);
-        String synthesizedName = operation.getId().getName() + "RequestContent";
+        String synthesizedName = stripNonAlphaNumericCharsIfNecessary(context, operation.getId().getName())
+                + "RequestContent";
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
@@ -391,7 +394,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             Shape operationOrError
     ) {
         ResponseObject.Builder responseBuilder = ResponseObject.builder();
-        responseBuilder.description(String.format("%s %s response", operationOrError.getId().getName(), statusCode));
+        String responseName = stripNonAlphaNumericCharsIfNecessary(context, operationOrError.getId().getName());
+        responseBuilder.description(String.format("%s %s response", responseName, statusCode));
         createResponseHeaderParameters(context, operationOrError)
                 .forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v)));
         addResponseContent(context, bindingIndex, eventStreamIndex, responseBuilder, statusCode, operationOrError);
@@ -526,12 +530,19 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         //
         // **NOTE: this same blurb applies to why we do this on input.**
         Schema schema = createDocumentSchema(context, operationOrError, bindings, messageType);
-        String synthesizedName = operationOrError.getId().getName() + "ResponseContent";
+        String synthesizedName = stripNonAlphaNumericCharsIfNecessary(context, operationOrError.getId().getName())
+                + "ResponseContent";
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
                 .build();
 
         responseBuilder.putContent(mediaType, mediaTypeObject);
+    }
+
+    private String stripNonAlphaNumericCharsIfNecessary(Context<T> context, String name) {
+        return context.getConfig().getAlphanumericOnlyRefs()
+                ? NON_ALPHA_NUMERIC.matcher(name).replaceAll("")
+                : name;
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -398,7 +398,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         responseBuilder.description(String.format("%s %s response", responseName, statusCode));
         createResponseHeaderParameters(context, operationOrError)
                 .forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v)));
-        addResponseContent(context, bindingIndex, eventStreamIndex, responseBuilder, statusCode, operationOrError);
+        addResponseContent(context, bindingIndex, eventStreamIndex, responseBuilder, operationOrError);
         return responseBuilder.build();
     }
 
@@ -416,7 +416,6 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             HttpBindingIndex bindingIndex,
             EventStreamIndex eventStreamIndex,
             ResponseObject.Builder responseBuilder,
-            String statusCode,
             Shape operationOrError
     ) {
         List<HttpBinding> payloadBindings = bindingIndex.getResponseBindings(

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
@@ -69,6 +70,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
 
     private static final String AWS_EVENT_STREAM_CONTENT_TYPE = "application/vnd.amazon.eventstream";
     private static final Pattern NON_ALPHA_NUMERIC = Pattern.compile("[^A-Za-z0-9]");
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractRestProtocol.class.getName());
 
     /** The type of message being created. */
     enum MessageType { REQUEST, RESPONSE, ERROR }
@@ -540,8 +543,11 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     }
 
     private String stripNonAlphaNumericCharsIfNecessary(Context<T> context, String name) {
-        return context.getConfig().getAlphanumericOnlyRefs()
-                ? NON_ALPHA_NUMERIC.matcher(name).replaceAll("")
-                : name;
+        String alphanumericOnly = NON_ALPHA_NUMERIC.matcher(name).replaceAll("");
+        if (context.getConfig().getAlphanumericOnlyRefs() && !alphanumericOnly.equals(name)) {
+            LOGGER.info("Removing non-alphanumeric characters from " + name);
+            return alphanumericOnly;
+        }
+        return name;
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -1,7 +1,8 @@
 package software.amazon.smithy.openapi.fromsmithy.protocols;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.InputStream;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,7 +17,6 @@ import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.utils.IoUtils;
 
 public class AwsRestJson1ProtocolTest {
-    private static final Logger LOGGER = Logger.getLogger(AwsRestJson1ProtocolTest.class.getName());
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -46,7 +46,7 @@ public class AwsRestJson1ProtocolTest {
         InputStream openApiStream = getClass().getResourceAsStream(openApiModel);
 
         if (openApiStream == null) {
-            LOGGER.warning("OpenAPI model not found for test case: " + openApiModel);
+            fail("OpenAPI model not found for test case: " + openApiModel);
         } else {
             Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
             Node.assertEquals(result, expectedNode);
@@ -88,7 +88,7 @@ public class AwsRestJson1ProtocolTest {
         InputStream openApiStream = getClass().getResourceAsStream(openApiModel);
 
         if (openApiStream == null) {
-            LOGGER.warning("OpenAPI model not found for test case: " + openApiModel);
+            fail("OpenAPI model not found for test case: " + openApiModel);
         } else {
             Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
             Node.assertEquals(result, expectedNode);
@@ -113,7 +113,7 @@ public class AwsRestJson1ProtocolTest {
         InputStream openApiStream = getClass().getResourceAsStream(openApiModel);
 
         if (openApiStream == null) {
-            LOGGER.warning("OpenAPI model not found for test case: " + openApiModel);
+            fail("OpenAPI model not found for test case: " + openApiModel);
         } else {
             Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
             Node.assertEquals(result, expectedNode);

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -94,4 +94,29 @@ public class AwsRestJson1ProtocolTest {
             Node.assertEquals(result, expectedNode);
         }
     }
+
+    @Test
+    public void canRemoveNonAlphaNumericDocumentNames() {
+        String smithy = "non-alphanumeric-content-names.json";
+        Model model = Model.assembler()
+                .addImport(getClass().getResource(smithy))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        config.setAlphanumericOnlyRefs(true);
+        OpenApi result = OpenApiConverter.create()
+                .config(config)
+                .convert(model);
+        String openApiModel = smithy.replace(".json", ".openapi.json");
+        InputStream openApiStream = getClass().getResourceAsStream(openApiModel);
+
+        if (openApiStream == null) {
+            LOGGER.warning("OpenAPI model not found for test case: " + openApiModel);
+        } else {
+            Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
+            Node.assertEquals(result, expectedNode);
+        }
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/non-alphanumeric-content-names.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/non-alphanumeric-content-names.json
@@ -1,0 +1,78 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "smithy.example#Service": {
+      "type": "service",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "smithy.example#_CreateDocument"
+        }
+      ],
+      "traits": {
+        "aws.protocols#restJson1": {}
+      }
+    },
+    "smithy.example#_CreateDocument": {
+      "type": "operation",
+      "input": {
+        "target": "smithy.example#_CreateDocumentInputOutput"
+      },
+      "output": {
+        "target": "smithy.example#_CreateDocumentInputOutput"
+      },
+      "errors": [
+        {
+          "target": "smithy.example#_CreateDocumentError"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "uri": "/document",
+          "method": "POST"
+        }
+      }
+    },
+    "smithy.example#_CreateDocumentInputOutput": {
+      "type": "structure",
+      "members": {
+        "abc": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpQuery": "ABC"
+          }
+        },
+        "def": {
+          "target": "smithy.api#Integer"
+        },
+        "hij": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpHeader": "X-Hij1"
+          }
+        }
+      }
+    },
+    "smithy.example#_CreateDocumentError": {
+      "type": "structure",
+      "members": {
+        "abc": {
+          "target": "smithy.api#String"
+        },
+        "def": {
+          "target": "smithy.api#Integer"
+        },
+        "hij": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpHeader": "X-Hij2"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/non-alphanumeric-content-names.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/non-alphanumeric-content-names.openapi.json
@@ -1,0 +1,115 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/document": {
+      "post": {
+        "operationId": "_CreateDocument",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDocumentRequestContent"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ABC",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Hij1",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CreateDocument 200 response",
+            "headers": {
+              "X-Hij1": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDocumentResponseContent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "CreateDocumentError 400 response",
+            "headers": {
+              "X-Hij2": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDocumentErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateDocumentErrorResponseContent": {
+        "type": "object",
+        "properties": {
+          "abc": {
+            "type": "string"
+          },
+          "def": {
+            "type": "number",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "CreateDocumentRequestContent": {
+        "type": "object",
+        "properties": {
+          "def": {
+            "type": "number",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "CreateDocumentResponseContent": {
+        "type": "object",
+        "properties": {
+          "abc": {
+            "type": "string"
+          },
+          "def": {
+            "type": "number",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some vendors, including Amazon API Gateway, require that shape names are alphanumeric only.

This PR assures that the synthesized `ResponseContent` and `RequestContent` shapes have alphanumeric names when the `alphanumericOnlyRefs` configuration setting has been set to `true`, as with `smithy-aws-apigateway-openapi`.  The descriptions on schemas are updated to match when non-alphanumeric characters have been removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
