### PR TITLE
Remove extraneous newlines from query tests

### DIFF
--- a/smithy-aws-protocol-tests/model/awsQuery/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/empty-input-output.smithy
@@ -25,9 +25,7 @@ apply NoInputAndNoOutput @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-            Action=NoInputAndNoOutput
-            &Version=2020-01-08""",
+        body: "Action=NoInputAndNoOutput&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded"
     }
 ])
@@ -59,9 +57,7 @@ apply NoInputAndOutput @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=NoInputAndOutput
-              &Version=2020-01-08""",
+        body: "Action=NoInputAndOutput&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded"
     }
 ])
@@ -96,9 +92,7 @@ apply EmptyInputAndEmptyOutput @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=EmptyInputAndEmptyOutput
-              &Version=2020-01-08""",
+        body: "Action=EmptyInputAndEmptyOutput&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded"
     },
 ])

--- a/smithy-aws-protocol-tests/model/awsQuery/endpoints.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/endpoints.smithy
@@ -20,9 +20,7 @@ use smithy.test#httpRequestTests
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-            Action=EndpointOperation
-            &Version=2020-01-08""",
+        body: "Action=EndpointOperation&Version=2020-01-0",
         bodyMediaType: "application/x-www-form-urlencoded",
         host: "example.com",
         resolvedHost: "foo.example.com",
@@ -45,10 +43,7 @@ operation EndpointOperation {}
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-            Action=EndpointWithHostLabelOperation
-            &Version=2020-01-08
-            &label=bar""",
+        body: "Action=EndpointWithHostLabelOperation&Version=2020-01-08&label=bar",
         bodyMediaType: "application/x-www-form-urlencoded",
         host: "example.com",
         resolvedHost: "foo.bar.example.com",

--- a/smithy-aws-protocol-tests/model/awsQuery/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input-lists.smithy
@@ -26,14 +26,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &ListArg.member.1=foo
-              &ListArg.member.2=bar
-              &ListArg.member.3=baz
-              &ComplexListArg.member.1.hi=hello
-              &ComplexListArg.member.2.hi=hola""",
+        body: "Action=QueryLists&Version=2020-01-08&ListArg.member.1=foo&ListArg.member.2=bar&ListArg.member.3=baz&ComplexListArg.member.1.hi=hello&ComplexListArg.member.2.hi=hola",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: ["foo", "bar", "baz"],
@@ -56,9 +49,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08""",
+        body: "Action=QueryLists&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: []
@@ -73,11 +64,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &FlattenedListArg.1=A
-              &FlattenedListArg.2=B""",
+        body: "Action=QueryLists&Version=2020-01-08&FlattenedListArg.1=A&FlattenedListArg.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedListArg: ["A", "B"]
@@ -92,11 +79,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &ListArgWithXmlNameMember.item.1=A
-              &ListArgWithXmlNameMember.item.2=B""",
+        body: "Action=QueryLists&Version=2020-01-08&ListArgWithXmlNameMember.item.1=A&ListArgWithXmlNameMember.item.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArgWithXmlNameMember: ["A", "B"]
@@ -111,11 +94,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &Hi.1=A
-              &Hi.2=B""",
+        body: "Action=QueryLists&Version=2020-01-08&Hi.1=A&Hi.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedListArgWithXmlName: ["A", "B"]

