### PR TITLE
Add host validation to http request tests

### DIFF
--- a/docs/source/1.0/spec/aws/customizations/index.rst
+++ b/docs/source/1.0/spec/aws/customizations/index.rst
@@ -9,3 +9,4 @@ AWS Service Customizations
 
     apigateway-customizations
     glacier-customizations
+    machinelearning-customizations

--- a/docs/source/1.0/spec/aws/customizations/machinelearning-customizations.rst
+++ b/docs/source/1.0/spec/aws/customizations/machinelearning-customizations.rst
@@ -1,0 +1,22 @@
+======================================
+Amazon Machine Learning Customizations
+======================================
+
+.. contents:: Table of contents
+    :depth: 1
+    :local:
+    :backlinks: none
+
+
+----------------------------------------
+Set host to value of ``PredictEndpoint``
+----------------------------------------
+
+The `Predict operation`_ makes use of an endpoint provided by other operations
+in the service. The operation expects that the request will be sent to the
+host specified in the ``PredictEndpoint`` parameter. An AWS client SHOULD
+automatically set the host for the request to the host from the
+``PredictEndpoint`` value.
+
+
+.. _Predict operation: https://docs.aws.amazon.com/machine-learning/latest/APIReference/API_Predict.html

--- a/docs/source/1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/1.0/spec/http-protocol-compliance-tests.rst
@@ -103,6 +103,17 @@ that support the following members:
       - ``string``
       - **Required**. The request-target of the HTTP request, not including
         the query string (for example, "/foo/bar").
+    * - host
+      - ``string``
+      - The host / endpoint provided to the client, not including the path or
+        scheme (for example, "example.com").
+    * - resolvedHost
+      - ``string``
+      - The host / endpoint that the client should send to, not including the
+        path or scheme (for example, "prefix.example.com").
+
+        This can differ from the host provided to the client if, for instance,
+        the operation has a member with the :ref:`endpoint-trait`.
     * - authScheme
       - shape ID
       - A shape ID that specifies the optional authentication scheme to

--- a/smithy-aws-protocol-tests/model/awsJson1_1/services/machinelearning.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/services/machinelearning.smithy
@@ -1,0 +1,182 @@
+$version: "1.0"
+
+namespace com.amazonaws.machinelearning
+
+use aws.api#service
+use aws.auth#sigv4
+use aws.protocols#awsJson1_1
+use smithy.test#httpRequestTests
+
+@service(
+    sdkId: "Machine Learning",
+    arnNamespace: "machinelearning",
+    cloudFormationName: "MachineLearning",
+    cloudTrailEventSource: "machinelearning.amazonaws.com",
+    endpointPrefix: "machinelearning",
+)
+@sigv4(
+    name: "machinelearning",
+)
+@awsJson1_1
+@title("Amazon Machine Learning")
+@xmlNamespace(
+    uri: "http://machinelearning.amazonaws.com/doc/2014-12-12/",
+)
+service AmazonML_20141212 {
+    version: "2014-12-12",
+    operations: [
+        Predict,
+    ],
+}
+
+@httpRequestTests([
+    {
+        id: "MachinelearningPredictEndpoint",
+        documentation: """
+            MachineLearning's api makes use of generated endpoints that the
+            customer is then expected to use for the Predict operation. Having
+            to alter the endpoint for a specific operation would be cumbersome,
+            so an AWS client should be able to do it for them.""",
+        protocol: awsJson1_1,
+        method: "POST",
+        uri: "/",
+        host: "example.com",
+        resolvedHost: "custom.example.com",
+        body: "{\"MLModelId\": \"foo\", \"Record\": {}, \"PredictEndpoint\": \"https://custom.example.com\"}",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        params: {
+            MLModelId: "foo",
+            Record: {},
+            PredictEndpoint: "https://custom.example.com/",
+        }
+    }
+])
+operation Predict {
+    input: PredictInput,
+    output: PredictOutput,
+    errors: [
+        InternalServerException,
+        InvalidInputException,
+        LimitExceededException,
+        PredictorNotMountedException,
+        ResourceNotFoundException,
+    ],
+}
+
+@error("server")
+@httpError(500)
+structure InternalServerException {
+    message: ErrorMessage,
+    code: ErrorCode,
+}
+
+@error("client")
+@httpError(400)
+structure InvalidInputException {
+    message: ErrorMessage,
+    code: ErrorCode,
+}
+
+@error("client")
+@httpError(417)
+structure LimitExceededException {
+    message: ErrorMessage,
+    code: ErrorCode,
+}
+
+structure PredictInput {
+    @required
+    MLModelId: EntityId,
+    @required
+    Record: Record,
+    @required
+    PredictEndpoint: VipURLUnvalidated,
+}
+
+structure Prediction {
+    predictedLabel: Label,
+    predictedValue: floatLabel,
+    predictedScores: ScoreValuePerLabelMap,
+    details: DetailsMap,
+}
+
+@error("client")
+@httpError(400)
+structure PredictorNotMountedException {
+    message: ErrorMessage,
+}
+
+structure PredictOutput {
+    Prediction: Prediction,
+}
+
+@error("client")
+@httpError(404)
+structure ResourceNotFoundException {
+    message: ErrorMessage,
+    code: ErrorCode,
+}
+
+map DetailsMap {
+    key: DetailsAttributes,
+    value: DetailsValue,
+}
+
+map Record {
+    key: VariableName,
+    value: VariableValue,
+}
+
+map ScoreValuePerLabelMap {
+    key: Label,
+    value: ScoreValue,
+}
+
+@enum([
+    {
+        value: "PredictiveModelType",
+        name: "PREDICTIVE_MODEL_TYPE",
+    },
+    {
+        value: "Algorithm",
+        name: "ALGORITHM",
+    },
+])
+string DetailsAttributes
+
+@length(
+    min: 1,
+)
+string DetailsValue
+
+@length(
+    min: 1,
+    max: 64,
+)
+@pattern("[a-zA-Z0-9_.-]+")
+string EntityId
+
+integer ErrorCode
+
+@length(
+    min: 0,
+    max: 2048,
+)
+string ErrorMessage
+
+@box
+float floatLabel
+
+@length(
+    min: 1,
+)
+string Label
+
+float ScoreValue
+
+string VariableName
+
+string VariableValue
+
+string VipURLUnvalidated

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -37,6 +37,17 @@ structure HttpRequestTestCase {
     @length(min: 1)
     uri: String,
 
+    /// The host / endpoint provided to the client, not including the path
+    /// or scheme (for example, "example.com").
+    host: String,
+
+    /// The host / endpoint that the client should send to, not including
+    /// the path or scheme (for example, "prefix.example.com").
+    ///
+    /// This can differ from the host provided to the client if the `hostPrefix`
+    /// member of the `endpoint` trait is set, for instance.
+    resolvedHost: String,
+
     /// The optional authentication scheme shape ID to assume. It's
     /// possible that specific authentication schemes might influence
     /// the serialization logic of an HTTP request.

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-request-features.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-request-features.smithy
@@ -19,6 +19,8 @@ structure testScheme {}
         authScheme: testScheme,
         method: "POST",
         uri: "/",
+        host: "example.com",
+        resolvedHost: "prefix.example.com",
         queryParams: ["foo=baz"],
         forbidQueryParams: ["Nope"],
         requireQueryParams: ["Yap"],


### PR DESCRIPTION
This adds the ability for the http request tests to model assertions
on the host. This can be useful for asserting that the endpoint trait
is properly supported, as well as allowing for testing things like
AWS clients' ability to resolve hosts based on the service id and
region.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
