### PR TITLE
Update CFN quickstart plugin version

### DIFF
--- a/docs/source/1.0/guides/generating-cloudformation-resources.rst
+++ b/docs/source/1.0/guides/generating-cloudformation-resources.rst
@@ -60,7 +60,7 @@ Resource Schemas from a Smithy model :ref:`using a buildscript dependency
 
     plugins {
         java
-        id("software.amazon.smithy").version("0.5.1")
+        id("software.amazon.smithy").version("0.5.2")
     }
 
     buildscript {


### PR DESCRIPTION
Updates the Smithy Gradle Plugin version number used in the CloudFormation Resource Schema guide.  Thanks to @kshammer for the associated fix in #738.

Changes Smithy Gradle Plugin version to `0.5.2`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
