### PR TITLE
Warn when using jsonAdd with schemas

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAdd.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/OpenApiJsonAdd.java
@@ -58,6 +58,14 @@ public final class OpenApiJsonAdd implements OpenApiMapper {
         for (Map.Entry<String, Node> entry : add.entrySet()) {
             try {
                 LOGGER.info(() -> "OpenAPI `jsonAdd`: adding `" + entry.getKey() + "`");
+
+                if (entry.getKey().startsWith("/components/schemas")) {
+                    LOGGER.severe("Adding schemas to the generated OpenAPI model directly means that "
+                                  + "clients, servers, and other artifacts generated from your Smithy "
+                                  + "model don't know about all of the shapes used in the service. You "
+                                  + "almost certainly should not do this.");
+                }
+
                 result = NodePointer.parse(entry.getKey())
                         .addWithIntermediateValues(result, entry.getValue().toNode())
                         .expectObjectNode();


### PR DESCRIPTION
Using the jsonAdd feature with the Smithy to OpenAPI converter is
probably never what you actually want to do. It means that clients,
servers, and other artifacts generated from the Smithy model don't know
about the shapes being defined only in OpenAPI. This PR adds a severe
log warning when this is detected.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
