### PR TITLE
Improve Selector usability

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -87,10 +87,10 @@ public final class SelectCommand implements Command {
         } else {
             // Show the JSON output for writing with --vars.
             List<Node> result = new ArrayList<>();
-            selector.runner().model(model).selectMatches((shape, vars) -> {
+            selector.consumeMatches(model, match -> {
                 result.add(Node.objectNodeBuilder()
-                        .withMember("shape", Node.from(shape.getId().toString()))
-                        .withMember("vars", collectVars(vars))
+                        .withMember("shape", Node.from(match.getShape().getId().toString()))
+                        .withMember("vars", collectVars(match))
                         .build());
             });
             Cli.stdout(Node.prettyPrintJson(new ArrayNode(result, SourceLocation.NONE)));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
@@ -54,10 +54,8 @@ final class ValidatorDefinition {
 
         // If there's a selector, create a list of candidate shape IDs that can be emitted.
         if (selector != null) {
-            candidates = selector.runner()
-                    .model(model)
-                    .selectShapes()
-                    .stream()
+            candidates = selector
+                    .shapes(model)
                     .map(Shape::getId)
                     .collect(Collectors.toSet());
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Selector evaluation context object.
@@ -28,7 +27,7 @@ import software.amazon.smithy.utils.MapUtils;
 final class Context {
 
     NeighborProviderIndex neighborIndex;
-    private Map<String, Set<Shape>> variables;
+    private final Map<String, Set<Shape>> variables;
 
     Context(NeighborProviderIndex neighborIndex) {
         this.neighborIndex = neighborIndex;
@@ -43,15 +42,6 @@ final class Context {
     Context clearVars() {
         variables.clear();
         return this;
-    }
-
-    /**
-     * Copies the current set of variables to an immutable map.
-     *
-     * @return Returns a copy of the variables.
-     */
-    Map<String, Set<Shape>> copyVars() {
-        return MapUtils.copyOf(variables);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/IdentitySelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/IdentitySelector.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.selector;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+
+/**
+ * An optimized Selector implementation that uses the provided Model directly
+ * rather than needing to send each shape through the Selector machinery.
+ *
+ * @see Selector#IDENTITY
+ */
+final class IdentitySelector implements Selector {
+    @Override
+    public Set<Shape> select(Model model) {
+        return model.toSet();
+    }
+
+    @Override
+    public Stream<Shape> shapes(Model model) {
+        return model.shapes();
+    }
+
+    @Override
+    public Stream<ShapeMatch> matches(Model model) {
+        return model.shapes().map(shape -> new ShapeMatch(shape, Collections.emptyMap()));
+    }
+
+    @Override
+    public String toString() {
+        return "*";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Selector && toString().equals(other.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,17 +15,18 @@
 
 package software.amazon.smithy.model.selector;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceException;
-import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
  * Matches a set of shapes using a selector expression.
@@ -33,7 +34,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 public interface Selector {
 
     /** A selector that always returns all provided values. */
-    Selector IDENTITY = new WrappedSelector("*", ListUtils.of(InternalSelector.IDENTITY));
+    Selector IDENTITY = new IdentitySelector();
 
     /**
      * Parses a selector expression.
@@ -42,7 +43,11 @@ public interface Selector {
      * @return Returns the parsed {@link Selector}.
      */
     static Selector parse(String expression) {
-        return SelectorParser.parse(expression);
+        if (expression.equals("*")) {
+            return IDENTITY;
+        } else {
+            return SelectorParser.parse(expression);
+        }
     }
 
     /**
@@ -67,7 +72,65 @@ public interface Selector {
      * @return Returns the matching shapes.
      */
     default Set<Shape> select(Model model) {
-        return runner().model(model).selectShapes();
+        return shapes(model).collect(Collectors.toSet());
+    }
+
+    /**
+     * Matches a selector to a set of shapes and receives each matched shape
+     * with the variables that were set when the shape was matched.
+     *
+     * @param model Model to select shapes from.
+     * @param shapeMatchConsumer Receives each matched shape and the vars available when the shape was matched.
+     */
+    default void consumeMatches(Model model, Consumer<ShapeMatch> shapeMatchConsumer) {
+        matches(model).forEach(shapeMatchConsumer);
+    }
+
+    /**
+     * Returns a stream of shapes in a model that match the selector.
+     *
+     * @param model Model to match the selector against.
+     * @return Returns a stream of matching shapes.
+     */
+    Stream<Shape> shapes(Model model);
+
+    /**
+     * Returns a stream of {@link ShapeMatch} objects for each match found in
+     * a model.
+     *
+     * @param model Model to match the selector against.
+     * @return Returns a stream of {@code ShapeMatch} objects.
+     */
+    Stream<ShapeMatch> matches(Model model);
+
+    /**
+     * Represents a selector match found in the model.
+     *
+     * <p>The {@code getShape} method is used to get the shape that matched,
+     * and all of the contextual variables that were set when the match
+     * occurred can be accessed using typical {@link Map} methods like
+     * {@code get}, {@code contains}, etc.
+     */
+    final class ShapeMatch extends HashMap<String, Set<Shape>> {
+        private final Shape shape;
+
+        /**
+         * @param shape Shape that matched.
+         * @param variables Variables that matched. This map is copied into ShapeMatch.
+         */
+        public ShapeMatch(Shape shape, Map<String, Set<Shape>> variables) {
+            super(variables);
+            this.shape = shape;
+        }
+
+        /**
+         * Gets the matching shape.
+         *
+         * @return Returns the matching shape.
+         */
+        public Shape getShape() {
+            return shape;
+        }
     }
 
     /**
@@ -76,79 +139,43 @@ public interface Selector {
      *
      * @return Returns the created runner.
      */
-    Runner runner();
+    @Deprecated
+    default Runner runner() {
+        return new Runner(this);
+    }
 
     /**
      * Builds the execution environment for a selector and executes selectors.
+     *
+     * @deprecated This class is no longer necessary. It was originally intended
+     *  to allow more customization to how selectors are executed against a model,
+     *  but this has proven unnecessary.
      */
+    @Deprecated
     final class Runner {
 
-        private final InternalSelector delegate;
-        private final Class<? extends Shape> startingShapeType;
+        private final Selector selector;
         private Model model;
 
-        Runner(InternalSelector delegate, Class<? extends Shape> startingShapeType) {
-            this.delegate = delegate;
-            this.startingShapeType = startingShapeType;
+        Runner(Selector selector) {
+            this.selector = selector;
         }
 
-        /**
-         * Sets the <em>required</em> model to use to select shapes with.
-         *
-         * @param model Model used in the selector evaluation.
-         * @return Returns the Runner.
-         */
+        @Deprecated
         public Runner model(Model model) {
             this.model = model;
             return this;
         }
 
-        /**
-         * Runs the selector and returns the set of matching shapes.
-         *
-         * @return Returns the set of matching shapes.
-         * @throws IllegalStateException if a {@code model} has not been set.
-         */
+        @Deprecated
         public Set<Shape> selectShapes() {
-            Set<Shape> result = new HashSet<>();
-            pushShapes((ctx, s) -> {
-                result.add(s);
-                return true;
-            });
-            return result;
+            return selector.select(Objects.requireNonNull(model, "model not set"));
         }
 
-        private Context createContext() {
-            SmithyBuilder.requiredState("model", model);
-            return new Context(NeighborProviderIndex.of(model));
-        }
-
-        /**
-         * Matches a selector to a set of shapes and receives each matched shape
-         * with the variables that were set when the shape was matched.
-         *
-         * @param matchConsumer Receives each matched shape and the vars available when the shape was matched.
-         * @throws IllegalStateException if a {@code model} has not been set.
-         */
+        @Deprecated
         public void selectMatches(BiConsumer<Shape, Map<String, Set<Shape>>> matchConsumer) {
-            pushShapes((ctx, s) -> {
-                matchConsumer.accept(s, ctx.copyVars());
-                return true;
-            });
-        }
-
-        private void pushShapes(InternalSelector.Receiver acceptor) {
-            Context context = createContext();
-
-            if (startingShapeType != null) {
-                model.shapes(startingShapeType).forEach(shape -> {
-                    delegate.push(context.clearVars(), shape, acceptor);
-                });
-            } else {
-                for (Shape shape : model.toSet()) {
-                    delegate.push(context.clearVars(), shape, acceptor);
-                }
-            }
+            selector.consumeMatches(Objects.requireNonNull(model, "model not set"),
+                                    m -> matchConsumer.accept(m.getShape(), m));
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
 
 package software.amazon.smithy.model.selector;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
  * Provides a toString method that prints the expression.
- *
- * <p>This is the only concrete implementation of Selector that is
- * exported from the package.
  */
 final class WrappedSelector implements Selector {
     private final String expression;
@@ -48,22 +52,90 @@ final class WrappedSelector implements Selector {
     }
 
     @Override
-    public Runner runner() {
-        return new Runner(delegate, startingShapeType);
-    }
-
-    @Override
     public String toString() {
         return expression;
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof WrappedSelector && expression.equals(((WrappedSelector) other).expression);
+        return other instanceof Selector && toString().equals(other.toString());
     }
 
     @Override
     public int hashCode() {
         return expression.hashCode();
+    }
+
+    @Override
+    public Set<Shape> select(Model model) {
+        Set<Shape> result = new HashSet<>();
+        // This is more optimized than using shapes() and collecting to a Set
+        // because it avoids creating streams and buffering the result of
+        // pushing each shape into internal selectors.
+        pushShapes(model, (ctx, s) -> {
+            result.add(s);
+            return true;
+        });
+        return result;
+    }
+
+    @Override
+    public void consumeMatches(Model model, Consumer<ShapeMatch> shapeMatchConsumer) {
+        // This is more optimized than using matches() and collecting to a Set
+        // because it avoids creating streams and buffering the result of
+        // pushing each shape into internal selectors.
+        pushShapes(model, (ctx, s) -> {
+            shapeMatchConsumer.accept(new ShapeMatch(s, ctx.getVars()));
+            return true;
+        });
+    }
+
+    @Override
+    public Stream<Shape> shapes(Model model) {
+        Context context = createContext(model);
+        return streamStartingShape(model).flatMap(shape -> {
+            List<Shape> result = new ArrayList<>();
+            delegate.push(context.clearVars(), shape, (ctx, s) -> {
+                result.add(s);
+                return true;
+            });
+            return result.stream();
+        });
+    }
+
+    @Override
+    public Stream<ShapeMatch> matches(Model model) {
+        Context context = createContext(model);
+        return streamStartingShape(model).flatMap(shape -> {
+            List<ShapeMatch> result = new ArrayList<>();
+            delegate.push(context.clearVars(), shape, (ctx, s) -> {
+                result.add(new ShapeMatch(s, ctx.getVars()));
+                return true;
+            });
+            return result.stream();
+        });
+    }
+
+    private Context createContext(Model model) {
+        return new Context(NeighborProviderIndex.of(model));
+    }
+
+    private void pushShapes(Model model, InternalSelector.Receiver acceptor) {
+        Context context = createContext(model);
+
+        if (startingShapeType != null) {
+            model.shapes(startingShapeType).forEach(shape -> {
+                delegate.push(context.clearVars(), shape, acceptor);
+            });
+        } else {
+            for (Shape shape : model.toSet()) {
+                delegate.push(context.clearVars(), shape, acceptor);
+            }
+        }
+    }
+
+    private Stream<? extends Shape> streamStartingShape(Model model) {
+        // Optimization for selectors that start with a type.
+        return startingShapeType != null ? model.shapes(startingShapeType) : model.shapes();
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/IdentitySelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/IdentitySelectorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.selector;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.StringShape;
+
+public class IdentitySelectorTest {
+    @Test
+    public void createdFromSelectorParse() {
+        Selector s = Selector.parse("*");
+
+        assertThat(s, instanceOf(IdentitySelector.class));
+    }
+
+    @Test
+    public void returnsAllShapes() {
+        Selector s = Selector.parse("*");
+        Model model = Model.builder()
+                .addShape(StringShape.builder().id("com.foo#A").build())
+                .addShape(StringShape.builder().id("com.foo#B").build())
+                .build();
+
+        assertThat(s.select(model), equalTo(model.toSet()));
+    }
+
+    @Test
+    public void returnsAllShapesInStream() {
+        Selector s = Selector.parse("*");
+        Model model = Model.builder()
+                .addShape(StringShape.builder().id("com.foo#A").build())
+                .addShape(StringShape.builder().id("com.foo#B").build())
+                .build();
+
+        assertThat(s.shapes(model).collect(Collectors.toSet()), equalTo(model.toSet()));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/TopDownSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/TopDownSelectorTest.java
@@ -79,9 +79,9 @@ public class TopDownSelectorTest {
     public void topDownWithNoDisqualifiersWithServiceVariableFollowedByFilter() {
         Map<ShapeId, ShapeId> matches = new HashMap<>();
         Selector.parse("service $service(*) :topdown([trait|smithy.example#a]) resource")
-                .runner()
-                .model(model2)
-                .selectMatches((s, vars) -> matches.put(s.getId(), vars.get("service").iterator().next().getId()));
+                .consumeMatches(model2, match -> {
+                    matches.put(match.getShape().getId(), match.get("service").iterator().next().getId());
+                });
 
         assertThat(matches, hasKey(ShapeId.from("smithy.example#R1")));
         assertThat(matches.get(ShapeId.from("smithy.example#R1")), equalTo(ShapeId.from("smithy.example#Service1")));


### PR DESCRIPTION
This commit improves the usability of Selectors by adding new methods to
the Selector interface and by deprecating its runner functionality. The
new methods include methods to stream matching shapes, stream matches,
and consume matches. Streaming matches and shapes requires a minimal
amount of buffering, and they provide the ability to more easily perform
checks like determine if any shapes in a model match a selector. If all
matching shapes are necessary, calling select is preferred. If consuming
matches can be done in a way that is push-based (e.g., writing to CLI
output), then using consumeMatches is preferred to matches.

The previous runner() method of Selector is now deprecated and just
delegates calls back to the Selector. runner() was initially intended to
allow for the customization of the environment in which a selector is
executed, but this design turned out to be unnecessary, and as such, the
need to create a runner and use a kind of builder interface to use
Selectors made them awkward to work with for no benefit.

A final change is made to implement an IdentitySelector to optimize
matching all shapes in a model.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
