### PR TITLE
Remove TieredStopAtLevel from the CLI

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 application {
     mainClass = "software.amazon.smithy.cli.SmithyCli"
     applicationName = "smithy"
-    applicationDefaultJvmArgs = ["-XX:TieredStopAtLevel=2", "-Xshare:auto"]
+    applicationDefaultJvmArgs = ["-Xshare:auto"]
 }
 
 runtime {


### PR DESCRIPTION
The CLI previously used `-XX:TieredStopAtLevel=2` to limit the amount of
intermediate compilation the CLI would perform. This helps a little bit
with quicker startups in the CLI, but it also caused the CLI to perform
significantly slower for longer running tasks like validating hundreds
of thousands of models.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
