### PR TITLE
Updated plugin version in quickstart docs

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -830,7 +830,7 @@ The ``build.gradle.kts`` should have the following contents:
 .. code-block:: kotlin
 
     plugins {
-        id("software.amazon.smithy").version("0.5.1")
+        id("software.amazon.smithy").version("0.5.2")
     }
 
     repositories {


### PR DESCRIPTION
*Issue #, if available:*
The code within the quickstart does not work on windows due to an issue that has been solved in a later version of the plugin https://github.com/awslabs/smithy-gradle-plugin/issues/27. 

*Description of changes:*
Updated the version listed in the quickstart. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
