### PR TITLE
Add support for CodeWriter interpolation alignment

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -365,6 +365,21 @@ import java.util.regex.Pattern;
  * System.out.println(writer.toString());
  * // Outputs: "[1, 2, 3]\n"
  * }</pre>
+ *
+ * <h3>Inline block alignment</h3>
+ *
+ * <p>The long-form interpolation syntax allows for
+ * <em>inline block alignment</em>, which means that any newline emitted by
+ * the interpolation is automatically aligned with the column of where the
+ * interpolation occurs. Inline block indentation is defined by preceding
+ * the closing '}' character with '|' (e.g., <code>${L|}</code>):
+ *
+ * <pre>{@code
+ * CodeWriter writer = new CodeWriter();
+ * writer.write("$L: ${L|}", "Names", "Bob\nKaren\nLuis");
+ * System.out.println(writer.toString());
+ * // Outputs: "Names: Bob\n       Karen\n       Luis\n"
+ * }</pre>
  */
 public class CodeWriter {
     private static final Pattern LINES = Pattern.compile("\\r?\\n");

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
@@ -381,4 +381,73 @@ public class CodeFormatterTest {
             writer.write("${L@foo!}", "default");
         });
     }
+
+    @Test
+    public void inlineAlignmentMustOccurInBraces() {
+        CodeWriter writer = createWriter();
+        writer.write("  $L|", "a\nb");
+
+        assertThat(writer.toString(), equalTo("  a\nb|\n"));
+    }
+
+    @Test
+    public void detectsBlockAlignmentEof() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            CodeWriter writer = createWriter();
+            writer.write("${L|", "default");
+        });
+    }
+
+    @Test
+    public void expandsAlignedRelativeFormatters() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$L: ${L|}", "Names", "Bob\nKaren\nLuis");
+
+        assertThat(writer.toString(), equalTo("Names: Bob\n       Karen\n       Luis\n"));
+    }
+
+    @Test
+    public void expandsAlignedPositionalFormatters() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$1L: ${2L|}", "Names", "Bob\nKaren\nLuis");
+
+        assertThat(writer.toString(), equalTo("Names: Bob\n       Karen\n       Luis\n"));
+    }
+
+    @Test
+    public void expandsAlignedRelativeFormattersWithWindowsNewlines() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$L: ${L|}", "Names", "Bob\r\nKaren\r\nLuis");
+
+        assertThat(writer.toString(), equalTo("Names: Bob\r\n       Karen\r\n       Luis\n"));
+    }
+
+    @Test
+    public void expandsAlignedRelativeFormattersWithCarriageReturns() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$L: ${L|}", "Names", "Bob\rKaren\rLuis");
+
+        assertThat(writer.toString(), equalTo("Names: Bob\r       Karen\r       Luis\n"));
+    }
+
+    @Test
+    public void expandsAlignedBlocksWithNewlines() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$1L() {\n" +
+                     "    ${2L|}\n" +
+                     "}", "method", "// this\n// is a test.");
+
+        assertThat(writer.toString(), equalTo("method() {\n    // this\n    // is a test.\n}\n"));
+    }
+
+    @Test
+    public void alignedBlocksComposeWithPrefixes() {
+        CodeWriter writer = new CodeWriter();
+        writer.setNewlinePrefix("| ");
+        writer.write("$1L() {\n" +
+                     "    ${2L|}\n" +
+                     "}", "method", "// this\n// is a test.");
+
+        assertThat(writer.toString(), equalTo("| method() {\n|     // this\n|     // is a test.\n| }\n"));
+    }
 }


### PR DESCRIPTION
This commit adds support for aligning interpolated values with the
column in which the interpolation occurs. This ensures that any newlines
contained in the expanded text are automatically aligned with where the
interpolation occured, allowing for easy and more specific alignment of
generated code for things like method parameters.

Any brace interpolation syntax that ends with '|}' will now use
alignment.

For example:

```
CodeWriter writer = new CodeWriter();
writer.write("$1L() {\n" +
             "    ${2L|}\n" +
             "}", "method", "// this\n// is a test.");
```

Outputs:

```
method() {
    // this
    // is a test.
}
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
