### PR TITLE
Add docs/tests for Glacier customizations

### DIFF
--- a/docs/source/1.0/spec/aws/glacier-customizations.rst
+++ b/docs/source/1.0/spec/aws/glacier-customizations.rst
@@ -1,0 +1,42 @@
+=============================
+Amazon Glacier Customizations
+=============================
+
+.. contents:: Table of contents
+    :depth: 1
+    :local:
+    :backlinks: none
+
+
+--------------------------------
+``X-Amz-Glacier-Version`` header
+--------------------------------
+
+A client for Amazon Glacier MUST set the ``X-Amz-Glacier-Version`` header to
+the value of the service shape's ``version`` property for all requests.
+
+
+---------------------------
+Default value for accountId
+---------------------------
+
+Many operations in Amazon Glacier have an ``accountId`` member that is bound
+to the URI. Customers can specify the string "-" to indicate that the
+account making the request should be used. Since this is what customers
+usually want, clients SHOULD set this value by default.
+
+
+---------------------------
+Default checksum generation
+---------------------------
+
+When uploading an archive as part of the `UploadArchive`_ or `UploadPart`_
+operations, the ``X-Amz-Content-Sha256`` and ``X-Amz-Sha256-Tree-Hash``
+headers MUST be set. Since the logic for computing these headers is static,
+clients SHOULD populate them by default. See `computing checksums`_ for details
+on how to calculate the values for these headers.
+
+
+.. _UploadArchive: https://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html
+.. _UploadPart: https://docs.aws.amazon.com/amazonglacier/latest/dev/api-upload-part.html
+.. _computing checksums: https://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html

--- a/docs/source/1.0/spec/aws/glacier-customizations.rst
+++ b/docs/source/1.0/spec/aws/glacier-customizations.rst
@@ -30,7 +30,7 @@ usually want, clients SHOULD set this value by default.
 Default checksum generation
 ---------------------------
 
-When uploading an archive as part of the `UploadArchive`_ or `UploadPart`_
+When uploading an archive as part of the `UploadArchive`_ or `UploadMultipartPart`_
 operations, the ``X-Amz-Content-Sha256`` and ``X-Amz-Sha256-Tree-Hash``
 headers MUST be set. Since the logic for computing these headers is static,
 clients SHOULD populate them by default. See `computing checksums`_ for details
@@ -38,5 +38,5 @@ on how to calculate the values for these headers.
 
 
 .. _UploadArchive: https://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html
-.. _UploadPart: https://docs.aws.amazon.com/amazonglacier/latest/dev/api-upload-part.html
+.. _UploadMultipartPart: https://docs.aws.amazon.com/amazonglacier/latest/dev/api-upload-part.html
 .. _computing checksums: https://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html

--- a/docs/source/1.0/spec/aws/index.rst
+++ b/docs/source/1.0/spec/aws/index.rst
@@ -28,3 +28,13 @@ AWS Protocols
     aws-restxml-protocol
     aws-query-protocol
     aws-ec2-query-protocol
+
+AWS Service Customizations
+==========================
+
+.. rst-class:: large-toctree
+
+.. toctree::
+    :maxdepth: 3
+
+    glacier-customizations

