### PR TITLE
Update null value serde tests for servers

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
@@ -22,6 +22,22 @@ use smithy.test#httpResponseTests
         },
         method: "POST",
         uri: "/",
+        appliesTo: "client",
+    },
+    {
+        id: "AwsJson11ServersDontDeserializeNullStructureValues",
+        documentation: "Null structure values are dropped",
+        protocol: awsJson1_1,
+        body: """
+            {
+                "string": null
+            }""",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        params: {},
+        method: "POST",
+        uri: "/",
+        appliesTo: "server",
     },
     {
         id: "AwsJson11MapsSerializeNullValues",
@@ -77,6 +93,20 @@ use smithy.test#httpResponseTests
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/x-amz-json-1.1"},
         params: {},
+        appliesTo: "client",
+    },
+    {
+        id: "AwsJson11ServersDontSerializeNullStructureValues",
+        documentation: "Null structure values are dropped",
+        protocol: awsJson1_1,
+        code: 200,
+        body: "{}",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        params: {
+            string: null
+        },
+        appliesTo: "server",
     },
     {
         id: "AwsJson11MapsDeserializeNullValues",

--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -28,6 +28,7 @@ apply HttpPayloadTraits @httpRequestTests([
         method: "POST",
         uri: "/HttpPayloadTraits",
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "Content-Type": "application/octet-stream",
             "X-Foo": "Foo"
@@ -47,6 +48,7 @@ apply HttpPayloadTraits @httpRequestTests([
         method: "POST",
         uri: "/HttpPayloadTraits",
         body: "",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -63,6 +65,7 @@ apply HttpPayloadTraits @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -77,6 +80,7 @@ apply HttpPayloadTraits @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -110,6 +114,7 @@ apply HttpPayloadTraitsWithMediaType @httpRequestTests([
         method: "POST",
         uri: "/HttpPayloadTraitsWithMediaType",
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "text/plain"
@@ -131,6 +136,7 @@ apply HttpPayloadTraitsWithMediaType @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "text/plain"

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -288,8 +288,20 @@ operation OmitsNullSerializesEmptyString {
 
 apply OmitsNullSerializesEmptyString @httpRequestTests([
     {
-        id: "RestJsonOmitsNullSerializesEmptyString",
-        documentation: "Serializes empty query strings but omits null",
+        id: "RestJsonOmitsNullQuery",
+        documentation: "Omits null query values",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/OmitsNullSerializesEmptyString",
+        body: "",
+        params: {
+            nullValue: null
+        },
+        "appliesTo": "client",
+    },
+    {
+        id: "RestJsonSerializesEmptyQueryValue",
+        documentation: "Serializes empty query strings",
         protocol: restJson1,
         method: "GET",
         uri: "/OmitsNullSerializesEmptyString",
@@ -298,10 +310,9 @@ apply OmitsNullSerializesEmptyString @httpRequestTests([
             "Empty=",
         ],
         params: {
-            nullValue: null,
             emptyString: "",
-        }
-    }
+        },
+    },
 ])
 
 structure OmitsNullSerializesEmptyStringInput {

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -72,6 +72,23 @@ apply SimpleScalarProperties @httpRequestTests([
         params: {
             stringValue: null
         },
+        appliesTo: "client",
+    },
+    {
+        id: "RestJsonServersDontSerializeNullStructureValues",
+        documentation: "Rest Json should not deserialize null structure values",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+            {
+                "string": null
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {},
+        appliesTo: "server",
     },
 ])
 
@@ -124,6 +141,21 @@ apply SimpleScalarProperties @httpResponseTests([
             "Content-Type": "application/json",
         },
         params: {},
+        appliesTo: "client",
+    },
+    {
+        id: "RestJsonServersDontSerializeNullStructureValues",
+        documentation: "Rest Json should not serialize null structure values",
+        protocol: restJson1,
+        code: 200,
+        body: "{}",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            stringValue: null
+        },
+        appliesTo: "server",
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -66,6 +66,7 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: "{}",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -137,6 +138,7 @@ apply SimpleScalarProperties @httpResponseTests([
               {
                   "stringValue": null
               }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -149,6 +151,7 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "{}",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },

--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -27,6 +27,7 @@ apply StreamingTraits @httpRequestTests([
         method: "POST",
         uri: "/StreamingTraits",
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "application/octet-stream"
@@ -43,6 +44,7 @@ apply StreamingTraits @httpRequestTests([
         method: "POST",
         uri: "/StreamingTraits",
         body: "",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -59,6 +61,7 @@ apply StreamingTraits @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "application/octet-stream"
@@ -74,6 +77,7 @@ apply StreamingTraits @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -113,6 +117,7 @@ apply StreamingTraitsRequireLength @httpRequestTests([
         method: "POST",
         uri: "/StreamingTraitsRequireLength",
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "application/octet-stream"
@@ -132,6 +137,7 @@ apply StreamingTraitsRequireLength @httpRequestTests([
         method: "POST",
         uri: "/StreamingTraitsRequireLength",
         body: "",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -148,6 +154,7 @@ apply StreamingTraitsRequireLength @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "application/octet-stream"
@@ -166,6 +173,7 @@ apply StreamingTraitsRequireLength @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo"
         },
@@ -205,6 +213,7 @@ apply StreamingTraitsWithMediaType @httpRequestTests([
         method: "POST",
         uri: "/StreamingTraitsWithMediaType",
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "text/plain"
@@ -223,6 +232,7 @@ apply StreamingTraitsWithMediaType @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "blobby blob blob",
+        bodyMediaType: "application/octet-stream",
         headers: {
             "X-Foo": "Foo",
             "Content-Type": "text/plain"

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -274,8 +274,20 @@ operation OmitsNullSerializesEmptyString {
 
 apply OmitsNullSerializesEmptyString @httpRequestTests([
     {
-        id: "OmitsNullSerializesEmptyString",
-        documentation: "Serializes empty query strings but omits null",
+        id: "RestXmlOmitsNullQuery",
+        documentation: "Omits null query values",
+        protocol: restXml,
+        method: "GET",
+        uri: "/OmitsNullSerializesEmptyString",
+        body: "",
+        params: {
+            nullValue: null,
+        },
+        appliesTo: "client",
+    },
+    {
+        id: "RestXmlSerializesEmptyString",
+        documentation: "Serializes empty query strings",
         protocol: restXml,
         method: "GET",
         uri: "/OmitsNullSerializesEmptyString",
@@ -284,9 +296,8 @@ apply OmitsNullSerializesEmptyString @httpRequestTests([
             "Empty=",
         ],
         params: {
-            nullValue: null,
             emptyString: "",
-        }
+        },
     }
 ])
 


### PR DESCRIPTION
This updates the tests that handle null values in json / http
protocols to differentiate between client and server behavior.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
