### PR TITLE
Disable HTML doclint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,14 @@ project.afterEvaluate {
     }
 }
 
+// Disable HTML doclint to work around heading tag sequence validation
+// inconsistencies between JDK15 and earlier Java versions.
+allprojects {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:-html', '-quiet')
+    }
+}
+
 /*
  * Sonatype Staging Finalization
  * ====================================================


### PR DESCRIPTION
Closes #763

Disables HTML doclint to allow builds to succeed on JDK15.

This works around inconsistencies between the HTML heading tag sequence validation between JDK15 and earlier versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
