### PR TITLE
Add protocol tests for String & Enum HTTP payloads

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
@@ -1,10 +1,13 @@
+$version: "1.0"
 namespace aws.protocoltests.restjson
+
 use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
 
 @http(uri: "/EnumPayload", method: "POST")
 @httpRequestTests([
     {
-        id: "EnumPayload",
+        id: "EnumPayloadRequest",
         uri: "/EnumPayload",
         body: "enumvalue",
         params: { payload: "enumvalue" },
@@ -12,8 +15,18 @@ use smithy.test#httpRequestTests
         protocol: "aws.protocols#restJson1"
     }
 ])
+@httpResponseTests([
+    {
+        id: "EnumPayloadResponse",
+        body: "enumvalue",
+        params: { payload: "enumvalue" },
+        protocol: "aws.protocols#restJson1",
+        code: 200
+    }
+])
 operation HttpEnumPayload {
-    input: EnumPayloadInput
+    input: EnumPayloadInput,
+    output: EnumPayloadInput
 }
 
 structure EnumPayloadInput {
@@ -27,7 +40,7 @@ string StringEnum
 @http(uri: "/StringPayload", method: "POST")
 @httpRequestTests([
     {
-        id: "StringPayload",
+        id: "StringPayloadRequest",
         uri: "/StringPayload",
         body: "rawstring",
         params: { payload: "rawstring" },
@@ -35,11 +48,22 @@ string StringEnum
         protocol: "aws.protocols#restJson1"
     }
 ])
+@httpResponseTests([
+    {
+        id: "StringPayloadResponse",
+        body: "rawstring",
+        params: { payload: "rawstring" },
+        protocol: "aws.protocols#restJson1",
+        code: 200
+    }
+])
 operation HttpStringPayload {
-    input: StringPayloadInput
+    input: StringPayloadInput,
+    output: StringPayloadInput
 }
 
 structure StringPayloadInput {
     @httpPayload
     payload: String
 }
+

--- a/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
@@ -1,0 +1,45 @@
+namespace aws.protocoltests.restjson
+use smithy.test#httpRequestTests
+
+@http(uri: "/EnumPayload", method: "POST")
+@httpRequestTests([
+    {
+        id: "EnumPayload",
+        uri: "/EnumPayload",
+        body: "enumvalue",
+        params: { payload: "enumvalue" },
+        method: "POST",
+        protocol: "aws.protocols#restJson1"
+    }
+])
+operation HttpEnumPayload {
+    input: EnumPayloadInput
+}
+
+structure EnumPayloadInput {
+    @httpPayload
+    payload: StringEnum
+}
+
+@enum([{"value": "enumvalue", "name": "V"}])
+string StringEnum
+
+@http(uri: "/StringPayload", method: "POST")
+@httpRequestTests([
+    {
+        id: "StringPayload",
+        uri: "/StringPayload",
+        body: "rawstring",
+        params: { payload: "rawstring" },
+        method: "POST",
+        protocol: "aws.protocols#restJson1"
+    }
+])
+operation HttpStringPayload {
+    input: StringPayloadInput
+}
+
+structure StringPayloadInput {
+    @httpPayload
+    payload: String
+}

--- a/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
@@ -1,4 +1,5 @@
 $version: "1.0"
+
 namespace aws.protocoltests.restjson
 
 use smithy.test#httpRequestTests

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -52,6 +52,8 @@ service RestJson {
         HttpPayloadTraits,
         HttpPayloadTraitsWithMediaType,
         HttpPayloadWithStructure,
+        HttpEnumPayload,
+        HttpStringPayload,
 
         // @httpResponseCode tests
         HttpResponseCode,


### PR DESCRIPTION
*Description of changes:* There are no protocol tests for Strings or enum-marked-strings for restJson.

*Tests*: The Rust SDK passes these tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
