### PR TITLE
Describe and support non-numeric floats

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -512,27 +512,6 @@ useIntegerType (``boolean``)
             }
         }
 
-.. _generate-openapi-setting-supportNonNumericFloats:
-
-supportNonNumericFloats (``boolean``)
-    Set to true to add support for NaN, Infinity, and -Infinity in float
-    and double shapes. These values will be serialized as strings. The
-    OpenAPI document will be updated to refer to them as a "oneOf" of number
-    and string.
-
-    By default, these non-numeric values are not supported.
-
-    .. code-block:: json
-
-        {
-            "version": "1.0",
-            "plugins": {
-                "openapi": {
-                    "service": "smithy.example#Weather",
-                    "supportNonNumericFloats": true
-                }
-            }
-        }
 
 ----------------------------------
 JSON schema configuration settings
@@ -681,6 +660,62 @@ disableFeatures (``[string]``)
                     "service": "smithy.example#Weather",
                     "disableFeatures": ["propertyNames"]
                 }
+            }
+        }
+
+
+.. _generate-openapi-setting-supportNonNumericFloats:
+
+supportNonNumericFloats (``boolean``)
+    Set to true to add support for NaN, Infinity, and -Infinity in float
+    and double shapes. These values will be serialized as strings. The
+    JSON Schema document will be updated to refer to them as a "oneOf" of
+    number and string.
+
+    By default, these non-numeric values are not supported.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "supportNonNumericFloats": true
+                }
+            }
+        }
+
+    When this is disabled (the default), references to floats/doubles will
+    look like this:
+
+    .. code-block: json
+
+        {
+            "floatMember": {
+                "type": "number"
+            }
+        }
+
+    With this enabled, references to floats/doubles will look like this:
+
+    .. code-block:: json
+
+        {
+            "floatMember": {
+                "oneOf": [
+                    {
+                        "type": "number"
+                    },
+                    {
+                        "type": "string",
+                        "enum": [
+                            "NaN",
+                            "Infinity",
+                            "-Infinity"
+                        ]
+                    }
+                ]
             }
         }
 

--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -512,6 +512,28 @@ useIntegerType (``boolean``)
             }
         }
 
+.. _generate-openapi-setting-supportNonNumericFloats:
+
+supportNonNumericFloats (``boolean``)
+    Set to true to add support for NaN, Infinity, and -Infinity in float
+    and double shapes. These values will be serialized as strings. The
+    OpenAPI document will be updated to refer to them as a "oneOf" of number
+    and string.
+
+    By default, these non-numeric values are not supported.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "supportNonNumericFloats": true
+                }
+            }
+        }
+
 ----------------------------------
 JSON schema configuration settings
 ----------------------------------

--- a/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -390,28 +390,7 @@ serialized in the response.
 
 
 .. _ec2Query-non-numeric-float-serialization:
-
-------------------------------------------
-Non-numeric float and double serialization
-------------------------------------------
-
-Smithy floats and doubles are defined by IEE754, which includes special values
-for "not a number" and both positive and negative infinity. Unless otherwise
-specified, the ``ec2Query`` treats those special values as strings with the
-following values:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    * - Special Value
-      - String Value
-    * - Not a number
-      - ``NaN``
-    * - positive infinity
-      - ``Infinity``
-    * - negative infinity
-      - ``-Infinity``
+.. include:: non-numeric-floats.rst.template
 
 
 .. _ec2Query-compliance-tests:

--- a/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -389,6 +389,31 @@ serialized in the response.
     </Errors>
 
 
+.. _ec2Query-non-numeric-float-serialization:
+
+------------------------------------------
+Non-numeric float and double serialization
+------------------------------------------
+
+Smithy floats and doubles are defined by IEE754, which includes special values
+for "not a number" and both positive and negative infinity. Unless otherwise
+specified, the ``ec2Query`` treats those special values as strings with the
+following values:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    * - Special Value
+      - String Value
+    * - Not a number
+      - ``NaN``
+    * - positive infinity
+      - ``Infinity``
+    * - negative infinity
+      - ``-Infinity``
+
+
 .. _ec2Query-compliance-tests:
 
 -------------------------

--- a/docs/source/1.0/spec/aws/aws-json.rst.template
+++ b/docs/source/1.0/spec/aws/aws-json.rst.template
@@ -90,9 +90,11 @@ to convert each shape type:
     * - ``long``
       - JSON number
     * - ``float``
-      - JSON number
+      - JSON number for numeric values. JSON strings for ``NaN``, ``Infinity``,
+        and ``-Infinity``.
     * - ``double``
-      - JSON number
+      - JSON number for numeric values. JSON strings for ``NaN``, ``Infinity``,
+        and ``-Infinity``
     * - ``bigDecimal``
       - JSON number. Unfortunately, this protocol serializes bigDecimal
         shapes as a normal JSON number. Many JSON parsers will either
@@ -129,6 +131,29 @@ to convert each shape type:
     * - ``union``
       - JSON object. A union is serialized identically as a ``structure``
         shape, but only a single member can be set to a non-null value.
+
+
+------------------------------------------
+Non-numeric float and double serialization
+------------------------------------------
+
+Smithy floats and doubles are defined by IEE754, which includes special values
+for "not a number" and both positive and negative infinity. Unless otherwise
+specified, the |quoted shape name| treats those special values as
+strings with the following values:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    * - Special Value
+      - String Value
+    * - Not a number
+      - ``NaN``
+    * - positive infinity
+      - ``Infinity``
+    * - negative infinity
+      - ``-Infinity``
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/1.0/spec/aws/aws-json.rst.template
+++ b/docs/source/1.0/spec/aws/aws-json.rst.template
@@ -133,29 +133,6 @@ to convert each shape type:
         shape, but only a single member can be set to a non-null value.
 
 
-------------------------------------------
-Non-numeric float and double serialization
-------------------------------------------
-
-Smithy floats and doubles are defined by IEE754, which includes special values
-for "not a number" and both positive and negative infinity. Unless otherwise
-specified, the |quoted shape name| treats those special values as
-strings with the following values:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    * - Special Value
-      - String Value
-    * - Not a number
-      - ``NaN``
-    * - positive infinity
-      - ``Infinity``
-    * - negative infinity
-      - ``-Infinity``
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Empty body serialization
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -168,6 +145,9 @@ When an operation has no modeled output or no output parameters are provided,
 server implementations SHOULD send an empty response body. The server MUST
 still send the protocol's ``Content-Type`` header in this case. Clients MUST
 also accept an empty JSON object as the response body.
+
+
+.. include:: non-numeric-floats.rst.template
 
 
 -----------------------------

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -441,6 +441,31 @@ is used to distinguish which specific error is serialized in the response.
     </ErrorResponse>
 
 
+.. _ec2Query-non-numeric-float-serialization:
+
+------------------------------------------
+Non-numeric float and double serialization
+------------------------------------------
+
+Smithy floats and doubles are defined by IEE754, which includes special values
+for "not a number" and both positive and negative infinity. Unless otherwise
+specified, the ``awsQuery`` treats those special values as strings with the
+following values:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    * - Special Value
+      - String Value
+    * - Not a number
+      - ``NaN``
+    * - positive infinity
+      - ``Infinity``
+    * - negative infinity
+      - ``-Infinity``
+
+
 .. _awsQuery-error-response-code:
 
 Error HTTP response code resolution

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -441,29 +441,8 @@ is used to distinguish which specific error is serialized in the response.
     </ErrorResponse>
 
 
