### PR TITLE
Update sample xml to match structure name for test.

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -276,7 +276,7 @@ apply IgnoreQueryParamsInResponse @httpResponseTests([
         headers: {
             "Content-Type": "application/xml"
         },
-        body: "<IgnoreQueryParamsInResponseInputOutput><baz>bam</baz></IgnoreQueryParamsInResponseInputOutput>",
+        body: "<IgnoreQueryParamsInResponseOutput><baz>bam</baz></IgnoreQueryParamsInResponseOutput>",
         bodyMediaType: "application/xml",
         params: {
             baz: "bam"


### PR DESCRIPTION

*Issue #, if available:* N/A

*Description of changes:*
* Update text Xml to match structure name
* It's expected that this will enable the test to pass if protocol implementation is compiliant

Response from @kstich from internal discussion:

```
It's possible, would need to validate by updating and running another SDK's tests. I think others might not be validating the name of the root node for the response when deserializing.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
