### PR TITLE
Fix list and map ec2 query serialization docs

### DIFF
--- a/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -211,6 +211,16 @@ that affect serialization:
 .. |quoted shape name| replace:: ``ec2Query``
 .. |name resolution text| replace:: See :ref:`aws.protocols#ec2QueryName-query-key-naming`
    for how to serialize a property using a custom name
+.. |query collection text| replace::
+    Each value provided in the collection is serialized as a separate key with
+    a "." separator and a "1" indexed incrementing counter appended to the
+    container's key.
+.. |query map text| replace::
+    Map serialization is currently undefined for this protocol.
+.. |query aggregate text| replace::
+    Each member value provided for the shape is serialized as a separate key
+    with a "." separator and the member name appended to the container's key.
+    |name resolution text|. Members with null values are not serialized.
 .. include:: aws-query-serialization.rst.template
 
 

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -95,6 +95,27 @@ that affect serialization:
 
 .. |quoted shape name| replace:: ``awsQuery``
 .. |name resolution text| replace:: The :ref:`xmlName-trait` can be used to serialize a property using a custom name
+.. |query collection text| replace::
+    Each value provided in the collection is serialized as a separate key with
+    a "." separator, the string "member", a "." separator, and a "1" indexed
+    incrementing counter appended to the container's key.
+    |name resolution text| instead of "member". The :ref:`xmlFlattened-trait`
+    can be used to unwrap the values into a containing structure or union,
+    with the key not containing the initial "." separator and ``member``
+    segment.
+.. |query map text| replace::
+    Each key and value in each pair provided in the map is serialized as a
+    separate key with a "." separator, the string "entry", a "." separator,
+    a "1" indexed incrementing counter, a "." separator, and the string
+    "key" or "value" (for member keys or values, respectively) appended to
+    the container's key. |name resolution text| instead of "member", "key",
+    or "value". The :ref:`xmlFlattened-trait` can be used to unwrap the
+    values into a containing structure or union, with the key not
+    containing the initial "." separator and "entry" segment.
+.. |query aggregate text| replace::
+    Each member value provided for the shape is serialized as a separate key
+    with a "." separator and the member name appended to the container's key.
+    |name resolution text|. Members with null values are not serialized.
 .. include:: aws-query-serialization.rst.template
 
 

--- a/docs/source/1.0/spec/aws/aws-query-serialization.rst.template
+++ b/docs/source/1.0/spec/aws/aws-query-serialization.rst.template
@@ -79,28 +79,6 @@ Simple shapes are serialized according to the following rules:
 Aggregate shapes are serialized with additional segments for members appended
 to the input's key.
 
-.. |query collection text| replace::
-    Each value provided in the collection is serialized as a separate key with
-    a "." separator, the string "member", a "." separator, and a "1" indexed
-    incrementing counter appended to the container's key.
-    |name resolution text| instead of "member". The :ref:`xmlFlattened-trait`
-    can be used to unwrap the values into a containing structure or union,
-    with the key not containing the initial "." separator and ``member``
-    segment.
-.. |query map text| replace::
-    Each key and value in each pair provided in the map is serialized as a
-    separate key with a "." separator, the string "entry", a "." separator,
-    a "1" indexed incrementing counter, a "." separator, and the string
-    "key" or "value" (for member keys or values, respectively) appended to
-    the container's key. |name resolution text| instead of "member", "key",
-    or "value". The :ref:`xmlFlattened-trait` can be used to unwrap the
-    values into a containing structure or union, with the key not
-    containing the initial "." separator and "entry" segment.
-.. |query aggregate text| replace::
-    Each member value provided for the shape is serialized as a separate key
-    with a "." separator and the member name appended to the container's key.
-    |name resolution text|. Members with null values are not serialized.
-
 .. list-table::
     :header-rows: 1
     :widths: 25 75


### PR DESCRIPTION
This fixes the query serialization docs for ec2Query:

* Lists are always flat
* Maps are undefined


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
