### PR TITLE
Parse numbers as BigDecimal or BigInteger when needed.

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -724,7 +724,11 @@ final class IdlModelParser extends SimpleParser {
         String lexeme = ParserUtils.parseNumber(this);
 
         if (lexeme.contains("e") || lexeme.contains(".")) {
-            return new NumberNode(Double.valueOf(lexeme), location);
+            double value = Double.parseDouble(lexeme);
+            if (Double.isFinite(value)) {
+                return new NumberNode(value, location);
+            }
+            return new NumberNode(new BigDecimal(lexeme), location);
         } else {
             try {
                 return new NumberNode(Long.parseLong(lexeme), location);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.loader;
 
 import static java.lang.String.format;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -721,10 +722,15 @@ final class IdlModelParser extends SimpleParser {
     NumberNode parseNumberNode() {
         SourceLocation location = currentLocation();
         String lexeme = ParserUtils.parseNumber(this);
+
         if (lexeme.contains("e") || lexeme.contains(".")) {
             return new NumberNode(Double.valueOf(lexeme), location);
         } else {
-            return new NumberNode(Long.parseLong(lexeme), location);
+            try {
+                return new NumberNode(Long.parseLong(lexeme), location);
+            } catch (NumberFormatException e) {
+                return new NumberNode(new BigDecimal(lexeme), location);
+            }
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.loader;
 import static java.lang.String.format;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -723,7 +724,7 @@ final class IdlModelParser extends SimpleParser {
         SourceLocation location = currentLocation();
         String lexeme = ParserUtils.parseNumber(this);
 
-        if (lexeme.contains("e") || lexeme.contains(".")) {
+        if (lexeme.contains("e") || lexeme.contains("E")  || lexeme.contains(".")) {
             double value = Double.parseDouble(lexeme);
             if (Double.isFinite(value)) {
                 return new NumberNode(value, location);
@@ -733,7 +734,7 @@ final class IdlModelParser extends SimpleParser {
             try {
                 return new NumberNode(Long.parseLong(lexeme), location);
             } catch (NumberFormatException e) {
-                return new NumberNode(new BigDecimal(lexeme), location);
+                return new NumberNode(new BigInteger(lexeme), location);
             }
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
@@ -79,7 +79,12 @@ public final class NodeHandler extends JsonHandler<List<Node>, Map<StringNode, N
         if (string.contains(".")) {
             value = new NumberNode(new BigDecimal(string), location);
         } else {
-            value = new NumberNode(Long.parseLong(string), location);
+            try {
+                value = new NumberNode(Long.parseLong(string), location);
+            } catch (NumberFormatException e) {
+                value = new NumberNode(new BigDecimal(string), location);
+            }
+
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.node.internal;
 
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -76,13 +77,17 @@ public final class NodeHandler extends JsonHandler<List<Node>, Map<StringNode, N
 
     @Override
     void endNumber(String string, SourceLocation location) {
-        if (string.contains(".")) {
+        if (string.contains("e") || string.contains("E") || string.contains(".")) {
+            double doubleValue = Double.parseDouble(string);
+            if (Double.isFinite(doubleValue)) {
+                value = new NumberNode(doubleValue, location);
+            }
             value = new NumberNode(new BigDecimal(string), location);
         } else {
             try {
                 value = new NumberNode(Long.parseLong(string), location);
             } catch (NumberFormatException e) {
-                value = new NumberNode(new BigDecimal(string), location);
+                value = new NumberNode(new BigInteger(string), location);
             }
 
         }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
@@ -183,8 +183,32 @@
                 "com.example#bDecimal": 1.7976931348623157E+309
             }
         },
+        "com.example#Y": {
+            "type": "string",
+            "traits": {
+                "com.example#bDecimal": 2E+308
+            }
+        },
+        "com.example#Z": {
+            "type": "string",
+            "traits": {
+                "com.example#bDecimal": 2E+308
+            }
+        },
+        "com.example#ZA": {
+            "type": "string",
+            "traits": {
+                "com.example#bInteger": 9223372036854775808
+            }
+        },
         "com.example#bDecimal": {
             "type": "bigDecimal",
+            "traits": {
+                "smithy.api#trait": {}
+            }
+        },
+        "com.example#bInteger": {
+            "type": "bigInteger",
             "traits": {
                 "smithy.api#trait": {}
             }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
@@ -177,6 +177,12 @@
                 "com.example#bDecimal": 9223372036854775808
             }
         },
+        "com.example#X": {
+            "type": "string",
+            "traits": {
+                "com.example#bDecimal": 1.7976931348623157E+309
+            }
+        },
         "com.example#bDecimal": {
             "type": "bigDecimal",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.json
@@ -171,6 +171,18 @@
                 "smithy.api#documentation": ""
             }
         },
+        "com.example#W": {
+            "type": "string",
+            "traits": {
+                "com.example#bDecimal": 9223372036854775808
+            }
+        },
+        "com.example#bDecimal": {
+            "type": "bigDecimal",
+            "traits": {
+                "smithy.api#trait": {}
+            }
+        },
         "com.example#numeric": {
             "type": "integer",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
@@ -143,3 +143,15 @@ string W
 
 @com.example#bDecimal(1.7976931348623157E+309)
 string X
+
+@com.example#bDecimal(2e+308)
+string Y
+
+@com.example#bDecimal(2E+308)
+string Z
+
+@trait
+bigInteger bInteger
+
+@com.example#bInteger(9223372036854775808)
+string ZA

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
@@ -134,3 +134,9 @@ apply E @deprecated
 
 @documentation("")
 string V
+
+@trait
+bigDecimal bDecimal
+
+@com.example#bDecimal(9223372036854775808)
+string W

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/traits.smithy
@@ -140,3 +140,6 @@ bigDecimal bDecimal
 
 @com.example#bDecimal(9223372036854775808)
 string W
+
+@com.example#bDecimal(1.7976931348623157E+309)
+string X


### PR DESCRIPTION
Currently, numbers greater than 9223372036854775807 fail to be parsed from the IDL with `NumberFormatException`, even when the underlying implementation supports BigDecimal and BigInteger.

This PR updates the IdlModelParser and NodeHandler to use fall back to using `BigDecimal` or `BigInteger` where appropriate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
