### PR TITLE
Support service renames when flattening namespaces

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -894,9 +894,13 @@ namespace. Shapes not connected to a service will not be flattened.
         separate :ref:`service closures <service-closure>`.
 
 The following example will flatten the namespaces of the shapes connected to
-the ``ns.bar#MyService`` service into the target namespace, ``ns.foo``. Shapes
-tagged with ``baz`` or ``qux`` will also be flattened into the ``ns.foo``
-namespace, so long as they don't conflict with a shape within the :ref:`service closure <service-closure>`.
+the ``ns.bar#MyService`` service into the target namespace, ``ns.foo``. All
+shapes within :ref:`service closure <service-closure>` with be flattened into
+the target namespace, including shapes that have been renamed to disambiguate
+them through the service shape's ``rename`` property. Shapes tagged with
+``baz`` or ``qux`` will also be flattened into the ``ns.foo`` namespace, so
+long as they don't conflict with a shape within the
+:ref:`service closure <service-closure>`.
 
 .. tabs::
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FlattenNamespaces.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FlattenNamespaces.java
@@ -164,7 +164,16 @@ public final class FlattenNamespaces extends ConfigurableProjectionTransformer<F
         return shapeWalker.walkShapes(service).stream()
                 .filter(FunctionalUtils.not(Prelude::isPreludeShape))
                 .map(shape -> Pair.of(shape.getId(), updateNamespace(shape.getId(), config.getNamespace())))
+                .map(pair -> applyServiceRenames(pair, service))
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+    }
+
+    private Pair<ShapeId, ShapeId> applyServiceRenames(Pair<ShapeId, ShapeId> pair, ServiceShape service) {
+        if (!service.getRename().containsKey(pair.getLeft())) {
+            return pair;
+        }
+        ShapeId newId = ShapeId.fromParts(pair.getRight().getNamespace(), service.getRename().get(pair.getLeft()));
+        return Pair.of(pair.getLeft(), newId);
     }
 
     private Set<ShapeId> getTaggedShapesToInclude(Set<String> tags, Model model) {

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/flatten-namespaces-with-renames.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/flatten-namespaces-with-renames.json
@@ -1,0 +1,40 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "ns.foo#MyService": {
+      "type": "service",
+      "version": "2017-02-11",
+      "operations": [
+        {
+          "target": "ns.foo#GetSomething"
+        }
+      ],
+      "rename": {
+        "foo.example#Widget": "FooWidget"
+      }
+    },
+    "ns.foo#GetSomething": {
+      "type": "operation",
+      "output": {
+        "target": "ns.foo#GetSomethingOutput"
+      }
+    },
+    "ns.foo#GetSomethingOutput": {
+      "type": "structure",
+      "members": {
+        "widget1": {
+          "target": "ns.bar#Widget"
+        },
+        "fooWidget": {
+          "target": "foo.example#Widget"
+        }
+      }
+    },
+    "ns.bar#Widget": {
+      "type": "structure"
+    },
+    "foo.example#Widget": {
+      "type": "structure"
+    }
+  }
+}


### PR DESCRIPTION
Adds support for service renames (#734) when using the `flattenNamespaces` transformer.

Any shapes that have been configured on the service to be renamed will also be flattened into the target namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
