### PR TITLE
add new awsQuery tests for nested structs and fix endpoint test

### DIFF
--- a/smithy-aws-protocol-tests/model/awsQuery/endpoints.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/endpoints.smithy
@@ -20,7 +20,7 @@ use smithy.test#httpRequestTests
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: "Action=EndpointOperation&Version=2020-01-0",
+        body: "Action=EndpointOperation&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded",
         host: "example.com",
         resolvedHost: "foo.example.com",

--- a/smithy-aws-protocol-tests/model/awsQuery/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input-lists.smithy
@@ -100,6 +100,23 @@ apply QueryLists @httpRequestTests([
             FlattenedListArgWithXmlName: ["A", "B"]
         }
     },
+    {
+        id: "QueryNestedStructWithList",
+        documentation: "Nested structure with a list member",
+        protocol: awsQuery,
+        method: "POST",
+        uri: "/",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: "Action=QueryLists&Version=2020-01-08&NestedWithList.ListArg.member.1=A&NestedWithList.ListArg.member.2=B",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        params: {
+            NestedWithList: {
+                ListArg: ["A", "B"]
+            }
+        }
+    },
 ])
 
 structure QueryListsInput {
@@ -115,9 +132,15 @@ structure QueryListsInput {
     @xmlFlattened
     @xmlName("Hi")
     FlattenedListArgWithXmlName: ListWithXmlName,
+
+    NestedWithList: NestedStructWithList
 }
 
 list ListWithXmlName {
     @xmlName("item")
     member: String
+}
+
+structure NestedStructWithList {
+    ListArg: StringList
 }

--- a/smithy-aws-protocol-tests/model/awsQuery/input-maps.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input-maps.smithy
@@ -167,6 +167,26 @@ apply QueryMaps @httpRequestTests([
             }
         }
     },
+    {
+        id: "QueryNestedStructWithMap",
+        documentation: "Serializes nested struct with map member",
+        protocol: awsQuery,
+        method: "POST",
+        uri: "/",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: "Action=QueryMaps&Version=2020-01-08&NestedStructWithMap.MapArg.entry.1.key=bar&NestedStructWithMap.MapArg.entry.1.value=Bar&NestedStructWithMap.MapArg.entry.2.key=foo&NestedStructWithMap.MapArg.entry.2.value=Foo",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        params: {
+            NestedStructWithMap: {
+                MapArg: {
+                    bar: "Bar",
+                    foo: "Foo",
+                }
+            }
+        }
+    },
 ])
 
 structure QueryMapsInput {
@@ -187,6 +207,8 @@ structure QueryMapsInput {
     FlattenedMapWithXmlName: MapWithXmlName,
 
     MapOfLists: MapOfLists,
+
+    NestedStructWithMap: NestedStructWithMap,
 }
 
 map ComplexMap {
@@ -205,4 +227,8 @@ map MapWithXmlName {
 map MapOfLists {
     key: String,
     value: StringList,
+}
+
+structure NestedStructWithMap {
+    MapArg: StringMap
 }

--- a/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
@@ -85,6 +85,23 @@ apply QueryLists @httpRequestTests([
             ListArgWithXmlName: ["A", "B"]
         }
     },
+    {
+        id: "Ec2ListNestedStructWithList",
+        documentation: "Nested structure with a list member",
+        protocol: ec2Query,
+        method: "POST",
+        uri: "/",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: "Action=QueryLists&Version=2020-01-08&NestedWithList.ListArg.member.1=A&NestedWithList.ListArg.member.2=B",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        params: {
+            NestedWithList: {
+                ListArg: ["A", "B"]
+            }
+        }
+    },
 ])
 
 structure QueryListsInput {
@@ -96,9 +113,15 @@ structure QueryListsInput {
 
     @xmlName("Hi")
     ListArgWithXmlName: ListWithXmlName,
+
+    NestedWithList: NestedStructWithList,
 }
 
 list ListWithXmlName {
     @xmlName("item")
     member: String
+}
+
+structure NestedStructWithList {
+    ListArg: StringList
 }

--- a/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
@@ -94,7 +94,7 @@ apply QueryLists @httpRequestTests([
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: "Action=QueryLists&Version=2020-01-08&NestedWithList.ListArg.member.1=A&NestedWithList.ListArg.member.2=B",
+        body: "Action=QueryLists&Version=2020-01-08&NestedWithList.ListArg.1=A&NestedWithList.ListArg.2=B",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             NestedWithList: {


### PR DESCRIPTION
*Description of changes:*
We ran into an issue with our serializer implementation on a real service (SES) that had a nested structure with list input (specifically [SendEmailRequest.Destination$ToAddresses](https://github.com/aws/aws-sdk-go-v2/blob/main/codegen/sdk-codegen/aws-models/ses.2010-12-01.json#L1834). I've added tests for both lists and maps (double check for correctness). Also there appears to be a broken test unless I'm mistaken, I've fixed that as well. 

- Adds tests lists/maps in a nested structure
- Fix the expected version of the `AwsQueryEndpointTrait` test



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
