### PR TITLE
Add renameShapes transformer

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -1038,8 +1038,9 @@ shapes that are being renamed.
       - Description
     * - renamed
       - ``Map<shapeId, shapeId>``
-      - The map of :ref:`shape IDs ` to rename. Each key ``shapeId`` will be
-        renamed to the value ``shapeId``.
+      - The map of :ref:`shape IDs <shape-id>` to rename. Each key ``shapeId`` will be
+        renamed to the value ``shapeId``. Each :ref:`shape ID <shape-id>` must be
+        be an absolute shape ID.
 
 The following example renames the ``ns.foo#Bar`` shape to ``ns.foo#Baz``.
 Any references to ``ns.foo#Bar`` on other shapes will also be updated.

--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -1021,6 +1021,50 @@ but keeps the shape if it has any of the provided tags:
             }
         }
 
+.. _renameShapes-transform:
+
+renameShapes
+------------
+
+Renames shapes within the model, including updating any references to the
+shapes that are being renamed.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - renamed
+      - ``Map<shapeId, shapeId>``
+      - The map of shape ids of shapes that will be renamed, from the key,
+        to its value.
+
+The following example renames the ``ns.foo#Bar`` shape to ``ns.foo#Baz``.
+Any references to ``ns.foo#Bar`` on other shapes will also be updated.
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "renameShapes",
+                            "args": {
+                                "renamed": {
+                                    "ns.foo#Bar": "ns.foo#Baz"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
 
 .. _build_envars:
 

--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -1038,8 +1038,8 @@ shapes that are being renamed.
       - Description
     * - renamed
       - ``Map<shapeId, shapeId>``
-      - The map of shape ids of shapes that will be renamed, from the key,
-        to its value.
+      - The map of :ref:`shape IDs ` to rename. Each key ``shapeId`` will be
+        renamed to the value ``shapeId``.
 
 The following example renames the ``ns.foo#Bar`` shape to ``ns.foo#Baz``.
 Any references to ``ns.foo#Bar`` on other shapes will also be updated.

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
@@ -39,15 +39,16 @@ public class RenameShapes extends ConfigurableProjectionTransformer<RenameShapes
         /**
          * Sets the map of `from` shape ids to the `to` shape id values that they shapes
          * will be renamed to.
+         *
          * @param renamed The map of shapes to rename.
          */
         public void setRenamed(Map<String, String> renamed) {
-
             this.renamed = renamed;
         }
 
         /**
          * Gets the map of shape ids to be renamed.
+         *
          * @return The map of shapes to rename.
          */
         public Map<String, String> getRenamed() {

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.transform.ModelTransformer;
+
+/**
+ * {@code renameShapes} updates a model by renaming shapes. When
+ * configuring the transformer, a `renamed` property must be set as a
+ * map with the keys as the `from` shape ids that will be renamed `to`
+ * the shape id values. Any references to a renamed shape will also be
+ * updated.
+ */
+public class RenameShapes extends ConfigurableProjectionTransformer<RenameShapes.Config> {
+
+    public static final class Config {
+
+        private Map<String, String> renamed;
+
+        /**
+         * Sets the map of `from` shape ids to the `to` shape id values that they shapes
+         * will be renamed to.
+         * @param renamed The map of shapes to rename.
+         */
+        public void setRenamed(Map<String, String> renamed) {
+
+            this.renamed = renamed;
+        }
+
+        /**
+         * Gets the map of shape ids to be renamed.
+         * @return The map of shapes to rename.
+         */
+        public Map<String, String> getRenamed() {
+            return renamed;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        if (config.getRenamed() == null || config.getRenamed().isEmpty()) {
+            throw new SmithyBuildException(
+                    "'renamed' property must be set and non-empty on renameShapes transformer.");
+        }
+        Model model = context.getModel();
+
+        return ModelTransformer.create().renameShapes(model, getShapeIdsToRename(config, model));
+    }
+
+    @Override
+    public String getName() {
+        return "renameShapes";
+    }
+
+    private Map<ShapeId, ShapeId> getShapeIdsToRename(Config config, Model model) {
+        Map<ShapeId, ShapeId> shapeIdMap = new HashMap<>();
+        for (String fromShape : config.getRenamed().keySet()) {
+            ShapeId fromShapeId = ShapeId.from(fromShape);
+            if (!model.getShape(fromShapeId.toShapeId()).isPresent()) {
+                throw new SmithyBuildException(
+                        String.format("'%s' to be renamed does not exist in model.", fromShapeId)
+                );
+            }
+            shapeIdMap.put(fromShapeId, ShapeId.from(config.getRenamed().get(fromShape)));
+        }
+        return shapeIdMap;
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
@@ -33,6 +33,9 @@ import software.amazon.smithy.model.transform.ModelTransformer;
  */
 public class RenameShapes extends ConfigurableProjectionTransformer<RenameShapes.Config> {
 
+    /**
+     * {@code renameShapes} configuration settings.
+     */
     public static final class Config {
 
         private Map<String, String> renamed;

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -14,3 +14,4 @@ software.amazon.smithy.build.transforms.IncludeTraits
 software.amazon.smithy.build.transforms.IncludeTraitsByTag
 software.amazon.smithy.build.transforms.RemoveTraitDefinitions
 software.amazon.smithy.build.transforms.RemoveUnusedShapes
+software.amazon.smithy.build.transforms.RenameShapes

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RenameShapesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RenameShapesTest.java
@@ -103,4 +103,38 @@ public class RenameShapesTest {
                 .build();
         Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
     }
+
+    @Test
+    public void throwsWhenFromShapeIsInvalid() {
+        Model model = Model.assembler()
+                .addUnparsedModel("N/A", "{ \"smithy\": \"1.0\" }")
+                .assemble()
+                .unwrap();
+        ObjectNode renamed = Node.objectNode()
+                .withMember("Bar", "ns.foo#Baz");
+        ObjectNode config = Node.objectNode()
+                .withMember("renamed", renamed);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(config)
+                .build();
+        Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
+    }
+
+    @Test
+    public void throwsWhenToShapeIsInvalid() {
+        Model model = Model.assembler()
+                .addUnparsedModel("N/A", "{ \"smithy\": \"1.0\" }")
+                .assemble()
+                .unwrap();
+        ObjectNode renamed = Node.objectNode()
+                .withMember("ns.foo#Bar", "Baz");
+        ObjectNode config = Node.objectNode()
+                .withMember("renamed", renamed);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(config)
+                .build();
+        Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
+    }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RenameShapesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RenameShapesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.not;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.FunctionalUtils;
+
+public class RenameShapesTest {
+
+    @Test
+    public void renameShapes() throws Exception {
+        Model model = Model.assembler()
+                .addImport(Paths.get(getClass().getResource("rename-shapes.json").toURI()))
+                .assemble()
+                .unwrap();
+        ObjectNode renamed = Node.objectNode()
+                .withMember("ns.foo#Bar", "ns.foo#Baz")
+                .withMember("ns.foo#Qux", "ns.foo#Corge");
+        ObjectNode config = Node.objectNode()
+                .withMember("renamed", renamed);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(config)
+                .build();
+        Model result = new RenameShapes().transform(context);
+        List<String> ids = result.shapes()
+                .filter(FunctionalUtils.not(Prelude::isPreludeShape))
+                .map(Shape::getId)
+                .map(Object::toString)
+                .collect(Collectors.toList());
+
+        assertThat(ids, containsInAnyOrder("ns.foo#MyService", "ns.foo#Baz", "ns.foo#Corge", "ns.foo#Corge$foo"));
+        assertThat(ids, not(containsInAnyOrder("ns.foo#Bar", "ns.foo#Qux")));
+    }
+
+    @Test
+    public void throwsWhenRenamedPropertyIsNotConfigured() {
+        Model model = Model.assembler()
+                .addUnparsedModel("N/A", "{ \"smithy\": \"1.0\" }")
+                .assemble()
+                .unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("badConfig", Node.from("foo")))
+                .build();
+        Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
+    }
+
+    @Test
+    public void throwsWhenRenamedPropertyMapIsEmpty() {
+        Model model = Model.assembler()
+                .addUnparsedModel("N/A", "{ \"smithy\": \"1.0\" }")
+                .assemble()
+                .unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("renamed", Node.nullNode()))
+                .build();
+        Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
+    }
+
+    @Test
+    public void throwsWhenShapeToBeRenamedIsNotFound() {
+        Model model = Model.assembler()
+                .addUnparsedModel("N/A", "{ \"smithy\": \"1.0\" }")
+                .assemble()
+                .unwrap();
+        ObjectNode renamed = Node.objectNode()
+                .withMember("ns.foo#Bar", "ns.foo#Baz");
+        ObjectNode config = Node.objectNode()
+                .withMember("renamed", renamed);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(config)
+                .build();
+        Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/rename-shapes.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/rename-shapes.json
@@ -1,0 +1,28 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "ns.foo#MyService": {
+      "type": "service",
+      "version": "2017-01-19",
+      "operations": [
+        {
+          "target": "ns.foo#Bar"
+        }
+      ]
+    },
+    "ns.foo#Bar": {
+      "type": "operation",
+      "output": {
+        "target": "ns.foo#Qux"
+      }
+    },
+    "ns.foo#Qux": {
+      "type": "structure",
+      "members": {
+        "foo": {
+          "target": "smithy.api#String"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a `renamesShapes` transformer that can be used to rename shapes in a projection by configuration through smithy-build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
