### PR TITLE
Failing Request Test Draft

### DIFF
--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/FailingHttpRequestTest.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/FailingHttpRequestTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Defines a test case for an HTTP request.
+ */
+public abstract class FailingHttpRequestTest implements ToNode  {
+    protected HttpRequestTestCase inner;
+    protected FailureCause failureCause;
+
+    public static FailingHttpRequestTest fromNode(Node node) {
+        HttpRequestTestCase inner = HttpRequestTestCase.fromNode(node);
+        FailureCause failureCause = FailureCause.fromNode(node.expectObjectNode().expectMember("failureCause"));
+        AppliesTo appliesTo = inner.getAppliesTo().orElseThrow(() -> new RuntimeException("For failing test cases, applies to must be defined"));
+        if (appliesTo == AppliesTo.CLIENT) {
+            return new Client(inner, failureCause);
+        } else {
+            return new Server(inner, failureCause);
+        }
+    }
+
+    @Override
+    public Node toNode() {
+        return inner.toNode();
+    }
+
+    public FailureCause getFailureCause() {
+        return failureCause;
+    }
+
+    static class Client extends FailingHttpRequestTest {
+        private Client(HttpRequestTestCase inner, FailureCause failureCause) {
+            this.inner = inner;
+            this.failureCause = failureCause;
+        }
+
+        public ObjectNode getParams() {
+            return this.inner.getParams();
+        }
+    }
+
+    static class Server extends FailingHttpRequestTest {
+        Server(HttpRequestTestCase inner, FailureCause failureCause) {
+            this.inner = inner;
+            this.failureCause = failureCause;
+            if (!inner.getParams().isEmpty()) {
+                throw new RuntimeException("Params for server test must be null");
+            }
+
+            if (getMethod() == null || getUri() == null || getHeaders() == null) {
+                throw new RuntimeException("Server tests must specify a full HTTP request");
+            }
+        }
+
+        public String getMethod() {
+            return inner.getMethod();
+        }
+
+        public String getUri() {
+            return inner.getUri();
+        }
+
+        public Optional<String> getBody() {
+            return inner.getBody();
+        }
+
+        public Map<String, String> getHeaders() {
+            return inner.getHeaders();
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/FailingHttpRequestTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/FailingHttpRequestTestsTrait.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.ListUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Defines HTTP request protocol tests.
+ */
+public final class FailingHttpRequestTestsTrait extends AbstractTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.test#failingHttpRequestTests");
+
+    private final List<FailingHttpRequestTest> tests;
+
+    public FailingHttpRequestTestsTrait(List<FailingHttpRequestTest> testCases) {
+        this(SourceLocation.NONE, testCases);
+    }
+
+    public FailingHttpRequestTestsTrait(SourceLocation sourceLocation, List<FailingHttpRequestTest> testCases) {
+        super(ID, sourceLocation);
+        this.tests = ListUtils.copyOf(testCases);
+    }
+
+    public static final class Provider extends AbstractTrait.Provider {
+        public Provider() {
+            super(ID);
+        }
+
+        @Override
+        public Trait createTrait(ShapeId target, Node value) {
+            ArrayNode values = value.expectArrayNode();
+            List<FailingHttpRequestTest> testCases = values.getElementsAs(FailingHttpRequestTest::fromNode);
+            return new FailingHttpRequestTestsTrait(value.getSourceLocation(), testCases);
+        }
+    }
+
+    public List<FailingHttpRequestTest> getTests() {
+        return tests;
+    }
+
+    public List<FailingHttpRequestTest.Client> getClientTests() {
+        return tests.stream().filter((test) -> test instanceof FailingHttpRequestTest.Client).map(test -> (FailingHttpRequestTest.Client) test).collect(Collectors.toList());
+    }
+
+    public List<FailingHttpRequestTest.Server> getServerTests() {
+        return tests.stream().filter((test) -> test instanceof FailingHttpRequestTest.Server).map(test -> (FailingHttpRequestTest.Server) test).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Node createNode() {
+        return getTests().stream().collect(ArrayNode.collect());
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/FailureCause.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/FailureCause.java
@@ -1,0 +1,32 @@
+package software.amazon.smithy.protocoltests.traits;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+
+public abstract class FailureCause {
+    private static final String GENERIC = "generic";
+    public static class Generic extends FailureCause {
+        private final String message;
+        public Generic(String message) {
+            this.message = message;
+        }
+
+        public static Generic fromNode(Node node) {
+            return new Generic(node.expectStringNode().getValue());
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public static FailureCause fromNode(Node node) {
+        ObjectNode o = node.expectObjectNode();
+        if (o.containsMember(GENERIC)) {
+            return Generic.fromNode(o.expectMember(GENERIC));
+        } else {
+            // This should be unreachable if the input was a valid Smithy model
+            throw new RuntimeException("Unreachable");
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestCase.java
@@ -49,8 +49,8 @@ public final class HttpRequestTestCase extends HttpMessageTestCase implements To
 
     private HttpRequestTestCase(Builder builder) {
         super(builder);
-        method = SmithyBuilder.requiredState(METHOD, builder.method);
-        uri = SmithyBuilder.requiredState(URI, builder.uri);
+        method = builder.method;
+        uri = builder.uri;
         host = builder.host;
         resolvedHost = builder.resolvedHost;
         queryParams = ListUtils.copyOf(builder.queryParams);
@@ -90,8 +90,14 @@ public final class HttpRequestTestCase extends HttpMessageTestCase implements To
         HttpRequestTestCase.Builder builder = builder();
         updateBuilderFromNode(builder, node);
         ObjectNode o = node.expectObjectNode();
-        builder.method(o.expectStringMember(METHOD).getValue());
-        builder.uri(o.expectStringMember(URI).getValue());
+
+        o.getStringMember(METHOD).ifPresent(method -> {
+            builder.method(method.getValue());
+        });
+
+        o.getStringMember(URI).ifPresent(uri -> {
+            builder.uri(uri.getValue());
+        });
         o.getStringMember(HOST).ifPresent(stringNode -> builder.host(stringNode.getValue()));
         o.getStringMember(RESOLVED_HOST).ifPresent(stringNode -> builder.resolvedHost(stringNode.getValue()));
         o.getArrayMember(QUERY_PARAMS).ifPresent(queryParams -> {
@@ -109,8 +115,8 @@ public final class HttpRequestTestCase extends HttpMessageTestCase implements To
     @Override
     public Node toNode() {
         ObjectNode.Builder node = super.toNode().expectObjectNode().toBuilder();
-        node.withMember(METHOD, getMethod());
-        node.withMember(URI, getUri());
+        node.withOptionalMember(METHOD, Optional.ofNullable(getMethod()).map(StringNode::from));
+        node.withOptionalMember(URI, Optional.ofNullable(getUri()).map(StringNode::from));
         node.withOptionalMember(HOST, getHost().map(StringNode::from));
         node.withOptionalMember(RESOLVED_HOST, getResolvedHost().map(StringNode::from));
         if (!queryParams.isEmpty()) {

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -1,2 +1,3 @@
 software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait$Provider
 software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait$Provider
+software.amazon.smithy.protocoltests.traits.FailingHttpRequestTestsTrait$Provider

--- a/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/TraitTest.java
+++ b/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/TraitTest.java
@@ -134,4 +134,25 @@ public class TraitTest {
                 .map(HttpMessageTestCase::getId)
                 .collect(Collectors.toList());
     }
+
+    @Test
+    public void failingRequestTestCase() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("test-failing-request.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        FailingHttpRequestTest.Client clientTest = model.expectShape(ShapeId.from("smithy.example#SayHello"))
+                .getTrait(FailingHttpRequestTestsTrait.class)
+                .get()
+                .getClientTests().get(0);
+
+        assertThat(clientTest.getParams().expectStringMember("greeting").getValue(), equalTo("Hi \uD83D\uDE39"));
+        assertThat(((FailureCause.Generic) clientTest.getFailureCause()).getMessage(), equalTo("Greeting must only contain valid ascii"));
+
+        FailingHttpRequestTest.Server serverTest = model.expectShape(ShapeId.from("smithy.example#SayHello"))
+                .getTrait(FailingHttpRequestTestsTrait.class)
+                .get()
+                .getServerTests().get(0);
+    }
 }

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/test-failing-request.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/test-failing-request.smithy
@@ -1,0 +1,39 @@
+namespace smithy.example
+
+use smithy.test#failingHttpRequestTests
+
+@trait
+@protocolDefinition
+structure exampleProtocol {}
+
+@http(method: "POST", uri: "/")
+@failingHttpRequestTests([
+    {
+        id: "say_hello",
+        protocol: exampleProtocol,
+        params: {
+            "greeting": "Hi 😹",
+            "name": "Teddy"
+        },
+        failureCause: { generic: "Greeting must only contain valid ascii" },
+        appliesTo: "client"
+    },
+    {
+        id: "say_hello",
+        protocol: exampleProtocol,
+        uri: "/?k=v",
+        method: "POST",
+        failureCause: { generic: "Invalid request body" },
+        appliesTo: "server"
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    @httpHeader("X-Greeting")
+    greeting: String,
+
+    name: String
+}


### PR DESCRIPTION
This is a draft of how failing request test support may be added in a way that will support failing requests for both server and client implementations.

This has a few issues & required cleanups, just want to see if we're directionally on the same page.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