-.. _ec2Query-non-numeric-float-serialization:
-
-------------------------------------------
-Non-numeric float and double serialization
-------------------------------------------
-
-Smithy floats and doubles are defined by IEE754, which includes special values
-for "not a number" and both positive and negative infinity. Unless otherwise
-specified, the ``awsQuery`` treats those special values as strings with the
-following values:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    * - Special Value
-      - String Value
-    * - Not a number
-      - ``NaN``
-    * - positive infinity
-      - ``Infinity``
-    * - negative infinity
-      - ``-Infinity``
+.. _awsQuery-non-numeric-float-serialization:
+.. include:: non-numeric-floats.rst.template
 
 
 .. _awsQuery-error-response-code:

--- a/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
@@ -246,9 +246,11 @@ JSON shape serialization
     * - ``long``
       - JSON number
     * - ``float``
-      - JSON number
+      - JSON number for numeric values. JSON strings for ``NaN``, ``Infinity``,
+        and ``-Infinity``
     * - ``double``
-      - JSON number
+      - JSON number for numeric values. JSON strings for ``NaN``, ``Infinity``,
+        and ``-Infinity``
     * - ``bigDecimal``
       - JSON number. Unfortunately, this protocol serializes bigDecimal
         shapes as a normal JSON number. Many JSON parsers will either
@@ -295,6 +297,29 @@ The ``aws.protocols#restJson1`` protocol supports all of the HTTP binding traits
 defined in the :ref:`HTTP protocol bindings <http-traits>` specification. The
 serialization formats and and behaviors described for each trait are supported
 as defined in the ``aws.protocols#restJson1`` protocol.
+
+
+------------------------------------------
+Non-numeric float and double serialization
+------------------------------------------
+
+Smithy floats and doubles are defined by IEE754, which includes special values
+for "not a number" and both positive and negative infinity. Unless otherwise
+specified, the ``aws.protocols#restJson1`` treats those special values as
+strings with the following values:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    * - Special Value
+      - String Value
+    * - Not a number
+      - ``NaN``
+    * - positive infinity
+      - ``Infinity``
+    * - negative infinity
+      - ``-Infinity``
 
 
 .. restJson1-errors:

--- a/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
@@ -299,27 +299,8 @@ serialization formats and and behaviors described for each trait are supported
 as defined in the ``aws.protocols#restJson1`` protocol.
 
 
-------------------------------------------
-Non-numeric float and double serialization
-------------------------------------------
-
-Smithy floats and doubles are defined by IEE754, which includes special values
-for "not a number" and both positive and negative infinity. Unless otherwise
-specified, the ``aws.protocols#restJson1`` treats those special values as
-strings with the following values:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    * - Special Value
-      - String Value
-    * - Not a number
-      - ``NaN``
-    * - positive infinity
-      - ``Infinity``
-    * - negative infinity
-      - ``-Infinity``
+.. |quoted shape name| replace:: ``aws.protocols#restJson1``
+.. include:: non-numeric-floats.rst.template
 
 
 .. restJson1-errors:

--- a/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
@@ -249,6 +249,29 @@ serialization formats and and behaviors described for each trait are supported
 as defined in the ``aws.protocols#restXml`` protocol.
 
 
+------------------------------------------
+Non-numeric float and double serialization
+------------------------------------------
+
+Smithy floats and doubles are defined by IEE754, which includes special values
+for "not a number" and both positive and negative infinity. Unless otherwise
+specified, the ``aws.protocols#restXml`` treats those special values as
+strings with the following values:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    * - Special Value
+      - String Value
+    * - Not a number
+      - ``NaN``
+    * - positive infinity
+      - ``Infinity``
+    * - negative infinity
+      - ``-Infinity``
+
+
 .. _restXml-errors:
 
 -----------------------------

--- a/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
@@ -249,27 +249,8 @@ serialization formats and and behaviors described for each trait are supported
 as defined in the ``aws.protocols#restXml`` protocol.
 
 
-------------------------------------------
-Non-numeric float and double serialization
-------------------------------------------
-
-Smithy floats and doubles are defined by IEE754, which includes special values
-for "not a number" and both positive and negative infinity. Unless otherwise
-specified, the ``aws.protocols#restXml`` treats those special values as
-strings with the following values:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    * - Special Value
-      - String Value
-    * - Not a number
-      - ``NaN``
-    * - positive infinity
-      - ``Infinity``
-    * - negative infinity
-      - ``-Infinity``
+.. |quoted shape name| replace:: ``aws.protocols#restXml``
+.. include:: non-numeric-floats.rst.template
 
 
 .. _restXml-errors:

--- a/docs/source/1.0/spec/aws/non-numeric-floats.rst.template
+++ b/docs/source/1.0/spec/aws/non-numeric-floats.rst.template
@@ -1,0 +1,21 @@
+------------------------------------------
+Non-numeric float and double serialization
+------------------------------------------
+
+Smithy floats and doubles are defined by IEEE-754, which includes special values
+for "not a number" and both positive and negative infinity. Unless otherwise
+specified, the |quoted shape name| protocol treats those special values as
+strings with the following values:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    * - Special Value
+      - String Value
+    * - Not a number
+      - ``NaN``
+    * - Positive infinity
+      - ``Infinity``
+    * - Negative infinity
+      - ``-Infinity``

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -2334,11 +2334,13 @@ target from traits and how their values are defined in
       - number
       - The value MUST fall within the range of -2^63 to (2^63)-1.
     * - float
-      - number
-      - A normal JSON number.
+      - string | number
+      - The value MUST be either a normal JSON number or one of the following
+        string values: ``"NaN"``, ``"Infinity"``, ``"-Infinity"``.
     * - double