--- a/smithy-aws-protocol-tests/model/awsQuery/input-maps.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input-maps.smithy
@@ -32,13 +32,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &MapArg.entry.1.key=bar
-              &MapArg.entry.1.value=Bar
-              &MapArg.entry.2.key=foo
-              &MapArg.entry.2.value=Foo""",
+        body: "Action=QueryMaps&Version=2020-01-08&MapArg.entry.1.key=bar&MapArg.entry.1.value=Bar&MapArg.entry.2.key=foo&MapArg.entry.2.value=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapArg: {
@@ -56,11 +50,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &Foo.entry.1.key=foo
-              &Foo.entry.1.value=Foo""",
+        body: "Action=QueryMaps&Version=2020-01-08&Foo.entry.1.key=foo&Foo.entry.1.value=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             RenamedMapArg: {
@@ -77,13 +67,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &ComplexMapArg.entry.1.key=bar
-              &ComplexMapArg.entry.1.value.hi=Bar
-              &ComplexMapArg.entry.2.key=foo
-              &ComplexMapArg.entry.2.value.hi=Foo""",
+        body: "Action=QueryMaps&Version=2020-01-08&ComplexMapArg.entry.1.key=bar&ComplexMapArg.entry.1.value.hi=Bar&ComplexMapArg.entry.2.key=foo&ComplexMapArg.entry.2.value.hi=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ComplexMapArg: {
@@ -105,9 +89,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08""",
+        body: "Action=QueryMaps&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapArg: {}
@@ -122,13 +104,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &MapWithXmlMemberName.entry.1.K=bar
-              &MapWithXmlMemberName.entry.1.V=Bar
-              &MapWithXmlMemberName.entry.2.K=foo
-              &MapWithXmlMemberName.entry.2.V=Foo""",
+        body: "Action=QueryMaps&Version=2020-01-08&MapWithXmlMemberName.entry.1.K=bar&MapWithXmlMemberName.entry.1.V=Bar&MapWithXmlMemberName.entry.2.K=foo&MapWithXmlMemberName.entry.2.V=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapWithXmlMemberName: {
@@ -146,13 +122,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &FlattenedMap.1.key=bar
-              &FlattenedMap.1.value=Bar
-              &FlattenedMap.2.key=foo
-              &FlattenedMap.2.value=Foo""",
+        body: "Action=QueryMaps&Version=2020-01-08&FlattenedMap.1.key=bar&FlattenedMap.1.value=Bar&FlattenedMap.2.key=foo&FlattenedMap.2.value=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedMap: {
@@ -170,13 +140,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &Hi.1.K=bar
-              &Hi.1.V=Bar
-              &Hi.2.K=foo
-              &Hi.2.V=Foo""",
+        body: "Action=QueryMaps&Version=2020-01-08&Hi.1.K=bar&Hi.1.V=Bar&Hi.2.K=foo&Hi.2.V=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FlattenedMapWithXmlName: {
@@ -194,15 +158,7 @@ apply QueryMaps @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryMaps
-              &Version=2020-01-08
-              &MapOfLists.entry.1.key=bar
-              &MapOfLists.entry.1.value.member.1=C
-              &MapOfLists.entry.1.value.member.2=D
-              &MapOfLists.entry.2.key=foo
-              &MapOfLists.entry.2.value.member.1=A
-              &MapOfLists.entry.2.value.member.2=B""",
+        body: "Action=QueryMaps&Version=2020-01-08&MapOfLists.entry.1.key=bar&MapOfLists.entry.1.value.member.1=C&MapOfLists.entry.1.value.member.2=D&MapOfLists.entry.2.key=foo&MapOfLists.entry.2.value.member.1=A&MapOfLists.entry.2.value.member.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             MapOfLists: {

