### PR TITLE
Add tags and appliesTo to protocol tests

### DIFF
--- a/docs/source/1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/1.0/spec/http-protocol-compliance-tests.rst
@@ -202,6 +202,21 @@ that support the following members:
       - ``string``
       - A description of the test and what is being asserted defined in
         CommonMark_.
+    * - tags
+      - ``[string]``
+      - Attaches a list of tags that allow test cases to be categorized and
+        grouped.
+    * - appliesTo
+      - ``string``, one of "client" or "server"
+      - Indicates that the test case is only to be implemented by "client" or
+        "server" implementations. This property is useful for identifying and
+        testing edge cases of clients and servers that are impossible or
+        undesirable to test in *both* client and server implementations. For
+        example, a "server" test might be useful to ensure a service can
+        gracefully receive a request that optionally contains a payload.
+
+        Is is assumed that test cases that do not define an ``appliesTo``
+        member are implemented by both client and server implementations.
 
 
 HTTP request example
@@ -410,6 +425,21 @@ structures that support the following members:
       - ``string``
       - A description of the test and what is being asserted defined in
         CommonMark_.
+    * - tags
+      - ``[string]``
+      - Attaches a list of tags that allow test cases to be categorized and
+        grouped.
+    * - appliesTo
+      - ``string``, one of "client" or "server"
+      - Indicates that the test case is only to be implemented by "client" or
+        "server" implementations. This property is useful for identifying and
+        testing edge cases of clients and servers that are impossible or
+        undesirable to test in *both* client and server implementations. For
+        example, a "client" test might be useful to ensure a client can
+        gracefully receive a response that optionally contains a payload.
+
+        Is is assumed that test cases that do not define an ``appliesTo``
+        member are implemented by both client and server implementations.
 
 
 HTTP response example

