### PR TITLE
Add core contributors to PRs by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add core contributors to all prs by default
+* @srchase @kstich @JordonPhillips @mtdowling


### PR DESCRIPTION
This adds a codeowners file that will automatically request reviews from the core contributors on each pr. We could make it more complicated but that doesn't seem necessary right now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