--- a/smithy-aws-protocol-tests/model/awsQuery/input.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input.smithy
@@ -27,11 +27,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Foo=val1
-              &Bar=val2""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Foo=val1&Bar=val2",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Foo: "val1",
@@ -50,11 +46,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Foo=val1
-              &Baz=true""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Foo=val1&Baz=true",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Foo: "val1",
@@ -73,10 +65,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Baz=false""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Baz=false",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Baz: false,
@@ -94,10 +83,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Bam=10""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Bam=10",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Bam: 10,
@@ -115,10 +101,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Boo=10.8""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Boo=10.8",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Boo: 10.8,
@@ -136,10 +119,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Qux=dmFsdWU%3D""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Qux=dmFsdWU%3D",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Qux: "value",
@@ -157,10 +137,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &FooEnum=Foo""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FooEnum=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FooEnum: "Foo",
@@ -200,12 +177,7 @@ apply QueryTimestamps @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=QueryTimestamps
-              &Version=2020-01-08
-              &normalFormat=2015-01-25T08%3A00%3A00Z
-              &epochMember=1422172800
-              &epochTarget=1422172800""",
+        body: "Action=QueryTimestamps&Version=2020-01-08&normalFormat=2015-01-25T08%3A00%3A00Z&epochMember=1422172800&epochTarget=1422172800",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             normalFormat: 1422172800,
@@ -247,12 +219,7 @@ apply NestedStructures @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=NestedStructures
-              &Version=2020-01-08
-              &Nested.StringArg=foo
-              &Nested.OtherArg=true
-              &Nested.RecursiveArg.StringArg=baz""",
+        body: "Action=NestedStructures&Version=2020-01-08&Nested.StringArg=foo&Nested.OtherArg=true&Nested.RecursiveArg.StringArg=baz",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Nested: {
@@ -295,10 +262,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=QueryIdempotencyTokenAutoFill
-              &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000000""",
+        body: "Action=QueryIdempotencyTokenAutoFill&Version=2020-01-08&token=00000000-0000-4000-8000-000000000000",
         bodyMediaType: "application/x-www-form-urlencoded",
         appliesTo: "client",
     },
@@ -314,10 +278,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=QueryIdempotencyTokenAutoFill
-              &Version=2020-01-08
-              &token=00000000-0000-4000-8000-000000000123""",
+        body: "Action=QueryIdempotencyTokenAutoFill&Version=2020-01-08&token=00000000-0000-4000-8000-000000000123",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"

--- a/smithy-aws-protocol-tests/model/ec2Query/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/empty-input-output.smithy
@@ -27,9 +27,7 @@ apply NoInputAndOutput @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=NoInputAndOutput
-              &Version=2020-01-08""",
+        body: "Action=NoInputAndOutput&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded"
     }
 ])
@@ -73,9 +71,7 @@ apply EmptyInputAndEmptyOutput @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=EmptyInputAndEmptyOutput
-              &Version=2020-01-08""",
+        body: "Action=EmptyInputAndEmptyOutput&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded"
     },
 ])

--- a/smithy-aws-protocol-tests/model/ec2Query/endpoints.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/endpoints.smithy
@@ -20,9 +20,7 @@ use smithy.test#httpRequestTests
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-            Action=EndpointOperation
-            &Version=2020-01-08""",
+        body: "Action=EndpointOperation&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded",
         host: "example.com",
         resolvedHost: "foo.example.com",
@@ -45,10 +43,7 @@ operation EndpointOperation {}
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-            Action=EndpointWithHostLabelOperation
-            &Version=2020-01-08
-            &Label=bar""",
+        body: "Action=EndpointWithHostLabelOperation&Version=2020-01-08&Label=bar",
         bodyMediaType: "application/x-www-form-urlencoded",
         host: "example.com",
         resolvedHost: "foo.bar.example.com",