-      - number
-      - A normal JSON number.
+      - string | number
+      - The value MUST be either a normal JSON number or one of the following
+        string values: ``"NaN"``, ``"Infinity"``, ``"-Infinity"``.
     * - bigDecimal
       - string | number
       - bigDecimal values can be serialized as strings to avoid rounding

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/NonNumericFloatsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/NonNumericFloatsTest.java
@@ -1,0 +1,29 @@
+package software.amazon.smithy.aws.apigateway.openapi;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.utils.IoUtils;
+
+public class NonNumericFloatsTest {
+    @Test
+    public void handlesNonNumericFloats() {
+        Model model = Model.assembler(getClass().getClassLoader())
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("non-numeric-floats.json"))
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.smithy#MyService"));
+        config.setSupportNonNumericFloats(true);
+        ObjectNode result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("non-numeric-floats.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/non-numeric-floats.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/non-numeric-floats.json
@@ -1,0 +1,40 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "example.smithy#MyService": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "example.smithy#MyOperation"
+                }
+            ],
+            "traits": {
+                "aws.protocols#restJson1": {}
+            }
+        },
+        "example.smithy#MyOperation": {
+            "type": "operation",
+            "input": {
+                "target": "example.smithy#MyOperationInput"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/foo",
+                    "method": "POST"
+                }
+            }
+        },
+        "example.smithy#MyOperationInput": {
+            "type": "structure",
+            "members": {
+                "floatMember": {
+                    "target": "smithy.api#Float"
+                },
+                "doubleMember": {
+                    "target": "smithy.api#Double"
+                }
+            }
+        }
+    }
+}

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/non-numeric-floats.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/non-numeric-floats.openapi.json
@@ -1,0 +1,71 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "MyService",
+        "version": "2006-03-01"
+    },
+    "paths": {
+        "/foo": {
+            "post": {
+                "operationId": "MyOperation",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MyOperationRequestContent"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "MyOperation response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "MyOperationRequestContent": {
+                "type": "object",
+                "properties": {
+                    "floatMember": {
+                        "oneOf": [
+                            {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "NaN",
+                                    "Infinity",
+                                    "-Infinity"
+                                ]
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "doubleMember": {
+                        "oneOf": [
+                            {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "NaN",
+                                    "Infinity",
+                                    "-Infinity"
+                                ]
+                            }
+                        ],
+                        "nullable": true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/smithy-aws-protocol-tests/model/awsJson1_0/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/json-structs.smithy
@@ -20,6 +20,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "NaN",
                 "doubleValue": "NaN"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.0",
             "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
@@ -40,6 +41,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "Infinity",
                 "doubleValue": "Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.0",
             "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
@@ -60,6 +62,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "-Infinity",
                 "doubleValue": "-Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.0",
             "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
@@ -82,6 +85,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "NaN",
                 "doubleValue": "NaN"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.0",
         },
@@ -100,6 +104,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "Infinity",
                 "doubleValue": "Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.0",
         },
@@ -118,6 +123,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "-Infinity",
                 "doubleValue": "-Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.0",
         },

--- a/smithy-aws-protocol-tests/model/awsJson1_0/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/json-structs.smithy
@@ -1,0 +1,140 @@
+// This file defines test cases that serialize structures.
+
+$version: "1.0"
+
+namespace aws.protocoltests.json10
+
+use aws.protocols#awsJson1_0
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply SimpleScalarProperties @httpRequestTests([
+    {
+        id: "AwsJson10SupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: awsJson1_0,
+        method: "POST",
+        uri: "/",
+        body: """
+            {
+                "floatValue": "NaN",
+                "doubleValue": "NaN"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+            "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "AwsJson10SupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: awsJson1_0,
+        method: "POST",
+        uri: "/",
+        body: """
+            {
+                "floatValue": "Infinity",
+                "doubleValue": "Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+            "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "AwsJson10SupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: awsJson1_0,
+        method: "POST",
+        uri: "/",
+        body: """
+            {
+                "floatValue": "-Infinity",
+                "doubleValue": "-Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+            "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
+])
+
+apply SimpleScalarProperties @httpResponseTests([
+    {
+        id: "AwsJson10SupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: awsJson1_0,
+        code: 200,
+        body: """
+            {
+                "floatValue": "NaN",
+                "doubleValue": "NaN"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "AwsJson10SupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: awsJson1_0,
+        code: 200,
+        body: """
+            {
+                "floatValue": "Infinity",
+                "doubleValue": "Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "AwsJson10SupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: awsJson1_0,
+        code: 200,
+        body: """
+            {
+                "floatValue": "-Infinity",
+                "doubleValue": "-Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
+])
+
+// This example serializes simple scalar types in the top level JSON document.
+operation SimpleScalarProperties {
+    input: SimpleScalarPropertiesInputOutput,
+    output: SimpleScalarPropertiesInputOutput
+}
+
+structure SimpleScalarPropertiesInputOutput {
+    floatValue: Float,
+    doubleValue: Double,
+}

--- a/smithy-aws-protocol-tests/model/awsJson1_0/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/main.smithy
@@ -16,6 +16,7 @@ service JsonRpc10 {
         NoInputAndNoOutput,
         NoInputAndOutput,
         EmptyInputAndEmptyOutput,
+        SimpleScalarProperties,
 
         // Errors
         GreetingWithErrors,

--- a/smithy-aws-protocol-tests/model/awsJson1_1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/json-structs.smithy
@@ -1,0 +1,142 @@
+// This file defines test cases that serialize structures. Over time this
+// will take over much of what is in kitchen-sink as it gets refactored
+// to not put everything into such a small number of tests.
+
+$version: "1.0"
+
+namespace aws.protocoltests.json
+
+use aws.protocols#awsJson1_1
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply SimpleScalarProperties @httpRequestTests([
+    {
+        id: "AwsJson11SupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: awsJson1_1,
+        method: "POST",
+        uri: "/",
+        body: """
+            {
+                "floatValue": "NaN",
+                "doubleValue": "NaN"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "AwsJson11SupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: awsJson1_1,
+        method: "POST",
+        uri: "/",
+        body: """
+            {
+                "floatValue": "Infinity",
+                "doubleValue": "Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "AwsJson11SupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: awsJson1_1,
+        method: "POST",
+        uri: "/",
+        body: """
+            {
+                "floatValue": "-Infinity",
+                "doubleValue": "-Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
+])
+
+apply SimpleScalarProperties @httpResponseTests([
+    {
+        id: "AwsJson11SupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: awsJson1_1,
+        code: 200,
+        body: """
+            {
+                "floatValue": "NaN",
+                "doubleValue": "NaN"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "AwsJson11SupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: awsJson1_1,
+        code: 200,
+        body: """
+            {
+                "floatValue": "Infinity",
+                "doubleValue": "Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "AwsJson11SupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: awsJson1_1,
+        code: 200,
+        body: """
+            {
+                "floatValue": "-Infinity",
+                "doubleValue": "-Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
+])
+
+// This example serializes simple scalar types in the top level JSON document.
+operation SimpleScalarProperties {
+    input: SimpleScalarPropertiesInputOutput,
+    output: SimpleScalarPropertiesInputOutput
+}
+
+structure SimpleScalarPropertiesInputOutput {
+    floatValue: Float,
+    doubleValue: Double,
+}

--- a/smithy-aws-protocol-tests/model/awsJson1_1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/json-structs.smithy
@@ -22,6 +22,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "NaN",
                 "doubleValue": "NaN"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
             "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
@@ -42,6 +43,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "Infinity",
                 "doubleValue": "Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
             "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
@@ -62,6 +64,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "-Infinity",
                 "doubleValue": "-Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
             "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
@@ -84,6 +87,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "NaN",
                 "doubleValue": "NaN"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
         },
@@ -102,6 +106,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "Infinity",
                 "doubleValue": "Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
         },
@@ -120,6 +125,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "-Infinity",
                 "doubleValue": "-Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
         },

--- a/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
@@ -22,6 +22,7 @@ service JsonProtocol {
     operations: [
         EmptyOperation,
         KitchenSinkOperation,
+        SimpleScalarProperties,
         OperationWithOptionalInputOutput,
         PutAndGetInlineDocuments,
         JsonEnums,

--- a/smithy-aws-protocol-tests/model/awsQuery/input.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input.smithy
@@ -142,7 +142,64 @@ apply SimpleInputParams @httpRequestTests([
         params: {
             FooEnum: "Foo",
         }
-    }
+    },
+    {
+        id: "AwsQuerySupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: awsQuery,
+        method: "POST",
+        uri: "/",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FloatValue=NaN&Boo=NaN",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            FloatValue: "NaN",
+            Boo: "NaN",
+        }
+    },
+    {
+        id: "AwsQuerySupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: awsQuery,
+        method: "POST",
+        uri: "/",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FloatValue=Infinity&Boo=Infinity",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            FloatValue: "Infinity",
+            Boo: "Infinity",
+        }
+    },
+    {
+        id: "AwsQuerySupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: awsQuery,
+        method: "POST",
+        uri: "/",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FloatValue=-Infinity&Boo=-Infinity",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            FloatValue: "-Infinity",
+            Boo: "-Infinity",
+        }
+    },
 ])
 
 structure SimpleInputParamsInput {
@@ -150,6 +207,7 @@ structure SimpleInputParamsInput {
     Bar: String,
     Baz: Boolean,
     Bam: Integer,
+    FloatValue: Float,
     Boo: Double,
     Qux: Blob,
     FooEnum: FooEnum,

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -55,7 +55,73 @@ apply SimpleScalarXmlProperties @httpResponseTests([
             floatValue: 5.5,
             doubleValue: 6.5,
         }
-    }
+    },
+    {
+        id: "AwsQuerySupportsNaNFloatOutputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: awsQuery,
+        code: 200,
+        body: """
+              <SimpleScalarXmlPropertiesResponse xmlns="https://example.com/">
+                  <SimpleScalarXmlPropertiesResult>
+                      <floatValue>NaN</floatValue>
+                      <doubleValue>NaN</doubleValue>
+                  </SimpleScalarXmlPropertiesResult>
+              </SimpleScalarXmlPropertiesResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml"
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "AwsQuerySupportsInfinityFloatOutputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: awsQuery,
+        code: 200,
+        body: """
+              <SimpleScalarXmlPropertiesResponse xmlns="https://example.com/">
+                  <SimpleScalarXmlPropertiesResult>
+                      <floatValue>Infinity</floatValue>
+                      <doubleValue>Infinity</doubleValue>
+                  </SimpleScalarXmlPropertiesResult>
+              </SimpleScalarXmlPropertiesResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml"
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "AwsQuerySupportsNegativeInfinityFloatOutputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: awsQuery,
+        code: 200,
+        body: """
+              <SimpleScalarXmlPropertiesResponse xmlns="https://example.com/">
+                  <SimpleScalarXmlPropertiesResult>
+                      <floatValue>-Infinity</floatValue>
+                      <doubleValue>-Infinity</doubleValue>
+                  </SimpleScalarXmlPropertiesResult>
+              </SimpleScalarXmlPropertiesResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml"
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
 ])
 
 structure SimpleScalarXmlPropertiesOutput {

--- a/smithy-aws-protocol-tests/model/ec2Query/input.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input.smithy
@@ -198,6 +198,63 @@ apply SimpleInputParams @httpRequestTests([
             UsesXmlName: "Hi",
         }
     },
+    {
+        id: "Ec2QuerySupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: ec2Query,
+        method: "POST",
+        uri: "/",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FloatValue=NaN&Boo=NaN",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            FloatValue: "NaN",
+            Boo: "NaN",
+        }
+    },
+    {
+        id: "Ec2QuerySupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: ec2Query,
+        method: "POST",
+        uri: "/",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FloatValue=Infinity&Boo=Infinity",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            FloatValue: "Infinity",
+            Boo: "Infinity",
+        }
+    },
+    {
+        id: "Ec2QuerySupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: ec2Query,
+        method: "POST",
+        uri: "/",
+        body: "Action=SimpleInputParams&Version=2020-01-08&FloatValue=-Infinity&Boo=-Infinity",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            FloatValue: "-Infinity",
+            Boo: "-Infinity",
+        }
+    },
 ])
 
 structure SimpleInputParamsInput {
@@ -205,6 +262,7 @@ structure SimpleInputParamsInput {
     Bar: String,
     Baz: Boolean,
     Bam: Integer,
+    FloatValue: Float,
     Boo: Double,
     Qux: Blob,
     FooEnum: FooEnum,

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -55,7 +55,73 @@ apply SimpleScalarXmlProperties @httpResponseTests([
             floatValue: 5.5,
             doubleValue: 6.5,
         }
-    }
+    },
+    {
+        id: "Ec2QuerySupportsNaNFloatOutputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: ec2Query,
+        code: 200,
+        body: """
+              <SimpleScalarXmlPropertiesResponse xmlns="https://example.com/">
+                  <SimpleScalarXmlPropertiesResult>
+                      <floatValue>NaN</floatValue>
+                      <doubleValue>NaN</doubleValue>
+                  </SimpleScalarXmlPropertiesResult>
+              </SimpleScalarXmlPropertiesResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml;charset=UTF-8"
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "Ec2QuerySupportsInfinityFloatOutputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: ec2Query,
+        code: 200,
+        body: """
+              <SimpleScalarXmlPropertiesResponse xmlns="https://example.com/">
+                  <SimpleScalarXmlPropertiesResult>
+                      <floatValue>Infinity</floatValue>
+                      <doubleValue>Infinity</doubleValue>
+                  </SimpleScalarXmlPropertiesResult>
+              </SimpleScalarXmlPropertiesResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml;charset=UTF-8"
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "Ec2QuerySupportsNegativeInfinityFloatOutputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: ec2Query,
+        code: 200,
+        body: """
+              <SimpleScalarXmlPropertiesResponse xmlns="https://example.com/">
+                  <SimpleScalarXmlPropertiesResult>
+                      <floatValue>-Infinity</floatValue>
+                      <doubleValue>-Infinity</doubleValue>
+                  </SimpleScalarXmlPropertiesResult>
+              </SimpleScalarXmlPropertiesResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml;charset=UTF-8"
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
 ])
 
 structure SimpleScalarXmlPropertiesOutput {

--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -120,6 +120,54 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             headerEnumList: ["Foo", "Bar", "Baz"],
         }
     },
+    {
+        id: "RestJsonSupportsNaNFloatHeaderInputs",
+        documentation: "Supports handling NaN float header values.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        body: "",
+        headers: {
+            "X-Float": "NaN",
+            "X-Double": "NaN",
+        },
+        params: {
+            headerFloat: "NaN",
+            headerDouble: "NaN",
+        }
+    },
+    {
+        id: "RestJsonSupportsInfinityFloatHeaderInputs",
+        documentation: "Supports handling Infinity float header values.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        body: "",
+        headers: {
+            "X-Float": "Infinity",
+            "X-Double": "Infinity",
+        },
+        params: {
+            headerFloat: "Infinity",
+            headerDouble: "Infinity",
+        }
+    },
+    {
+        id: "RestJsonSupportsNegativeInfinityFloatHeaderInputs",
+        documentation: "Supports handling -Infinity float header values.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        body: "",
+        headers: {
+            "X-Float": "-Infinity",
+            "X-Double": "-Infinity",
+        },
+        params: {
+            headerFloat: "-Infinity",
+            headerDouble: "-Infinity",
+        }
+    },
 ])
 
 apply InputAndOutputWithHeaders @httpResponseTests([
@@ -203,6 +251,48 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         params: {
             headerEnum: "Foo",
             headerEnumList: ["Foo", "Bar", "Baz"],
+        }
+    },
+    {
+        id: "RestJsonSupportsNaNFloatHeaderOutputs",
+        documentation: "Supports handling NaN float header values.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "X-Float": "NaN",
+            "X-Double": "NaN",
+        },
+        params: {
+            headerFloat: "NaN",
+            headerDouble: "NaN",
+        }
+    },
+    {
+        id: "RestJsonSupportsInfinityFloatHeaderOutputs",
+        documentation: "Supports handling Infinity float header values.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "X-Float": "Infinity",
+            "X-Double": "Infinity",
+        },
+        params: {
+            headerFloat: "Infinity",
+            headerDouble: "Infinity",
+        }
+    },
+    {
+        id: "RestJsonSupportsNegativeInfinityFloatHeaderOutputs",
+        documentation: "Supports handling -Infinity float header values.",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "X-Float": "-Infinity",
+            "X-Double": "-Infinity",
+        },
+        params: {
+            headerFloat: "-Infinity",
+            headerDouble: "-Infinity",
         }
     },
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -195,3 +195,58 @@ structure HttpRequestWithGreedyLabelInPathInput {
     @required
     baz: String,
 }
+
+apply HttpRequestWithFloatLabels @httpRequestTests([
+    {
+        id: "RestJsonSupportsNaNFloatLabels",
+        documentation: "Supports handling NaN float label values.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/FloatHttpLabels/NaN/NaN",
+        body: "",
+        params: {
+            float: "NaN",
+            double: "NaN",
+        }
+    },
+    {
+        id: "RestJsonSupportsInfinityFloatLabels",
+        documentation: "Supports handling Infinity float label values.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/FloatHttpLabels/Infinity/Infinity",
+        body: "",
+        params: {
+            float: "Infinity",
+            double: "Infinity",
+        }
+    },
+    {
+        id: "RestJsonSupportsNegativeInfinityFloatLabels",
+        documentation: "Supports handling -Infinity float label values.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/FloatHttpLabels/-Infinity/-Infinity",
+        body: "",
+        params: {
+            float: "-Infinity",
+            double: "-Infinity",
+        }
+    },
+])
+
+@readonly
+@http(method: "GET", uri: "/FloatHttpLabels/{float}/{double}")
+operation HttpRequestWithFloatLabels {
+    input: HttpRequestWithFloatLabelsInput
+}
+
+structure HttpRequestWithFloatLabelsInput {
+    @httpLabel
+    @required
+    float: Float,
+    
+    @httpLabel
+    @required
+    double: Double,
+}

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -125,7 +125,55 @@ apply AllQueryStringTypes @httpRequestTests([
         params: {
 		queryString: "%:/?#[]@!$&'()*+,;=😹"
         }
-    }
+    },
+    {
+        id: "RestJsonSupportsNaNFloatQueryValues",
+        documentation: "Supports handling NaN float query values.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "Float=NaN",
+            "Double=NaN",
+        ],
+        params: {
+            queryFloat: "NaN",
+            queryDouble: "NaN",
+        }
+    },
+    {
+        id: "RestJsonSupportsInfinityFloatQueryValues",
+        documentation: "Supports handling Infinity float query values.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "Float=Infinity",
+            "Double=Infinity",
+        ],
+        params: {
+            queryFloat: "Infinity",
+            queryDouble: "Infinity",
+        }
+    },
+    {
+        id: "RestJsonSupportsNegativeInfinityFloatQueryValues",
+        documentation: "Supports handling -Infinity float query values.",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "Float=-Infinity",
+            "Double=-Infinity",
+        ],
+        params: {
+            queryFloat: "-Infinity",
+            queryDouble: "-Infinity",
+        }
+    },
 ])
 
 structure AllQueryStringTypesInput {

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -85,6 +85,7 @@ apply SimpleScalarProperties @httpRequestTests([
             {
                 "stringValue": null
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -102,6 +103,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "NaN",
                 "doubleValue": "NaN"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -121,6 +123,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "Infinity",
                 "doubleValue": "Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -140,6 +143,7 @@ apply SimpleScalarProperties @httpRequestTests([
                 "floatValue": "-Infinity",
                 "doubleValue": "-Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -227,6 +231,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "NaN",
                 "doubleValue": "NaN"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -245,6 +250,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "Infinity",
                 "doubleValue": "Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },
@@ -263,6 +269,7 @@ apply SimpleScalarProperties @httpResponseTests([
                 "floatValue": "-Infinity",
                 "doubleValue": "-Infinity"
             }""",
+        bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/json",
         },

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -91,6 +91,63 @@ apply SimpleScalarProperties @httpRequestTests([
         params: {},
         appliesTo: "server",
     },
+    {
+        id: "RestJsonSupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+            {
+                "floatValue": "NaN",
+                "doubleValue": "NaN"
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "RestJsonSupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+            {
+                "floatValue": "Infinity",
+                "doubleValue": "Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "RestJsonSupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+            {
+                "floatValue": "-Infinity",
+                "doubleValue": "-Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
 ])
 
 apply SimpleScalarProperties @httpResponseTests([
@@ -159,6 +216,60 @@ apply SimpleScalarProperties @httpResponseTests([
             stringValue: null
         },
         appliesTo: "server",
+    },
+    {
+        id: "RestJsonSupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "floatValue": "NaN",
+                "doubleValue": "NaN"
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "RestJsonSupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "floatValue": "Infinity",
+                "doubleValue": "Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "RestJsonSupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "floatValue": "-Infinity",
+                "doubleValue": "-Infinity"
+            }""",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -33,6 +33,7 @@ service RestJson {
         HttpRequestWithLabels,
         HttpRequestWithLabelsAndTimestampFormat,
         HttpRequestWithGreedyLabelInPath,
+        HttpRequestWithFloatLabels,
 
         // @httpQuery and @httpQueryParams tests
         AllQueryStringTypes,

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -102,6 +102,69 @@ apply SimpleScalarProperties @httpRequestTests([
             stringValue: "string with white    space",
         }
     },
+    {
+        id: "RestXmlSupportsNaNFloatInputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: restXml,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <floatValue>NaN</floatValue>
+                  <doubleValue>NaN</doubleValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "RestXmlSupportsInfinityFloatInputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: restXml,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <floatValue>Infinity</floatValue>
+                  <doubleValue>Infinity</doubleValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "RestXmlSupportsNegativeInfinityFloatInputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: restXml,
+        method: "PUT",
+        uri: "/SimpleScalarProperties",
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <floatValue>-Infinity</floatValue>
+                  <doubleValue>-Infinity</doubleValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
 ])
 
 apply SimpleScalarProperties @httpResponseTests([
@@ -232,7 +295,67 @@ apply SimpleScalarProperties @httpResponseTests([
             foo: "Foo",
             stringValue: "string with white    space",
         }
-    }
+    },
+    {
+        id: "RestXmlSupportsNaNFloatOutputs",
+        documentation: "Supports handling NaN float values.",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <floatValue>NaN</floatValue>
+                  <doubleValue>NaN</doubleValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            floatValue: "NaN",
+            doubleValue: "NaN",
+        }
+    },
+    {
+        id: "RestXmlSupportsInfinityFloatOutputs",
+        documentation: "Supports handling Infinity float values.",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <floatValue>Infinity</floatValue>
+                  <doubleValue>Infinity</doubleValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            floatValue: "Infinity",
+            doubleValue: "Infinity",
+        }
+    },
+    {
+        id: "RestXmlSupportsNegativeInfinityFloatOutputs",
+        documentation: "Supports handling -Infinity float values.",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <SimpleScalarPropertiesInputOutput>
+                  <floatValue>-Infinity</floatValue>
+                  <doubleValue>-Infinity</doubleValue>
+              </SimpleScalarPropertiesInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            floatValue: "-Infinity",
+            doubleValue: "-Infinity",
+        }
+    },
 ])
 
 structure SimpleScalarPropertiesInputOutput {

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -120,6 +120,54 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             headerEnumList: ["Foo", "Bar", "Baz"],
         }
     },
