### PR TITLE
Revert "Tighten substitution pattern for Fn::Sub (#842)"

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitution.java
@@ -45,7 +45,7 @@ final class CloudFormationSubstitution implements ApiGatewayMapper {
 
     private static final Logger LOGGER = Logger.getLogger(CloudFormationSubstitution.class.getName());
     private static final String SUBSTITUTION_KEY = "Fn::Sub";
-    private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{[A-Za-z0-9.:]+}");
+    private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{.+}");
 
     /**
      * This is a hardcoded list of paths that are known to contain ARNs or identifiers

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CloudFormationSubstitutionTest.java
@@ -69,6 +69,6 @@ public class CloudFormationSubstitutionTest {
                 .config(config)
                 .convertToNode(model);
 
-        Node.assertEquals(actual, expected);
+        Node.assertEquals(expected, actual);
     }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cloudformation-substitutions.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cloudformation-substitutions.json
@@ -25,12 +25,6 @@
                 "smithy.api#http": {
                     "uri": "/foo",
                     "method": "GET"
-                },
-                "aws.apigateway#integration": {
-                    "httpMethod": "POST",
-                    "payloadFormatVersion": "2.0",
-                    "type": "aws_proxy",
-                    "uri": "arn:${Token[AWS.Partition.9]}:apigateway:us-east-1:lambda:path/2015-03-31/functions/${Token[TOKEN.108]}/invocations"
                 }
             }
         }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-not-performed.json
@@ -12,12 +12,6 @@
           "200": {
             "description": "MyOperation response"
           }
-        },
-        "x-amazon-apigateway-integration": {
-          "httpMethod": "POST",
-          "payloadFormatVersion": "2.0",
-          "type": "aws_proxy",
-          "uri": "arn:${Token[AWS.Partition.9]}:apigateway:us-east-1:lambda:path/2015-03-31/functions/${Token[TOKEN.108]}/invocations"
         }
       }
     }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/substitution-performed.json
@@ -12,12 +12,6 @@
           "200": {
             "description": "MyOperation response"
           }
-        },
-        "x-amazon-apigateway-integration": {
-          "httpMethod": "POST",
-          "payloadFormatVersion": "2.0",
-          "type": "aws_proxy",
-          "uri": "arn:${Token[AWS.Partition.9]}:apigateway:us-east-1:lambda:path/2015-03-31/functions/${Token[TOKEN.108]}/invocations"
         }
       }
     }


### PR DESCRIPTION
This reverts commit fd5731f73a59ddbfe550a186ba654bed11e0efa0.

*Description of changes:*
https://github.com/awslabs/smithy/pull/842 was made with the assumption that in the Smithy model, the strings that need Fn::Sub contain the final values as CloudFormation expects. It did not consider that those string could contain placeholder literals, like `<lambdaFunction>` or `{{REPLACEME}}` that could be post-processed by something like the CDK to generate the values as CloudFormation expects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
