### PR TITLE
fix: protocol tests, update bodyMediaType to application/xml

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -253,7 +253,7 @@ apply IgnoreQueryParamsInResponse @httpResponseTests([
             "Content-Type": "application/xml"
         },
         body: "<IgnoreQueryParamsInResponseInputOutput><baz>bam</baz></IgnoreQueryParamsInResponseInputOutput>",
-        bodyMediaType: "xml",
+        bodyMediaType: "application/xml",
         params: {
             baz: "bam"
         }


### PR DESCRIPTION
Updating protocol unit test to use `application/xml` instead of `xml`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
