### PR TITLE
Remove chasecoa from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add core contributors to all prs by default
-* @srchase @kstich @JordonPhillips @mtdowling
+* @kstich @JordonPhillips @mtdowling


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
