### PR TITLE
Tighten substitution pattern for Fn::Sub

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
@@ -45,7 +45,7 @@ final class CloudFormationSubstitution implements ApiGatewayMapper {
 
     private static final Logger LOGGER = Logger.getLogger(CloudFormationSubstitution.class.getName());
     private static final String SUBSTITUTION_KEY = "Fn::Sub";
-    private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{.+}");
+    private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{[A-Za-z0-9.:]+}");
 
     /**
      * This is a hardcoded list of paths that are known to contain ARNs or identifiers

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
@@ -69,6 +69,6 @@ public class CloudFormationSubstitutionTest {
                 .config(config)
                 .convertToNode(model);
 
-        Node.assertEquals(expected, actual);
+        Node.assertEquals(actual, expected);
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cloudformation-substitutions.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cloudformation-substitutions.json
@@ -25,6 +25,12 @@
                 "smithy.api#http": {
                     "uri": "/foo",
                     "method": "GET"
+                },
+                "aws.apigateway#integration": {
+                    "httpMethod": "POST",
+                    "payloadFormatVersion": "2.0",
+                    "type": "aws_proxy",
+                    "uri": "arn:${Token[AWS.Partition.9]}:apigateway:us-east-1:lambda:path/2015-03-31/functions/${Token[TOKEN.108]}/invocations"
                 }
             }
         }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
@@ -12,6 +12,12 @@
           "200": {
             "description": "MyOperation response"
           }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "payloadFormatVersion": "2.0",
+          "type": "aws_proxy",
+          "uri": "arn:${Token[AWS.Partition.9]}:apigateway:us-east-1:lambda:path/2015-03-31/functions/${Token[TOKEN.108]}/invocations"
         }
       }
     }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
@@ -12,6 +12,12 @@
           "200": {
             "description": "MyOperation response"
           }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "payloadFormatVersion": "2.0",
+          "type": "aws_proxy",
+          "uri": "arn:${Token[AWS.Partition.9]}:apigateway:us-east-1:lambda:path/2015-03-31/functions/${Token[TOKEN.108]}/invocations"
         }
       }
     }


### PR DESCRIPTION
*Description of changes:*
CloudFormation variables can be parameter names, resource logical IDs
or resource attributes.

* Parameter names: can be alphanumeric or pseudo-parameters, which can
  be prefixed with "AWS::"
* Resource logical IDs: can be alphanumeric.
* Resource attributes: specified as resourceLogicalId.attributeName,
  where attributeName is also alphanumeric.

*Issue #, if available:*
This change was needed as part of https://github.com/adamthom-amzn/smithy-typescript-ssdk-demo/pull/28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
