### PR TITLE
Percent Encoding Test & Spec Enhancements

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -663,7 +663,7 @@ structure with the ``httpLabel`` trait MUST have a corresponding
   ``1985-04-12T23%3A20%3A50.52Z``). The :ref:`timestampFormat-trait`
   MAY be used to use a custom serialization format.
 - Reserved characters defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>`
-  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=``).
+  and the `%` itself MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
 - However, if the label is greedy, then "/" MUST NOT be percent-encoded
   because greedy labels are meant to span multiple path segments.
 
@@ -894,8 +894,8 @@ request:
 
 * "&" is used to separate query string parameter key-value pairs.
 * "=" is used to separate query string parameter names from values.
-* Reserved characters in keys and values as defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>`
-  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=``).
+* Reserved characters in keys and values as defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>` and `%`
+  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
 * ``boolean`` values are serialized as ``true`` or ``false``.
 * ``timestamp`` values are serialized as an :rfc:`3339`
   ``date-time`` string by default (for example, ``1985-04-12T23:20:50.52Z``,

--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -39,6 +39,24 @@ apply HttpRequestWithLabels @httpRequestTests([
             timestamp: 1576540098
         }
     },
+    {
+        id: "RestJsonHttpRequestLabelEscaping",
+        documentation: "Sends a GET request that uses URI label bindings",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/HttpRequestWithLabels/%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z",
+        body: "",
+        params: {
+            string: "%:/?#[]@!$&'()*+,;=😹",
+            short: 1,
+            integer: 2,
+            long: 3,
+            float: 4.1,
+            double: 5.1,
+            boolean: true,
+            timestamp: 1576540098
+        }
+    },
 ])
 
 structure HttpRequestWithLabelsInput {

--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -159,10 +159,10 @@ apply HttpRequestWithGreedyLabelInPath @httpRequestTests([
         documentation: "Serializes greedy labels and normal labels",
         protocol: restJson1,
         method: "GET",
-        uri: "/HttpRequestWithGreedyLabelInPath/foo/hello/baz/there/guy",
+        uri: "/HttpRequestWithGreedyLabelInPath/foo/hello%2Fescape/baz/there/guy",
         body: "",
         params: {
-            foo: "hello",
+            foo: "hello/escape",
             baz: "there/guy",
         }
     },

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -111,6 +111,20 @@ apply AllQueryStringTypes @httpRequestTests([
                 "QueryParamsStringKeyB": "Bar",
             },
         }
+    },
+    {
+        id: "RestJsonQueryStringEscaping",
+        documentation: "Handles escaping all required characters in the query string.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+		"String=%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9",
+        ],
+        params: {
+		queryString: "%:/?#[]@!$&'()*+,;=😹"
+        }
     }
 ])
 


### PR DESCRIPTION
*Description of changes:*
Two separate commits that increase coverage of percent encoding tests:
1. The current test actually admits buggy behavior where neither greedy nor non-greedy labels are escaped, a bug I know
impacts at least 1 SDK. This updates the test to include `/` in the non-greedy label to ensure that it is, in fact, escaped.
2. Add test for httpLabel/httpQuery escaping.
    Smithy recently amended the HTTP label spec to clarify the set of characters that must be escaped. But, due to
a peculiarity of the spec, it Smithy omitted the `%` character from this set which definitely needs to be escaped.

    This diff updates the spec and adds exhaustive test cases for both. These tests have been run on and pass the Rust SDK protocol test suite. (They also went the other way, I had 2 bugs caused by copy-paste errors converting the Smithy set to the percent encoding set used by the Rust SDK).

    Exhaustive tests are important here, because I suspect other SDKs may have similar copy-paste errors, furthermore, several of these characters, namely: `:()!,` may not be escaped by a "out of the box" percent encoder but these are known to cause problems when sent to AWS services.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
