### PR TITLE
Fix ABNF selector_expression

### DIFF
--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -1575,7 +1575,7 @@ Selectors are defined by the following ABNF_ grammar.
     selector_expression                  :`selector_shape_types`
                                          :/ `selector_attr`
                                          :/ `selector_scoped_attr`
-                                         :/ `selector_function_args`
+                                         :/ `selector_function`
                                          :/ `selector_forward_undirected_neighbor`
                                          :/ `selector_reverse_undirected_neighbor`
                                          :/ `selector_forward_directed_neighbor`


### PR DESCRIPTION
Fixes the `selector_expression` entry in the selectors grammar documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