+    {
+        id: "RestXmlSupportsNaNFloatHeaderInputs",
+        documentation: "Supports handling NaN float header values.",
+        protocol: restXml,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        body: "",
+        headers: {
+            "X-Float": "NaN",
+            "X-Double": "NaN",
+        },
+        params: {
+            headerFloat: "NaN",
+            headerDouble: "NaN",
+        }
+    },
+    {
+        id: "RestXmlSupportsInfinityFloatHeaderInputs",
+        documentation: "Supports handling Infinity float header values.",
+        protocol: restXml,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        body: "",
+        headers: {
+            "X-Float": "Infinity",
+            "X-Double": "Infinity",
+        },
+        params: {
+            headerFloat: "Infinity",
+            headerDouble: "Infinity",
+        }
+    },
+    {
+        id: "RestXmlSupportsNegativeInfinityFloatHeaderInputs",
+        documentation: "Supports handling -Infinity float header values.",
+        protocol: restXml,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        body: "",
+        headers: {
+            "X-Float": "-Infinity",
+            "X-Double": "-Infinity",
+        },
+        params: {
+            headerFloat: "-Infinity",
+            headerDouble: "-Infinity",
+        }
+    },
 ])
 
 apply InputAndOutputWithHeaders @httpResponseTests([
@@ -208,6 +256,51 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         params: {
             headerEnum: "Foo",
             headerEnumList: ["Foo", "Bar", "Baz"],
+        }
+    },
+    {
+        id: "RestXmlSupportsNaNFloatHeaderOutputs",
+        documentation: "Supports handling NaN float header values.",
+        protocol: restXml,
+        code: 200,
+        headers: {
+            "X-Float": "NaN",
+            "X-Double": "NaN",
+        },
+        body: "",
+        params: {
+            headerFloat: "NaN",
+            headerDouble: "NaN",
+        }
+    },
+    {
+        id: "RestXmlSupportsInfinityFloatHeaderOutputs",
+        documentation: "Supports handling Infinity float header values.",
+        protocol: restXml,
+        code: 200,
+        headers: {
+            "X-Float": "Infinity",
+            "X-Double": "Infinity",
+        },
+        body: "",
+        params: {
+            headerFloat: "Infinity",
+            headerDouble: "Infinity",
+        }
+    },
+    {
+        id: "RestXmlSupportsNegativeInfinityFloatHeaderOutputs",
+        documentation: "Supports handling -Infinity float header values.",
+        protocol: restXml,
+        code: 200,
+        headers: {
+            "X-Float": "-Infinity",
+            "X-Double": "-Infinity",
+        },
+        body: "",
+        params: {
+            headerFloat: "-Infinity",
+            headerDouble: "-Infinity",
         }
     },
 ])