--- a/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
@@ -26,14 +26,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &ListArg.1=foo
-              &ListArg.2=bar
-              &ListArg.3=baz
-              &ComplexListArg.1.Hi=hello
-              &ComplexListArg.2.Hi=hola""",
+        body: "Action=QueryLists&Version=2020-01-08&ListArg.1=foo&ListArg.2=bar&ListArg.3=baz&ComplexListArg.1.Hi=hello&ComplexListArg.2.Hi=hola",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: ["foo", "bar", "baz"],
@@ -56,9 +49,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08""",
+        body: "Action=QueryLists&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: []
@@ -73,11 +64,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &ListArgWithXmlNameMember.1=A
-              &ListArgWithXmlNameMember.2=B""",
+        body: "Action=QueryLists&Version=2020-01-08&ListArgWithXmlNameMember.1=A&ListArgWithXmlNameMember.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArgWithXmlNameMember: ["A", "B"]
@@ -92,11 +79,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: """
-              Action=QueryLists
-              &Version=2020-01-08
-              &Hi.1=A
-              &Hi.2=B""",
+        body: "Action=QueryLists&Version=2020-01-08&Hi.1=A&Hi.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArgWithXmlName: ["A", "B"]

--- a/smithy-aws-protocol-tests/model/ec2Query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input.smithy
@@ -28,11 +28,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Foo=val1
-              &Bar=val2""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Foo=val1&Bar=val2",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Foo: "val1",
@@ -51,11 +47,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Foo=val1
-              &Baz=true""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Foo=val1&Baz=true",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Foo: "val1",
@@ -74,10 +66,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Baz=false""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Baz=false",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Baz: false,
@@ -95,10 +84,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Bam=10""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Bam=10",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Bam: 10,
@@ -116,10 +102,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Boo=10.8""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Boo=10.8",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Boo: 10.8,
@@ -137,10 +120,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &Qux=dmFsdWU%3D""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&Qux=dmFsdWU%3D",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Qux: "value",
@@ -158,10 +138,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &FooEnum=Foo""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FooEnum=Foo",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             FooEnum: "Foo",
@@ -179,10 +156,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &A=Hi""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&A=Hi",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             HasQueryName: "Hi",
@@ -200,10 +174,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &B=Hi""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&B=Hi",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             HasQueryAndXmlName: "Hi",
@@ -221,10 +192,7 @@ apply SimpleInputParams @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=SimpleInputParams
-              &Version=2020-01-08
-              &C=Hi""",
+        body: "Action=SimpleInputParams&Version=2020-01-08&C=Hi",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             UsesXmlName: "Hi",
@@ -274,12 +242,7 @@ apply QueryTimestamps @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=QueryTimestamps
-              &Version=2020-01-08
-              &NormalFormat=2015-01-25T08%3A00%3A00Z
-              &EpochMember=1422172800
-              &EpochTarget=1422172800""",
+        body: "Action=QueryTimestamps&Version=2020-01-08&NormalFormat=2015-01-25T08%3A00%3A00Z&EpochMember=1422172800&EpochTarget=1422172800",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             normalFormat: 1422172800,
@@ -321,12 +284,7 @@ apply NestedStructures @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=NestedStructures
-              &Version=2020-01-08
-              &Nested.StringArg=foo
-              &Nested.OtherArg=true
-              &Nested.RecursiveArg.StringArg=baz""",
+        body: "Action=NestedStructures&Version=2020-01-08&Nested.StringArg=foo&Nested.OtherArg=true&Nested.RecursiveArg.StringArg=baz",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             Nested: {
@@ -369,10 +327,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=QueryIdempotencyTokenAutoFill
-              &Version=2020-01-08
-              &Token=00000000-0000-4000-8000-000000000000""",
+        body: "Action=QueryIdempotencyTokenAutoFill&Version=2020-01-08&Token=00000000-0000-4000-8000-000000000000",
         bodyMediaType: "application/x-www-form-urlencoded",
         appliesTo: "client",
     },
@@ -388,10 +343,7 @@ apply QueryIdempotencyTokenAutoFill @httpRequestTests([
         requireHeaders: [
             "Content-Length"
         ],
-        body: """
-              Action=QueryIdempotencyTokenAutoFill
-              &Version=2020-01-08
-              &Token=00000000-0000-4000-8000-000000000123""",
+        body: "Action=QueryIdempotencyTokenAutoFill&Version=2020-01-08&Token=00000000-0000-4000-8000-000000000123",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             token: "00000000-0000-4000-8000-000000000123"


### PR DESCRIPTION
This removes all the newlines from query formatted bodies in the AWS
protocol tests. While these made the tests easier to read, they
weren't actually valid since a client sending a body formatted that
way would encounter errors.

EC2 formats their docs that way, but they [make it clear](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Query-Requests.html) that it's just for readability:

> To make these example requests even easier to read, AWS documentation may present them in the following format:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
