### PR TITLE
Update RestJsonServersDontSerializeNullStructureValues body

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -83,7 +83,7 @@ apply SimpleScalarProperties @httpRequestTests([
         uri: "/SimpleScalarProperties",
         body: """
             {
-                "string": null
+                "stringValue": null
             }""",
         headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
I think this is a bug in the `RestJsonServersDontSerializeNullStructureValues` protocol codegen test.  There doesn't seem to be a member called "string", and I suspect the intention was to use `stringValue`.

If this is not the intent, please let me know.  Thanks!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
