### PR TITLE
Fix typos in spec about member shape IDs

### DIFF
--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -779,7 +779,7 @@ able to maintain backward compatibility.
 .. rubric:: Structure member shape IDs
 
 The shape ID of a member of a structure is the structure shape ID, followed
-by "#", followed by the member name, For example, the shape ID of the "foo"
+by ``$``, followed by the member name. For example, the shape ID of the ``foo``
 member in the above example is ``smithy.example#MyStructure$foo``.
 
 
@@ -871,7 +871,7 @@ able to maintain backward compatibility.
 .. rubric:: Union member shape IDs
 
 The shape ID of a member of a union is the union shape ID, followed
-by "#", followed by the member name. For example, the shape ID of the "i32"
+by ``$``, followed by the member name. For example, the shape ID of the ``i32``
 member in the above example is ``smithy.example#MyUnion$i32``.
 
 


### PR DESCRIPTION
This pull request fixes an apparent typo in the spec, where `#` was used instead of `$`.
I also changed the formatting slightly to bring it in line with other parts of the document.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
