### PR TITLE
Remove unused `Message` field from ComplexError

### DIFF
--- a/smithy-aws-protocol-tests/model/awsQuery/xml-errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-errors.smithy
@@ -127,7 +127,6 @@ apply ComplexError @httpResponseTests([
                  <Error>
                     <Type>Sender</Type>
                     <Code>ComplexError</Code>
-                    <Message>Hi</Message>
                     <TopLevel>Top level</TopLevel>
                     <Nested>
                         <Foo>bar</Foo>


### PR DESCRIPTION
*Description of changes:*

Updates the protocol test to _not_ include the `<Message>` parameter which isn't present in the model.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