--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -44,7 +44,7 @@ service Glacier {
         params: {
             accountId: "foo",
             vaultName: "bar",
-        }
+        },
     },
     {
         id: "GlacierChecksums",
@@ -61,7 +61,8 @@ service Glacier {
         params: {
             accountId: "foo",
             vaultName: "bar",
-        }
+        },
+        appliesTo: "client",
     },
     {
         id: "GlacierAccountId",
@@ -79,7 +80,8 @@ service Glacier {
         params: {
             accountId: "",
             vaultName: "bar",
-        }
+        },
+        appliesTo: "client",
     }
 ])
 @http(
@@ -116,7 +118,8 @@ operation UploadArchive {
             accountId: "foo",
             vaultName: "bar",
             uploadId: "baz",
-        }
+        },
+        appliesTo: "client",
     }
 ])
 @http(

--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -1,0 +1,168 @@
+$version: "1.0"
+
+namespace com.amazonaws.glacier
+
+use aws.api#service
+use aws.auth#sigv4
+use aws.protocols#restJson1
+use smithy.test#httpRequestTests
+
+@service(
+    sdkId: "Glacier",
+    arnNamespace: "glacier",
+    cloudFormationName: "Glacier",
+    cloudTrailEventSource: "glacier.amazonaws.com",
+    endpointPrefix: "glacier",
+)
+@sigv4(
+    name: "glacier",
+)
+@restJson1
+@title("Amazon Glacier")
+@xmlNamespace(
+    uri: "http://glacier.amazonaws.com/doc/2012-06-01/",
+)
+service Glacier {
+    version: "2012-06-01",
+    operations: [
+        UploadArchive,
+    ],
+}
+
+@httpRequestTests([
+    {
+        id: "GlacierVersionHeader",
+        documentation: "Glacier requires that a version header be set on all requests.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/foo/vaults/bar/archives",
+        headers: {
+            "X-Amz-Glacier-Version": "2012-06-01",
+        },
+        body: "",
+        params: {
+            accountId: "foo",
+            vaultName: "bar",
+        }
+    },
+    {
+        id: "GlacierChecksums",
+        documentation: "Glacier requires checksum headers that are cumbersome to provide.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/foo/vaults/bar/archives",
+        headers: {
+            "X-Amz-Glacier-Version": "2012-06-01",
+            "X-Amz-Content-Sha256": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+            "X-Amz-Sha256-Tree-Hash": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        },
+        body: "hello world",
+        params: {
+            accountId: "foo",
+            vaultName: "bar",
+        }
+    },
+    {
+        id: "GlacierAccountId",
+        documentation: """
+            Glacier requires that the account id be set, but you can just use a
+            hyphen (-) to indicate the current account. This should be default
+            behavior if the customer provides a null or empty string.""",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/-/vaults/bar/archives",
+        headers: {
+            "X-Amz-Glacier-Version": "2012-06-01",
+        },
+        body: "",
+        params: {
+            accountId: "",
+            vaultName: "bar",
+        }
+    }
+])
+@http(
+    method: "POST",
+    uri: "/{accountId}/vaults/{vaultName}/archives",
+    code: 201,
+)
+operation UploadArchive {
+    input: UploadArchiveInput,
+    output: ArchiveCreationOutput,
+    errors: [
+        InvalidParameterValueException,
+        MissingParameterValueException,
+        RequestTimeoutException,
+        ResourceNotFoundException,
+        ServiceUnavailableException,
+    ],
+}
+
+structure ArchiveCreationOutput {
+    @httpHeader("Location")
+    location: string,
+    @httpHeader("x-amz-sha256-tree-hash")
+    checksum: string,
+    @httpHeader("x-amz-archive-id")
+    archiveId: string,
+}
+
+@error("client")
+@httpError(400)
+structure InvalidParameterValueException {
+    type: string,
+    code: string,
+    message: string,
+}
+
+@error("client")
+@httpError(400)
+structure MissingParameterValueException {
+    type: string,
+    code: string,
+    message: string,
+}
+
+@error("client")
+@httpError(408)
+structure RequestTimeoutException {
+    type: string,
+    code: string,
+    message: string,
+}
+
+@error("client")
+@httpError(404)
+structure ResourceNotFoundException {
+    type: string,
+    code: string,
+    message: string,
+}
+
+@error("server")
+@httpError(500)
+structure ServiceUnavailableException {
+    type: string,
+    code: string,
+    message: string,
+}
+
+structure UploadArchiveInput {
+    @httpLabel
+    @required
+    vaultName: string,
+    @httpLabel
+    @required
+    accountId: string,
+    @httpHeader("x-amz-archive-description")
+    archiveDescription: string,
+    @httpHeader("x-amz-sha256-tree-hash")
+    checksum: string,
+    @httpPayload
+    body: Stream,
+}
+
+@streaming
+blob Stream
+
+string string

--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -1,5 +1,10 @@
 $version: "1.0"
 
+metadata suppressions = [{
+    id: "HttpMethodSemantics",
+    namespace: "com.amazonaws.glacier",
+}]
+
 namespace com.amazonaws.glacier
 
 use aws.api#service
@@ -103,7 +108,7 @@ operation UploadArchive {
 
 @httpRequestTests([
     {
-        id: "GlacierChecksums",
+        id: "GlacierMultipartChecksums",
         documentation: "Glacier requires checksum headers that are cumbersome to provide.",
         protocol: restJson1,
         method: "POST",


### PR DESCRIPTION
This adds documentation and protocol tests for the customizations required to generate Glacier client.

For the protocol tests, I included a representative subset of the Glacier model with protocol tests added in. I'm unsure if this is the right strategy though. The other option would be to include the entire model. That would reduce the risk of excluding too much, but also potentially results in having some truly massive models buried in this repo.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
