### PR TITLE
Use plugin version 0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then, apply the Smithy Gradle Plugin in your `build.gradle.kts` file and run
 
 ```kotlin
 plugins {
-   id("software.amazon.smithy").version("0.5.2")
+   id("software.amazon.smithy").version("0.5.3")
 }
 ```
 

--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -21,7 +21,7 @@ The following example configures a project to use the Smithy Gradle plugin:
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.2")
+            id("software.amazon.smithy").version("0.5.3")
         }
 
 
@@ -138,7 +138,7 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.2")
+            id("software.amazon.smithy").version("0.5.3")
         }
 
         // The SmithyExtension is used to customize the build. This example
@@ -184,7 +184,7 @@ build that uses the "external" projection.
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.2")
+            id("software.amazon.smithy").version("0.5.3")
         }
 
         buildscript {

--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -115,7 +115,7 @@ specification from a Smithy model using a buildscript dependency:
 
     plugins {
         java
-        id("software.amazon.smithy").version("0.5.2")
+        id("software.amazon.smithy").version("0.5.3")
     }
 
     buildscript {

--- a/docs/source/1.0/guides/generating-cloudformation-resources.rst
+++ b/docs/source/1.0/guides/generating-cloudformation-resources.rst
@@ -60,7 +60,7 @@ Resource Schemas from a Smithy model :ref:`using a buildscript dependency
 
     plugins {
         java
-        id("software.amazon.smithy").version("0.5.2")
+        id("software.amazon.smithy").version("0.5.3")
     }
 
     buildscript {

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -763,7 +763,7 @@ Then create a new ``build.gradle.kts`` file:
 .. code-block:: kotlin
 
     plugins {
-        id("software.amazon.smithy").version("0.5.2")
+        id("software.amazon.smithy").version("0.5.3")
     }
 
     repositories {
@@ -830,7 +830,7 @@ The ``build.gradle.kts`` should have the following contents:
 .. code-block:: kotlin
 
     plugins {
-        id("software.amazon.smithy").version("0.5.2")
+        id("software.amazon.smithy").version("0.5.3")
     }
 
     repositories {

--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-    id "software.amazon.smithy" version "0.5.2"
+    id "software.amazon.smithy" version "0.5.3"
 }
 
 description = "Defines protocol tests for AWS HTTP protocols."


### PR DESCRIPTION
Updates `smithy-aws-protocol-tests` to use version `0.5.3` of the [Smithy Gradle Plugin](https://github.com/awslabs/smithy-gradle-plugin).

Docs are also updated to recommend using this version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
