### PR TITLE
Warn against potentially risky hostPrefixes

### DIFF
--- a/docs/source/1.0/spec/core/endpoint-traits.rst
+++ b/docs/source/1.0/spec/core/endpoint-traits.rst
@@ -44,6 +44,12 @@ The ``endpoint`` trait is a structure that contains the following members:
         :ref:`hostLabel-trait`. The ``hostPrefix`` MUST NOT contain a scheme,
         userinfo, or port.
 
+        .. warning::
+
+            A host prefix that contains labels SHOULD end in a period (``.``) as
+            otherwise there is a risk of clients inadvertently sending data to
+            a domain that you do not control.
+
 The following example defines an operation that uses a custom endpoint:
 
 .. tabs::
@@ -401,7 +407,10 @@ Value type
 
 Operations marked with the :ref:`endpoint-trait` MAY contain labels in the
 ``hostPrefix`` property. These labels reference top-level operation input
-structure members that MUST be annotated with the ``hostLabel`` trait. Any
+structure members that MUST be annotated with the ``hostLabel`` trait. The
+contents of the label match the member's name. For example, a host prefix
+value of ``{spam}.eggs.`` MUST apply to an operation whose input contains a
+member named ``spam`` that is annotated with the ``hostLabel`` trait. Any
 ``hostLabel`` trait applied to a member that is not a top-level input member
 to an operation marked with the :ref:`endpoint-trait` will be ignored.
 
@@ -412,7 +421,7 @@ to an operation marked with the :ref:`endpoint-trait` will be ignored.
         namespace smithy.example
 
         @readonly
-        @endpoint(hostPrefix: "{foo}.data")
+        @endpoint(hostPrefix: "{foo}.data.")
         operation GetStatus {
             input: GetStatusInput,
             output: GetStatusOutput

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/host-request-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/host-request-validator.errors
@@ -6,3 +6,4 @@
 [ERROR] ns.foo#H: The `endpoint` trait hostPrefix, H.1234567890123456789012345678901234567890123456789012345678901234., could not expand in to a valid RFC 3986 host: H.1234567890123456789012345678901234567890123456789012345678901234. | HostLabelTrait
 [ERROR] ns.foo#J: The `endpoint` trait hostPrefix, 1234567890123456789012345678901234567890123456789012345678901234.J., could not expand in to a valid RFC 3986 host: 1234567890123456789012345678901234567890123456789012345678901234.J. | HostLabelTrait
 [ERROR] ns.foo#K: The `endpoint` trait hostPrefix, data.||+., could not expand in to a valid RFC 3986 host: data.||+. | HostLabelTrait
+[DANGER] ns.foo#LabelWithoutTrailingPeriod: `endpoint` trait hostPrefix contains host labels and does not end in a period (`.`). This can result in clients inadvertently sending data to domains you do not control. | HostLabelTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/host-request-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/host-request-validator.json
@@ -40,6 +40,9 @@
                 },
                 {
                     "target": "ns.foo#M"
+                },
+                {
+                    "target": "ns.foo#LabelWithoutTrailingPeriod"
                 }
             ]
         },
@@ -48,7 +51,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "A-{foo}"
+                    "hostPrefix": "A-{foo}."
                 }
             }
         },
@@ -63,7 +66,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "B-{foo}"
+                    "hostPrefix": "B-{foo}."
                 }
             }
         },
@@ -81,7 +84,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "C-{foo}"
+                    "hostPrefix": "C-{foo}."
                 }
             }
         },
@@ -105,7 +108,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "D-{foo}"
+                    "hostPrefix": "D-{foo}."
                 }
             }
         },
@@ -128,7 +131,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "E-{foo}"
+                    "hostPrefix": "E-{foo}."
                 }
             }
         },
@@ -151,7 +154,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "F-{foo}"
+                    "hostPrefix": "F-{foo}."
                 }
             }
         },
@@ -175,7 +178,7 @@
             "traits": {
                 "smithy.api#readonly": {},
                 "smithy.api#endpoint": {
-                    "hostPrefix": "G-{foo}-{bar}"
+                    "hostPrefix": "G-{foo}-{bar}."
                 }
             }
         },
@@ -267,6 +270,18 @@
                         "smithy.api#hostLabel": {},
                         "smithy.api#required": {}
                     }
+                }
+            }
+        },
+        "ns.foo#LabelWithoutTrailingPeriod": {
+            "type": "operation",
+            "input": {
+                "target": "ns.foo#MInput"
+            },
+            "traits": {
+                "smithy.api#readonly": {},
+                "smithy.api#endpoint": {
+                    "hostPrefix": "{foo}"
                 }
             }
         },


### PR DESCRIPTION
This updates the documentation and adds a warning for the case where a `hostPrefix` contains a host label but does not end in a period. This is potentially risky since it could change the domain to something that the modeler doesn't control. For example, a host label of `{foo}` combined with a configured endpoint `example.com` could result in a resolved host of `mistakeexample.com` when the modeler wanted it to resolve to `mistake.example.com`. If the modeler doesn't own EVERY domain suffixed by the configured endpoint then it is possible that customer data will be exposed.

Resolves #778 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
