### PR TITLE
Fix query string-string map protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -29,6 +29,7 @@ operation AllQueryStringTypes {
 }
 
 apply AllQueryStringTypes @httpRequestTests([
+
     {
         id: "RestJsonAllQueryStringTypes",
         documentation: "Serializes query string parameters with all supported types",
@@ -71,8 +72,6 @@ apply AllQueryStringTypes @httpRequestTests([
             "EnumList=Foo",
             "EnumList=Baz",
             "EnumList=Bar",
-            "QueryParamsStringKeyA=Foo",
-            "QueryParamsStringKeyB=Bar",
         ],
         params: {
             queryString: "Hello there",
@@ -93,9 +92,23 @@ apply AllQueryStringTypes @httpRequestTests([
             queryTimestampList: [1, 2, 3],
             queryEnum: "Foo",
             queryEnumList: ["Foo", "Baz", "Bar"],
+        }
+    },
+    {
+        id: "RestJsonQueryStringMap",
+        documentation: "Handles query string maps",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "QueryParamsStringKeyA=Foo",
+            "QueryParamsStringKeyB=Bar",
+        ],
+        params: {
             queryParamsMapOfStrings: {
                 "QueryParamsStringKeyA": "Foo",
-                "QueryParamsStringKeyB": "Bar"
+                "QueryParamsStringKeyB": "Bar",
             },
         }
     }

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -71,8 +71,6 @@ apply AllQueryStringTypes @httpRequestTests([
             "EnumList=Foo",
             "EnumList=Baz",
             "EnumList=Bar",
-            "QueryParamsStringKeyA=Foo",
-            "QueryParamsStringKeyB=Bar",
         ],
         params: {
             queryString: "Hello there",
@@ -93,9 +91,23 @@ apply AllQueryStringTypes @httpRequestTests([
             queryTimestampList: [1, 2, 3],
             queryEnum: "Foo",
             queryEnumList: ["Foo", "Baz", "Bar"],
+        }
+    },
+    {
+        id: "RestXmlQueryStringMap",
+        documentation: "Handles query string maps",
+        protocol: restXml,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "QueryParamsStringKeyA=Foo",
+            "QueryParamsStringKeyB=Bar",
+        ],
+        params: {
             queryParamsMapOfStrings: {
                 "QueryParamsStringKeyA": "Foo",
-                "QueryParamsStringKeyB": "Bar"
+                "QueryParamsStringKeyB": "Bar",
             },
         }
     }


### PR DESCRIPTION
This fixes an issue with the protocol tests for query maps where there was a string-string map that didn't include everything else that was in the test. To keep things simple I split it off into its own test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
