### PR TITLE
Add "double" format to epoch-seconds timestamps

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -382,7 +382,8 @@
         "type": "object",
         "properties": {
           "createdAt": {
-            "type": "number"
+            "type": "number",
+            "format": "double"
           },
           "id": {
             "type": "string"

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
@@ -382,7 +382,8 @@
         "type": "object",
         "properties": {
           "createdAt": {
-            "type": "number"
+            "type": "number",
+            "format": "double"
           },
           "id": {
             "type": "string"

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors-wildcards.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors-wildcards.openapi.json
@@ -181,7 +181,8 @@
                 "type": "object",
                 "properties": {
                     "createdAt": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "double"
                     },
                     "id": {
                         "type": "string"

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors.openapi.json
@@ -181,7 +181,8 @@
                 "type": "object",
                 "properties": {
                     "createdAt": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "double"
                     },
                     "id": {
                         "type": "string"

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -17,11 +17,13 @@ package software.amazon.smithy.jsonschema;
 
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 
@@ -328,5 +330,21 @@ public class JsonSchemaConfig {
      */
     public void setService(ShapeId service) {
         this.service = service;
+    }
+
+    /**
+     * Detects the TimestampFormat of the given shape, falling back to the
+     * configured default format specified in {@link #setDefaultTimestampFormat(TimestampFormatTrait.Format)}.
+     *
+     * @param shape Shape to extract the timestamp format from.
+     * @return Returns the optionally detected format.
+     */
+    public Optional<String> detectJsonTimestampFormat(Shape shape) {
+        if (shape.isTimestampShape() || shape.hasTrait(TimestampFormatTrait.class)) {
+            return Optional.of(shape.getTrait(TimestampFormatTrait.class)
+                    .map(TimestampFormatTrait::getValue)
+                    .orElseGet(() -> getDefaultTimestampFormat().toString()));
+        }
+        return Optional.empty();
     }
 }

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/TimestampMapper.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/TimestampMapper.java
@@ -31,7 +31,7 @@ final class TimestampMapper implements JsonSchemaMapper {
 
     @Override
     public Schema.Builder updateSchema(Shape shape, Schema.Builder builder, JsonSchemaConfig config) {
-        String format = extractTimestampFormat(shape, config);
+        String format = config.detectJsonTimestampFormat(shape).orElse(null);
 
         if (format == null) {
             return builder;
@@ -48,15 +48,5 @@ final class TimestampMapper implements JsonSchemaMapper {
                 // Handle any future "epoch-*" formats like epoch-millis.
                 return format.startsWith("epoch-") ? builder.type("number") : builder.type("string");
         }
-    }
-
-    private static String extractTimestampFormat(Shape shape, JsonSchemaConfig config) {
-        if (shape.isTimestampShape() || shape.hasTrait(TimestampFormatTrait.class)) {
-            return shape.getTrait(TimestampFormatTrait.class)
-                    .map(TimestampFormatTrait::getValue)
-                    .orElseGet(() -> config.getDefaultTimestampFormat().toString());
-        }
-
-        return null;
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.traits.BoxTrait;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.model.ExternalDocumentation;
 import software.amazon.smithy.utils.MapUtils;
@@ -88,6 +89,12 @@ public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
                     String blobFormat = ((OpenApiConfig) config).getDefaultBlobFormat();
                     return builder.format(blobFormat);
                 }
+            } else if (shape.isTimestampShape()) {
+                // Add the "double" format when epoch-seconds is used
+                // to account for optional millisecond precision.
+                config.detectJsonTimestampFormat(shape)
+                        .filter(format -> format.equals(TimestampFormatTrait.EPOCH_SECONDS))
+                        .ifPresent(format -> builder.format("double"));
             } else if (shape.hasTrait(SensitiveTrait.class)) {
                 builder.format("password");
             }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service-integer.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service-integer.openapi.json
@@ -216,7 +216,8 @@
             "type": "string"
           },
           "time": {
-            "type": "number"
+            "type": "number",
+            "format": "double"
           },
           "list": {
             "type": "array",

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -216,7 +216,8 @@
             "type": "string"
           },
           "time": {
-            "type": "number"
+            "type": "number",
+            "format": "double"
           },
           "list": {
             "type": "array",


### PR DESCRIPTION
OpenAPI supports a format called "double" on the "number" type to indicate
that a number is a double precision floating point number. Timestamps
that use epoch-seconds have been updated to use this format so that
stricter JSON Schema validators don't error when they encounter
decimals. "double" is only added as a format when performing OpenAPI
conversions and are not added by default when performing JSON Schema
conversions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
