### PR TITLE
Update gradle plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then, apply the Smithy Gradle Plugin in your `build.gradle.kts` file and run
 
 ```kotlin
 plugins {
-   id("software.amazon.smithy").version("0.5.0")
+   id("software.amazon.smithy").version("0.5.2")
 }
 ```
 

--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -21,7 +21,7 @@ The following example configures a project to use the Smithy Gradle plugin:
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.0")
+            id("software.amazon.smithy").version("0.5.2")
         }
 
 
@@ -138,7 +138,7 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.0")
+            id("software.amazon.smithy").version("0.5.2")
         }
 
         // The SmithyExtension is used to customize the build. This example
@@ -184,7 +184,7 @@ build that uses the "external" projection.
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.0")
+            id("software.amazon.smithy").version("0.5.2")
         }
 
         buildscript {

--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -115,7 +115,7 @@ specification from a Smithy model using a buildscript dependency:
 
     plugins {
         java
-        id("software.amazon.smithy").version("0.5.0")
+        id("software.amazon.smithy").version("0.5.2")
     }
 
     buildscript {


### PR DESCRIPTION
Updates the README and docs to specify version `0.5.2` of the Smithy Gradle Plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
