### PR TITLE
Set baseImportPath to . when config parent is empty

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.build.model;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,7 +45,11 @@ final class ConfigLoader {
     static SmithyBuildConfig load(Path path) {
         try {
             String content = IoUtils.readUtf8File(path);
-            return load(path.getParent(), loadWithJson(path, content).expectObjectNode());
+            Path baseImportPath = path.getParent();
+            if (baseImportPath == null) {
+                baseImportPath = Paths.get(".");
+            }
+            return load(baseImportPath, loadWithJson(path, content).expectObjectNode());
         } catch (ModelSyntaxException e) {
             throw new SmithyBuildException(e);
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
@@ -277,6 +277,12 @@ public final class Cli {
             setUseAnsiColors(false);
         }
 
+        if (throwable instanceof NullPointerException) {
+            Colors.BOLD_RED.out("A null pointer exception occurred while running the Smithy CLI. The --stacktrace "
+                    + "argument can be used to get more information. Please open an issue with the Smithy team "
+                    + "on GitHub so this can be investigated: https://github.com/awslabs/smithy/issues");
+        }
+
         Colors.BOLD_RED.out(throwable.getMessage());
         if (hasArgument(args, STACKTRACE)) {
             StringWriter sw = new StringWriter();


### PR DESCRIPTION
Unfortunately I couldn't really write a test for this since it relies on the config file existing in the in the current working directory.

Fixes #811

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
