### PR TITLE
add restXml tests for flattened list of structures

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
@@ -28,6 +28,7 @@ use smithy.test#httpResponseTests
 /// 6. Flattened XML lists with @xmlName.
 /// 7. Flattened XML lists with @xmlNamespace.
 /// 8. Lists of structures.
+/// 9. Flattened XML list of structures
 @idempotent
 @http(uri: "/XmlLists", method: "PUT")
 operation XmlLists {
@@ -96,6 +97,14 @@ apply XmlLists @httpRequestTests([
                           <other>4</other>
                       </item>
                   </myStructureList>
+                  <flattenedStructureList>
+                      <value>5</value>
+                      <other>6</other>
+                  </flattenedStructureList>
+                  <flattenedStructureList>
+                      <value>7</value>
+                      <other>8</other>
+                  </flattenedStructureList>
               </XmlListsInputOutput>
               """,
         bodyMediaType: "application/xml",
@@ -121,6 +130,16 @@ apply XmlLists @httpRequestTests([
                 {
                     a: "3",
                     b: "4",
+                }
+            ],
+            flattenedStructureList: [
+                {
+                    a: "5",
+                    b: "6",
+                },
+                {
+                    a: "7",
+                    b: "8",
                 }
             ]
         }
@@ -191,6 +210,14 @@ apply XmlLists @httpResponseTests([
                           <other>4</other>
                       </item>
                   </myStructureList>
+                  <flattenedStructureList>
+                      <value>5</value>
+                      <other>6</other>
+                  </flattenedStructureList>
+                  <flattenedStructureList>
+                      <value>7</value>
+                      <other>8</other>
+                  </flattenedStructureList>
               </XmlListsInputOutput>
               """,
         bodyMediaType: "application/xml",
@@ -218,6 +245,16 @@ apply XmlLists @httpResponseTests([
                 {
                     a: "3",
                     b: "4",
+                }
+            ],
+            flattenedStructureList: [
+                {
+                    a: "5",
+                    b: "6",
+                },
+                {
+                    a: "7",
+                    b: "8",
                 }
             ]
         }
@@ -321,7 +358,10 @@ structure XmlListsInputOutput {
     flattenedListWithNamespace: ListWithNamespace,
 
     @xmlName("myStructureList")
-    structureList: StructureList
+    structureList: StructureList,
+
+    @xmlFlattened
+    flattenedStructureList: StructureList
 }
 
 list RenamedListMembers {


### PR DESCRIPTION
*Description of changes:*
* Adds a test for ignoring the root element name since some services like S3 do not send a root element that matches the structure shape id from the model
* expanded the xml list test to include a flattened list of structures (we had an issue in Kotlin where the deserializer state got messed up by this case, maybe it helps someone else)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
