### PR TITLE
Run CI on JDK15 and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11]
-        os: [ubuntu-latest, windows-latest]
+        java: [8, 11, 15]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updates CI to run builds on JDK15 and macOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
