### PR TITLE
Fix uri formatting in xml example.

### DIFF
--- a/docs/source/1.0/spec/core/xml-traits.rst
+++ b/docs/source/1.0/spec/core/xml-traits.rst
@@ -1003,7 +1003,7 @@ The XML serialization is:
 
 .. code-block:: xml
 
-    <MyStructure xmlns="http//foo.com">
+    <MyStructure xmlns="http://foo.com">
         <foo>example</foo>
         <bar>example</bar>
     </MyStructure>
@@ -1024,7 +1024,7 @@ The XML serialization is:
 
 .. code-block:: xml
 
-    <MyStructure xmlns:baz="http//foo.com">
+    <MyStructure xmlns:baz="http://foo.com">
         <foo>example</foo>
         <baz:bar>example</baz:bar>
     </MyStructure>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Perhaps the colon is removed due to some escaping issue or whathave you, but in case not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