--- a/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
@@ -177,3 +177,58 @@ structure HttpRequestWithGreedyLabelInPathInput {
     @required
     baz: String,
 }
+
+apply HttpRequestWithFloatLabels @httpRequestTests([
+    {
+        id: "RestXmlSupportsNaNFloatLabels",
+        documentation: "Supports handling NaN float label values.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/FloatHttpLabels/NaN/NaN",
+        body: "",
+        params: {
+            float: "NaN",
+            double: "NaN",
+        }
+    },
+    {
+        id: "RestXmlSupportsInfinityFloatLabels",
+        documentation: "Supports handling Infinity float label values.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/FloatHttpLabels/Infinity/Infinity",
+        body: "",
+        params: {
+            float: "Infinity",
+            double: "Infinity",
+        }
+    },
+    {
+        id: "RestXmlSupportsNegativeInfinityFloatLabels",
+        documentation: "Supports handling -Infinity float label values.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/FloatHttpLabels/-Infinity/-Infinity",
+        body: "",
+        params: {
+            float: "-Infinity",
+            double: "-Infinity",
+        }
+    },
+])
+
+@readonly
+@http(method: "GET", uri: "/FloatHttpLabels/{float}/{double}")
+operation HttpRequestWithFloatLabels {
+    input: HttpRequestWithFloatLabelsInput
+}
+
+structure HttpRequestWithFloatLabelsInput {
+    @httpLabel
+    @required
+    float: Float,
+    
+    @httpLabel
+    @required
+    double: Double,
+}

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -110,7 +110,55 @@ apply AllQueryStringTypes @httpRequestTests([
                 "QueryParamsStringKeyB": "Bar",
             },
         }
