### PR TITLE
Add recommended trait

### DIFF
--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -570,6 +570,10 @@ in a response.
             }
         }
 
+.. seealso::
+
+   :ref:`recommended-trait`
+
 
 .. _uniqueItems:
 

--- a/docs/source/1.0/spec/core/documentation-traits.rst
+++ b/docs/source/1.0/spec/core/documentation-traits.rst
@@ -296,6 +296,48 @@ filtered version of the model.
         }
 
 
+.. _recommended-trait:
+
+---------------------
+``recommended`` trait
+---------------------
+
+Summary
+    Indicates that a structure member SHOULD be set. This trait is useful when
+    the majority of use cases for a structure benefit from providing a value
+    for a member, but the member is not actually :ref:`required <required-trait>`
+    or cannot be made required backward compatibly.
+Trait selector
+    ``structure > member``
+Value type
+    Structure with the following members:
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 10 10 80
+
+        * - Property
+          - Type
+          - Description
+        * - reason
+          - ``string``
+          - Provides a reason why the member is recommended.
+Conflicts with
+   :ref:`required-trait`
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        structure PutContentsInput {
+            @required
+            contents: String,
+
+            @recommended(reason: "Validation will reject contents if they are invalid.")
+            validateContents: Boolean,
+        }
+
+
 .. _sensitive-trait:
 
 -------------------

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class RecommendedTrait extends AbstractTrait implements ToSmithyBuilder<RecommendedTrait> {
+    public static final ShapeId ID = ShapeId.from("smithy.api#recommended");
+
+    private final String reason;
+
+    private RecommendedTrait(Builder builder) {
+        super(ID, builder.sourceLocation);
+        this.reason = builder.reason;
+    }
+
+    /**
+     * Gets the reason it is recommended to set this member.
+     *
+     * @return returns the optional reason.
+     */
+    public Optional<String> getReason() {
+        return Optional.ofNullable(reason);
+    }
+
+    @Override
+    protected Node createNode() {
+        return new ObjectNode(MapUtils.of(), getSourceLocation())
+                .withOptionalMember("reason", getReason().map(Node::from));
+    }
+
+    @Override
+    public RecommendedTrait.Builder toBuilder() {
+        return builder().reason(reason).sourceLocation(getSourceLocation());
+    }
+
+    /**
+     * @return Returns a new RecommendedTrait builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a RecommendedTrait.
+     */
+    public static final class Builder extends AbstractTraitBuilder<RecommendedTrait, Builder> {
+        private String reason;
+
+        public Builder reason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        @Override
+        public RecommendedTrait build() {
+            return new RecommendedTrait(this);
+        }
+    }
+
+    public static final class Provider implements TraitService {
+        @Override
+        public ShapeId getShapeId() {
+            return ID;
+        }
+
+        @Override
+        public RecommendedTrait createTrait(ShapeId target, Node value) {
+            ObjectNode objectNode = value.expectObjectNode();
+            String reason = objectNode.getStringMember("reason")
+                    .map(StringNode::getValue)
+                    .orElse(null);
+            return builder().sourceLocation(value).reason(reason).build();
+        }
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -41,6 +41,7 @@ software.amazon.smithy.model.traits.PrivateTrait$Provider
 software.amazon.smithy.model.traits.ProtocolDefinitionTrait$Provider
 software.amazon.smithy.model.traits.RangeTrait$Provider
 software.amazon.smithy.model.traits.ReadonlyTrait$Provider
+software.amazon.smithy.model.traits.RecommendedTrait$Provider
 software.amazon.smithy.model.traits.ReferencesTrait$Provider
 software.amazon.smithy.model.traits.RequiredTrait$Provider
 software.amazon.smithy.model.traits.RequiresLengthTrait$Provider

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -478,6 +478,13 @@ string pattern
 @tags(["diff.error.add"])
 structure required {}
 
+/// Indicates that a structure member SHOULD be set.
+@trait(selector: "structure > member", conflicts: [required])
+structure recommended {
+    /// Provides a reason why the member is recommended.
+    reason: String,
+}
+
 /// Marks a list or map as sparse.
 @trait(selector: ":is(list, map)")
 @tags(["diff.error.const"])

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/recommended/recommended-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/recommended/recommended-trait.smithy
@@ -1,0 +1,8 @@
+// There are no errors in this file. It is to ensure that the member
+// is found in the prelude.
+namespace smithy.example
+
+structure Foo {
+    @recommended
+    baz: String,
+}


### PR DESCRIPTION
This commit adds support for a `recommended` structure member trait.

> Indicates that a structure member SHOULD be set. This trait is useful when the majority of use cases for a structure benefit from providing a value for a member, but the member is not actually required or cannot be made required backward compatibly.