### PR TITLE
Update Protocol Test with more complex XML Unescaping

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -142,12 +142,14 @@ apply SimpleScalarProperties @httpResponseTests([
         }
     },
     {
-        id: "SimpleScalarPropertiesWithEscapedCharacter",
+        id: "SimpleScalarPropertiesComplexEscapes",
         documentation: """
         Serializes string with escaping.
 
         This validates the three escape types: literal, decimal and hexadecimal. It also validates that unescaping properly
         handles the case where unescaping an & produces a newly formed escape sequence (this should not be re-unescaped).
+
+        Servers may produce different output, this test is designed different unescapes clients must handle
         """,
         protocol: restXml,
         code: 200,
@@ -164,6 +166,27 @@ apply SimpleScalarProperties @httpResponseTests([
         params: {
             foo: "Foo",
             stringValue: "escaped data: &lt;\r\n",
+        },
+        appliesTo: "client",
+    },
+    {
+        id: "SimpleScalarPropertiesWithEscapedCharacter",
+        documentation: "Serializes string with escaping",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <stringValue>&lt;string&gt;</stringValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            stringValue: "<string>",
         }
     },
     {

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -146,7 +146,7 @@ apply SimpleScalarProperties @httpResponseTests([
         documentation: """
         Serializes string with escaping.
 
-        This validates the three escape types: literal, decimal and hexidecimal. It also validates that unescaping properly
+        This validates the three escape types: literal, decimal and hexadecimal. It also validates that unescaping properly
         handles the case where unescaping an & produces a newly formed escape sequence (this should not be re-unescaped).
         """,
         protocol: restXml,

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -143,12 +143,17 @@ apply SimpleScalarProperties @httpResponseTests([
     },
     {
         id: "SimpleScalarPropertiesWithEscapedCharacter",
-        documentation: "Serializes string with escaping",
+        documentation: """
+        Serializes string with escaping.
+
+        This validates the three escape types: literal, decimal and hexidecimal. It also validates that unescaping properly
+        handles the case where unescaping an & produces a newly formed escape sequence (this should not be re-unescaped).
+        """,
         protocol: restXml,
         code: 200,
         body: """
               <SimpleScalarPropertiesInputOutput>
-                  <stringValue>&lt;string&gt;</stringValue>
+                  <stringValue>escaped data: &amp;lt;&#xD;&#10;</stringValue>
               </SimpleScalarPropertiesInputOutput>
               """,
         bodyMediaType: "application/xml",
@@ -158,7 +163,7 @@ apply SimpleScalarProperties @httpResponseTests([
         },
         params: {
             foo: "Foo",
-            stringValue: "<string>",
+            stringValue: "escaped data: &lt;\r\n",
         }
     },
     {


### PR DESCRIPTION
*Description of changes:*

Add protocol response test to cover XML escaping of literals as well as decimal & hexadecimal escape sequences.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