-    }
+    },
+    {
+        id: "RestXmlSupportsNaNFloatQueryValues",
+        documentation: "Supports handling NaN float query values.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "Float=NaN",
+            "Double=NaN",
+        ],
+        params: {
+            queryFloat: "NaN",
+            queryDouble: "NaN",
+        }
+    },
+    {
+        id: "RestXmlSupportsInfinityFloatQueryValues",
+        documentation: "Supports handling Infinity float query values.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "Float=Infinity",
+            "Double=Infinity",
+        ],
+        params: {
+            queryFloat: "Infinity",
+            queryDouble: "Infinity",
+        }
+    },
+    {
+        id: "RestXmlSupportsNegativeInfinityFloatQueryValues",
+        documentation: "Supports handling -Infinity float query values.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "Float=-Infinity",
+            "Double=-Infinity",
+        ],
+        params: {
+            queryFloat: "-Infinity",
+            queryDouble: "-Infinity",
+        }
+    },
 ])
 
 structure AllQueryStringTypesInput {

--- a/smithy-aws-protocol-tests/model/restXml/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/main.smithy
@@ -31,6 +31,7 @@ service RestXml {
         HttpRequestWithLabels,
         HttpRequestWithLabelsAndTimestampFormat,
         HttpRequestWithGreedyLabelInPath,
+        HttpRequestWithFloatLabels,
 
         // @httpQuery and @httpQueryParams tests
         AllQueryStringTypes,

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -108,6 +108,7 @@ public class JsonSchemaConfig {
     private final ConcurrentHashMap<Class, Object> extensionCache = new ConcurrentHashMap<>();
     private final NodeMapper nodeMapper = new NodeMapper();
     private ShapeId service;
+    private boolean supportNonNumericFloats = false;
 
     public JsonSchemaConfig() {
         nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
@@ -346,5 +347,23 @@ public class JsonSchemaConfig {
                     .orElseGet(() -> getDefaultTimestampFormat().toString()));
         }
         return Optional.empty();
+    }
+
+    public boolean getSupportNonNumericFloats() {
+        return supportNonNumericFloats;
+    }
+
+    /**
+     * Set to true to add support for NaN, Infinity, and -Infinity in float
+     * and double shapes. These values will be serialized as strings. The
+     * OpenAPI document will be updated to refer to them as a "oneOf" of number
+     * and string.
+     *
+     * <p>By default, non-numeric values are not supported.
+     *
+     * @param supportNonNumericFloats True if non-numeric float values should be supported.
+     */
+    public void setSupportNonNumericFloats(boolean supportNonNumericFloats) {
+        this.supportNonNumericFloats = supportNonNumericFloats;
     }
 }

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -18,8 +18,10 @@ package software.amazon.smithy.jsonschema;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node.NonNumericFloat;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.BlobShape;
@@ -53,9 +55,7 @@ import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.utils.ListUtils;
 
 final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
-    private static final List<String> NON_NUMERIC_FLOAT_VALUES = ListUtils.of(
-            "NaN", "Infinity", "-Infinity"
-    );
+    private static final Set<String> NON_NUMERIC_FLOAT_VALUES = NonNumericFloat.stringRepresentations();
 
     private final Model model;
     private final JsonSchemaConverter converter;

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/SupportNonNumericFloatsTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/SupportNonNumericFloatsTest.java
@@ -1,0 +1,34 @@
+package software.amazon.smithy.jsonschema;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.utils.IoUtils;
+
+public class SupportNonNumericFloatsTest {
+    @Test
+    public void addsNonNumericFloatSupport() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("non-numeric-floats.json"))
+                .assemble()
+                .unwrap();
+
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setSupportNonNumericFloats(true);
+        SchemaDocument result = JsonSchemaConverter.builder()
+                .config(config)
+                .model(model)
+                .build()
+                .convert();
+        assertThat(result.getDefinitions().keySet(), not(empty()));
+
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("non-numeric-floats.jsonschema.json")));
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/non-numeric-floats.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/non-numeric-floats.json
@@ -1,0 +1,37 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "example.smithy#MyService": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "example.smithy#MyOperation"
+                }
+            ]
+        },
+        "example.smithy#MyOperation": {
+            "type": "operation",
+            "input": {
+                "target": "example.smithy#MyOperationInput"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/foo",
+                    "method": "POST"
+                }
+            }
+        },
+        "example.smithy#MyOperationInput": {
+            "type": "structure",
+            "members": {
+                "floatMember": {
+                    "target": "smithy.api#Float"
+                },
+                "doubleMember": {
+                    "target": "smithy.api#Double"
+                }
+            }
+        }
+    }
+}

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/non-numeric-floats.jsonschema.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/non-numeric-floats.jsonschema.json
@@ -1,0 +1,39 @@
+{
+    "definitions": {
+        "MyOperationInput": {
+            "type": "object",
+            "properties": {
+                "doubleMember": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": [
+                                "NaN",
+                                "Infinity",
+                                "-Infinity"
+                            ]
+                        }
+                    ]
+                },
+                "floatMember": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": [
+                                "NaN",
+                                "Infinity",
+                                "-Infinity"
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -21,10 +21,12 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -721,5 +723,57 @@ public abstract class Node implements FromSourceLocation, ToNode {
                         .collect(ArrayNode.collect(node.getSourceLocation()));
             }
         });
