### PR TITLE
Fix ci badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Smithy
-[![Build Status](https://github.com/awslabs/smithy/workflows/ci/badge.svg)](https://github.com/awslabs/smithy/workflows/ci)
+[![Build Status](https://github.com/awslabs/smithy/workflows/ci/badge.svg)](https://github.com/awslabs/smithy/actions/workflows/ci.yml)
 
 Smithy defines and generates clients, services, and documentation for
 any protocol.


### PR DESCRIPTION
This fixes the ci bade link to point to: https://github.com/awslabs/smithy/workflows/ci.yml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
