### PR TITLE
Make CLI output improvements

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -29,6 +29,7 @@ public final class SmithyCli {
     public static final String DISCOVER = "--discover";
     public static final String DISCOVER_CLASSPATH = "--discover-classpath";
     public static final String ALLOW_UNKNOWN_TRAITS = "--allow-unknown-traits";
+    public static final String SEVERITY = "--severity";
 
     private ClassLoader classLoader = getClass().getClassLoader();
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -68,6 +68,9 @@ public final class BuildCommand implements Command {
                 .option(SmithyCli.DISCOVER, "-d", "Enables model discovery, merging in models found inside of jars")
                 .parameter(SmithyCli.DISCOVER_CLASSPATH, "Enables model discovery using a custom classpath for models")
                 .option(SmithyCli.ALLOW_UNKNOWN_TRAITS, "Ignores unknown traits when building models")
+                .parameter(SmithyCli.SEVERITY, "Sets a minimum validation event severity to display. "
+                                               + "Defaults to NOTE. Can be set to SUPPRESSED, NOTE, WARNING, "
+                                               + "DANGER, ERROR.")
                 .positional("<MODELS>", "Path to Smithy models or directories")
                 .build();
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -42,6 +42,9 @@ public final class ValidateCommand implements Command {
                 .option(SmithyCli.ALLOW_UNKNOWN_TRAITS, "Ignores unknown traits when validating models")
                 .option(SmithyCli.DISCOVER, "-d", "Enables model discovery, merging in models found inside of jars")
                 .parameter(SmithyCli.DISCOVER_CLASSPATH, "Enables model discovery using a custom classpath for models")
+                .parameter(SmithyCli.SEVERITY, "Sets a minimum validation event severity to display. "
+                                               + "Defaults to NOTE. Can be set to SUPPRESSED, NOTE, WARNING, "
+                                               + "DANGER, ERROR.")
                 .positional("<MODELS>", "Path to Smithy models or directories")
                 .build();
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -21,9 +21,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import software.amazon.smithy.cli.Cli;
 import software.amazon.smithy.cli.CliError;
-import software.amazon.smithy.cli.Colors;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.validation.ContextualValidationEventFormatter;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 
@@ -46,25 +44,9 @@ final class Validator {
     }
 
     static void validate(ValidatedResult<Model> result, Set<Feature> features) {
-        ContextualValidationEventFormatter formatter = new ContextualValidationEventFormatter();
-
-        boolean stdout = features.contains(Feature.STDOUT);
         boolean quiet = features.contains(Feature.QUIET);
+        boolean stdout = features.contains(Feature.STDOUT);
         Consumer<String> writer = stdout ? Cli.getStdout() : Cli.getStderr();
-
-        result.getValidationEvents().stream()
-                .filter(event -> event.getSeverity() != Severity.SUPPRESSED)
-                .sorted()
-                .forEach(event -> {
-                    if (event.getSeverity() == Severity.WARNING) {
-                        Colors.YELLOW.write(writer, formatter.format(event));
-                    } else if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
-                        Colors.RED.write(writer, formatter.format(event));
-                    } else {
-                        writer.accept(event.toString());
-                    }
-                    writer.accept("");
-                });
 
         long errors = result.getValidationEvents(Severity.ERROR).size();
         long dangers = result.getValidationEvents(Severity.DANGER).size();

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/ValidateCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/ValidateCommandTest.java
@@ -17,15 +17,18 @@ package software.amazon.smithy.cli.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.SmithyCli;
+import software.amazon.smithy.model.validation.Severity;
 
 public class ValidateCommandTest {
     @Test
@@ -71,5 +74,84 @@ public class ValidateCommandTest {
     public void allowsUnknownTrait() throws URISyntaxException {
         String model = Paths.get(getClass().getResource("unknown-trait.smithy").toURI()).toString();
         SmithyCli.create().run("validate", "--allow-unknown-traits", model);
+    }
+
+    @Test
+    public void canSetSeverityToSuppressed() throws Exception {
+        String result = runValidationEventsTest(Severity.SUPPRESSED);
+
+        assertThat(result, containsString("EmitSuppressed"));
+        assertThat(result, containsString("EmitNotes"));
+        assertThat(result, containsString("EmitWarnings"));
+        assertThat(result, containsString("EmitDangers"));
+        assertThat(result, containsString("TraitTarget"));
+    }
+
+    @Test
+    public void canSetSeverityToNote() throws Exception {
+        String result = runValidationEventsTest(Severity.NOTE);
+
+        assertThat(result, not(containsString("EmitSuppressed")));
+        assertThat(result, containsString("EmitNotes"));
+        assertThat(result, containsString("EmitWarnings"));
+        assertThat(result, containsString("EmitDangers"));
+        assertThat(result, containsString("TraitTarget"));
+    }
+
+    @Test
+    public void canSetSeverityToWarning() throws Exception {
+        String result = runValidationEventsTest(Severity.WARNING);
+
+        assertThat(result, not(containsString("EmitSuppressed")));
+        assertThat(result, not(containsString("EmitNotes")));
+        assertThat(result, containsString("EmitWarnings"));
+        assertThat(result, containsString("EmitDangers"));
+        assertThat(result, containsString("TraitTarget"));
+    }
+
+    @Test
+    public void canSetSeverityToDanger() throws Exception {
+        String result = runValidationEventsTest(Severity.DANGER);
+
+        assertThat(result, not(containsString("EmitSuppressed")));
+        assertThat(result, not(containsString("EmitNotes")));
+        assertThat(result, not(containsString("EmitWarnings")));
+        assertThat(result, containsString("EmitDangers"));
+        assertThat(result, containsString("TraitTarget"));
+    }
+
+    @Test
+    public void canSetSeverityToError() throws Exception {
+        String result = runValidationEventsTest(Severity.ERROR);
+
+        assertThat(result, not(containsString("EmitSuppressed")));
+        assertThat(result, not(containsString("EmitNotes")));
+        assertThat(result, not(containsString("EmitWarnings")));
+        assertThat(result, not(containsString("EmitDangers")));
+        assertThat(result, containsString("TraitTarget"));
+    }
+
+    private String runValidationEventsTest(Severity severity) throws Exception {
+        PrintStream err = System.err;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+        System.setErr(printStream);
+
+        Path validationEventsModel = Paths.get(getClass().getResource("validation-events.smithy").toURI());
+        try {
+            SmithyCli.create().run("validate", "--severity", severity.toString(), validationEventsModel.toString());
+        } catch (RuntimeException e) {
+            // ignore the error since everything we need was captured via stderr.
+        }
+
+        System.setErr(err);
+        return outputStream.toString("UTF-8");
+    }
+
+    @Test
+    public void validatesSeverity() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> SmithyCli.create().run("validate", "--severity", "FOO"));
     }
 }

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/validation-events.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/validation-events.smithy
@@ -1,0 +1,50 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "EmitSuppressed",
+        severity: "NOTE",
+        configuration: {
+            selector: "[id = smithy.example#Suppressed]"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "EmitNotes",
+        severity: "NOTE",
+        configuration: {
+            selector: "[id = smithy.example#Note]"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "EmitWarnings",
+        severity: "WARNING",
+        configuration: {
+            selector: "[id = smithy.example#Warning]"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "EmitDangers",
+        severity: "DANGER",
+        configuration: {
+            selector: "[id = smithy.example#Danger]"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["EmitSuppressed"])
+string Suppressed
+
+string Note
+
+string Warning
+
+string Danger
+
+@required // this trait is invalid and causes an error.
+string Error

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -37,6 +37,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -53,7 +54,6 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
-import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -641,5 +641,22 @@ public class ModelAssemblerTest {
                 .unwrap();
 
         assertThat(model, equalTo(model2));
+    }
+
+    @Test
+    public void canListenToEvents() {
+        List<ValidationEvent> toEmit = new ArrayList<>();
+        toEmit.add(ValidationEvent.builder().id("a").severity(Severity.WARNING).message("").build());
+        toEmit.add(ValidationEvent.builder().id("b").severity(Severity.WARNING).message("").build());
+        toEmit.add(ValidationEvent.builder().id("c").severity(Severity.WARNING).message("").build());
+        List<ValidationEvent> collectedEvents = Collections.synchronizedList(new ArrayList<>());
+
+        Model.assembler()
+                .addValidator(model -> toEmit)
+                .validationEventListener(collectedEvents::add)
+                .assemble()
+                .unwrap();
+
+        assertThat(collectedEvents, equalTo(toEmit));
     }
 }


### PR DESCRIPTION
This commit closes #797

The CLI will now log validation events as they occur rather than waiting
until all events are encountered before writing them. This makes the CLI
a bit more responsive when validating hundreds of thousands of shapes.

Other improvements were added to the CLI output as well, including the
--severity parameter to set the minimum severity to display in output.
This can significantly cut down on noise when model files emit things <
DANGER.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