+    }
+
+    /**
+     * Non-numeric values for floats and doubles.
+     */
+    public enum NonNumericFloat {
+        NAN("NaN"),
+        POSITIVE_INFINITY("Infinity"),
+        NEGATIVE_INFINITY("-Infinity");
+
+        private final String stringRepresentation;
+
+        NonNumericFloat(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation;
+        }
+
+        /**
+         * @return The string representation of this non-numeric float.
+         */
+        public String getStringRepresentation() {
+            return stringRepresentation;
+        }
+
+        /**
+         * @return All the possible string representations of non-numeric floats.
+         */
+        public static Set<String> stringRepresentations() {
+            Set<String> values = new LinkedHashSet<>();
+            for (NonNumericFloat value : NonNumericFloat.values()) {
+                values.add(value.getStringRepresentation());
+            }
+            return values;
+        }
+
+        /**
+         * Convert a string value into a NonNumericFloat.
+         *
+         * @param value A string representation of a non-numeric float value.
+         * @return A NonNumericFloat that represents the given string value or empty if there is no associated value.
+         */
+        public static Optional<NonNumericFloat> fromStringRepresentation(String value) {
+            switch (value) {
+                case "NaN":
+                    return Optional.of(NAN);
+                case "Infinity":
+                    return Optional.of(POSITIVE_INFINITY);
+                case "-Infinity":
+                    return Optional.of(NEGATIVE_INFINITY);
+                default:
+                    return Optional.empty();
+            }
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -211,7 +211,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     @Override
     public List<ValidationEvent> floatShape(FloatShape shape) {
-        return value.isNumberNode()
+        return value.isNumberNode() || value.isStringNode()
                ? applyPlugins(shape)
                : invalidShape(shape, NodeType.NUMBER);
     }
@@ -224,7 +224,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     @Override
     public List<ValidationEvent> doubleShape(DoubleShape shape) {
-        return value.isNumberNode()
+        return value.isNumberNode() || value.isStringNode()
                ? applyPlugins(shape)
                : invalidShape(shape, NodeType.NUMBER);
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
@@ -51,6 +51,7 @@ public interface NodeValidatorPlugin {
      */
     static List<NodeValidatorPlugin> getBuiltins() {
         return ListUtils.of(
+                new NonNumericFloatValuesPlugin(),
                 new BlobLengthPlugin(),
                 new CollectionLengthPlugin(),
                 new IdRefPlugin(),

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NonNumericFloatValuesPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NonNumericFloatValuesPlugin.java
@@ -15,21 +15,18 @@
 
 package software.amazon.smithy.model.validation.node;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.Node.NonNumericFloat;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Validates the specific set of non-numeric values allowed for floats and doubles.
  */
 final class NonNumericFloatValuesPlugin implements NodeValidatorPlugin  {
-    private static final Set<String> NON_NUMERIC_FLOAT_VALUES = new LinkedHashSet<>(ListUtils.of(
-            "NaN", "Infinity", "-Infinity"
-    ));
+    private static final Set<String> NON_NUMERIC_FLOAT_VALUES = NonNumericFloat.stringRepresentations();
 
     @Override
     public void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NonNumericFloatValuesPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NonNumericFloatValuesPlugin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.node;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Validates the specific set of non-numeric values allowed for floats and doubles.
+ */
+final class NonNumericFloatValuesPlugin implements NodeValidatorPlugin  {
+    private static final Set<String> NON_NUMERIC_FLOAT_VALUES = new LinkedHashSet<>(ListUtils.of(
+            "NaN", "Infinity", "-Infinity"
+    ));
+
+    @Override
+    public void apply(Shape shape, Node value, Context context, BiConsumer<FromSourceLocation, String> emitter) {
+        if (!(shape.isFloatShape() || shape.isDoubleShape()) || !value.isStringNode()) {
+            return;
+        }
+        String nodeValue = value.expectStringNode().getValue();
+        if (!NON_NUMERIC_FLOAT_VALUES.contains(nodeValue)) {
+            emitter.accept(value, String.format(
+                    "Value for `%s` must either be numeric or one of the following strings: [\"%s\"], but was \"%s\"",
+                    shape.getId(), String.join("\", \"", NON_NUMERIC_FLOAT_VALUES), nodeValue
+            ));
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -47,8 +47,14 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
             StringNode node,
             BiConsumer<FromSourceLocation, String> emitter
     ) {
-        // Should we fail on NaN?
         NonNumericFloat.fromStringRepresentation(node.getValue()).ifPresent(value -> {
+            if (value.equals(NonNumericFloat.NAN)) {
+                emitter.accept(node, String.format(
+                        "Value provided for `%s` must be a number because the `smithy.api#range` trait is applied, "
+                                + "but found \"%s\"",
+                        shape.getId(), node.getValue()));
+            }
+
             if (trait.getMin().isPresent() && value.equals(NonNumericFloat.NEGATIVE_INFINITY)) {
                 emitter.accept(node, String.format(
                         "Value provided for `%s` must be greater than or equal to %s, but found \"%s\"",

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -140,23 +140,27 @@ public class NodeValidationVisitorTest {
 
                 // float
                 {"ns.foo#Float", "10", null},
-                {"ns.foo#Float", "\"NaN\"", null},
-                {"ns.foo#Float", "\"Infinity\"", null},
-                {"ns.foo#Float", "\"-Infinity\"", null},
-                {"ns.foo#Float", "\"+Infinity\"", new String[] {"Value for `ns.foo#Float` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
+                {"smithy.api#Float", "\"NaN\"", null},
+                {"smithy.api#Float", "\"Infinity\"", null},
+                {"smithy.api#Float", "\"-Infinity\"", null},
+                {"smithy.api#Float", "\"+Infinity\"", new String[] {"Value for `smithy.api#Float` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
                 {"ns.foo#Float", "true", new String[] {"Expected number value for float shape, `ns.foo#Float`; found boolean value, `true`"}},
                 {"ns.foo#Float", "21", new String[] {"Value provided for `ns.foo#Float` must be less than or equal to 20, but found 21"}},
+                {"ns.foo#Float", "\"Infinity\"", new String[] {"Value provided for `ns.foo#Float` must be less than or equal to 20, but found \"Infinity\""}},
                 {"ns.foo#Float", "9", new String[] {"Value provided for `ns.foo#Float` must be greater than or equal to 10, but found 9"}},
+                {"ns.foo#Float", "\"-Infinity\"", new String[] {"Value provided for `ns.foo#Float` must be greater than or equal to 10, but found \"-Infinity\""}},
 
                 // double
                 {"ns.foo#Double", "10", null},
-                {"ns.foo#Double", "\"NaN\"", null},
-                {"ns.foo#Double", "\"Infinity\"", null},
-                {"ns.foo#Double", "\"-Infinity\"", null},
-                {"ns.foo#Double", "\"+Infinity\"", new String[] {"Value for `ns.foo#Double` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
+                {"smithy.api#Double", "\"NaN\"", null},
+                {"smithy.api#Double", "\"Infinity\"", null},
+                {"smithy.api#Double", "\"-Infinity\"", null},
+                {"smithy.api#Double", "\"+Infinity\"", new String[] {"Value for `smithy.api#Double` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
                 {"ns.foo#Double", "true", new String[] {"Expected number value for double shape, `ns.foo#Double`; found boolean value, `true`"}},
                 {"ns.foo#Double", "21", new String[] {"Value provided for `ns.foo#Double` must be less than or equal to 20, but found 21"}},
+                {"ns.foo#Double", "\"Infinity\"", new String[] {"Value provided for `ns.foo#Double` must be less than or equal to 20, but found \"Infinity\""}},
                 {"ns.foo#Double", "9", new String[] {"Value provided for `ns.foo#Double` must be greater than or equal to 10, but found 9"}},
+                {"ns.foo#Double", "\"-Infinity\"", new String[] {"Value provided for `ns.foo#Double` must be greater than or equal to 10, but found \"-Infinity\""}},
 
                 // bigInteger
                 {"ns.foo#BigInteger", "10", null},

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -140,12 +140,20 @@ public class NodeValidationVisitorTest {
 
                 // float
                 {"ns.foo#Float", "10", null},
+                {"ns.foo#Float", "\"NaN\"", null},
+                {"ns.foo#Float", "\"Infinity\"", null},
+                {"ns.foo#Float", "\"-Infinity\"", null},
+                {"ns.foo#Float", "\"+Infinity\"", new String[] {"Value for `ns.foo#Float` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
                 {"ns.foo#Float", "true", new String[] {"Expected number value for float shape, `ns.foo#Float`; found boolean value, `true`"}},
                 {"ns.foo#Float", "21", new String[] {"Value provided for `ns.foo#Float` must be less than or equal to 20, but found 21"}},
                 {"ns.foo#Float", "9", new String[] {"Value provided for `ns.foo#Float` must be greater than or equal to 10, but found 9"}},
 
                 // double
                 {"ns.foo#Double", "10", null},
+                {"ns.foo#Double", "\"NaN\"", null},
+                {"ns.foo#Double", "\"Infinity\"", null},
+                {"ns.foo#Double", "\"-Infinity\"", null},
+                {"ns.foo#Double", "\"+Infinity\"", new String[] {"Value for `ns.foo#Double` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
                 {"ns.foo#Double", "true", new String[] {"Expected number value for double shape, `ns.foo#Double`; found boolean value, `true`"}},
                 {"ns.foo#Double", "21", new String[] {"Value provided for `ns.foo#Double` must be less than or equal to 20, but found 21"}},
                 {"ns.foo#Double", "9", new String[] {"Value provided for `ns.foo#Double` must be greater than or equal to 10, but found 9"}},

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -141,6 +141,7 @@ public class NodeValidationVisitorTest {
                 // float
                 {"ns.foo#Float", "10", null},
                 {"smithy.api#Float", "\"NaN\"", null},
+                {"ns.foo#Float", "\"NaN\"", new String[] {"Value provided for `ns.foo#Float` must be a number because the `smithy.api#range` trait is applied, but found \"NaN\""}},
                 {"smithy.api#Float", "\"Infinity\"", null},
                 {"smithy.api#Float", "\"-Infinity\"", null},
                 {"smithy.api#Float", "\"+Infinity\"", new String[] {"Value for `smithy.api#Float` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},
@@ -153,6 +154,7 @@ public class NodeValidationVisitorTest {
                 // double
                 {"ns.foo#Double", "10", null},
                 {"smithy.api#Double", "\"NaN\"", null},
+                {"ns.foo#Double", "\"NaN\"", new String[] {"Value provided for `ns.foo#Double` must be a number because the `smithy.api#range` trait is applied, but found \"NaN\""}},
                 {"smithy.api#Double", "\"Infinity\"", null},
                 {"smithy.api#Double", "\"-Infinity\"", null},
                 {"smithy.api#Double", "\"+Infinity\"", new String[] {"Value for `smithy.api#Double` must either be numeric or one of the following strings: [\"NaN\", \"Infinity\", \"-Infinity\"], but was \"+Infinity\""}},

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
@@ -16,12 +16,15 @@
 package software.amazon.smithy.openapi.fromsmithy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.jsonschema.JsonSchemaConfig;
 import software.amazon.smithy.jsonschema.JsonSchemaConverter;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.jsonschema.SchemaDocument;
@@ -196,6 +199,32 @@ public class OpenApiJsonSchemaMapperTest {
     }
 
     @Test
+    public void supportsNonNumericFloatFormat() {
+        FloatShape shape = FloatShape.builder().id("a.b#C").build();
+        Model model = Model.builder().addShape(shape).build();
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setSupportNonNumericFloats(true);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .addMapper(new OpenApiJsonSchemaMapper())
+                .config(config)
+                .model(model)
+                .build()
+                .convertShape(shape);
+
+        Schema rootSchema = document.getRootSchema();
+        assertFalse(rootSchema.getFormat().isPresent());
+        Schema numericSchema = null;
+        for (Schema schema : rootSchema.getOneOf()) {
+            if (schema.getType().isPresent() && schema.getType().get().equals("number")) {
+                numericSchema = schema;
+                break;
+            }
+        }
+        assertNotNull(numericSchema);
+        assertThat(numericSchema.getFormat().get(), equalTo("float"));
+    }
+
+    @Test
     public void supportsDoubleFormat() {
         DoubleShape shape = DoubleShape.builder().id("a.b#C").build();
         Model model = Model.builder().addShape(shape).build();
@@ -206,6 +235,32 @@ public class OpenApiJsonSchemaMapperTest {
                 .convertShape(shape);
 
         assertThat(document.getRootSchema().getFormat().get(), equalTo("double"));
+    }
+
+    @Test
+    public void supportsNonNumericDoubleFormat() {
+        DoubleShape shape = DoubleShape.builder().id("a.b#C").build();
+        Model model = Model.builder().addShape(shape).build();
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setSupportNonNumericFloats(true);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .addMapper(new OpenApiJsonSchemaMapper())
+                .config(config)
+                .model(model)
+                .build()
+                .convertShape(shape);
+
+        Schema rootSchema = document.getRootSchema();
+        assertFalse(rootSchema.getFormat().isPresent());
+        Schema numericSchema = null;
+        for (Schema schema : rootSchema.getOneOf()) {
+            if (schema.getType().isPresent() && schema.getType().get().equals("number")) {
+                numericSchema = schema;
+                break;
+            }
+        }
+        assertNotNull(numericSchema);
+        assertThat(numericSchema.getFormat().get(), equalTo("double"));
     }
 
     @Test

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/vendor-params-validation.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/vendor-params-validation.errors
@@ -1,5 +1,5 @@
 [WARNING] smithy.example#SayGoodbye: Protocol test case defined a `vendorParamsShape` but no `vendorParams` | HttpResponseTestsOutput
 [WARNING] smithy.example#SayGoodbye: smithy.test#httpResponseTests.1.vendorParams: Invalid structure member `additional` found for `smithy.example#emptyVendorParamsStructure` | HttpResponseTestsOutput
-[ERROR] smithy.example#MyError: smithy.test#httpResponseTests.0.vendorParams.float: Expected number value for float shape, `smithy.api#Float`; found string value, `Hi` | HttpResponseTestsError
+[ERROR] smithy.example#MyError: smithy.test#httpResponseTests.0.vendorParams.float: Value for `smithy.api#Float` must either be numeric or one of the following strings: ["NaN", "Infinity", "-Infinity"], but was "Hi" | HttpResponseTestsError
 [ERROR] smithy.example#SayHello: smithy.test#httpRequestTests.0.vendorParams: Missing required structure member `integer` for `smithy.example#simpleVendorParamsStructure` | HttpRequestTestsInput
 [ERROR] smithy.example#SayHello: smithy.test#httpRequestTests.1.vendorParams.boolean: Expected boolean value for boolean shape, `smithy.api#Boolean`; found string value, `Hi` | HttpRequestTestsInput


### PR DESCRIPTION
This documents how the non-numeric floating point values `NaN`, `Infinity`, and `-Infinity` are handled in protocols. Essentially they are serialized as the protocol's strings with those values. Protocol tests have been added to each AWS protocol to assert that behavior.

Since JSON explicitly disallows these values, the jsonschema tooling doesn't enable them by default. This was also done because defaulting that behavior would be a breaking change. 

Fixes #812 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
