### PR TITLE
Upgrade Pygments

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=1.7.0,<1.8.0
-pygments==2.4.2
+pygments==2.7.4
 sphinx-tabs==1.1.7
 
 # This package has not been published to pypi

--- a/docs/setup.py
+++ b/docs/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-requires = ["sphinx>=1.7.0,<1.8.0", "pygments==2.4.2", "sphinx-tabs==1.1.7"]
+requires = ["sphinx>=1.7.0,<1.8.0", "pygments==2.7.4", "sphinx-tabs==1.1.7"]
 
 # Register the custom Smithy loader with Pygments.
 # See: http://pygments.org/docs/plugins/


### PR DESCRIPTION
Upgrade Pygments to 2.7.4

Resolves CVE-2021-27291

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
