### PR TITLE
Add support for validating vendorParams

### DIFF
--- a/docs/source/1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/1.0/spec/http-protocol-compliance-tests.rst
@@ -198,6 +198,15 @@ that support the following members:
         request. For example, some vendors might utilize environment
         variables, configuration files on disk, or other means to influence
         the serialization formats used by clients or servers.
+
+        If a ``vendorParamsShape`` is set, these parameters MUST be compatible
+        with that shape's definition.
+    * - vendorParamsShape
+      - shape ID
+      - A shape to be used to validate the ``vendorParams`` member contents.
+
+        If set, the parameters in ``vendorParams`` MUST be compatible with this
+        shape's definition.
     * - documentation
       - ``string``
       - A description of the test and what is being asserted defined in
@@ -421,6 +430,15 @@ structures that support the following members:
         response. For example, some vendors might utilize environment
         variables, configuration files on disk, or other means to influence
         the serialization formats used by clients or servers.
+
+        If a ``vendorParamsShape`` is set, these parameters MUST be compatible
+        with that shape's definition.
+    * - vendorParamsShape
+      - shape ID
+      - A shape to be used to validate the ``vendorParams`` member contents.
+
+        If set, the parameters in ``vendorParams`` MUST be compatible with this
+        shape's definition.
     * - documentation
       - ``string``
       - A description of the test and what is being asserted defined in

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMessageTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMessageTestCase.java
@@ -40,6 +40,7 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
     private static final String BODY = "body";
     private static final String BODY_MEDIA_TYPE = "bodyMediaType";
     private static final String PARAMS = "params";
+    private static final String VENDOR_PARAMS_SHAPE = "vendorParamsShape";
     private static final String VENDOR_PARAMS = "vendorParams";
     private static final String HEADERS = "headers";
     private static final String FORBID_HEADERS = "forbidHeaders";
@@ -54,6 +55,7 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
     private final String body;
     private final String bodyMediaType;
     private final ObjectNode params;
+    private final ShapeId vendorParamsShape;
     private final ObjectNode vendorParams;
     private final Map<String, String> headers;
     private final List<String> forbidHeaders;
@@ -69,6 +71,7 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
         body = builder.body;
         bodyMediaType = builder.bodyMediaType;
         params = builder.params;
+        vendorParamsShape = builder.vendorParamsShape;
         vendorParams = builder.vendorParams;
         headers = Collections.unmodifiableMap(new TreeMap<>(builder.headers));
         forbidHeaders = ListUtils.copyOf(builder.forbidHeaders);
@@ -105,6 +108,10 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
         return params;
     }
 
+    public Optional<ShapeId> getVendorParamsShape() {
+        return Optional.ofNullable(vendorParamsShape);
+    }
+
     public ObjectNode getVendorParams() {
         return vendorParams;
     }
@@ -139,6 +146,7 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
         o.getStringMember(BODY).map(StringNode::getValue).ifPresent(builder::body);
         o.getStringMember(BODY_MEDIA_TYPE).map(StringNode::getValue).ifPresent(builder::bodyMediaType);
         o.getObjectMember(PARAMS).ifPresent(builder::params);
+        o.getStringMember(VENDOR_PARAMS_SHAPE).map(StringNode::expectShapeId).ifPresent(builder::vendorParamsShape);
         o.getObjectMember(VENDOR_PARAMS).ifPresent(builder::vendorParams);
         o.getStringMember(APPLIES_TO).map(AppliesTo::fromNode).ifPresent(builder::appliesTo);
 
@@ -170,7 +178,8 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
                 .withOptionalMember(AUTH_SCHEME, getAuthScheme().map(ShapeId::toString).map(Node::from))
                 .withOptionalMember(BODY, getBody().map(Node::from))
                 .withOptionalMember(BODY_MEDIA_TYPE, getBodyMediaType().map(Node::from))
