### PR TITLE
Adjust query string parameter tests for servers

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -105,9 +105,9 @@ apply AllQueryStringTypes @httpRequestTests([
             "QueryParamsStringKeyB=Bar",
         ],
         params: {
-            queryParamsMapOfStrings: {
-                "QueryParamsStringKeyA": "Foo",
-                "QueryParamsStringKeyB": "Bar",
+            queryParamsMapOfStringList: {
+                "QueryParamsStringKeyA": ["Foo"],
+                "QueryParamsStringKeyB": ["Bar"],
             },
         }
     },
@@ -232,7 +232,7 @@ structure AllQueryStringTypesInput {
     queryEnumList: FooEnumList,
 
     @httpQueryParams
-    queryParamsMapOfStrings: StringMap,
+    queryParamsMapOfStringList: StringListMap,
 }
 
 /// This example uses a constant query string parameters and a label.


### PR DESCRIPTION
*Description of changes:*
On the server side, `@httpQueryParams` holds all of the query parameter values
in the request, so if any of the query parameters has a list value, then
`@httpQueryParams` must target a map with a list value, otherwise a 400 will be
thrown during deserialization, instead of discarding excess query param values.

An alternative solution could be to adjust SSDK behavior where `@httpQueryParams` would only receive query parameter values that were not otherwise explicitly bound to a structure member.

Prior art in this area is for the service to truncate to the last specified query parameter value when binding all query parameters to a map of strings, and since that's not at all a desirable behavior, and this doesn't change what gets put on the wire, we have considerable leeway to choose the behavior we want.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
