### PR TITLE
Make various perf improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
     id "jacoco"
     id "com.github.spotbugs" version "4.6.0"
     id "io.codearte.nexus-staging" version "0.21.0"
-    id "me.champeau.gradle.jmh" version "0.5.3"
+    id "me.champeau.jmh" version "0.6.4"
 }
 
 ext {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -171,7 +171,6 @@
         <!-- See http://checkstyle.sf.net/config_coding.html -->
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
-        <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>

--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -104,4 +104,11 @@
         <Class name="software.amazon.smithy.model.knowledge.NeighborProviderIndex"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>
+
+    <!-- Spotbugs for some reason isn't seeing that Objects.requireNonNull prevents a null return.
+         this is used when dereferencing a WeakReference to the Model. -->
+    <Match>
+        <Class name="software.amazon.smithy.model.knowledge.HttpBindingIndex"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
 </FindBugsFilter>

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
@@ -47,10 +47,8 @@ public final class ArnIndex implements KnowledgeIndex {
 
     public ArnIndex(Model model) {
         // Pre-compute the ARN services.
-        for (Shape shape : model.getShapesWithTrait(ServiceTrait.class)) {
-            shape.asServiceShape().ifPresent(service -> {
-                arnServices.put(service.getId(), service.expectTrait(ServiceTrait.class).getArnNamespace());
-            });
+        for (Shape service : model.getServiceShapesWithTrait(ServiceTrait.class)) {
+            arnServices.put(service.getId(), service.expectTrait(ServiceTrait.class).getArnNamespace());
         }
 
         // Pre-compute all of the ArnTemplates in a service shape.

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTemplateValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTemplateValidator.java
@@ -48,8 +48,8 @@ public final class ArnTemplateValidator extends AbstractValidator {
     public List<ValidationEvent> validate(Model model) {
         ArnIndex arnIndex = ArnIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(ServiceTrait.class)) {
-            shape.asServiceShape().ifPresent(service -> events.addAll(validateService(model, arnIndex, service)));
+        for (ServiceShape service : model.getServiceShapesWithTrait(ServiceTrait.class)) {
+            events.addAll(validateService(model, arnIndex, service));
         }
         return events;
     }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/EventSourceValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/EventSourceValidator.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.utils.MapUtils;
@@ -44,10 +43,8 @@ public final class EventSourceValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(ServiceTrait.class)) {
-            shape.asServiceShape()
-                    .flatMap(service -> validateService(service, service.expectTrait(ServiceTrait.class)))
-                    .ifPresent(events::add);
+        for (ServiceShape service : model.getServiceShapesWithTrait(ServiceTrait.class)) {
+            validateService(service, service.expectTrait(ServiceTrait.class)).ifPresent(events::add);
         }
         return events;
     }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/SdkServiceIdValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/SdkServiceIdValidator.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidationUtils;
@@ -71,10 +70,8 @@ public final class SdkServiceIdValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(ServiceTrait.class)) {
-            shape.asServiceShape()
-                    .flatMap(service -> validateService(service, service.expectTrait(ServiceTrait.class)))
-                    .ifPresent(events::add);
+        for (ServiceShape service : model.getServiceShapesWithTrait(ServiceTrait.class)) {
+            validateService(service, service.expectTrait(ServiceTrait.class)).ifPresent(events::add);
         }
         return events;
     }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformer.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformer.java
@@ -62,15 +62,13 @@ public final class CleanClientDiscoveryTraitTransformer implements ModelTransfor
 
     private Set<Shape> getServicesToUpdate(Model model, Set<ShapeId> removedOperations, Set<ShapeId> removedErrors) {
         Set<Shape> result = new HashSet<>();
-        for (Shape shape : model.getShapesWithTrait(ClientEndpointDiscoveryTrait.class)) {
-            shape.asServiceShape().ifPresent(service -> {
-                ClientEndpointDiscoveryTrait trait = service.expectTrait(ClientEndpointDiscoveryTrait.class);
-                if (removedOperations.contains(trait.getOperation()) || removedErrors.contains(trait.getError())) {
-                    ServiceShape.Builder builder = service.toBuilder();
-                    builder.removeTrait(ClientEndpointDiscoveryTrait.ID);
-                    result.add(builder.build());
-                }
-            });
+        for (ServiceShape service : model.getServiceShapesWithTrait(ClientEndpointDiscoveryTrait.class)) {
+            ClientEndpointDiscoveryTrait trait = service.expectTrait(ClientEndpointDiscoveryTrait.class);
+            if (removedOperations.contains(trait.getOperation()) || removedErrors.contains(trait.getError())) {
+                ServiceShape.Builder builder = service.toBuilder();
+                builder.removeTrait(ClientEndpointDiscoveryTrait.ID);
+                result.add(builder.build());
+            }
         }
         return result;
     }
@@ -92,15 +90,13 @@ public final class CleanClientDiscoveryTraitTransformer implements ModelTransfor
 
         // Get all endpoint discovery operations
         Set<Shape> result = new HashSet<>();
-        for (Shape shape : model.getShapesWithTrait(ClientDiscoveredEndpointTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                ClientDiscoveredEndpointTrait trait = operation.expectTrait(ClientDiscoveredEndpointTrait.class);
-                // Only get the ones where discovery is optional, as it is safe to remove in that case.
-                // Only get the ones that aren't still bound to a service that requires endpoint discovery.
-                if (!trait.isRequired() && !stillBoundOperations.contains(operation.getId())) {
-                    result.add(operation.toBuilder().removeTrait(ClientDiscoveredEndpointTrait.ID).build());
-                }
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(ClientDiscoveredEndpointTrait.class)) {
+            ClientDiscoveredEndpointTrait trait = operation.expectTrait(ClientDiscoveredEndpointTrait.class);
+            // Only get the ones where discovery is optional, as it is safe to remove in that case.
+            // Only get the ones that aren't still bound to a service that requires endpoint discovery.
+            if (!trait.isRequired() && !stillBoundOperations.contains(operation.getId())) {
+                result.add(operation.toBuilder().removeTrait(ClientDiscoveredEndpointTrait.ID).build());
+            }
         }
         return result;
     }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
@@ -41,25 +41,23 @@ public final class ClientEndpointDiscoveryIndex implements KnowledgeIndex {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         OperationIndex opIndex = OperationIndex.of(model);
 
-        for (Shape shape : model.getShapesWithTrait(ClientEndpointDiscoveryTrait.class)) {
-            shape.asServiceShape().ifPresent(service -> {
-                ClientEndpointDiscoveryTrait trait = service.expectTrait(ClientEndpointDiscoveryTrait.class);
-                ShapeId endpointOperationId = trait.getOperation();
-                ShapeId endpointErrorId = trait.getError();
+        for (ServiceShape service : model.getServiceShapesWithTrait(ClientEndpointDiscoveryTrait.class)) {
+            ClientEndpointDiscoveryTrait trait = service.expectTrait(ClientEndpointDiscoveryTrait.class);
+            ShapeId endpointOperationId = trait.getOperation();
+            ShapeId endpointErrorId = trait.getError();
 
-                Optional<OperationShape> endpointOperation = model.getShape(endpointOperationId)
-                        .flatMap(Shape::asOperationShape);
-                Optional<StructureShape> endpointError = model.getShape(endpointErrorId)
-                        .flatMap(Shape::asStructureShape);
+            Optional<OperationShape> endpointOperation = model.getShape(endpointOperationId)
+                    .flatMap(Shape::asOperationShape);
+            Optional<StructureShape> endpointError = model.getShape(endpointErrorId)
+                    .flatMap(Shape::asStructureShape);
 
-                if (endpointOperation.isPresent() && endpointError.isPresent()) {
-                    Map<ShapeId, ClientEndpointDiscoveryInfo> serviceInfo = getOperations(
-                            service, endpointOperation.get(), endpointError.get(), topDownIndex, opIndex);
-                    if (!serviceInfo.isEmpty()) {
-                        endpointDiscoveryInfo.put(service.getId(), serviceInfo);
-                    }
+            if (endpointOperation.isPresent() && endpointError.isPresent()) {
+                Map<ShapeId, ClientEndpointDiscoveryInfo> serviceInfo = getOperations(
+                        service, endpointOperation.get(), endpointError.get(), topDownIndex, opIndex);
+                if (!serviceInfo.isEmpty()) {
+                    endpointDiscoveryInfo.put(service.getId(), serviceInfo);
                 }
-            });
+            }
         }
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryValidator.java
@@ -48,10 +48,8 @@ public final class ClientEndpointDiscoveryValidator extends AbstractValidator {
         OperationIndex opIndex = OperationIndex.of(model);
 
         Map<ServiceShape, ClientEndpointDiscoveryTrait> endpointDiscoveryServices = new HashMap<>();
-        for (Shape shape : model.getShapesWithTrait(ClientEndpointDiscoveryTrait.class)) {
-            shape.asServiceShape().ifPresent(service -> {
-                endpointDiscoveryServices.put(service, service.expectTrait(ClientEndpointDiscoveryTrait.class));
-            });
+        for (ServiceShape service : model.getServiceShapesWithTrait(ClientEndpointDiscoveryTrait.class)) {
+            endpointDiscoveryServices.put(service, service.expectTrait(ClientEndpointDiscoveryTrait.class));
         }
 
         List<ValidationEvent> validationEvents = endpointDiscoveryServices.values().stream()

--- a/smithy-model/build.gradle
+++ b/smithy-model/build.gradle
@@ -21,7 +21,7 @@ ext {
     moduleName = "software.amazon.smithy.model"
 }
 
-apply plugin: "me.champeau.gradle.jmh"
+apply plugin: "me.champeau.jmh"
 
 dependencies {
     api project(":smithy-utils")

--- a/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/test-model.smithy
+++ b/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/test-model.smithy
@@ -18,7 +18,6 @@ operation Resource1Operation {}
 resource Resource1_2 {}
 
 resource Resource1_1 {
-    type: resource,
     operations: [Resource1_1_Operation],
     resources: [Resource1_1_1, Resource1_1_2]
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -159,8 +159,12 @@ public final class Model implements ToSmithyBuilder<Model> {
     private TraitCache getTraitCache() {
         TraitCache cache = traitCache;
         if (cache == null) {
-            cache = new TraitCache(this.shapeMap.values());
-            traitCache = cache;
+            synchronized (this) {
+                cache = traitCache;
+                if (cache == null) {
+                    traitCache = cache = new TraitCache(this.shapeMap.values());
+                }
+            }
         }
         return cache;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -33,11 +33,32 @@ import software.amazon.smithy.model.knowledge.KnowledgeIndex;
 import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.NumberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.TraitFactory;
@@ -190,6 +211,424 @@ public final class Model implements ToSmithyBuilder<Model> {
     public Set<Shape> getShapesWithTrait(Class<? extends Trait> trait) {
         Map<Class<? extends Trait>, Set<Shape>> mappings = getTraitCache().traitsToShapes;
         return Collections.unmodifiableSet(mappings.getOrDefault(trait, Collections.emptySet()));
+    }
+
+    /**
+     * Gets an immutable set of all bigDecimals in the Model.
+     *
+     * @return Returns the Set of {@code bigDecimals}s.
+     */
+    public Set<BigDecimalShape> getBigDecimalShapes() {
+        return toSet(BigDecimalShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all bigDecimals in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code bigdecimal}s that have a specific trait.
+     */
+    public Set<BigDecimalShape> getBigDecimalShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), BigDecimalShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all bigIntegers in the Model.
+     *
+     * @return Returns the Set of {@code bigIntegers}s.
+     */
+    public Set<BigIntegerShape> getBigIntegerShapes() {
+        return toSet(BigIntegerShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all bigIntegers in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code bigIntegers}s that have a specific trait.
+     */
+    public Set<BigIntegerShape> getBigIntegerShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), BigIntegerShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all blobs in the Model.
+     *
+     * @return Returns the Set of {@code blob}s.
+     */
+    public Set<BlobShape> getBlobShapes() {
+        return toSet(BlobShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all blobs in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code blob}s that have a specific trait.
+     */
+    public Set<BlobShape> getBlobShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), BlobShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all booleans in the Model.
+     *
+     * @return Returns the Set of {@code boolean}s.
+     */
+    public Set<BooleanShape> getBooleanShapes() {
+        return toSet(BooleanShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all booleans in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code boolean}s that have a specific trait.
+     */
+    public Set<BooleanShape> getBooleanShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), BooleanShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all bytes in the Model.
+     *
+     * @return Returns the Set of {@code byte}s.
+     */
+    public Set<ByteShape> getByteShapes() {
+        return toSet(ByteShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all bytes in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code byte}s that have a specific trait.
+     */
+    public Set<ByteShape> getByteShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), ByteShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all documents in the Model.
+     *
+     * @return Returns the Set of {@code document}s.
+     */
+    public Set<DocumentShape> getDocumentShapes() {
+        return toSet(DocumentShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all documents in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code document}s that have a specific trait.
+     */
+    public Set<DocumentShape> getDocumentShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), DocumentShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all doubles in the Model.
+     *
+     * @return Returns the Set of {@code double}s.
+     */
+    public Set<DoubleShape> getDoubleShapes() {
+        return toSet(DoubleShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all doubles in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code double}s that have a specific trait.
+     */
+    public Set<DoubleShape> getDoubleShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), DoubleShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all floats in the Model.
+     *
+     * @return Returns the Set of {@code float}s.
+     */
+    public Set<FloatShape> getFloatShapes() {
+        return toSet(FloatShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all floats in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code float}s that have a specific trait.
+     */
+    public Set<FloatShape> getFloatShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), FloatShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all integers in the Model.
+     *
+     * @return Returns the Set of {@code integer}s.
+     */
+    public Set<IntegerShape> getIntegerShapes() {
+        return toSet(IntegerShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all integers in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code integer}s that have a specific trait.
+     */
+    public Set<IntegerShape> getIntegerShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), IntegerShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all lists in the Model.
+     *
+     * @return Returns the Set of {@code list}s.
+     */
+    public Set<ListShape> getListShapes() {
+        return toSet(ListShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all lists in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code list}s that have a specific trait.
+     */
+    public Set<ListShape> getListShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), ListShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all longs in the Model.
+     *
+     * @return Returns the Set of {@code long}s.
+     */
+    public Set<LongShape> getLongShapes() {
+        return toSet(LongShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all longs in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code long}s that have a specific trait.
+     */
+    public Set<LongShape> getLongShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), LongShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all maps in the Model.
+     *
+     * @return Returns the Set of {@code map}s.
+     */
+    public Set<MapShape> getMapShapes() {
+        return toSet(MapShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all maps in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code map}s that have a specific trait.
+     */
+    public Set<MapShape> getMapShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), MapShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all members in the Model.
+     *
+     * @return Returns the Set of {@code member}s.
+     */
+    public Set<MemberShape> getMemberShapes() {
+        return toSet(MemberShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all members in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code member}s that have a specific trait.
+     */
+    public Set<MemberShape> getMemberShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), MemberShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all operations in the Model.
+     *
+     * @return Returns the Set of {@code operation}s.
+     */
+    public Set<OperationShape> getOperationShapes() {
+        return toSet(OperationShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all operations in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code operation}s that have a specific trait.
+     */
+    public Set<OperationShape> getOperationShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), OperationShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all resources in the Model.
+     *
+     * @return Returns the Set of {@code resource}s.
+     */
+    public Set<ResourceShape> getResourceShapes() {
+        return toSet(ResourceShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all resources in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code resource}s that have a specific trait.
+     */
+    public Set<ResourceShape> getResourceShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), ResourceShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all services in the Model.
+     *
+     * @return Returns the Set of {@code service}s.
+     */
+    public Set<ServiceShape> getServiceShapes() {
+        return toSet(ServiceShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all services in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code service}s that have a specific trait.
+     */
+    public Set<ServiceShape> getServiceShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), ServiceShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all sets in the Model.
+     *
+     * @return Returns the Set of {@code set}s.
+     */
+    public Set<SetShape> getSetShapes() {
+        return toSet(SetShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all sets in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code set}s that have a specific trait.
+     */
+    public Set<SetShape> getSetShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), SetShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all shorts in the Model.
+     *
+     * @return Returns the Set of {@code short}s.
+     */
+    public Set<ShortShape> getShortShapes() {
+        return toSet(ShortShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all shorts in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code short}s that have a specific trait.
+     */
+    public Set<ShortShape> getShortShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), ShortShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all strings in the Model.
+     *
+     * @return Returns the Set of {@code string}s.
+     */
+    public Set<StringShape> getStringShapes() {
+        return toSet(StringShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all strings in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code string}s that have a specific trait.
+     */
+    public Set<StringShape> getStringShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), StringShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all structures in the Model.
+     *
+     * @return Returns the Set of {@code structure}s.
+     */
+    public Set<StructureShape> getStructureShapes() {
+        return toSet(StructureShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all structures in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code structure}s that have a specific trait.
+     */
+    public Set<StructureShape> getStructureShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), StructureShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all timestamps in the Model.
+     *
+     * @return Returns the Set of {@code timestamp}s.
+     */
+    public Set<TimestampShape> getTimestampShapes() {
+        return toSet(TimestampShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all timestamps in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code timestamp}s that have a specific trait.
+     */
+    public Set<TimestampShape> getTimestampShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), TimestampShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all unions in the Model.
+     *
+     * @return Returns the Set of {@code union}s.
+     */
+    public Set<UnionShape> getUnionShapes() {
+        return toSet(UnionShape.class);
+    }
+
+    /**
+     * Gets an immutable set of all unions in the Model that have a specific trait.
+     *
+     * @param trait The exact trait class to look for on shapes.
+     * @return Returns the set of {@code union}s that have a specific trait.
+     */
+    public Set<UnionShape> getUnionShapesWithTrait(Class<? extends Trait> trait) {
+        return new ShapeTypeFilteredSet<>(getShapesWithTrait(trait), UnionShape.class);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/ShapeTypeFilteredSet.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/ShapeTypeFilteredSet.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import software.amazon.smithy.model.shapes.Shape;
+
+/**
+ * Provides a view of a set returned by the getXwithTrait methods so that only
+ * shapes of a specific type are treated as present within the set.
+ *
+ * @param <T> Type of shape to project out of the Set.
+ */
+final class ShapeTypeFilteredSet<T extends Shape> extends AbstractSet<T> {
+
+    private final Set<Shape> shapes;
+    private final Class<T> shapeType;
+
+    // -1 means that the size is yet to be computed and cached.
+    private volatile int size = -1;
+
+    ShapeTypeFilteredSet(Set<Shape> shapes, Class<T> shapeType) {
+        this.shapes = shapes;
+        this.shapeType = shapeType;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return o.getClass() == shapeType && super.contains(o);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new FilteredIterator<>(shapes.iterator(), shapeType);
+    }
+
+    @Override
+    public int size() {
+        // Computing the size of the set is O(N) because we need to iterate
+        // over every value and test if it's of the right type. The size is
+        // cached to avoid doing this repeatedly.
+        int result = size;
+
+        if (result == -1) {
+            result = 0;
+            for (Shape shape : shapes) {
+                if (shapeType == shape.getClass()) {
+                    result++;
+                }
+            }
+            size = result;
+        }
+
+        return result;
+    }
+
+    private static final class FilteredIterator<T extends Shape> implements Iterator<T> {
+        private final Iterator<Shape> iterator;
+        private final Class<T> shapeType;
+        private T next;
+
+        FilteredIterator(Iterator<Shape> iterator, Class<T> shapeType) {
+            this.iterator = iterator;
+            this.shapeType = shapeType;
+
+            // Always compute the first element in the iterator.
+            next = computeNext();
+        }
+
+        @SuppressWarnings("unchecked")
+        private T computeNext() {
+            // Filter out shapes of other types.
+            while (iterator.hasNext()) {
+                Shape nextCandidate = iterator.next();
+                if (shapeType == nextCandidate.getClass()) {
+                    return (T) nextCandidate;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public T next() {
+            if (next == null) {
+                throw new NoSuchElementException("No more shapes in iterator");
+            }
+
+            T result = next;
+            next = computeNext();
+
+            return result;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
@@ -40,7 +40,8 @@ public final class BottomUpIndex implements KnowledgeIndex {
 
     public BottomUpIndex(Model model) {
         PathFinder pathFinder = PathFinder.create(model);
-        model.shapes(ServiceShape.class).forEach(service -> {
+
+        for (ServiceShape service : model.toSet(ServiceShape.class)) {
             Map<ShapeId, List<EntityShape>> serviceBindings = new HashMap<>();
             parentBindings.put(service.getId(), serviceBindings);
             for (PathFinder.Path path : pathFinder.search(service, SELECTOR)) {
@@ -56,7 +57,7 @@ public final class BottomUpIndex implements KnowledgeIndex {
                 // Add the end shape (a resource or operation) to the service bindings.
                 serviceBindings.put(path.getEndShape().getId(), shapes);
             }
-        });
+        }
     }
 
     public static BottomUpIndex of(Model model) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/BottomUpIndex.java
@@ -41,7 +41,7 @@ public final class BottomUpIndex implements KnowledgeIndex {
     public BottomUpIndex(Model model) {
         PathFinder pathFinder = PathFinder.create(model);
 
-        for (ServiceShape service : model.toSet(ServiceShape.class)) {
+        for (ServiceShape service : model.getServiceShapes()) {
             Map<ShapeId, List<EntityShape>> serviceBindings = new HashMap<>();
             parentBindings.put(service.getId(), serviceBindings);
             for (PathFinder.Path path : pathFinder.search(service, SELECTOR)) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
@@ -45,7 +45,7 @@ public final class EventStreamIndex implements KnowledgeIndex {
     public EventStreamIndex(Model model) {
         OperationIndex operationIndex = OperationIndex.of(model);
 
-        for (OperationShape operation : model.toSet(OperationShape.class)) {
+        for (OperationShape operation : model.getOperationShapes()) {
             operationIndex.getInput(operation).ifPresent(input -> {
                 computeEvents(model, operation, input, inputInfo);
             });

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
@@ -45,14 +45,14 @@ public final class EventStreamIndex implements KnowledgeIndex {
     public EventStreamIndex(Model model) {
         OperationIndex operationIndex = OperationIndex.of(model);
 
-        model.shapes(OperationShape.class).forEach(operation -> {
+        for (OperationShape operation : model.toSet(OperationShape.class)) {
             operationIndex.getInput(operation).ifPresent(input -> {
                 computeEvents(model, operation, input, inputInfo);
             });
             operationIndex.getOutput(operation).ifPresent(output -> {
                 computeEvents(model, operation, output, outputInfo);
             });
-        });
+        }
     }
 
     public static EventStreamIndex of(Model model) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -67,18 +67,14 @@ public final class HttpBindingIndex implements KnowledgeIndex {
         this.model = new WeakReference<>(model);
         OperationIndex opIndex = OperationIndex.of(model);
 
-        for (Shape shape : model.getShapesWithTrait(HttpTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                requestBindings.put(operation.getId(), computeRequestBindings(opIndex, operation));
-                responseBindings.put(operation.getId(), computeResponseBindings(opIndex, operation));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(HttpTrait.class)) {
+            requestBindings.put(operation.getId(), computeRequestBindings(opIndex, operation));
+            responseBindings.put(operation.getId(), computeResponseBindings(opIndex, operation));
         }
 
         // Add error structure bindings.
-        for (Shape shape : model.getShapesWithTrait(ErrorTrait.class)) {
-            shape.asStructureShape().ifPresent(structure -> {
-                responseBindings.put(structure.getId(), createStructureBindings(structure, false));
-            });
+        for (StructureShape structure : model.getStructureShapesWithTrait(ErrorTrait.class)) {
+            responseBindings.put(structure.getId(), createStructureBindings(structure, false));
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -53,7 +53,9 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
 
     public IdentifierBindingIndex(Model model) {
         OperationIndex operationIndex = OperationIndex.of(model);
-        model.shapes(ResourceShape.class).forEach(resource -> processResource(resource, operationIndex, model));
+        for (ResourceShape resource : model.toSet(ResourceShape.class)) {
+            processResource(resource, operationIndex, model);
+        }
     }
 
     public static IdentifierBindingIndex of(Model model) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -53,7 +53,7 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
 
     public IdentifierBindingIndex(Model model) {
         OperationIndex operationIndex = OperationIndex.of(model);
-        for (ResourceShape resource : model.toSet(ResourceShape.class)) {
+        for (ResourceShape resource : model.getResourceShapes()) {
             processResource(resource, operationIndex, model);
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
@@ -60,7 +60,7 @@ public class NullableIndex implements KnowledgeIndex {
             }
         }
 
-        for (MemberShape member : model.toSet(MemberShape.class)) {
+        for (MemberShape member : model.getMemberShapes()) {
             if (isMemberNullable(model, member)) {
                 nullableShapes.add(member.getId());
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
@@ -43,7 +43,7 @@ public final class OperationIndex implements KnowledgeIndex {
     private final Map<ShapeId, List<StructureShape>> errors = new HashMap<>();
 
     public OperationIndex(Model model) {
-        for (OperationShape operation : model.toSet(OperationShape.class)) {
+        for (OperationShape operation : model.getOperationShapes()) {
             operation.getInput()
                     .flatMap(id -> getStructure(model, id))
                     .ifPresent(shape -> inputs.put(operation.getId(), shape));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -49,7 +49,7 @@ public final class PaginatedIndex implements KnowledgeIndex {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         OperationIndex opIndex = OperationIndex.of(model);
 
-        for (ServiceShape service : model.toSet(ServiceShape.class)) {
+        for (ServiceShape service : model.getServiceShapes()) {
             PaginatedTrait serviceTrait = service.getTrait(PaginatedTrait.class).orElse(null);
             Map<ShapeId, PaginationInfo> mappings = new HashMap<>();
             for (OperationShape operation : topDownIndex.getContainedOperations(service)) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
@@ -62,10 +62,13 @@ public final class TopDownIndex implements KnowledgeIndex {
             }
         };
 
-        model.shapes(ResourceShape.class).forEach(resource -> findContained(
-                resource.getId(), walker.walkShapes(resource, filter)));
-        model.shapes(ServiceShape.class).forEach(resource -> findContained(
-                resource.getId(), walker.walkShapes(resource, filter)));
+        for (ResourceShape resource : model.toSet(ResourceShape.class)) {
+            findContained(resource.getId(), walker.walkShapes(resource, filter));
+        }
+
+        for (ServiceShape service : model.toSet(ServiceShape.class)) {
+            findContained(service.getId(), walker.walkShapes(service, filter));
+        }
     }
 
     public static TopDownIndex of(Model model) {
@@ -76,7 +79,7 @@ public final class TopDownIndex implements KnowledgeIndex {
         Set<ResourceShape> containedResources = new TreeSet<>();
         Set<OperationShape> containedOperations = new TreeSet<>();
 
-        shapes.forEach(shape -> {
+        for (Shape shape : shapes) {
             if (!shape.getId().equals(container)) {
                 if (shape instanceof ResourceShape) {
                     containedResources.add((ResourceShape) shape);
@@ -84,7 +87,7 @@ public final class TopDownIndex implements KnowledgeIndex {
                     containedOperations.add((OperationShape) shape);
                 }
             }
-        });
+        }
 
         operations.put(container, Collections.unmodifiableSet(containedOperations));
         resources.put(container, Collections.unmodifiableSet(containedResources));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/TopDownIndex.java
@@ -62,11 +62,11 @@ public final class TopDownIndex implements KnowledgeIndex {
             }
         };
 
-        for (ResourceShape resource : model.toSet(ResourceShape.class)) {
+        for (ResourceShape resource : model.getResourceShapes()) {
             findContained(resource.getId(), walker.walkShapes(resource, filter));
         }
 
-        for (ServiceShape service : model.toSet(ServiceShape.class)) {
+        for (ServiceShape service : model.getServiceShapes()) {
             findContained(service.getId(), walker.walkShapes(service, filter));
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -201,8 +201,8 @@ final class IdlModelParser extends SimpleParser {
 
     private void onVersion(Node value) {
         if (!value.isStringNode()) {
-            value.expectStringNode("The $version control statement must have a string value, but found "
-                                   + Node.printJson(value));
+            value.expectStringNode(() -> "The $version control statement must have a string value, but found "
+                                         + Node.printJson(value));
         }
 
         String parsedVersion = value.expectStringNode().getValue();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
@@ -75,6 +75,14 @@ public final class Prelude {
         private static Model loadPrelude() {
             return Model.assembler()
                     .disablePrelude()
+                    // Model validation is disabled when loading the prelude
+                    // because the prelude is validated during unit tests and
+                    // the prelude is immutable. However, if the prelude is
+                    // broken for whatever reason, ERROR events encountered
+                    // when performing model validation that uses the prelude
+                    // will still cause an error, meaning the prelude is still
+                    // validated when actually loading and using other models.
+                    .disableValidation()
                     .traitFactory(ModelAssembler.LazyTraitFactoryHolder.INSTANCE)
                     .addImport(Prelude.class.getResource("prelude.smithy"))
                     .assemble()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborProvider.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborProvider.java
@@ -99,8 +99,11 @@ public interface NeighborProvider {
      * @return Returns the created neighbor provider.
      */
     static NeighborProvider precomputed(Model model, NeighborProvider provider) {
-        Map<Shape, List<Relationship>> relationships = new HashMap<>();
-        model.shapes().forEach(shape -> relationships.put(shape, provider.getNeighbors(shape)));
+        Set<Shape> shapes = model.toSet();
+        Map<Shape, List<Relationship>> relationships = new HashMap<>(shapes.size());
+        for (Shape shape : shapes) {
+            relationships.put(shape, provider.getNeighbors(shape));
+        }
         return shape -> relationships.getOrDefault(shape, ListUtils.of());
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -128,12 +128,12 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
                 relationship(shape, RelationshipType.INSTANCE_OPERATION, id)));
 
         // Find resource shapes that bind this resource to it.
-        for (ResourceShape resource : model.toSet(ResourceShape.class)) {
+        for (ResourceShape resource : model.getResourceShapes()) {
             addServiceAndResourceBindings(result, shape, resource);
         }
 
         // Find service shapes that bind this resource to it.
-        for (ServiceShape service : model.toSet(ServiceShape.class)) {
+        for (ServiceShape service : model.getServiceShapes()) {
             addServiceAndResourceBindings(result, shape, service);
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
@@ -75,6 +76,11 @@ public final class ArrayNode extends Node implements Iterable<Node> {
 
     @Override
     public ArrayNode expectArrayNode(String errorMessage) {
+        return this;
+    }
+
+    @Override
+    public ArrayNode expectArrayNode(Supplier<String> errorMessage) {
         return this;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/BooleanNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/BooleanNode.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.node;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.SourceLocation;
 
 /**
@@ -50,6 +51,11 @@ public final class BooleanNode extends Node {
 
     @Override
     public BooleanNode expectBooleanNode(String errorMessage) {
+        return this;
+    }
+
+    @Override
+    public BooleanNode expectBooleanNode(Supplier<String> errorMessage) {
         return this;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceException;
@@ -465,7 +466,7 @@ public abstract class Node implements FromSourceLocation, ToNode {
      * @throws ExpectationNotMetException when the node is not an {@code ObjectNode}.
      */
     public final ObjectNode expectObjectNode() {
-        return expectObjectNode(null);
+        return expectObjectNode((String) null);
     }
 
     /**
@@ -481,13 +482,25 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Casts the current node to an {@code ObjectNode}, throwing
+     * {@link ExpectationNotMetException} when the node is the wrong type.
+     *
+     * @param message Error message supplier.
+     * @return Returns an object node.
+     * @throws ExpectationNotMetException when the node is not an {@code ObjectNode}.
+     */
+    public ObjectNode expectObjectNode(Supplier<String> message) {
+        return expectObjectNode(message.get());
+    }
+
+    /**
      * Casts the current node to an {@code ArrayNode}.
      *
      * @return Returns an array node.
      * @throws ExpectationNotMetException when the node is not an {@code ArrayNode}.
      */
     public final ArrayNode expectArrayNode() {
-        return expectArrayNode(null);
+        return expectArrayNode((String) null);
     }
 
     /**
@@ -503,13 +516,25 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Casts the current node to an {@code ArrayNode}, throwing
+     * {@link ExpectationNotMetException} when the node is the wrong type.
+     *
+     * @param message Error message supplier.
+     * @return Returns an array node.
+     * @throws ExpectationNotMetException when the node is the wrong type.
+     */
+    public ArrayNode expectArrayNode(Supplier<String> message) {
+        return expectArrayNode(message.get());
+    }
+
+    /**
      * Casts the current node to a {@code StringNode}.
      *
      * @return Returns a string node.
      * @throws ExpectationNotMetException when the node is the wrong type.
      */
     public final StringNode expectStringNode() {
-        return expectStringNode(null);
+        return expectStringNode((String) null);
     }
 
     /**
@@ -525,13 +550,25 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Casts the current node to a {@code StringNode}, throwing
+     * {@link ExpectationNotMetException} when the node is the wrong type.
+     *
+     * @param message Error message supplier.
+     * @return Returns a string node.
+     * @throws ExpectationNotMetException when the node is the wrong type.
+     */
+    public StringNode expectStringNode(Supplier<String> message) {
+        return expectStringNode(message.get());
+    }
+
+    /**
      * Casts the current node to a {@code NumberNode}.
      *
      * @return Returns a number node.
      * @throws ExpectationNotMetException when the node is the wrong type.
      */
     public final NumberNode expectNumberNode() {
-        return expectNumberNode(null);
+        return expectNumberNode((String) null);
     }
 
     /**
@@ -547,13 +584,25 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Casts the current node to a {@code NumberNode}, throwing
+     * {@link ExpectationNotMetException} when the node is the wrong type.
+     *
+     * @param message Error message supplier.
+     * @return Returns a number node.
+     * @throws ExpectationNotMetException when the node is the wrong type.
+     */
+    public NumberNode expectNumberNode(Supplier<String> message) {
+        return expectNumberNode(message.get());
+    }
+
+    /**
      * Casts the current node to a {@code BooleanNode}.
      *
      * @return Returns a boolean node.
      * @throws ExpectationNotMetException when the node is the wrong type.
      */
     public final BooleanNode expectBooleanNode() {
-        return expectBooleanNode(null);
+        return expectBooleanNode((String) null);
     }
 
     /**
@@ -569,13 +618,25 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Casts the current node to a {@code BooleanNode}, throwing
+     * {@link ExpectationNotMetException} when the node is the wrong type.
+     *
+     * @param message Error message supplier.
+     * @return Returns a boolean node.
+     * @throws ExpectationNotMetException when the node is the wrong type.
+     */
+    public BooleanNode expectBooleanNode(Supplier<String> message) {
+        return expectBooleanNode(message.get());
+    }
+
+    /**
      * Casts the current node to a {@code NullNode}.
      *
      * @return Returns a null node.
      * @throws ExpectationNotMetException when the node is the wrong type.
      */
     public final NullNode expectNullNode() {
-        return expectNullNode(null);
+        return expectNullNode((String) null);
     }
 
     /**
@@ -588,6 +649,18 @@ public abstract class Node implements FromSourceLocation, ToNode {
      */
     public NullNode expectNullNode(String message) {
         throw new ExpectationNotMetException(expandMessage(message, NodeType.NULL.toString()), this);
+    }
+
+    /**
+     * Casts the current node to a {@code NullNode}, throwing
+     * {@link ExpectationNotMetException} when the node is the wrong type.
+     *
+     * @param message Error message supplier.
+     * @return Returns a null node.
+     * @throws ExpectationNotMetException when the node is the wrong type.
+     */
+    public NullNode expectNullNode(Supplier<String> message) {
+        return expectNullNode(message.get());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NullNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NullNode.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.node;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.SourceLocation;
 
 /**
@@ -39,6 +40,11 @@ public final class NullNode extends Node {
 
     @Override
     public NullNode expectNullNode(String errorMessage) {
+        return this;
+    }
+
+    @Override
+    public NullNode expectNullNode(Supplier<String> errorMessage) {
         return this;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NumberNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NumberNode.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.node;
 import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.SourceLocation;
 
 /**
@@ -80,6 +81,11 @@ public final class NumberNode extends Node {
 
     @Override
     public NumberNode expectNumberNode(String errorMessage) {
+        return this;
+    }
+
+    @Override
+    public NumberNode expectNumberNode(Supplier<String> errorMessage) {
         return this;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/ObjectNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/ObjectNode.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -74,6 +75,11 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
 
     @Override
     public ObjectNode expectObjectNode(String errorMessage) {
+        return this;
+    }
+
+    @Override
+    public ObjectNode expectObjectNode(Supplier<String> errorMessage) {
         return this;
     }
 
@@ -240,7 +246,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public Optional<StringNode> getStringMember(String memberName) {
         return getMember(memberName)
-                .map(n -> n.expectStringNode(format("Expected `%s` to be a string; found {type}", memberName)));
+                .map(n -> n.expectStringNode(() -> format("Expected `%s` to be a string; found {type}", memberName)));
     }
 
     /**
@@ -266,7 +272,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public Optional<NumberNode> getNumberMember(String memberName) {
         return getMember(memberName)
-                .map(n -> n.expectNumberNode(format("Expected `%s` to be a number; found {type}", memberName)));
+                .map(n -> n.expectNumberNode(() -> format("Expected `%s` to be a number; found {type}", memberName)));
     }
 
     /**
@@ -292,7 +298,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public Optional<ArrayNode> getArrayMember(String memberName) {
         return getMember(memberName)
-                .map(n -> n.expectArrayNode(format("Expected `%s` to be an array; found {type}", memberName)));
+                .map(n -> n.expectArrayNode(() -> format("Expected `%s` to be an array; found {type}", memberName)));
     }
 
     /**
@@ -305,7 +311,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public Optional<ObjectNode> getObjectMember(String memberName) {
         return getMember(memberName)
-                .map(n -> n.expectObjectNode(format("Expected `%s` to be an object; found {type}", memberName)));
+                .map(n -> n.expectObjectNode(() -> format("Expected `%s` to be an object; found {type}", memberName)));
     }
 
     /**
@@ -318,7 +324,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public Optional<BooleanNode> getBooleanMember(String memberName) {
         return getMember(memberName)
-                .map(n -> n.expectBooleanNode(format("Expected `%s` to be a boolean; found {type}", memberName)));
+                .map(n -> n.expectBooleanNode(() -> format("Expected `%s` to be a boolean; found {type}", memberName)));
     }
 
     /**
@@ -356,7 +362,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      *  present in the members map.
      */
     public Node expectMember(String name) {
-        return expectMember(name, format("Missing expected member `%s`.", name));
+        return expectMember(name, () -> format("Missing expected member `%s`.", name));
     }
 
     /**
@@ -374,6 +380,20 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
     }
 
     /**
+     * Gets the member with the given name, throwing
+     * {@link ExpectationNotMetException} when the member is not present.
+     *
+     * @param name Name of the member to get.
+     * @param errorMessage Error message supplier.
+     * @return Returns the node with the given member name.
+     * @throws ExpectationNotMetException when {@code memberName} is is not
+     *  present in the members map.
+     */
+    public Node expectMember(String name, Supplier<String> errorMessage) {
+        return getMember(name).orElseThrow(() -> new ExpectationNotMetException(errorMessage.get(), this));
+    }
+
+    /**
      * Gets a member and requires it to be an array.
      *
      * @param name Name of the member to get.
@@ -382,7 +402,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public ArrayNode expectArrayMember(String name) {
         return expectMember(name)
-                .expectArrayNode(format("Expected `%s` member to be an array, but found {type}.", name));
+                .expectArrayNode(() -> format("Expected `%s` member to be an array, but found {type}.", name));
     }
 
     /**
@@ -394,7 +414,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public BooleanNode expectBooleanMember(String name) {
         return expectMember(name)
-                .expectBooleanNode(format("Expected `%s` member to be a boolean, but found {type}.", name));
+                .expectBooleanNode(() -> format("Expected `%s` member to be a boolean, but found {type}.", name));
     }
 
     /**
@@ -406,7 +426,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public NullNode expectNullMember(String name) {
         return expectMember(name)
-                .expectNullNode(format("Expected `%s` member to be null, but found {type}.", name));
+                .expectNullNode(() -> format("Expected `%s` member to be null, but found {type}.", name));
     }
 
     /**
@@ -418,7 +438,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public NumberNode expectNumberMember(String name) {
         return expectMember(name)
-                .expectNumberNode(format("Expected `%s` member to be a number, but found {type}.", name));
+                .expectNumberNode(() -> format("Expected `%s` member to be a number, but found {type}.", name));
     }
 
     /**
@@ -430,7 +450,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public ObjectNode expectObjectMember(String name) {
         return expectMember(name)
-                .expectObjectNode(format("Expected `%s` member to be an object, but found {type}.", name));
+                .expectObjectNode(() -> format("Expected `%s` member to be an object, but found {type}.", name));
     }
 
     /**
@@ -442,7 +462,7 @@ public final class ObjectNode extends Node implements ToSmithyBuilder<ObjectNode
      */
     public StringNode expectStringMember(String name) {
         return expectMember(name)
-                .expectStringNode(format("Expected `%s` member to be a string, but found {type}.", name));
+                .expectStringNode(() -> format("Expected `%s` member to be a string, but found {type}.", name));
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/StringNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/StringNode.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -81,6 +82,11 @@ public final class StringNode extends Node {
 
     @Override
     public StringNode expectStringNode(String errorMessage) {
+        return this;
+    }
+
+    @Override
+    public StringNode expectStringNode(Supplier<String> errorMessage) {
         return this;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
@@ -15,6 +15,9 @@
 
 package software.amazon.smithy.model.selector;
 
+import java.util.Collection;
+import java.util.function.Function;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
@@ -51,6 +54,21 @@ interface InternalSelector {
      * @return Returns true to continue sending shapes to the selector.
      */
     boolean push(Context ctx, Shape shape, Receiver next);
+
+    /**
+     * Returns a function that is used to optimize which shapes in a model
+     * need to be evaluated.
+     *
+     * <p>For example, when selecting "structure", it is far less work
+     * to leverage {@link Model#toSet(Class)} than it is to send every shape
+     * through every selector.
+     *
+     * @return Returns a function that returns null if no optimization can
+     *   be made, or a Collection of Shapes if an optimization was made.
+     */
+    default Function<Model, Collection<? extends Shape>> optimize() {
+        return null;
+    }
 
     /**
      * Receives shapes from an InternalSelector.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.selector;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
@@ -56,15 +55,11 @@ final class ScopedAttributeSelector implements InternalSelector {
         AttributeValue create(AttributeValue value);
     }
 
-    private final BiFunction<Shape, Map<String, Set<Shape>>, AttributeValue> keyScope;
+    private final List<String> path;
     private final List<Assertion> assertions;
 
-    ScopedAttributeSelector(
-            BiFunction<Shape, Map<String, Set<Shape>>,
-                    AttributeValue> keyScope,
-            List<Assertion> assertions
-    ) {
-        this.keyScope = keyScope;
+    ScopedAttributeSelector(List<String> path, List<Assertion> assertions) {
+        this.path = path;
         this.assertions = assertions;
     }
 
@@ -79,7 +74,7 @@ final class ScopedAttributeSelector implements InternalSelector {
 
     private boolean matchesAssertions(Shape shape, Map<String, Set<Shape>> vars) {
         // First resolve the scope of the assertions.
-        AttributeValue scope = keyScope.apply(shape, vars);
+        AttributeValue scope = AttributeValue.shape(shape, vars).getPath(path);
 
         // If it's not present, then nothing could ever match.
         if (!scope.isPresent()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
@@ -15,6 +15,9 @@
 
 package software.amazon.smithy.model.selector;
 
+import java.util.Collection;
+import java.util.function.Function;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -33,5 +36,10 @@ final class ShapeTypeSelector implements InternalSelector {
         }
 
         return true;
+    }
+
+    @Override
+    public Function<Model, Collection<? extends Shape>> optimize() {
+        return model -> model.toSet(shapeType.getShapeClass());
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
@@ -43,14 +43,14 @@ abstract class NamedMembersShape extends Shape {
         // member has a valid ID that is prefixed with the shape ID.
         members = MapUtils.orderedCopyOf(builder.members);
 
-        members.forEach((key, value) -> {
-            ShapeId expected = getId().withMember(key);
-            if (!value.getId().equals(expected)) {
+        for (MemberShape member : members.values()) {
+            if (!member.getId().toString().startsWith(getId().toString())) {
+                ShapeId expected = getId().withMember(member.getMemberName());
                 throw new IllegalArgumentException(String.format(
                         "Expected the `%s` member of `%s` to have an ID of `%s` but found `%s`",
-                        key, getId(), expected, value.getId()));
+                        member.getMemberName(), getId(), expected, member.getId()));
             }
-        });
+        }
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
@@ -87,7 +87,9 @@ public interface Trait extends FromSourceLocation, ToNode, ToShapeId {
      * @return Returns the idiomatic trait name.
      */
     static String getIdiomaticTraitName(String traitName) {
-        return traitName.replace("smithy.api#", "");
+        return traitName.startsWith("smithy.api#")
+               ? traitName.substring("smithy.api#".length())
+               : traitName;
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
@@ -66,12 +66,17 @@ public interface Trait extends FromSourceLocation, ToNode, ToShapeId {
      * {@link Pair} of Shape and Trait if the trait is present on the
      * given shape.
      *
+     * <p>This method is deprecated because it generally results in harder
+     * to read code using unnamed tuples. Use {@link Shape#hasTrait(Class)}
+     * and {@link Shape#expectTrait(Class)} instead.
+     *
      * @param shape Shape to query for the trait.
      * @param traitClass Trait to retrieve.
      * @param <S> Shape
      * @param <T> Trait
      * @return Returns the Stream of the found trait or an empty stream.
      */
+    @Deprecated
     static <S extends Shape, T extends Trait> Stream<Pair<S, T>> flatMapStream(
             S shape,
             Class<T> traitClass

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/CleanTraitDefinitions.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.AuthDefinitionTrait;
 import software.amazon.smithy.model.traits.ProtocolDefinitionTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
@@ -43,42 +44,38 @@ public final class CleanTraitDefinitions implements ModelTransformerPlugin {
 
     private Set<Shape> getAuthDefShapesToReplace(Model model, Set<ShapeId> removedShapeIds) {
         Set<Shape> shapes = new HashSet<>();
-        for (Shape shape : model.getShapesWithTrait(AuthDefinitionTrait.class)) {
-            shape.asStructureShape().ifPresent(structure -> {
-                AuthDefinitionTrait authDefTrait = structure.expectTrait(AuthDefinitionTrait.class);
-                List<ShapeId> traits = authDefTrait.getTraits();
-                List<ShapeId> newTraits = excludeTraitsInSet(traits, removedShapeIds);
-                // Return early if re-built list of traits is the same as existing list.
-                if (!traits.equals(newTraits)) {
-                    // If the list of traits on the AuthDefinitionTrait has changed due to a trait shape being
-                    // removed from the model, return a new version of the shape with a new version of the trait.
-                    shapes.add(structure.toBuilder()
-                                       .addTrait(authDefTrait.toBuilder().traits(newTraits).build())
-                                       .build());
-                }
-            });
+        for (StructureShape structure : model.getStructureShapesWithTrait(AuthDefinitionTrait.class)) {
+            AuthDefinitionTrait authDefTrait = structure.expectTrait(AuthDefinitionTrait.class);
+            List<ShapeId> traits = authDefTrait.getTraits();
+            List<ShapeId> newTraits = excludeTraitsInSet(traits, removedShapeIds);
+            // Return early if re-built list of traits is the same as existing list.
+            if (!traits.equals(newTraits)) {
+                // If the list of traits on the AuthDefinitionTrait has changed due to a trait shape being
+                // removed from the model, return a new version of the shape with a new version of the trait.
+                shapes.add(structure.toBuilder()
+                                   .addTrait(authDefTrait.toBuilder().traits(newTraits).build())
+                                   .build());
+            }
         }
         return shapes;
     }
 
     private Set<Shape> getProtocolDefShapesToReplace(Model model, Set<ShapeId> removedShapeIds) {
         Set<Shape> shapes = new HashSet<>();
-        for (Shape shape : model.getShapesWithTrait(ProtocolDefinitionTrait.class)) {
-            shape.asStructureShape().ifPresent(structure -> {
-                ProtocolDefinitionTrait protocolDefinitionTrait = structure.expectTrait(ProtocolDefinitionTrait.class);
-                List<ShapeId> traits = protocolDefinitionTrait.getTraits();
-                List<ShapeId> newTraits = excludeTraitsInSet(traits, removedShapeIds);
+        for (StructureShape structure : model.getStructureShapesWithTrait(ProtocolDefinitionTrait.class)) {
+            ProtocolDefinitionTrait protocolDefinitionTrait = structure.expectTrait(ProtocolDefinitionTrait.class);
+            List<ShapeId> traits = protocolDefinitionTrait.getTraits();
+            List<ShapeId> newTraits = excludeTraitsInSet(traits, removedShapeIds);
 
-                // Return early if re-built list of traits is the same as existing list.
-                if (!traits.equals(newTraits)) {
-                    // If the list of traits on the ProtocolDefinitionTrait has changed due to a trait shape
-                    // being removed from the model, return a new version of the shape with a new version of
-                    // the trait.
-                    shapes.add(structure.toBuilder()
-                                       .addTrait(protocolDefinitionTrait.toBuilder().traits(newTraits).build())
-                                       .build());
-                }
-            });
+            // Return early if re-built list of traits is the same as existing list.
+            if (!traits.equals(newTraits)) {
+                // If the list of traits on the ProtocolDefinitionTrait has changed due to a trait shape
+                // being removed from the model, return a new version of the shape with a new version of
+                // the trait.
+                shapes.add(structure.toBuilder()
+                                   .addTrait(protocolDefinitionTrait.toBuilder().traits(newTraits).build())
+                                   .build());
+            }
         }
         return shapes;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
@@ -15,10 +15,9 @@
 
 package software.amazon.smithy.model.validation.node;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -40,11 +39,11 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
             Shape shape,
             LengthTrait trait,
             StringNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         String value = node.getValue();
-        int size = value.getBytes(Charset.forName("UTF-8")).length;
+        int size = value.getBytes(StandardCharsets.UTF_8).length;
 
         trait.getMin().ifPresent(min -> {
             if (size < min) {
@@ -54,7 +53,7 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
         });
 
         trait.getMax().ifPresent(max -> {
-            if (value.getBytes(Charset.forName("UTF-8")).length > max) {
+            if (value.getBytes(StandardCharsets.UTF_8).length > max) {
                 emitter.accept(node, "Value provided for `" + shape.getId() + "` must have no more than "
                                      + max + " bytes, but the provided value has " + size + " bytes");
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/CollectionLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/CollectionLengthPlugin.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.validation.node;
 
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -40,7 +39,7 @@ final class CollectionLengthPlugin extends MemberAndShapeTraitPlugin<CollectionS
             Shape shape,
             LengthTrait trait,
             ArrayNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         trait.getMin().ifPresent(min -> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/FilteredPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/FilteredPlugin.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.validation.node;
 
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
 
@@ -32,11 +31,11 @@ abstract class FilteredPlugin<S extends Shape, N extends Node> implements NodeVa
 
     @Override
     @SuppressWarnings("unchecked")
-    public final void apply(Shape shape, Node value, Model model, BiConsumer<FromSourceLocation, String> emitter) {
+    public final void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {
         if (shapeClass.isInstance(shape) && nodeClass.isInstance(value)) {
-            check((S) shape, (N) value, model, emitter);
+            check((S) shape, (N) value, context, emitter);
         }
     }
 
-    abstract void check(S shape, N node, Model model, BiConsumer<FromSourceLocation, String> emitter);
+    abstract void check(S shape, N node, Context context, BiConsumer<FromSourceLocation, String> emitter);
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.validation.node;
 
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -39,7 +38,7 @@ final class MapLengthPlugin extends MemberAndShapeTraitPlugin<MapShape, ObjectNo
             Shape shape,
             LengthTrait trait,
             ObjectNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         trait.getMin().ifPresent(min -> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MemberAndShapeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MemberAndShapeTraitPlugin.java
@@ -37,11 +37,11 @@ abstract class MemberAndShapeTraitPlugin<S extends Shape, N extends Node, T exte
 
     @Override
     @SuppressWarnings("unchecked")
-    public final void apply(Shape shape, Node value, Model model, BiConsumer<FromSourceLocation, String> emitter) {
+    public final void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {
         if (nodeClass.isInstance(value)
                 && shape.getTrait(traitClass).isPresent()
-                && isMatchingShape(shape, model)) {
-            check(shape, shape.getTrait(traitClass).get(), (N) value, model, emitter);
+                && isMatchingShape(shape, context.model())) {
+            check(shape, shape.getTrait(traitClass).get(), (N) value, context, emitter);
         }
     }
 
@@ -62,6 +62,6 @@ abstract class MemberAndShapeTraitPlugin<S extends Shape, N extends Node, T exte
             Shape shape,
             T trait,
             N value,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter);
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.validation.node;
 
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
@@ -37,7 +36,7 @@ final class PatternTraitPlugin extends MemberAndShapeTraitPlugin<StringShape, St
             Shape shape,
             PatternTrait trait,
             StringNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         if (!trait.getPattern().matcher(node.getValue()).find()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.validation.node;
 import java.math.BigDecimal;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.NumberNode;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -38,7 +37,7 @@ final class RangeTraitPlugin extends MemberAndShapeTraitPlugin<NumberShape, Numb
             Shape shape,
             RangeTrait trait,
             NumberNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         Number number = node.getValue();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringEnumPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringEnumPlugin.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.validation.node;
 import java.util.List;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.EnumTrait;
@@ -37,7 +36,7 @@ final class StringEnumPlugin extends FilteredPlugin<StringShape, StringNode> {
     protected void check(
             StringShape shape,
             StringNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         shape.getTrait(EnumTrait.class).ifPresent(trait -> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.validation.node;
 
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
@@ -37,7 +36,7 @@ final class StringLengthPlugin extends MemberAndShapeTraitPlugin<StringShape, St
             Shape shape,
             LengthTrait trait,
             StringNode node,
-            Model model,
+            Context context,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
         trait.getMin().ifPresent(min -> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
@@ -20,7 +20,6 @@ import java.time.format.DateTimeParseException;
 import java.util.function.BiConsumer;
 import java.util.logging.Logger;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -39,7 +38,7 @@ final class TimestampFormatPlugin implements NodeValidatorPlugin {
     private static final Logger LOGGER = Logger.getLogger(TimestampFormatPlugin.class.getName());
 
     @Override
-    public void apply(Shape shape, Node value, Model model, BiConsumer<FromSourceLocation, String> emitter) {
+    public void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {
         if (shape instanceof TimestampShape) {
             validate(shape, shape.getTrait(TimestampFormatTrait.class).orElse(null), value, emitter);
         } else if (shape instanceof MemberShape && shape.getTrait(TimestampFormatTrait.class).isPresent()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
@@ -35,8 +35,8 @@ public enum TimestampValidationStrategy implements NodeValidatorPlugin {
      */
     FORMAT {
         @Override
-        public void apply(Shape shape, Node value, Model model, BiConsumer<FromSourceLocation, String> emitter) {
-            new TimestampFormatPlugin().apply(shape, value, model, emitter);
+        public void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {
+            new TimestampFormatPlugin().apply(shape, value, context, emitter);
         }
     },
 
@@ -46,8 +46,8 @@ public enum TimestampValidationStrategy implements NodeValidatorPlugin {
      */
     EPOCH_SECONDS {
         @Override
-        public void apply(Shape shape, Node value, Model model, BiConsumer<FromSourceLocation, String> emitter) {
-            if (isTimestampMember(model, shape) && !value.isNumberNode()) {
+        public void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {
+            if (isTimestampMember(context.model(), shape) && !value.isNumberNode()) {
                 emitter.accept(shape, "Invalid " + value.getType() + " value provided for timestamp, `"
                                       + shape.getId() + "`. Expected a number that contains epoch "
                                       + "seconds with optional millisecond precision");

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventPayloadTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventPayloadTraitValidator.java
@@ -41,12 +41,11 @@ public final class EventPayloadTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(EventPayloadTrait.class)) {
-            shape.asMemberShape().ifPresent(member -> {
-                model.getShape(member.getContainer()).flatMap(Shape::asStructureShape).ifPresent(structure -> {
-                    validateEvent(structure, member).ifPresent(events::add);
-                });
-            });
+        for (MemberShape member : model.getMemberShapesWithTrait(EventPayloadTrait.class)) {
+            model.getShape(member.getContainer())
+                    .flatMap(Shape::asStructureShape)
+                    .flatMap(structure -> validateEvent(structure, member))
+                    .ifPresent(events::add);
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
@@ -34,10 +34,8 @@ public final class ExamplesTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(ExamplesTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                events.addAll(validateExamples(model, operation, operation.expectTrait(ExamplesTrait.class)));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(ExamplesTrait.class)) {
+            events.addAll(validateExamples(model, operation, operation.expectTrait(ExamplesTrait.class)));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
@@ -68,10 +68,8 @@ public final class HostLabelTraitValidator extends AbstractValidator {
 
         // Validate all operation shapes with the `endpoint` trait.
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(EndpointTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                events.addAll(validateStructure(model, operation, operation.expectTrait(EndpointTrait.class)));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(EndpointTrait.class)) {
+            events.addAll(validateStructure(model, operation, operation.expectTrait(EndpointTrait.class)));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpHeaderTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpHeaderTraitValidator.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.HttpHeaderTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -79,15 +78,13 @@ public final class HttpHeaderTraitValidator extends AbstractValidator {
 
         List<ValidationEvent> events = new ArrayList<>();
 
-        for (StructureShape structure : model.toSet(StructureShape.class)) {
+        for (StructureShape structure : model.getStructureShapes()) {
             events.addAll(validateStructure(structure));
         }
 
-        for (Shape shape : model.getShapesWithTrait(HttpHeaderTrait.class)) {
-            shape.asMemberShape().ifPresent(member -> {
-                HttpHeaderTrait httpHeaderTrait = member.expectTrait(HttpHeaderTrait.class);
-                validateHeader(member, httpHeaderTrait).ifPresent(events::add);
-            });
+        for (MemberShape member : model.getMemberShapesWithTrait(HttpHeaderTrait.class)) {
+            HttpHeaderTrait httpHeaderTrait = member.expectTrait(HttpHeaderTrait.class);
+            validateHeader(member, httpHeaderTrait).ifPresent(events::add);
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpLabelTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpLabelTraitValidator.java
@@ -56,10 +56,8 @@ public final class HttpLabelTraitValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         // Validate all operation shapes with the `http` trait.
-        for (Shape shape : model.getShapesWithTrait(HttpTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                events.addAll(validateStructure(model, operation, operation.expectTrait(HttpTrait.class)));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(HttpTrait.class)) {
+            events.addAll(validateStructure(model, operation, operation.expectTrait(HttpTrait.class)));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.model.traits.IdempotentTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
@@ -69,10 +68,8 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
 
         HttpBindingIndex bindingIndex = HttpBindingIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(HttpTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                events.addAll(validateOperation(bindingIndex, operation, operation.expectTrait(HttpTrait.class)));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(HttpTrait.class)) {
+            events.addAll(validateOperation(bindingIndex, operation, operation.expectTrait(HttpTrait.class)));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPayloadValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPayloadValidator.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
@@ -54,16 +53,12 @@ public final class HttpPayloadValidator extends AbstractValidator {
         HttpBindingIndex bindings = HttpBindingIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
 
-        for (Shape shape : model.getShapesWithTrait(HttpTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                events.addAll(validateOperation(bindings, opIndex, operation));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(HttpTrait.class)) {
+            events.addAll(validateOperation(bindings, opIndex, operation));
         }
 
-        for (Shape shape : model.getShapesWithTrait(ErrorTrait.class)) {
-            shape.asStructureShape().ifPresent(structure -> {
-                events.addAll(validateError(structure, bindings));
-            });
+        for (StructureShape structure : model.getStructureShapesWithTrait(ErrorTrait.class)) {
+            events.addAll(validateError(structure, bindings));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPrefixHeadersTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpPrefixHeadersTraitValidator.java
@@ -36,11 +36,9 @@ public final class HttpPrefixHeadersTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(HttpPrefixHeadersTrait.class)) {
-            shape.asMemberShape().ifPresent(member -> {
-                model.getShape(member.getContainer()).flatMap(Shape::asStructureShape).ifPresent(structure -> {
-                    events.addAll(validateMember(structure, member, member.expectTrait(HttpPrefixHeadersTrait.class)));
-                });
+        for (MemberShape member : model.getMemberShapesWithTrait(HttpPrefixHeadersTrait.class)) {
+            model.getShape(member.getContainer()).flatMap(Shape::asStructureShape).ifPresent(structure -> {
+                events.addAll(validateMember(structure, member, member.expectTrait(HttpPrefixHeadersTrait.class)));
             });
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryParamsTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryParamsTraitValidator.java
@@ -46,17 +46,16 @@ public final class HttpQueryParamsTraitValidator extends AbstractValidator {
     private List<ValidationEvent> validateQueryTraitUsage(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
 
-        for (Shape shape : model.getShapesWithTrait(HttpQueryParamsTrait.class)) {
-            shape.asMemberShape()
-                .flatMap(member -> model.getShape(member.getContainer())
-                .flatMap(Shape::asStructureShape))
-                .ifPresent(structure -> {
-                    // Gather the names of member shapes, as strings, that apply HttpQuery traits
-                    List<String> queryShapes = getMembersWithTrait(structure, HttpQueryTrait.class);
-                    if (queryShapes.size() > 0) {
-                        events.add(createNote(structure, shape.toShapeId().getMember().get(), queryShapes));
-                    }
-                });
+        for (MemberShape member : model.getMemberShapesWithTrait(HttpQueryParamsTrait.class)) {
+            model.getShape(member.getContainer())
+                    .flatMap(Shape::asStructureShape)
+                    .ifPresent(structure -> {
+                        // Gather the names of member shapes, as strings, that apply HttpQuery traits
+                        List<String> queryShapes = getMembersWithTrait(structure, HttpQueryTrait.class);
+                        if (queryShapes.size() > 0) {
+                            events.add(createNote(structure, member.getMemberName(), queryShapes));
+                        }
+                    });
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryTraitValidator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.HttpQueryTrait;
@@ -48,17 +49,15 @@ public final class HttpQueryTraitValidator extends AbstractValidator {
         Map<StructureShape, Map<String, Set<String>>> queryBindings = new HashMap<>();
 
         // Find all members in the model that have the HttpQuery trait.
-        for (Shape shape : model.getShapesWithTrait(HttpQueryTrait.class)) {
-            shape.asMemberShape().ifPresent(member -> {
-                // Get the structure of the member. Validation events are going to be
-                // applied to the structure and not to members.
-                model.getShape(member.getContainer()).flatMap(Shape::asStructureShape).ifPresent(structure -> {
-                    HttpQueryTrait trait = shape.expectTrait(HttpQueryTrait.class);
-                    queryBindings
-                            .computeIfAbsent(structure, s -> new HashMap<>())
-                            .computeIfAbsent(trait.getValue(), v -> new HashSet<>())
-                            .add(member.getMemberName());
-                });
+        for (MemberShape member : model.getMemberShapesWithTrait(HttpQueryTrait.class)) {
+            // Get the structure of the member. Validation events are going to be
+            // applied to the structure and not to members.
+            model.getShape(member.getContainer()).flatMap(Shape::asStructureShape).ifPresent(structure -> {
+                HttpQueryTrait trait = member.expectTrait(HttpQueryTrait.class);
+                queryBindings
+                        .computeIfAbsent(structure, s -> new HashMap<>())
+                        .computeIfAbsent(trait.getValue(), v -> new HashSet<>())
+                        .add(member.getMemberName());
             });
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpResponseCodeSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpResponseCodeSemanticsValidator.java
@@ -38,16 +38,12 @@ public final class HttpResponseCodeSemanticsValidator extends AbstractValidator 
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
 
-        for (Shape shape : model.getShapesWithTrait(HttpTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                validateOperationsWithHttpTrait(operation).ifPresent(events::add);
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(HttpTrait.class)) {
+            validateOperationsWithHttpTrait(operation).ifPresent(events::add);
         }
 
-        for (Shape shape : model.getShapesWithTrait(ErrorTrait.class)) {
-            shape.asStructureShape().ifPresent(structure -> {
-                validateError(structure, structure.expectTrait(ErrorTrait.class)).ifPresent(events::add);
-            });
+        for (StructureShape structure : model.getStructureShapesWithTrait(ErrorTrait.class)) {
+            validateError(structure, structure.expectTrait(ErrorTrait.class)).ifPresent(events::add);
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -68,11 +68,9 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         TopDownIndex topDown = TopDownIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
 
-        for (Shape shape : model.getShapesWithTrait(PaginatedTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                PaginatedTrait paginatedTrait = shape.expectTrait(PaginatedTrait.class);
-                events.addAll(validateOperation(model, topDown, opIndex, operation, paginatedTrait));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(PaginatedTrait.class)) {
+            PaginatedTrait paginatedTrait = operation.expectTrait(PaginatedTrait.class);
+            events.addAll(validateOperation(model, topDown, opIndex, operation, paginatedTrait));
         }
 
         return events;

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -57,13 +57,6 @@ public class HttpBindingIndexTest {
             .unwrap();
 
     @Test
-    public void throwsWhenShapeIsInvalid() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            HttpBindingIndex.of(model).getRequestBindings(ShapeId.from("ns.foo#Missing"));
-        });
-    }
-
-    @Test
     public void providesResponseCode() {
         HttpBindingIndex index = HttpBindingIndex.of(model);
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
@@ -17,18 +17,15 @@ package software.amazon.smithy.model.shapes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Field;
 import java.util.Collection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -250,24 +247,5 @@ public class ShapeTest {
         Shape shapeB = StringShape.builder().id("ns.foo#baz").addTrait(traitA).build();
 
         assertEquals(shapeA, shapeB);
-    }
-
-    @Test
-    public void drainsFromPriorityQueueWhenGivenBadInput() throws Exception {
-        for (int i = 0; i < 1024; i++) {
-            ShapeId.from("smithy.api#Foo" + i);
-        }
-
-        Field factoryField = ShapeId.class.getDeclaredField("FACTORY");
-        factoryField.setAccessible(true);
-        Object factory = factoryField.get(ShapeId.class);
-        Field map = factory.getClass().getDeclaredField("map");
-        map.setAccessible(true);
-        Object cache = map.get(factory);
-
-        // The size of the map is an estimate, so check if the value is +-... 25? I dunno.
-        int size = (int) cache.getClass().getMethod("size").invoke(cache);
-        assertThat(size, greaterThan(1024 - 25));
-        assertThat(size, lessThan(1024 + 25));
     }
 }

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeOutputValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttSubscribeOutputValidator.java
@@ -49,10 +49,8 @@ public final class MqttSubscribeOutputValidator extends AbstractValidator {
     public List<ValidationEvent> validate(Model model) {
         EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape shape : model.getShapesWithTrait(SubscribeTrait.class)) {
-            shape.asOperationShape().ifPresent(operation -> {
-                events.addAll(validateOperation(model, operation, eventStreamIndex));
-            });
+        for (OperationShape operation : model.getOperationShapesWithTrait(SubscribeTrait.class)) {
+            events.addAll(validateOperation(model, operation, eventStreamIndex));
         }
         return events;
     }

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ProtocolTestCaseValidator.java
@@ -51,8 +51,10 @@ abstract class ProtocolTestCaseValidator<T extends Trait> extends AbstractValida
         OperationIndex operationIndex = OperationIndex.of(model);
 
         return Stream.concat(model.shapes(OperationShape.class), model.shapes(StructureShape.class))
-                .flatMap(operation -> Trait.flatMapStream(operation, traitClass))
-                .flatMap(pair -> validateOperation(model, operationIndex, pair.left, pair.right).stream())
+                .filter(shape -> shape.hasTrait(traitClass))
+                .flatMap(shape -> {
+                    return validateOperation(model, operationIndex, shape, shape.expectTrait(traitClass)).stream();
+                })
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This commit makes various performance improvements that particularly help
when validating models with 100k+ shapes.

* Fixed JMH benchmarks so they work with the updated Gradle version.
* Model now uses a synchronized IdentityHashMap now to back the
  blackboard cache rather than a ConcurrentHashMap. This will actually
  now prevent duplicate work in creating KnowledgeIndexes. An
  IdentityHashMap was used because it works well for the classes
  used to cache knowledge indexes.
* HttpBindingIndex now uses a WeakReference to Model. This was
  previously an unnecessary cyclical reference.
* HttpBindingIndex no longer throws when attempting to access the
  HTTP bindings of shapes that don't exist or aren't operations.
  This prevents it from having to store a List entry for every
  single operation.
* Model#getShapesWithTraits was used everywhere possible rather
  than streaming over all shapes and looking for traits.
* Made optimizations to NullableIndex to no longer need to
  traverse every shape.
* Removed unnecessary streaming from OperationIndex.
* Removed unnecessary streaming from PaginatedIndex.
* Removed unnecessary streaming from NeighborVisitor.
* Updated Node expect methods to also accept a Supplier to create
  error messages if the expectation fails. This prevents needing to
  evaluate String.format even for valid node assertions.
* AttributeSelector no longer uses a BiFunction key supplier, and instead
  the attribute path is just passed in. This allows for the selector
  to also perform optimizations when determining if a shape has a trait
  by leveraging Model#getShapesWithTraits.
* InternalSelectors used to implement Selectors now support more general
  optimizations. This was previously hardcoded to only support an optimization
  for selecting shapes by type, but now selecting shapes by trait is
  optimized too.
* Minor optimization to structure and union loading so that when validating
  that members have a shape ID compatible with the container, an intermediate
  shape ID no longer is constructed.
* The ShapeId cache was increased from 1024 to 8192. This helps significantly
  with large models. The ShapeId cache was also updated to implement the
  LRA cache inside of the computeIfAbsent method.
* NodeValidationVisitor now has a Context object that supports caching
  selectors evaluated against a model. This helps significantly with IdRef
  validation.  To make this caching reusable, the visitor is now mutable
  after it is constructed.
* NodeValidationVisitor idRef now special cases "*" and uses the context
  cache.
* TraitTargetValidator has been simplified, special cases "*", and now
  uses a cache to speed up evaluating traits that use the same selectors.
* TraitValueValidator now reuses the same NodeValidationVisitor in order
  to reuse the same selector cache.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
