### PR TITLE
Add a model for validation errors

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,4 @@ include ':smithy-jmespath'
 include ":smithy-waiters"
 include ":smithy-aws-cloudformation-traits"
 include ":smithy-aws-cloudformation"
+include ":smithy-validation-model"

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+plugins {
+    id "software.amazon.smithy" version "0.5.3"
+}
+
+description = "This module provides support for validation in Smithy server SDKs"
+
+ext {
+    displayName = "Smithy :: Validation Support"
+    moduleName = "software.amazon.smithy.validation.model"
+}
+
+dependencies {
+    implementation project(":smithy-cli")
+}

--- a/smithy-validation-model/model/smithy.framework.validation.smithy
+++ b/smithy-validation-model/model/smithy.framework.validation.smithy
@@ -1,0 +1,33 @@
+$version: "1.0"
+
+namespace smithy.framework
+
+/// A standard error for input validation failures.
+/// This should be thrown by services when a member of the input structure
+/// falls outside of the modeled or documented constraints.
+@error("client")
+structure ValidationException {
+
+    /// A summary of the validation failure.
+    @required
+    message: String,
+
+    /// A list of specific failures encountered while validating the input.
+    /// A member can appear in this list more than once if it failed to satisfy multiple constraints.
+    fieldList: ValidationExceptionFieldList
+}
+
+/// Describes one specific validation failure for an input member.
+structure ValidationExceptionField {
+    /// A JSONPointer expression to the structure member whose value failed to satisfy the modeled constraints.
+    @required
+    path: String,
+
+    /// A detailed description of the validation failure.
+    @required
+    message: String
+}
+
+list ValidationExceptionFieldList {
+    member: ValidationExceptionField
+}


### PR DESCRIPTION
Server SDKs need a common, framework-level definition of a validation error
that service authors can opt into.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
