### PR TITLE
Start work towards version 1.1 of the IDL

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -52,7 +52,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final class Model implements ToSmithyBuilder<Model> {
 
     /** Specifies the highest supported version of the IDL. */
-    public static final String MODEL_VERSION = "1.0";
+    public static final String MODEL_VERSION = "1.1";
 
     /** The map of metadata keys to their "node" values. */
     private final Map<String, Node> metadata;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
@@ -61,7 +61,9 @@ final class LoaderUtils {
      * @return Returns true if this is a supported model version.
      */
     static boolean isVersionSupported(String versionString) {
-        return versionString.equals("1") || versionString.equals("1.0");
+        return versionString.equals("1")
+               || versionString.equals("1.0")
+               || versionString.equals("1.1");
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
@@ -84,7 +84,7 @@ final class ModelLoader {
     // is then used to delegate loading to different versions of the
     // Smithy JSON AST format.
     //
-    // This loader supports version 1.0. Support for 0.5 and 0.4 was removed in 0.10.
+    // This loader supports version 1.0 and 1.1. Support for 0.5 and 0.4 was removed in 0.10.
     static ModelFile loadParsedNode(TraitFactory traitFactory, Node node) {
         ObjectNode model = node.expectObjectNode("Smithy documents must be an object. Found {type}.");
         StringNode version = model.expectStringMember(SMITHY);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -345,7 +345,7 @@ public final class SmithyIdlModelSerializer {
             codeWriter.openBlock("$L $L {", shape.getType(), shape.getId().getName());
             for (MemberShape member : members) {
                 serializeTraits(member);
-                codeWriter.write("$L: $I,", member.getMemberName(), member.getTarget());
+                codeWriter.write("$L: $I", member.getMemberName(), member.getTarget());
             }
             codeWriter.closeBlock("}").write("");
         }
@@ -425,13 +425,13 @@ public final class SmithyIdlModelSerializer {
         public Void serviceShape(ServiceShape shape) {
             serializeTraits(shape);
             codeWriter.openBlock("service $L {", shape.getId().getName())
-                    .write("version: $S,", shape.getVersion());
+                    .write("version: $S", shape.getVersion());
             codeWriter.writeOptionalIdList("operations", shape.getOperations());
             codeWriter.writeOptionalIdList("resources", shape.getResources());
             if (!shape.getRename().isEmpty()) {
                 codeWriter.openBlock("rename: {", "}", () -> {
                     for (Map.Entry<ShapeId, String> entry : shape.getRename().entrySet()) {
-                        codeWriter.write("$S: $S,", entry.getKey(), entry.getValue());
+                        codeWriter.write("$S: $S", entry.getKey(), entry.getValue());
                     }
                 });
             }
@@ -448,16 +448,16 @@ public final class SmithyIdlModelSerializer {
                 shape.getIdentifiers().entrySet().stream()
                         .sorted(Map.Entry.comparingByKey())
                         .forEach(entry -> codeWriter.write(
-                                "$L: $I,", entry.getKey(), entry.getValue()));
-                codeWriter.closeBlock("},");
+                                "$L: $I", entry.getKey(), entry.getValue()));
+                codeWriter.closeBlock("}");
             }
 
-            shape.getPut().ifPresent(shapeId -> codeWriter.write("put: $I,", shapeId));
-            shape.getCreate().ifPresent(shapeId -> codeWriter.write("create: $I,", shapeId));
-            shape.getRead().ifPresent(shapeId -> codeWriter.write("read: $I,", shapeId));
-            shape.getUpdate().ifPresent(shapeId -> codeWriter.write("update: $I,", shapeId));
-            shape.getDelete().ifPresent(shapeId -> codeWriter.write("delete: $I,", shapeId));
-            shape.getList().ifPresent(shapeId -> codeWriter.write("list: $I,", shapeId));
+            shape.getPut().ifPresent(shapeId -> codeWriter.write("put: $I", shapeId));
+            shape.getCreate().ifPresent(shapeId -> codeWriter.write("create: $I", shapeId));
+            shape.getRead().ifPresent(shapeId -> codeWriter.write("read: $I", shapeId));
+            shape.getUpdate().ifPresent(shapeId -> codeWriter.write("update: $I", shapeId));
+            shape.getDelete().ifPresent(shapeId -> codeWriter.write("delete: $I", shapeId));
+            shape.getList().ifPresent(shapeId -> codeWriter.write("list: $I", shapeId));
             codeWriter.writeOptionalIdList("operations", shape.getOperations());
             codeWriter.writeOptionalIdList("collectionOperations", shape.getCollectionOperations());
             codeWriter.writeOptionalIdList("resources", shape.getResources());
@@ -476,8 +476,8 @@ public final class SmithyIdlModelSerializer {
             }
 
             codeWriter.openBlock("operation $L {", shape.getId().getName());
-            shape.getInput().ifPresent(shapeId -> codeWriter.write("input: $I,", shapeId));
-            shape.getOutput().ifPresent(shapeId -> codeWriter.write("output: $I,", shapeId));
+            shape.getInput().ifPresent(shapeId -> codeWriter.write("input: $I", shapeId));
+            shape.getOutput().ifPresent(shapeId -> codeWriter.write("output: $I", shapeId));
             codeWriter.writeOptionalIdList("errors", shape.getErrors());
             codeWriter.closeBlock("}");
             codeWriter.write("");
@@ -593,7 +593,6 @@ public final class SmithyIdlModelSerializer {
                 codeWriter.write("");
                 codeWriter.writeIndent();
                 serialize(element, member);
-                codeWriter.writeInline(",");
             }
             codeWriter.write("");
 
@@ -651,7 +650,6 @@ public final class SmithyIdlModelSerializer {
 
                 codeWriter.writeInline("\n$K: ", name.getValue());
                 serialize(value, member);
-                codeWriter.writeInline(",");
             });
             codeWriter.write("");
         }
@@ -769,8 +767,8 @@ public final class SmithyIdlModelSerializer {
             }
 
             openBlock("$L: [", textBeforeList);
-            shapeIds.stream().sorted().forEach(shapeId -> write("$I,", shapeId));
-            closeBlock("],");
+            shapeIds.stream().sorted().forEach(shapeId -> write("$I", shapeId));
+            closeBlock("]");
 
             return this;
         }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/boolean-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/boolean-traits.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/collection-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/collection-traits.smithy
@@ -1,15 +1,15 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 
 @trait
 list ListTrait {
-    member: String,
+    member: String
 }
 
 @trait
 set SetTrait {
-    member: String,
+    member: String
 }
 
 @ListTrait([])
@@ -17,11 +17,11 @@ set SetTrait {
 string Bar
 
 @ListTrait([
-    "first",
-    "second",
+    "first"
+    "second"
 ])
 @SetTrait([
-    "first",
-    "second",
+    "first"
+    "second"
 ])
 string Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/document-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/document-traits.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 
@@ -9,12 +9,12 @@ document DocumentTrait
 string Boolean
 
 @DocumentTrait([
-    "foo",
+    "foo"
 ])
 string List
 
 @DocumentTrait(
-    foo: "bar",
+    foo: "bar"
 )
 string Map
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
@@ -1,18 +1,18 @@
-$version: "1.0"
+$version: "1.1"
 
 metadata CaseSensitive = true
 metadata bool2 = false
 metadata caseSensitive = true
 metadata "example.array" = [
-    10,
-    true,
-    "hello",
+    10
+    true
+    "hello"
 ]
 metadata "example.bool1" = true
 metadata "key must be quoted" = true
 metadata null = null
 metadata number = 10
 metadata object = {
-    foo: "baz",
+    foo: "baz"
 }
 metadata string = "hello there"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/number-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/number-traits.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/object-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/object-traits.smithy
@@ -1,37 +1,37 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 
 @trait
 map MapTrait {
-    key: String,
-    value: String,
+    key: String
+    value: String
 }
 
 @trait
 structure StructureTrait {
-    collectionMember: StringList,
-    nestedMember: NestedMember,
-    shapeIdMember: ShapeId,
-    staticMember: String,
+    collectionMember: StringList
+    nestedMember: NestedMember
+    shapeIdMember: ShapeId
+    staticMember: String
 }
 
 @trait
 union UnionTrait {
-    boolean: Boolean,
-    string: String,
+    boolean: Boolean
+    string: String
 }
 
 structure NestedMember {
-    shapeIds: ShapeIdList,
+    shapeIds: ShapeIdList
 }
 
 list ShapeIdList {
-    member: ShapeId,
+    member: ShapeId
 }
 
 list StringList {
-    member: String,
+    member: String
 }
 
 @MapTrait
@@ -39,29 +39,29 @@ list StringList {
 string EmptyBody
 
 @MapTrait(
-    bar: "baz",
-    foo: "bar",
-    "must be quoted": "bam1",
-    "must.be.quoted": "bam2",
-    "must.be#quoted": "bam3",
-    "must.be#quoted$too": "bam4",
+    bar: "baz"
+    foo: "bar"
+    "must be quoted": "bam1"
+    "must.be.quoted": "bam2"
+    "must.be#quoted": "bam3"
+    "must.be#quoted$too": "bam4"
 )
 @StructureTrait(
     collectionMember: [
-        "foo",
-        "bar",
-    ],
+        "foo"
+        "bar"
+    ]
     nestedMember: {
         shapeIds: [
-            String,
-            EmptyBody,
-        ],
-    },
-    shapeIdMember: UnionTrait,
-    staticMember: "Foo",
+            String
+            EmptyBody
+        ]
+    }
+    shapeIdMember: UnionTrait
+    staticMember: "Foo"
 )
 @UnionTrait(
-    boolean: false,
+    boolean: false
 )
 string NonEmptyBody
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/optional-namespaces-are-stripped.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/optional-namespaces-are-stripped.smithy
@@ -1,11 +1,11 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 
 structure Structure {
-    localWithConflict: String,
-    prelude: Blob,
-    preludeWithConflict: smithy.api#String,
+    localWithConflict: String
+    prelude: Blob
+    preludeWithConflict: smithy.api#String
 }
 
 string String

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
@@ -1,19 +1,19 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 
 service EmptyService {
-    version: "2020-02-18",
+    version: "2020-02-18"
 }
 
 service MyService {
-    version: "2020-02-18",
+    version: "2020-02-18"
     operations: [
-        MyOperation,
-    ],
+        MyOperation
+    ]
     resources: [
-        MyResource,
-    ],
+        MyResource
+    ]
 }
 
 resource EmptyResource {
@@ -21,49 +21,49 @@ resource EmptyResource {
 
 resource MyResource {
     identifiers: {
-        id: String,
-    },
-    put: ResourceOperation,
-    create: ResourceOperation,
-    read: ReadonlyResourceOperation,
-    update: ResourceOperation,
-    delete: ResourceOperation,
-    list: ReadonlyResourceOperation,
+        id: String
+    }
+    put: ResourceOperation
+    create: ResourceOperation
+    read: ReadonlyResourceOperation
+    update: ResourceOperation
+    delete: ResourceOperation
+    list: ReadonlyResourceOperation
     operations: [
-        ResourceOperation,
-    ],
+        ResourceOperation
+    ]
     collectionOperations: [
-        ResourceOperation,
-    ],
+        ResourceOperation
+    ]
     resources: [
-        SubResource,
-    ],
+        SubResource
+    ]
 }
 
 resource SubResource {
     identifiers: {
-        id: String,
-    },
+        id: String
+    }
 }
 
 operation EmptyOperation {}
 
 operation MyOperation {
-    input: InputOutput,
-    output: InputOutput,
+    input: InputOutput
+    output: InputOutput
     errors: [
-        Error,
-    ],
+        Error
+    ]
 }
 
 @readonly
 operation ReadonlyResourceOperation {
-    input: ResourceOperationInput,
+    input: ResourceOperationInput
 }
 
 @idempotent
 operation ResourceOperation {
-    input: ResourceOperationInput,
+    input: ResourceOperationInput
 }
 
 @error("client")