-                .withOptionalMember(APPLIES_TO, getAppliesTo());
+                .withOptionalMember(APPLIES_TO, getAppliesTo())
+                .withOptionalMember(VENDOR_PARAMS_SHAPE, getVendorParamsShape().map(ShapeId::toString).map(Node::from));
 
         if (!headers.isEmpty()) {
             builder.withMember(HEADERS, ObjectNode.fromStringMap(getHeaders()));
@@ -222,6 +231,7 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
                 .forbidHeaders(forbidHeaders)
                 .requireHeaders(requireHeaders)
                 .params(params)
+                .vendorParamsShape(vendorParamsShape)
                 .vendorParams(vendorParams)
                 .documentation(documentation)
                 .authScheme(authScheme)
@@ -241,6 +251,7 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
         private String body;
         private String bodyMediaType;
         private ObjectNode params = Node.objectNode();
+        private ShapeId vendorParamsShape;
         private ObjectNode vendorParams = Node.objectNode();
         private AppliesTo appliesTo;
         private final Map<String, String> headers = new TreeMap<>();
@@ -287,6 +298,12 @@ public abstract class HttpMessageTestCase implements ToNode, Tagged {
         @SuppressWarnings("unchecked")
         public B params(ObjectNode params) {
             this.params = params;
+            return (B) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public B vendorParamsShape(ShapeId vendorParamsShape) {
+            this.vendorParamsShape = vendorParamsShape;
             return (B) this;
         }
 

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.protocoltests.traits;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
@@ -74,9 +75,28 @@ abstract class ProtocolTestCaseValidator<T extends Trait> extends AbstractValida
 
         for (int i = 0; i < testCases.size(); i++) {
             HttpMessageTestCase testCase = testCases.get(i);
+
+            // Validate the vendorParams for the test case if we have a shape defined.
+            Optional<ShapeId> vendorParamsShapeOptional = testCase.getVendorParamsShape();
+            ObjectNode vendorParams = testCase.getVendorParams();
+            if (vendorParamsShapeOptional.isPresent() && isValidatedBy(shape)) {
+                if (vendorParams.isEmpty()) {
+                    // Warn if vendorParamsShape is set on the case and no vendorParams is set.
+                    events.add(warning(shape, trait,
+                            "Protocol test case defined a `vendorParamsShape` but no `vendorParams`"));
+                } else {
+                    // Otherwise, validate the params against the shape.
+                    Shape vendorParamsShape = model.expectShape(vendorParamsShapeOptional.get());
+                    NodeValidationVisitor vendorParamsValidator = createVisitor(vendorParams, model, shape, i,
+                            ".vendorParams");
+                    events.addAll(vendorParamsShape.accept(vendorParamsValidator));
+                }
+            }
+
             StructureShape struct = getStructure(shape, operationIndex);
             if (struct != null) {
-                NodeValidationVisitor validator = createVisitor(testCase.getParams(), model, shape, i);
+                // Validate the params for the test case.
+                NodeValidationVisitor validator = createVisitor(testCase.getParams(), model, shape, i, ".params");
                 events.addAll(struct.accept(validator));
             } else if (!testCase.getParams().isEmpty() && isValidatedBy(shape)) {
                 events.add(error(shape, trait, String.format(
@@ -88,12 +108,18 @@ abstract class ProtocolTestCaseValidator<T extends Trait> extends AbstractValida
         return events;
     }
 
-    private NodeValidationVisitor createVisitor(ObjectNode value, Model model, Shape shape, int position) {
+    private NodeValidationVisitor createVisitor(
+            ObjectNode value,
+            Model model,
+            Shape shape,
+            int position,
+            String contextSuffix
+    ) {
         return NodeValidationVisitor.builder()
                 .model(model)
                 .eventShapeId(shape.getId())
                 .value(value)
-                .startingContext(traitId + "." + position + ".params")
+                .startingContext(traitId + "." + position + contextSuffix)
                 .eventId(getName())
                 .timestampValidationStrategy(TimestampValidationStrategy.EPOCH_SECONDS)
                 .allowBoxedNull(true)

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -115,7 +115,17 @@ structure HttpRequestTestCase {
     /// request. For example, some vendors might utilize environment
     /// variables, configuration files on disk, or other means to influence
     /// the serialization formats used by clients or servers.
+    ///
+    /// If a `vendorParamsShape` is set, these parameters MUST be compatible
+    /// with that shape's definition.
     vendorParams: Document,
+
+    /// A shape to be used to validate the `vendorParams` member contents.
+    ///
+    /// If set, the parameters in `vendorParams` MUST be compatible with this
+    /// shape's definition.
+    @idRef(failWhenMissing: true)
+    vendorParamsShape: String,
 
     /// A description of the test and what is being asserted.
     documentation: String,
@@ -216,7 +226,17 @@ structure HttpResponseTestCase {
     /// response. For example, some vendors might utilize environment
     /// variables, configuration files on disk, or other means to influence
     /// the serialization formats used by clients or servers.
+    ///
+    /// If a `vendorParamsShape` is set, these parameters MUST be compatible
+    /// with that shape's definition.
     vendorParams: Document,
+
+    /// A shape to be used to validate the `vendorParams` member contents.
+    ///
+    /// If set, the parameters in `vendorParams` MUST be compatible with this
+    /// shape's definition.
+    @idRef(failWhenMissing: true)
+    vendorParamsShape: String,
 
     /// A description of the test and what is being asserted.
     documentation: String,

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/missing-vendor-params-shape.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/missing-vendor-params-shape.errors
@@ -1,0 +1,2 @@
+[DANGER] -: Syntactic shape ID `missingVendorParamsStructure` does not resolve to a valid shape ID: `smithy.example#missingVendorParamsStructure`. Did you mean to quote this string? Are you missing a model file? | SyntacticShapeIdTarget
+[ERROR] -: Shape not found in model: smithy.example#missingVendorParamsStructure | Model

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/missing-vendor-params-shape.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/missing-vendor-params-shape.smithy
@@ -1,0 +1,31 @@
+namespace smithy.example
+
+use smithy.test#httpRequestTests
+
+@trait
+@protocolDefinition
+structure testProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpRequestTests([
+    {
+        id: "foo1",
+        protocol: testProtocol,
+        method: "POST",
+        uri: "/",
+        params: {
+            type: true
+        },
+        vendorParamsShape: missingVendorParamsStructure,
+        vendorParams: {
+            integer: 1,
+        }
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    type: Boolean
+}

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/vendor-params-validation.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/vendor-params-validation.errors
@@ -1,0 +1,5 @@
+[WARNING] smithy.example#SayGoodbye: Protocol test case defined a `vendorParamsShape` but no `vendorParams` | HttpResponseTestsOutput
+[WARNING] smithy.example#SayGoodbye: smithy.test#httpResponseTests.1.vendorParams: Invalid structure member `additional` found for `smithy.example#emptyVendorParamsStructure` | HttpResponseTestsOutput
+[ERROR] smithy.example#MyError: smithy.test#httpResponseTests.0.vendorParams.float: Expected number value for float shape, `smithy.api#Float`; found string value, `Hi` | HttpResponseTestsError
+[ERROR] smithy.example#SayHello: smithy.test#httpRequestTests.0.vendorParams: Missing required structure member `integer` for `smithy.example#simpleVendorParamsStructure` | HttpRequestTestsInput
+[ERROR] smithy.example#SayHello: smithy.test#httpRequestTests.1.vendorParams.boolean: Expected boolean value for boolean shape, `smithy.api#Boolean`; found string value, `Hi` | HttpRequestTestsInput

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/vendor-params-validation.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/vendor-params-validation.smithy
@@ -1,0 +1,103 @@
+namespace smithy.example
+
+use smithy.test#httpResponseTests
+use smithy.test#httpRequestTests
+
+@trait
+@protocolDefinition
+structure testProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpResponseTests([
+    {
+        id: "foo1",
+        protocol: testProtocol,
+        code: 200,
+        params: {},
+        vendorParamsShape: emptyVendorParamsStructure,
+    },
+    {
+        id: "foo2",
+        protocol: testProtocol,
+        code: 200,
+        params: {},
+        vendorParamsShape: emptyVendorParamsStructure,
+        vendorParams: {
+            additional: true,
+        }
+    }
+])
+operation SayGoodbye {
+    output: SayGoodbyeOutput
+}
+
+structure SayGoodbyeOutput {}
+
+@httpResponseTests([
+    {
+        id: "foo3",
+        protocol: testProtocol,
+        code: 200,
+        params: {
+            foo: 1
+        },
+        vendorParamsShape: simpleVendorParamsStructure,
+        vendorParams: {
+            integer: 1,
+            float: "Hi"
+        }
+    }
+])
+@error("client")
+structure MyError {
+    foo: Integer,
+}
+
+@http(method: "POST", uri: "/")
+@httpRequestTests([
+    {
+        id: "foo5",
+        protocol: testProtocol,
+        method: "POST",
+        uri: "/",
+        params: {
+            type: true
+        },
+        vendorParamsShape: simpleVendorParamsStructure,
+        vendorParams: {
+            float: 1.2
+        }
+    },
+    {
+        id: "foo6",
+        protocol: testProtocol,
+        method: "POST",
+        uri: "/",
+        params: {
+            type: true
+        },
+        vendorParamsShape: simpleVendorParamsStructure,
+        vendorParams: {
+            integer: 1,
+            boolean: "Hi"
+        }
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    type: Boolean
+}
+
+structure emptyVendorParamsStructure {}
+
+structure simpleVendorParamsStructure {
+    @required
+    integer: Integer,
+
+    boolean: Boolean,
+
+    float: Float,
+}


### PR DESCRIPTION
This commit adds a new member to HttpMessageTestCase based traits,
vendorParamsShape. When supplied, the parameters in vendorParams MUST
be compatible with the shape's definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
