### PR TITLE
Add doc build to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,25 @@ jobs:
 
       - name: Clean and build
         run: ./gradlew clean build -Plog-tests
+
+  build-docs:
+    runs-on: ubuntu-latest
+    name: Documentation Build
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install doc dependencies
+      run: cd docs && make install
+
+    - name: Build docs
+      run: cd docs && make html
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: built-docs
+        path: docs/build/html


### PR DESCRIPTION
This adds a CI step to run the documentation build. This should ensure that changes at least result in a successful build. It also uploads the docs built so you could look at them without having to build them yourself.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
