### PR TITLE
Add a protocol test for endpoints that contain path prefixes

### DIFF
--- a/docs/source/1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/1.0/spec/http-protocol-compliance-tests.rst
@@ -105,8 +105,12 @@ that support the following members:
         the query string (for example, "/foo/bar").
     * - host
       - ``string``
-      - The host / endpoint provided to the client, not including the path or
-        scheme (for example, "example.com").
+      - The host / endpoint provided to the client (for example, "example.com").
+        ``host`` MAY contain a path to indicate a base path from which each
+        operation in the service is appended to. For example, given a ``host``
+        of ``example.com/foo/bar`` and an operation path of ``/MyOperation``,
+        the resolved host of the operation is ``example.com`` and the resolved
+        path is ``/foo/bar/MyOperation``.
     * - resolvedHost
       - ``string``
       - The host / endpoint that the client should send to, not including the

--- a/smithy-aws-protocol-tests/model/restJson1/endpoint-paths.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/endpoint-paths.smithy
@@ -1,0 +1,24 @@
+// This file defines tests to ensure that implementations support endpoints with paths
+
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpRequestTests
+
+@httpRequestTests([
+    {
+        id: "RestJsonHostWithPath",
+        documentation: """
+                Custom endpoints supplied by users can have paths""",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/custom/HostWithPathOperation",
+        body: "",
+        host: "example.com/custom",
+        appliesTo: "client"
+    }
+])
+@http(uri: "/HostWithPathOperation", method: "GET")
+operation HostWithPathOperation {}

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -86,5 +86,8 @@ service RestJson {
         // @endpoint and @hostLabel trait tests
         EndpointOperation,
         EndpointWithHostLabelOperation,
+
+        // custom endpoints with paths
+        HostWithPathOperation,
     ]
 }


### PR DESCRIPTION
*Description of changes:*
Sometimes, a service will have a path prefix that is not modeled. This adds a
test that ensures REST-JSON clients will properly take that path into account.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
