### PR TITLE
Throw syntax exceptions on duplicate bindings

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -542,7 +542,7 @@ final class IdlModelParser extends SimpleParser {
     private void parseOperationStatement(ShapeId id, SourceLocation location) {
         ws();
         OperationShape.Builder builder = OperationShape.builder().id(id).source(location);
-        ObjectNode node = IdlNodeParser.parseObjectNode(this);
+        ObjectNode node = IdlNodeParser.parseObjectNode(this, id.toString());
         LoaderUtils.checkForAdditionalProperties(node, id, OPERATION_PROPERTY_NAMES, modelFile.events());
         modelFile.onShape(builder);
         optionalId(node, "input", builder::input);
@@ -553,7 +553,7 @@ final class IdlModelParser extends SimpleParser {
     private void parseServiceStatement(ShapeId id, SourceLocation location) {
         ws();
         ServiceShape.Builder builder = new ServiceShape.Builder().id(id).source(location);
-        ObjectNode shapeNode = IdlNodeParser.parseObjectNode(this);
+        ObjectNode shapeNode = IdlNodeParser.parseObjectNode(this, id.toString());
         LoaderUtils.checkForAdditionalProperties(shapeNode, id, SERVICE_PROPERTY_NAMES, modelFile.events());
         builder.version(shapeNode.expectStringMember(VERSION_KEY).getValue());
         modelFile.onShape(builder);
@@ -580,7 +580,7 @@ final class IdlModelParser extends SimpleParser {
         ws();
         ResourceShape.Builder builder = ResourceShape.builder().id(id).source(location);
         modelFile.onShape(builder);
-        ObjectNode shapeNode = IdlNodeParser.parseObjectNode(this);
+        ObjectNode shapeNode = IdlNodeParser.parseObjectNode(this, id.toString());
 
         LoaderUtils.checkForAdditionalProperties(shapeNode, id, RESOURCE_PROPERTY_NAMES, modelFile.events());
         optionalId(shapeNode, PUT_KEY, builder::put);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTraitParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTraitParser.java
@@ -121,6 +121,8 @@ final class IdlTraitParser {
     private static ObjectNode parseStructuredTrait(IdlModelParser parser, StringNode startingKey) {
         Map<StringNode, Node> entries = new LinkedHashMap<>();
         Node firstValue = IdlNodeParser.parseNode(parser);
+        // This put call can be done safely without checking for duplicates,
+        // as it's always the first member of the trait.
         entries.put(startingKey, firstValue);
         parser.ws();
 
@@ -150,6 +152,9 @@ final class IdlTraitParser {
         parser.ws();
         Node nextValue = IdlNodeParser.parseNode(parser);
         parser.ws();
-        entries.put(nextKey, nextValue);
+        Node previous = entries.put(nextKey, nextValue);
+        if (previous != null) {
+            throw parser.syntax("Duplicate member of trait: '" + nextKey.getValue() + '\'');
+        }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-operation-binding.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-operation-binding.errors
@@ -1,0 +1,1 @@
+[ERROR] -: Parse error at line 5, column 23 near `, | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-operation-binding.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-operation-binding.smithy
@@ -1,0 +1,8 @@
+namespace com.foo
+
+operation GetFoo {
+    input: GetFooInput,
+    input: GetFooInput,
+}
+
+structure GetFooInput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-resource-binding.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-resource-binding.errors
@@ -1,0 +1,1 @@
+[ERROR] -: Parse error at line 8, column 22 near `, | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-resource-binding.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-resource-binding.smithy
@@ -1,0 +1,11 @@
+namespace com.foo
+
+resource Foo {
+    identifiers: {
+        id: String,
+    },
+    create: createFoo,
+    create: createFoo,
+}
+
+operation createFoo {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-service-binding.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-service-binding.errors
@@ -1,0 +1,1 @@
+[ERROR] -: Parse error at line 5, column 26 near `, | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-service-binding.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-service-binding.smithy
@@ -1,0 +1,6 @@
+namespace com.foo
+
+service Foo {
+    version: "2020-07-02",
+    version: "2020-07-02",
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-member-names.errors
@@ -1,0 +1,1 @@
+[ERROR] -: Parse error at line 5, column 19 near `, | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-member-names.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-member-names.smithy
@@ -1,0 +1,7 @@
+namespace com.foo
+
+@deprecated(
+    message: "Foo",
+    message: "Foo",
+)
+structure Foo {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-object-keys.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-object-keys.errors
@@ -1,0 +1,1 @@
+[ERROR] -: Parse error at line 6, column 21 near `, | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-object-keys.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-trait-object-keys.smithy
@@ -1,0 +1,9 @@
+namespace com.foo
+
+@enum([
+    {
+        value: "foo",
+        value: "foo",
+    },
+])
+string Foo


### PR DESCRIPTION
This commit updates the Smithy IDL parsing to throw when duplicate
bindings or members are found in the following declarations: service,
resource, and operation shapes, applied structure traits, and applied
traits with members that are structures. This behavior is unsafe for
model writers and shouldn't be valid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