--- a/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
@@ -121,6 +121,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "FooError",
         },
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorUsingXAmznErrorTypeWithUri",
@@ -135,6 +136,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorUsingXAmznErrorTypeWithUriAndNamespace",
@@ -146,6 +148,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorUsingCode",
@@ -165,6 +168,7 @@ apply FooError @httpResponseTests([
                   "code": "FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorUsingCodeAndNamespace",
@@ -181,6 +185,7 @@ apply FooError @httpResponseTests([
                   "code": "aws.protocoltests.json10#FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorUsingCodeUriAndNamespace",
@@ -198,6 +203,7 @@ apply FooError @httpResponseTests([
                   "code": "aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorWithDunderType",
@@ -212,6 +218,7 @@ apply FooError @httpResponseTests([
                   "__type": "FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorWithDunderTypeAndNamespace",
@@ -228,6 +235,7 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.json10#FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson10FooErrorWithDunderTypeUriAndNamespace",
@@ -245,5 +253,6 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     }
 ])

--- a/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
@@ -120,6 +120,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "FooError",
         },
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorUsingXAmznErrorTypeWithUri",
@@ -134,6 +135,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorUsingXAmznErrorTypeWithUriAndNamespace",
@@ -145,6 +147,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorUsingCode",
@@ -164,6 +167,7 @@ apply FooError @httpResponseTests([
                   "code": "FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorUsingCodeAndNamespace",
@@ -180,6 +184,7 @@ apply FooError @httpResponseTests([
                   "code": "aws.protocoltests.restjson#FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorUsingCodeUriAndNamespace",
@@ -197,6 +202,7 @@ apply FooError @httpResponseTests([
                   "code": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorWithDunderType",
@@ -211,6 +217,7 @@ apply FooError @httpResponseTests([
                   "__type": "FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorWithDunderTypeAndNamespace",
@@ -227,6 +234,7 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.restjson#FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "AwsJson11FooErrorWithDunderTypeUriAndNamespace",
@@ -244,5 +252,6 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     }
 ])

--- a/smithy-aws-protocol-tests/model/awsQuery/input.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input.smithy
@@ -300,6 +300,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
               &Version=2020-01-08
               &token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
+        appliesTo: "client",
     },
     {
         id: "QueryProtocolIdempotencyTokenAutoFillIsSet",
@@ -320,7 +321,8 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-lists.smithy
@@ -154,7 +154,8 @@ apply XmlEmptyLists @httpResponseTests([
         params: {
             stringList: [],
             stringSet: [],
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-maps.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-maps.smithy
@@ -83,7 +83,8 @@ apply XmlEmptyMaps @httpResponseTests([
         },
         params: {
             myMap: {}
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "QueryXmlEmptySelfClosedMaps",
@@ -103,7 +104,8 @@ apply XmlEmptyMaps @httpResponseTests([
         },
         params: {
             myMap: {}
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -126,7 +126,8 @@ apply XmlEmptyBlobs @httpResponseTests([
         },
         params: {
             data: ""
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "QueryXmlEmptySelfClosedBlobs",
@@ -146,7 +147,8 @@ apply XmlEmptyBlobs @httpResponseTests([
         },
         params: {
             data: ""
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/ec2Query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input.smithy
@@ -374,6 +374,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
               &Version=2020-01-08
               &Token=00000000-0000-4000-8000-000000000000""",
         bodyMediaType: "application/x-www-form-urlencoded",
+        appliesTo: "client",
     },
     {
         id: "Ec2ProtocolIdempotencyTokenAutoFillIsSet",
@@ -394,7 +395,8 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
@@ -152,7 +152,8 @@ apply XmlEmptyLists @httpResponseTests([
         params: {
             stringList: [],
             stringSet: [],
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -127,7 +127,8 @@ apply XmlEmptyBlobs @httpResponseTests([
         },
         params: {
             data: ""
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "Ec2XmlEmptySelfClosedBlobs",
@@ -146,7 +147,8 @@ apply XmlEmptyBlobs @httpResponseTests([
         },
         params: {
             data: ""
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/errors.smithy
@@ -155,6 +155,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "FooError",
         },
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorUsingXAmznErrorTypeWithUri",
@@ -169,6 +170,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespace",
@@ -180,6 +182,7 @@ apply FooError @httpResponseTests([
         headers: {
             "X-Amzn-Errortype": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorUsingCode",
@@ -199,6 +202,7 @@ apply FooError @httpResponseTests([
                   "code": "FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorUsingCodeAndNamespace",
@@ -215,6 +219,7 @@ apply FooError @httpResponseTests([
                   "code": "aws.protocoltests.restjson#FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorUsingCodeUriAndNamespace",
@@ -232,6 +237,7 @@ apply FooError @httpResponseTests([
                   "code": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorWithDunderType",
@@ -246,6 +252,7 @@ apply FooError @httpResponseTests([
                   "__type": "FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorWithDunderTypeAndNamespace",
@@ -262,6 +269,7 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.restjson#FooError"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     },
     {
         id: "RestJsonFooErrorWithDunderTypeUriAndNamespace",
@@ -279,5 +287,6 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
+        appliesTo: "client",
     }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -284,7 +284,8 @@ apply NullAndEmptyHeadersClient @httpRequestTests([
             a: null,
             b: "",
             c: [],
-        }
+        },
+        appliesTo: "client",
     },
 ])
 
@@ -309,7 +310,8 @@ apply NullAndEmptyHeadersServer @httpResponseTests([
             a: null,
             b: "",
             c: [],
-        }
+        },
+        appliesTo: "server",
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -314,7 +314,8 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         body: "",
         queryParams: [
             "token=00000000-0000-4000-8000-000000000000",
-        ]
+        ],
+        appliesTo: "client",
     },
     {
         id: "RestJsonQueryIdempotencyTokenAutoFillIsSet",
@@ -328,7 +329,8 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         ],
         params: {
             token: "00000000-0000-4000-8000-000000000000"
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
@@ -252,7 +252,8 @@ apply XmlEmptyLists @httpRequestTests([
         params: {
             stringList: [],
             stringSet: [],
-        }
+        },
+        appliesTo: "client",
     }
 ])
 
@@ -275,7 +276,8 @@ apply XmlEmptyLists @httpResponseTests([
         params: {
             stringList: [],
             stringSet: [],
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -125,7 +125,8 @@ apply XmlEmptyMaps @httpRequestTests([
         },
         params: {
             myMap: {}
-        }
+        },
+        appliesTo: "client"
     }
 ])
 
@@ -146,7 +147,8 @@ apply XmlEmptyMaps @httpResponseTests([
         },
         params: {
             myMap: {}
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "XmlEmptySelfClosedMaps",
@@ -164,7 +166,8 @@ apply XmlEmptyMaps @httpResponseTests([
         },
         params: {
             myMap: {}
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -251,7 +251,8 @@ apply XmlEmptyStrings @httpRequestTests([
            },
            params: {
                emptyString: "",
-           }
+           },
+           appliesTo: "client",
        }
 ])
 
@@ -272,7 +273,8 @@ apply XmlEmptyStrings @httpResponseTests([
         },
         params: {
             emptyString: ""
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "XmlEmptySelfClosedStrings",
@@ -290,7 +292,8 @@ apply XmlEmptyStrings @httpResponseTests([
         },
         params: {
             emptyString: ""
-        }
+        },
+        appliesTo: "client",
     }
 ])
 
@@ -373,7 +376,8 @@ apply XmlEmptyBlobs @httpResponseTests([
         },
         params: {
             data: ""
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "XmlEmptySelfClosedBlobs",
@@ -391,7 +395,8 @@ apply XmlEmptyBlobs @httpResponseTests([
         },
         params: {
             data: ""
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -284,7 +284,8 @@ apply NullAndEmptyHeadersClient @httpRequestTests([
             a: null,
             b: "",
             c: [],
-        }
+        },
+        appliesTo: "client",
     },
 ])
 
@@ -309,7 +310,8 @@ apply NullAndEmptyHeadersServer @httpResponseTests([
             a: null,
             b: "",
             c: [],
-        }
+        },
+        appliesTo: "server",
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -315,7 +315,8 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         body: "",
         queryParams: [
             "token=00000000-0000-4000-8000-000000000000",
-        ]
+        ],
+        appliesTo: "client",
     },
     {
         id: "QueryIdempotencyTokenAutoFillIsSet",
@@ -329,7 +330,8 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         ],
         params: {
             token: "00000000-0000-4000-8000-000000000000"
-        }
+        },
+        appliesTo: "client",
     }
 ])
 

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/AppliesTo.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/AppliesTo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.Locale;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ToNode;
+
+/**
+ * Indicates that a compliance test case is only to be implemented by
+ * "client" or "server" implementations.
+ */
+public enum AppliesTo implements ToNode {
+    CLIENT,
+    SERVER;
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase(Locale.ENGLISH);
+    }
+
+    public static AppliesTo fromNode(Node node) {
+        String value = node.expectStringNode()
+                .expectOneOf("client", "server")
+                .toUpperCase(Locale.ENGLISH);
+        return AppliesTo.valueOf(value);
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.from(toString());
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestsTrait.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.protocoltests.traits;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
@@ -56,6 +57,23 @@ public final class HttpRequestTestsTrait extends AbstractTrait {
 
     public List<HttpRequestTestCase> getTestCases() {
         return testCases;
+    }
+
+    /**
+     * Gets all test cases that apply to a client or server.
+     *
+     * <p>Test cases that define an {@code appliesTo} member are tests that
+     * should only be implemented by clients or servers. Is is assumed that
+     * test cases that do not define an {@code appliesTo} member are
+     * implemented by both client and server implementations.
+     *
+     * @param appliesTo The type of test case to retrieve.
+     * @return Returns the matching test cases.
+     */
+    public List<HttpRequestTestCase> getTestCasesFor(AppliesTo appliesTo) {
+        return testCases.stream()
+                .filter(test -> !test.getAppliesTo().filter(value -> value != appliesTo).isPresent())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpResponseTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpResponseTestsTrait.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.protocoltests.traits;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
@@ -56,6 +57,23 @@ public final class HttpResponseTestsTrait extends AbstractTrait {
 
     public List<HttpResponseTestCase> getTestCases() {
         return testCases;
+    }
+
+    /**
+     * Gets all test cases that apply to a client or server.
+     *
+     * <p>Test cases that define an {@code appliesTo} member are tests that
+     * should only be implemented by clients or servers. Is is assumed that
+     * test cases that do not define an {@code appliesTo} member are
+     * implemented by both client and server implementations.
+     *
+     * @param appliesTo The type of test case to retrieve.
+     * @return Returns the matching test cases.
+     */
+    public List<HttpResponseTestCase> getTestCasesFor(AppliesTo appliesTo) {
+        return testCases.stream()
+                .filter(test -> !test.getAppliesTo().filter(value -> value != appliesTo).isPresent())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -119,6 +119,15 @@ structure HttpRequestTestCase {
 
     /// A description of the test and what is being asserted.
     documentation: String,
+
+    /// Applies a list of tags to the test.
+    tags: NonEmptyStringList,
+
+    /// Indicates that the test case is only to be implemented by "client" or
+    /// "server" implementations. This property is useful for identifying and
+    /// testing edge cases of clients and servers that are impossible or
+    /// undesirable to test in *both* client and server implementations.
+    appliesTo: AppliesTo,
 }
 
 @private
@@ -211,4 +220,37 @@ structure HttpResponseTestCase {
 
     /// A description of the test and what is being asserted.
     documentation: String,
+
+    /// Applies a list of tags to the test.
+    tags: NonEmptyStringList,
+
+    /// Indicates that the test case is only to be implemented by "client" or
+    /// "server" implementations. This property is useful for identifying and
+    /// testing edge cases of clients and servers that are impossible or
+    /// undesirable to test in *both* client and server implementations.
+    appliesTo: AppliesTo,
 }
+
+@private
+list NonEmptyStringList {
+    member: NonEmptyString,
+}
+
+@private
+@length(min: 1)
+string NonEmptyString
+
+@private
+@enum([
+    {
+        value: "client",
+        name: "CLIENT",
+        documentation: "The test only applies to client implementations."
+    },
+    {
+        value: "server",
+        name: "SERVER",
+        documentation: "The test only applies to server implementations."
+    },
+])
+string AppliesTo

--- a/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/TraitTest.java
+++ b/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/TraitTest.java
@@ -1,13 +1,31 @@
 package software.amazon.smithy.protocoltests.traits;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class TraitTest {
+
+    private static Model appliesToModel;
+
+    @BeforeAll
+    public static void before() {
+         appliesToModel = Model.assembler()
+                 .discoverModels()
+                 .addImport(TraitTest.class.getResource("test-with-appliesto.smithy"))
+                 .assemble()
+                 .unwrap();
+    }
+
     @Test
     public void simpleRequestTest() {
         Model model = Model.assembler()
@@ -40,5 +58,80 @@ public class TraitTest {
 
         assertThat(testCase.toBuilder().build(), equalTo(testCase));
         assertThat(HttpResponseTestCase.fromNode(testCase.toNode()), equalTo(testCase));
+    }
+
+    @Test
+    public void messageHasTags() {
+        Model model = Model.assembler()
+                .discoverModels()
+                .addImport(getClass().getResource("test-with-tags.smithy"))
+                .assemble()
+                .unwrap();
+        HttpRequestTestCase request = model.expectShape(ShapeId.from("smithy.example#SaySomething"))
+                .getTrait(HttpRequestTestsTrait.class)
+                .get()
+                .getTestCases()
+                .get(0);
+        HttpResponseTestCase response = model.expectShape(ShapeId.from("smithy.example#SaySomething"))
+                .getTrait(HttpResponseTestsTrait.class)
+                .get()
+                .getTestCases()
+                .get(0);
+
+        assertThat(request.getTags(), contains("foo", "bar"));
+        assertThat(request.toBuilder().build().getTags(), contains("foo", "bar"));
+        assertThat(response.getTags(), contains("baz", "qux"));
+        assertThat(response.toBuilder().build().getTags(), contains("baz", "qux"));
+
+        assertThat(request.toBuilder().build(), equalTo(request));
+        assertThat(HttpRequestTestCase.fromNode(request.toNode()), equalTo(request));
+
+        assertThat(response.toBuilder().build(), equalTo(response));
+        assertThat(HttpResponseTestCase.fromNode(response.toNode()), equalTo(response));
+    }
+
+    @Test
+    public void messageHasAppliesTo() {
+        HttpRequestTestsTrait requestTrait = appliesToModel.expectShape(ShapeId.from("smithy.example#SaySomething"))
+                .expectTrait(HttpRequestTestsTrait.class);
+        HttpRequestTestCase request = requestTrait.getTestCases().get(1);
+
+        assertThat(request.getAppliesTo().isPresent(), is(true));
+        assertThat(request.getAppliesTo().get(), equalTo(AppliesTo.CLIENT));
+        assertThat(request.toBuilder().build(), equalTo(request));
+        assertThat(HttpRequestTestCase.fromNode(request.toNode()), equalTo(request));
+
+        HttpResponseTestsTrait responseTrait = appliesToModel.expectShape(ShapeId.from("smithy.example#SaySomething"))
+                .expectTrait(HttpResponseTestsTrait.class);
+        HttpResponseTestCase response = responseTrait.getTestCases().get(1);
+
+        assertThat(response.getAppliesTo().isPresent(), is(true));
+        assertThat(response.getAppliesTo().get(), equalTo(AppliesTo.CLIENT));
+        assertThat(response.toBuilder().build(), equalTo(response));
+        assertThat(HttpResponseTestCase.fromNode(response.toNode()), equalTo(response));
+    }
+
+    @Test
+    public void canFilterTestsByAppliesTo() {
+        HttpRequestTestsTrait requestTrait = appliesToModel.expectShape(ShapeId.from("smithy.example#SaySomething"))
+                .expectTrait(HttpRequestTestsTrait.class);
+        HttpResponseTestsTrait responseTrait = appliesToModel.expectShape(ShapeId.from("smithy.example#SaySomething"))
+                .expectTrait(HttpResponseTestsTrait.class);
+
+        assertThat(getCaseIds(requestTrait.getTestCasesFor(AppliesTo.CLIENT)),
+                   containsInAnyOrder("say_hello_all", "say_hello_client"));
+        assertThat(getCaseIds(requestTrait.getTestCasesFor(AppliesTo.SERVER)),
+                   containsInAnyOrder("say_hello_all", "say_hello_server"));
+
+        assertThat(getCaseIds(responseTrait.getTestCasesFor(AppliesTo.CLIENT)),
+                   containsInAnyOrder("say_goodbye_all", "say_goodbye_client"));
+        assertThat(getCaseIds(responseTrait.getTestCasesFor(AppliesTo.SERVER)),
+                   containsInAnyOrder("say_goodbye_all", "say_goodbye_server"));
+    }
+
+    private List<String> getCaseIds(List<? extends HttpMessageTestCase> cases) {
+        return cases.stream()
+                .map(HttpMessageTestCase::getId)
+                .collect(Collectors.toList());
     }
 }

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/test-with-appliesto.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/test-with-appliesto.smithy
@@ -1,0 +1,64 @@
+namespace smithy.example
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@trait
+@protocolDefinition
+structure exampleProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpRequestTests([
+    {
+        id: "say_hello_all",
+        protocol: exampleProtocol,
+        params: {},
+        method: "POST",
+        uri: "/"
+    },
+    {
+        id: "say_hello_client",
+        protocol: exampleProtocol,
+        params: {},
+        method: "POST",
+        uri: "/",
+        appliesTo: "client"
+    },
+    {
+        id: "say_hello_server",
+        protocol: exampleProtocol,
+        params: {},
+        method: "POST",
+        uri: "/",
+        appliesTo: "server"
+    }
+])
+@httpResponseTests([
+    {
+        id: "say_goodbye_all",
+        protocol: exampleProtocol,
+        params: {},
+        code: 200
+    },
+    {
+        id: "say_goodbye_client",
+        protocol: exampleProtocol,
+        params: {},
+        code: 200,
+        appliesTo: "client"
+    },
+    {
+        id: "say_goodbye_server",
+        protocol: exampleProtocol,
+        params: {},
+        code: 200,
+        appliesTo: "server"
+    }
+])
+operation SaySomething {
+    input: SayHelloInput,
+    output: SayGoodbyeOutput
+}
+
+structure SayHelloInput {}
+structure SayGoodbyeOutput {}

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/test-with-tags.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/test-with-tags.smithy
@@ -1,0 +1,36 @@
+namespace smithy.example
+
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@trait
+@protocolDefinition
+structure exampleProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpRequestTests([
+    {
+        id: "say_hello",
+        protocol: exampleProtocol,
+        params: {},
+        method: "POST",
+        uri: "/",
+        tags: ["foo", "bar"],
+    }
+])
+@httpResponseTests([
+    {
+        id: "say_goodbye",
+        protocol: exampleProtocol,
+        params: {},
+        code: 200,
+        tags: ["baz", "qux"],
+    }
+])
+operation SaySomething {
+    input: SayHelloInput,
+    output: SayGoodbyeOutput
+}
+
+structure SayHelloInput {}
+structure SayGoodbyeOutput {}


### PR DESCRIPTION
This commit adds support for applying tags to individual test cases,
allowing them to be grouped much more granularly. It also adds support
for appliesTo, which allows test cases to indicate if they should only
be implemented by clients or servers. Test cases that do not define an
appliesTo member are to be implemented by both client and server
implementations.

Existing AWS protocol tests are updated to now utilize appliesTo rather
than adding tags to operations.