### PR TITLE
Fix broken code block in docs

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -691,7 +691,7 @@ supportNonNumericFloats (``boolean``)
     When this is disabled (the default), references to floats/doubles will
     look like this:
 
-    .. code-block: json
+    .. code-block:: json
 
         {
             "floatMember": {


### PR DESCRIPTION
This fixes an issue where a code block wasn't showing up [here](https://awslabs.github.io/smithy/1.0/guides/converting-to-openapi.html#generate-openapi-setting-supportnonnumericfloats).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
