### PR TITLE
Add IDL sugar for applying the required trait

### DIFF
--- a/docs/source/1.0/guides/style-guide.rst
+++ b/docs/source/1.0/guides/style-guide.rst
@@ -38,8 +38,9 @@ Smithy models SHOULD resemble the following example:
     /// More descriptive documentation if needed...
     structure MyStructure {
         /// Documentation about the member.
-        @required
-        foo: String
+        ///
+        /// Structure members should use "!" instead of the `@required` trait.
+        foo: String!
     }
 
     // Example of creating custom traits.

--- a/docs/source/1.0/spec/aws/aws-cloudformation.rst
+++ b/docs/source/1.0/spec/aws/aws-cloudformation.rst
@@ -193,8 +193,7 @@ The following example defines a CloudFormation resource that excludes the
 
         structure GetFooRequest {
             @httpLabel
-            @required
-            fooId: String
+            fooId: String!
         }
 
         structure GetFooResponse {
@@ -270,8 +269,7 @@ Given the following model without mutability traits applied,
         }
 
         structure GetFooRequest {
-            @required
-            fooId: String
+            fooId: String!
         }
 
         structure GetFooResponse {
@@ -287,8 +285,7 @@ Given the following model without mutability traits applied,
         }
 
         structure UpdateFooRequest {
-            @required
-            fooId: String
+            fooId: String!
 
             mutableProperty: ComplexProperty
             writeProperty: ComplexProperty
@@ -476,8 +473,7 @@ The following example defines a CloudFormation resource that marks the
         }
 
         structure GetFooRequest {
-            @required
-            fooId: String
+            fooId: String!
         }
 
         structure GetFooResponse {
@@ -629,8 +625,7 @@ The following example defines a CloudFormation resource that has the
         }
 
         structure GetFooRequest {
-            @required
-            fooId: String
+            fooId: String!
 
             @cfnAdditionalIdentifier
             fooAlias: String
@@ -703,8 +698,7 @@ Given the following model,
 
         structure GetFooRequest {
             @httpLabel
-            @required
-            fooId: String
+            fooId: String!
 
             @httpQuery("fooAlias")
             @cfnAdditionalIdentifier
@@ -735,8 +729,7 @@ Given the following model,
 
         structure UpdateFooRequest {
             @httpLabel
-            @required
-            fooId: String
+            fooId: String!
 
             fooAlias: String
             mutableProperty: ComplexProperty

--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -1011,8 +1011,7 @@ using an ``clientEndpointDiscoveryId``.
 
         structure GetObjectInput {
           @clientEndpointDiscoveryId
-          @required
-          Id: String
+          Id: String!
         }
 
         structure GetObjectOutput {

--- a/docs/source/1.0/spec/core/behavior-traits.rst
+++ b/docs/source/1.0/spec/core/behavior-traits.rst
@@ -255,9 +255,7 @@ explicitly on the operation.
 
         structure GetFoosOutput {
             nextToken: String
-
-            @required
-            foos: StringList
+            foos: StringList!
         }
 
         list StringList {
@@ -415,15 +413,12 @@ wrapper where the output token and items are referenced by paths.
         }
 
         structure GetFoosOutput {
-            @required
-            result: ResultWrapper
+            result: ResultWrapper!
         }
 
         structure ResultWrapper {
             nextToken: String
-
-            @required
-            foos: StringList
+            foos: StringList!
         }
 
         list StringList {

--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -542,6 +542,40 @@ operation. When a member that is part of the output of an operation or an
 error is marked as required, a service MUST provide a value for the member
 in a response.
 
+A structure member can be marked as required in the Smithy IDL by suffixing
+the shape ID target of a member with ``!``. This is purely syntactic sugar
+supported in the IDL for applying the ``@required`` trait.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        structure MyStructure {
+            foo: FooString!
+        }
+
+    .. code-tab:: json
+
+        {
+            "smithy": "1.0",
+            "shapes": {
+                "smithy.example#MyStructure": {
+                    "type": "structure",
+                    "members": {
+                        "foo": {
+                            "target": "smithy.example#FooString",
+                            "traits": {
+                                "smithy.api#required": {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+Using the long-form of ``@required`` works too, and it is semantically
+equivalent to using ``!``:
+
 .. tabs::
 
     .. code-tab:: smithy

--- a/docs/source/1.0/spec/core/documentation-traits.rst
+++ b/docs/source/1.0/spec/core/documentation-traits.rst
@@ -330,8 +330,7 @@ Conflicts with
     .. code-tab:: smithy
 
         structure PutContentsInput {
-            @required
-            contents: String
+            contents: String!
 
             @recommended(reason: "Validation will reject contents if they are invalid.")
             validateContents: Boolean

--- a/docs/source/1.0/spec/core/endpoint-traits.rst
+++ b/docs/source/1.0/spec/core/endpoint-traits.rst
@@ -66,9 +66,8 @@ The following example defines an operation that uses a custom endpoint:
         }
 
         structure GetStatusInput {
-            @required
             @hostLabel
-            foo: String
+            foo: String!
         }
 
     .. code-tab:: json
@@ -132,9 +131,8 @@ Given the following operation,
         }
 
         structure GetStatusInput {
-            @required
             @hostLabel
-            foo: String
+            foo: String!
         }
 
     .. code-tab:: json
@@ -197,13 +195,11 @@ Given the following operation,
         }
 
         structure GetStatusInput {
-            @required
             @hostLabel
-            foo: String
+            foo: String!
 
-            @required
             @hostLabel
-            bar: String
+            bar: String!
         }
 
     .. code-tab:: json
@@ -333,10 +329,9 @@ Given the following operation,
         }
 
         structure GetStatusInput {
-            @required
             @hostLabel
             @httpHeader("X-Foo")
-            foo: String
+            foo: String!
         }
 
     .. code-tab:: json
@@ -428,9 +423,8 @@ to an operation marked with the :ref:`endpoint-trait` will be ignored.
         }
 
         structure GetStatusInput {
-            @required
             @hostLabel
-            foo: String
+            foo: String!
         }
 
     .. code-tab:: json

--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -67,14 +67,12 @@ The following example defines an operation that uses HTTP bindings:
 
         structure PutObjectInput {
             // Sent in the URI label named "key".
-            @required
             @httpLabel
-            key: ObjectKey
+            key: ObjectKey!
 
             // Sent in the URI label named "bucketName".
-            @required
             @httpLabel
-            bucketName: String
+            bucketName: String!
 
             // Sent in the X-Foo header
             @httpHeader("X-Foo")
@@ -632,9 +630,8 @@ The following example defines an operation that send an HTTP label named
         }
 
         structure GetStatusInput {
-            @required
             @httpLabel
-            foo: String
+            foo: String!
         }
 
 .. rubric:: Relationship to :ref:`http-trait`
@@ -717,9 +714,8 @@ data in a response:
         }
 
         structure GetRandomBinaryDataOutput {
-            @required
             @httpHeader("Content-Type")
-            contentType: String
+            contentType: String!
 
             @httpPayload
             content: Blob
@@ -1013,8 +1009,7 @@ disregard the value set by ``httpQueryParams``. For example, given the following
 
         structure PutThingInput {
             @httpQuery
-            @required
-            thingId: String,
+            thingId: String!
 
             @httpQueryParams
             tags: MapOfStrings

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -46,8 +46,7 @@ The following example defines a model file with each section:
             use smithy.other.namespace#MyString
 
             structure MyStructure {
-                @required
-                foo: MyString
+                foo: MyString!
             }
 
     .. code-tab:: json
@@ -187,10 +186,13 @@ The Smithy IDL is defined by the following ABNF:
                            :/ "bigDecimal" / "timestamp"
     shape_members          :"{" `ws` *(`shape_member_kvp` `ws`) "}"
     shape_member_kvp       :`trait_statements` `identifier` `ws` ":" `ws` `shape_id`
+    structure_members      :"{" `ws` *(`structure_members_kvp` `ws`) "}"
+    structure_members_kvp  :`trait_statements` `identifier` `ws` ":" `ws` `shape_id` [`required_member_sugar`]
+    required_member_sugar: "!"
     list_statement :"list" `ws` `identifier` `ws` `shape_members`
     set_statement :"set" `ws` `identifier` `ws` `shape_members`
     map_statement :"map" `ws` `identifier` `ws` `shape_members`
-    structure_statement     :"structure" `ws` `identifier` `ws` `shape_members`
+    structure_statement     :"structure" `ws` `identifier` `ws` `structure_members`
     union_statement :"union" `ws` `identifier` `ws` `shape_members`
     service_statement :"service" `ws` `identifier` `ws` `node_object`
     operation_statement :"operation" `ws` `identifier` `ws` `node_object`
@@ -957,12 +959,11 @@ Traits can be applied to structure members:
         /// This is MyStructure.
         structure MyStructure {
             /// This is documentation for `foo`.
-            @required
-            foo: String,
+            foo: String
 
             /// This is documentation for `baz`.
             @deprecated
-            baz: Integer,
+            baz: Integer
         }
 
     .. code-tab:: json
@@ -976,8 +977,7 @@ Traits can be applied to structure members:
                         "foo": {
                             "target": "smithy.api#String",
                             "traits": {
-                                "smithy.api#documentation": "This is documentation for `foo`.",
-                                "smithy.api#required": {}
+                                "smithy.api#documentation": "This is documentation for `foo`."
                             }
                         },
                         "baz": {
@@ -994,6 +994,54 @@ Traits can be applied to structure members:
                 }
             }
         }
+
+A structure member can be marked with the :ref:`required-trait` by suffixing the shape ID
+target of a member with ``!``. The following Smithy IDL:
+
+.. code-block:: smithy
+
+    namespace smithy.example
+
+    structure MyStructure {
+        foo: String!
+    }
+
+Is equivalent to the following Smithy IDL:
+
+.. code-block:: smithy
+
+    namespace smithy.example
+
+    structure MyStructure {
+        @required
+        foo: String
+    }
+
+And is equivalent to the following Smithy JSON AST:
+
+.. code-block:: json
+
+    {
+        "smithy": "1.0",
+        "shapes": {
+            "smithy.example#MyStructure": {
+                "type": "structure",
+                "members": {
+                    "foo": {
+                        "target": "smithy.api#String",
+                        "traits": {
+                            "smithy.api#required": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+.. note::
+
+    The ``!`` syntactic sugar for structure members is not supported in the
+    JSON AST model representation.
 
 
 .. _idl-union:
@@ -1334,12 +1382,11 @@ members.
 
     @documentation("An animal in the animal kingdom")
     structure Animal {
-        @required
-        name: smithy.api#String,
+        name: smithy.api#String!
 
         @length(min: 0)
         @tags(["private-beta"])
-        age: smithy.api#Integer,
+        age: smithy.api#Integer
     }
 
 
@@ -1361,8 +1408,8 @@ Nested structure, map, and union values are defined using
 
     @structuredTrait(
         foo: {
-            bar: "baz",
-            qux: "true",
+            bar: "baz"
+            qux: "true"
         }
     )
 

--- a/docs/source/1.0/spec/core/index.rst
+++ b/docs/source/1.0/spec/core/index.rst
@@ -43,8 +43,7 @@ alongside Smithy IDL examples where appropriate. For example:
         use smithy.other.namespace#MyString
 
         structure MyStructure {
-            @required
-            foo: MyString
+            foo: MyString!
         }
 
     .. code-tab:: json

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -728,7 +728,8 @@ Structures are defined in the IDL using a
 :ref:`structure_statement <idl-structure>`.
 
 The following example defines a structure with two members, one of which
-is marked with the :ref:`required-trait`.
+is marked with the :ref:`required-trait` by suffixing the shape ID with
+``!``.
 
 .. tabs::
 
@@ -738,9 +739,7 @@ is marked with the :ref:`required-trait`.
 
         structure MyStructure {
             foo: String
-
-            @required
-            baz: Integer
+            baz: Integer!
         }
 
     .. code-tab:: json
@@ -1702,13 +1701,11 @@ For example, given the following model,
         }
 
         structure GetForecastInput {
-            @required
-            forecastId: ForecastId
+            forecastId: ForecastId!
         }
 
         structure GetForecastOutput {
-            @required
-            weather: WeatherData
+            weather: WeatherData!
         }
 
     .. code-tab:: json
@@ -1790,8 +1787,7 @@ Given the following model,
         }
 
         structure BatchPutForecastsInput {
-            @required
-            forecasts: BatchPutForecastList
+            forecasts: BatchPutForecastList!
         }
 
     .. code-tab:: json
@@ -1874,13 +1870,11 @@ For example, given the following,
     }
 
     structure GetHistoricalForecastInput {
-        @required
         @resourceIdentifier("forecastId")
-        customForecastIdName: ForecastId
+        customForecastIdName: ForecastId!
 
-        @required
         @resourceIdentifier("historicalId")
-        customHistoricalIdName: String
+        customHistoricalIdName: String!
     }
 
 the :ref:`resourceIdentifier-trait` on ``GetHistoricalForecastInput$customForecastIdName``
@@ -1943,8 +1937,7 @@ The following example defines the ``PutForecast`` operation.
 
     structure PutForecastInput {
         // The client provides the resource identifier.
-        @required
-        forecastId: ForecastId
+        forecastId: ForecastId!
 
         chanceOfRain: Float
     }
@@ -2018,8 +2011,7 @@ For example:
     }
 
     structure GetForecastInput {
-        @required
-        forecastId: ForecastId
+        forecastId: ForecastId!
     }
 
 
@@ -2045,8 +2037,7 @@ For example:
     }
 
     structure UpdateForecastInput {
-        @required
-        forecastId: ForecastId
+        forecastId: ForecastId!
 
         chanceOfRain: Float
     }
@@ -2075,8 +2066,7 @@ For example:
     }
 
     structure DeleteForecastInput {
-        @required
-        forecastId: ForecastId
+        forecastId: ForecastId!
     }
 
 
@@ -2111,8 +2101,7 @@ For example:
 
     structure ListForecastsOutput {
         nextToken: String
-        @required
-        forecasts: ForecastList
+        forecasts: ForecastList!
     }
 
     list ForecastList {
@@ -2469,20 +2458,15 @@ The following example defines two custom traits: ``beta`` and
         /// A trait that has members.
         @trait(selector: "string", conflicts: [beta])
         structure structuredTrait {
-            @required
-            lorem: StringShape
-
-            @required
-            ipsum: StringShape
-
+            lorem: StringShape!
+            ipsum: StringShape!
             dolor: StringShape
         }
 
         // Apply the "beta" trait to the "foo" member.
         structure MyShape {
-            @required
             @beta
-            foo: StringShape
+            foo: StringShape!
         }
 
         // Apply the structuredTrait to the string.

--- a/docs/source/1.0/spec/core/protocol-traits.rst
+++ b/docs/source/1.0/spec/core/protocol-traits.rst
@@ -123,8 +123,7 @@ support configuration settings.
     @protocolDefinition
     @trait(selector: "service")
     structure configurableExample {
-        @required
-        version: String
+        version: String!
     }
 
     @configurableExample(version: "1.0")

--- a/docs/source/1.0/spec/core/resource-traits.rst
+++ b/docs/source/1.0/spec/core/resource-traits.rst
@@ -215,21 +215,11 @@ The following example defines several references:
             ])
         structure ForecastInformation {
             someId: SomeShapeIdentifier
-
-            @required
-            forecastId: ForecastId
-
-            @required
-            meteorologistId: MeteorologistId
-
-            @required
-            otherData: SomeOtherShape
-
-            @required
-            bucketName: BucketName
-
-            @required
-            objectKey: ObjectKey
+            forecastId: ForecastId!
+            meteorologistId: MeteorologistId!
+            otherData: SomeOtherShape!
+            bucketName: BucketName!
+            objectKey: ObjectKey!
         }
 
 .. rubric:: References on string shapes
@@ -306,14 +296,12 @@ match for the name of the resource identifier.
         }
 
         structure GetFileInput {
-            @required
-            directory: String
+            directory: String!
 
             // resourceIdentifier is used because the input member name
             // does not match the resource identifier name
             @resourceIdentifier("fileName")
-            @required
-            name: String
+            name: String!
         }
 
 

--- a/docs/source/1.0/spec/core/stream-traits.rst
+++ b/docs/source/1.0/spec/core/stream-traits.rst
@@ -50,9 +50,8 @@ Validation
         }
 
         structure StreamingOperationOutput {
-            @required
             streamId: String
-            output: StreamingBlob
+            output: StreamingBlob!
         }
 
         @streaming
@@ -313,8 +312,7 @@ service, followed by the events sent in the payload of the HTTP message.
 
         structure PublishMessagesInput {
             @httpLabel
-            @required
-            room: String
+            room: String!
 
             @httpPayload
             messages: MessageStream
@@ -420,8 +418,7 @@ message.
 
         structure SubscribeToMessagesInput {
             @httpLabel
-            @required
-            room: String
+            room: String!
         }
 
         structure SubscribeToMessagesOutput {

--- a/docs/source/1.0/spec/core/type-refinement-traits.rst
+++ b/docs/source/1.0/spec/core/type-refinement-traits.rst
@@ -131,8 +131,7 @@ in Java).
         @retryable
         @httpError(429)
         structure ThrottlingError {
-            @required
-            message: String
+            message: String!
         }
 
 

--- a/docs/source/1.0/spec/mqtt.rst
+++ b/docs/source/1.0/spec/mqtt.rst
@@ -100,13 +100,11 @@ and ``{second}``, in the MQTT topic template:
         }
 
         structure ExampleOperationInput {
-            @required
             @topicLabel
-            first: String
+            first: String!
 
-            @required
             @topicLabel
-            second: String
+            second: String!
 
             message: String
         }
@@ -214,9 +212,8 @@ The following example defines an operation that publishes messages to the
         }
 
         structure PostFooInput {
-            @required
             @topicLabel
-            bar: String
+            bar: String!
 
             someValue: String,
             anotherValue: Boolean
@@ -331,9 +328,8 @@ topic using an :ref:`event stream <event-streams>`:
         }
 
         structure SubscribeForEventsInput {
-            @required
             @topicLabel
-            id: String
+            id: String!
         }
 
         structure SubscribeForEventsOutput {

--- a/docs/source/1.0/spec/waiters.rst
+++ b/docs/source/1.0/spec/waiters.rst
@@ -635,8 +635,7 @@ triggered if the ``status`` property equals ``failed``.
     }
 
     structure GetThingInput {
-        @required
-        name: String
+        name: String!
     }
 
     structure GetThingOutput {

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -222,34 +222,26 @@ Let's define the operation used to "read" a ``City``.
     structure GetCityInput {
         // "cityId" provides the identifier for the resource and
         // has to be marked as required.
-        @required
-        cityId: CityId
+        cityId: CityId!
     }
 
     structure GetCityOutput {
-        // "required" is used on output to indicate if the service
+        // Required is used on output to indicate if the service
         // will always provide a value for the member.
-        @required
-        name: String
-
-        @required
-        coordinates: CityCoordinates
+        name: String!
+        coordinates: CityCoordinates!
     }
 
     structure CityCoordinates {
-        @required
-        latitude: Float
-
-        @required
-        longitude: Float
+        latitude: Float!
+        longitude: Float!
     }
 
     // "error" is a trait that is used to specialize
     // a structure as an error.
     @error("client")
     structure NoSuchResource {
-        @required
-        resourceType: String
+        resourceType: String!
     }
 
 And define the operation used to "read" a ``Forecast``.
@@ -265,8 +257,7 @@ And define the operation used to "read" a ``Forecast``.
     // "cityId" provides the only identifier for the resource since
     // a Forecast doesn't have its own.
     structure GetForecastInput {
-        @required
-        cityId: CityId
+        cityId: CityId!
     }
 
     structure GetForecastOutput {
@@ -323,9 +314,7 @@ cities, so there's no way we could provide a ``City`` identifier.
 
     structure ListCitiesOutput {
         nextToken: String
-
-        @required
-        items: CitySummaries
+        items: CitySummaries!
     }
 
     // CitySummaries is a list of CitySummary structures.
@@ -336,11 +325,8 @@ cities, so there's no way we could provide a ``City`` identifier.
     // CitySummary contains a reference to a City.
     @references([{resource: City}])
     structure CitySummary {
-        @required
-        cityId: CityId
-
-        @required
-        name: String
+        cityId: CityId!
+        name: String!
     }
 
 The ``ListCities`` operation is :ref:`paginated <paginated-trait>`, meaning
@@ -391,8 +377,7 @@ service.
     }
 
     structure GetCurrentTimeOutput {
-        @required
-        time: Timestamp
+        time: Timestamp!
     }
 
 
@@ -549,35 +534,27 @@ Finally, the complete ``weather.smithy`` model should look like:
         structure GetCityInput {
             // "cityId" provides the identifier for the resource and
             // has to be marked as required.
-            @required
-            cityId: CityId
+            cityId: CityId!
         }
 
         structure GetCityOutput {
-            // "required" is used on output to indicate if the service
+            // Required is used on output to indicate if the service
             // will always provide a value for the member.
-            @required
-            name: String
-
-            @required
-            coordinates: CityCoordinates
+            name: String!
+            coordinates: CityCoordinates!
         }
 
         // This structure is nested within GetCityOutput.
         structure CityCoordinates {
-            @required
-            latitude: Float
-
-            @required
-            longitude: Float
+            latitude: Float!
+            longitude: Float!
         }
 
         // "error" is a trait that is used to specialize
         // a structure as an error.
         @error("client")
         structure NoSuchResource {
-            @required
-            resourceType: String
+            resourceType: String!
         }
 
         // The paginated trait indicates that the operation may
@@ -596,9 +573,7 @@ Finally, the complete ``weather.smithy`` model should look like:
 
         structure ListCitiesOutput {
             nextToken: String
-
-            @required
-            items: CitySummaries
+            items: CitySummaries!
         }
 
         // CitySummaries is a list of CitySummary structures.
@@ -609,11 +584,8 @@ Finally, the complete ``weather.smithy`` model should look like:
         // CitySummary contains a reference to a City.
         @references([{resource: City}])
         structure CitySummary {
-            @required
-            cityId: CityId
-
-            @required
-            name: String
+            cityId: CityId!
+            name: String!
         }
 
         @readonly
@@ -622,8 +594,7 @@ Finally, the complete ``weather.smithy`` model should look like:
         }
 
         structure GetCurrentTimeOutput {
-            @required
-            time: Timestamp
+            time: Timestamp!
         }
 
         @readonly
@@ -635,8 +606,7 @@ Finally, the complete ``weather.smithy`` model should look like:
         // "cityId" provides the only identifier for the resource since
         // a Forecast doesn't have its own.
         structure GetForecastInput {
-            @required
-            cityId: CityId
+            cityId: CityId!
         }
 
         structure GetForecastOutput {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -61,6 +61,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -366,10 +367,10 @@ final class IdlModelParser extends SimpleParser {
                 parseOperationStatement(id, location);
                 break;
             case "structure":
-                parseStructuredShape(id, location, StructureShape.builder());
+                parseStructuredShape(id, location, StructureShape.builder(), true);
                 break;
             case "union":
-                parseStructuredShape(id, location, UnionShape.builder());
+                parseStructuredShape(id, location, UnionShape.builder(), false);
                 break;
             case "list":
                 parseCollection(id, location, ListShape.builder());
@@ -443,11 +444,11 @@ final class IdlModelParser extends SimpleParser {
     private void parseCollection(ShapeId id, SourceLocation location, CollectionShape.Builder builder) {
         ws();
         builder.id(id).source(location);
-        parseMembers(id, SetUtils.of("member"));
+        parseMembers(id, SetUtils.of("member"), false);
         modelFile.onShape(builder.id(id));
     }
 
-    private void parseMembers(ShapeId id, Set<String> requiredMembers) {
+    private void parseMembers(ShapeId id, Set<String> requiredMembers, boolean structureMember) {
         Set<String> definedMembers = new HashSet<>();
         Set<String> remaining = requiredMembers.isEmpty()
                 ? requiredMembers
@@ -462,7 +463,7 @@ final class IdlModelParser extends SimpleParser {
                 break;
             }
 
-            parseMember(id, requiredMembers, definedMembers, remaining);
+            parseMember(id, requiredMembers, definedMembers, remaining, structureMember);
 
             // Clears out any previously captured documentation
             // comments that may have been found when parsing the member.
@@ -483,7 +484,13 @@ final class IdlModelParser extends SimpleParser {
         expect('}');
     }
 
-    private void parseMember(ShapeId parent, Set<String> required, Set<String> defined, Set<String> remaining) {
+    private void parseMember(
+            ShapeId parent,
+            Set<String> required,
+            Set<String> defined,
+            Set<String> remaining,
+            boolean structureMember
+    ) {
         // Parse optional member traits.
         List<TraitEntry> memberTraits = parseDocsAndTraits();
         SourceLocation memberLocation = currentLocation();
@@ -508,6 +515,14 @@ final class IdlModelParser extends SimpleParser {
         ShapeId memberId = parent.withMember(memberName);
         MemberShape.Builder memberBuilder = MemberShape.builder().id(memberId).source(memberLocation);
         String target = ParserUtils.parseShapeId(this);
+
+        if (structureMember && peek() == '!') {
+            // Create a synthetic Node to specify the location.
+            Node requiredTrait = new ObjectNode(Collections.emptyMap(), currentLocation());
+            expect('!');
+            memberTraits.add(new TraitEntry(RequiredTrait.ID.toString(), requiredTrait, true));
+        }
+
         modelFile.onShape(memberBuilder);
         modelFile.addForwardReference(target, memberBuilder::target);
         addTraits(memberId, memberTraits);
@@ -521,18 +536,23 @@ final class IdlModelParser extends SimpleParser {
         // on a builder. This does not suffer the same error messages as
         // structures/unions because list/set/map have a fixed and required
         // set of members that must be provided.
-        parseMembers(id, SetUtils.of("key", "value"));
+        parseMembers(id, SetUtils.of("key", "value"), false);
         modelFile.onShape(MapShape.builder().id(id).source(location));
     }
 
-    private void parseStructuredShape(ShapeId id, SourceLocation location, AbstractShapeBuilder builder) {
+    private void parseStructuredShape(
+            ShapeId id,
+            SourceLocation location,
+            AbstractShapeBuilder builder,
+            boolean structureMember
+    ) {
         // Register the structure/union with the loader before parsing members.
         // This will detect shape conflicts with other types (like an operation)
         // and still give useful error messages. Trying to parse members first
         // would otherwise result in cryptic error messages like:
         // "Member `foo.baz#Foo$Baz` cannot be added to software.amazon.smithy.model.shapes.OperationShape$Builder"
         modelFile.onShape(builder.id(id).source(location));
-        parseMembers(id, Collections.emptySet());
+        parseMembers(id, Collections.emptySet(), structureMember);
     }
 
     private void parseOperationStatement(ShapeId id, SourceLocation location) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -34,8 +34,10 @@ import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.DynamicTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.StringTrait;
 import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.Severity;
@@ -237,5 +239,20 @@ public class IdlModelLoaderTest {
         // Spot check for a specific "use" shape.
         assertThat(model.expectShape(ShapeId.from("smithy.example#MyService"), ServiceShape.class).getRename(),
                    equalTo(MapUtils.of(ShapeId.from("foo.example#Widget"), "FooWidget")));
+    }
+
+    @Test
+    public void addsLocationToRequiredSugarTraits() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("required-sugar-test.smithy"))
+                .assemble()
+                .unwrap();
+
+        StructureShape shape = model.expectShape(ShapeId.from("smithy.example#MyStruct"), StructureShape.class);
+        MemberShape member = shape.getMember("foo").get();
+        RequiredTrait trait = member.expectTrait(RequiredTrait.class);
+
+        assertThat(trait.getSourceLocation().getLine(), equalTo(4));
+        assertThat(trait.getSourceLocation().getColumn(), equalTo(16));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -136,4 +136,22 @@ public class SmithyIdlModelSerializerTest {
         Map<Path, String> serialized = serializer.serialize(model);
         assertThat(serialized.keySet(), contains(basePath.resolve("metadata.smithy")));
     }
+
+    @Test
+    public void serializesRequiredTraitsUsingSugar() {
+        ShapeId stringId = ShapeId.from("smithy.api#String");
+        StructureShape struct = StructureShape.builder()
+                .id("smithy.example#Struct")
+                .addMember("req", stringId, builder -> builder.addTrait(new RequiredTrait()))
+                .addMember("opt", stringId)
+                .build();
+        Model model = Model.builder().addShape(struct).build();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder().build();
+
+        Map<Path, String> serialized = serializer.serialize(model);
+        String output = serialized.values().iterator().next();
+
+        assertThat(output, not(containsString("@required")));
+        assertThat(output, containsString("String!"));
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/multiple-required-exclamations.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/multiple-required-exclamations.smithy
@@ -1,0 +1,6 @@
+// Parse error at line 5, column 17 near `!\n`: Expected a valid identifier character, but found '!'
+namespace smithy.example
+
+structure Foo {
+    bar: String!!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/required-sugar-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/required-sugar-test.smithy
@@ -1,0 +1,5 @@
+namespace smithy.example
+
+structure MyStruct {
+    foo: String!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/required-sugar.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/required-sugar.json
@@ -1,0 +1,81 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "example.weather#Foo": {
+            "type": "structure",
+            "members": {
+                "optional": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "Docs 1"
+                    }
+                },
+                "requiredRelative": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "Docs 2",
+                        "smithy.api#required": {}
+                    }
+                },
+                "requiredAbsolute": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "Docs",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "example.weather#FooNoDocs": {
+            "type": "structure",
+            "members": {
+                "optional": {
+                    "target": "smithy.api#String"
+                },
+                "requiredRelative": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "requiredAbsolute": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "example.weather#FooNoDocsWithCommas": {
+            "type": "structure",
+            "members": {
+                "optional": {
+                    "target": "smithy.api#String"
+                },
+                "requiredRelative": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "requiredAbsolute": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "example.weather#RequiredConflictsAreIgnored": {
+            "type": "structure",
+            "members": {
+                "required": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/required-sugar.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/required-sugar.smithy
@@ -1,0 +1,29 @@
+namespace example.weather
+
+structure Foo {
+    /// Docs 1
+    optional: String
+
+    /// Docs 2
+    requiredRelative: String!
+
+    /// Docs
+    requiredAbsolute: smithy.api#String!
+}
+
+structure FooNoDocs {
+    optional: String
+    requiredRelative: String!
+    requiredAbsolute: smithy.api#String!
+}
+
+structure FooNoDocsWithCommas {
+    optional: String,
+    requiredRelative: String!,
+    requiredAbsolute: smithy.api#String!,
+}
+
+structure RequiredConflictsAreIgnored {
+    @required
+    required: String!,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/required-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/required-trait.smithy
@@ -1,0 +1,7 @@
+$version: "1.1"
+
+namespace ns.foo
+
+structure Greeting {
+    phrase: String!
+}


### PR DESCRIPTION
Marking a structure member as required is a big deal, and it should be
something that's more visually apparent than the current `@required`
trait that can blend in with the rest of the traits applied to a
member.

This commit introduces sugar for applying the required trait to
structure members by suffixing a member with "!". This is semantically
equivalent to applying the trait using `@required` before the member or
using an `apply` statement with `@required`.

By applying the required trait using `!`, the vertical space needed to
define most structures should be reduced, making structures easier to
read.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