@@ -72,5 +72,5 @@ structure Error {}
 structure InputOutput {}
 
 structure ResourceOperationInput {
-    id: String,
+    id: String
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
@@ -1,30 +1,30 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 
 structure StructureWithMembers {
-    a: String,
-    b: String,
+    a: String
+    b: String
 }
 
 structure StructureWithoutMembers {}
 
 union Union {
-    byte: Byte,
-    double: Double,
+    byte: Byte
+    double: Double
 }
 
 list List {
-    member: String,
+    member: String
 }
 
 set Set {
-    member: String,
+    member: String
 }
 
 map Map {
-    key: String,
-    value: String,
+    key: String
+    value: String
 }
 
 bigDecimal BigDecimal

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/string-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/string-traits.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "1.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/input.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/input.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "1.0",
+    "smithy": "1.1",
     "metadata": {
         "shared": true
     },

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
@@ -1,11 +1,11 @@
-$version: "1.0"
+$version: "1.1"
 
 metadata shared = true
 
 namespace ns.primitives
 
 list StringList {
-    member: String,
+    member: String
 }
 
 string String

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "1.1"
 
 metadata shared = true
 
@@ -7,6 +7,6 @@ namespace ns.structures
 use ns.primitives#StringList
 
 structure Structure {
-    listMember: StringList,
-    stringMember: ns.primitives#String,
+    listMember: StringList
+    stringMember: ns.primitives#String
 }


### PR DESCRIPTION
Version 1.1 of the IDL will include the optional comma update, but it
should also include as many other syntactic changes as we can to reduce
the number of bumps needed for the IDL (for example, mixins, sugar for
optional and required traits).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
