### PR TITLE
Add bearerFormat to httpBearerAuth trait

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
@@ -102,12 +102,9 @@ public final class HttpBearerAuthTrait extends AbstractTrait implements ToSmithy
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            Builder builder = builder().sourceLocation(value.getSourceLocation());
             ObjectNode objectNode = value.expectObjectNode();
-            objectNode.getStringMember(BEARER_FORMAT)
-                    .map(StringNode::getValue)
-                    .ifPresent(builder::bearerFormat);
-            return builder.build();
+            Builder builder = new HttpBearerAuthTrait(objectNode).toBuilder();
+            return builder.sourceLocation(value.getSourceLocation()).build();
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
@@ -37,6 +37,15 @@ public final class HttpBearerAuthTrait extends AbstractTrait implements ToSmithy
         bearerFormat = builder.bearerFormat;
     }
 
+    public HttpBearerAuthTrait() {
+        this(Node.objectNode());
+    }
+
+    public HttpBearerAuthTrait(ObjectNode node) {
+        super(ID, node);
+        bearerFormat = node.getStringMember(BEARER_FORMAT).map(StringNode::getValue).orElse(null);
+    }
+
     /**
      * Gets the bearer format.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpBearerAuthTrait.java
@@ -15,28 +15,90 @@
 
 package software.amazon.smithy.model.traits;
 
+import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * An auth scheme trait uses HTTP bearer auth.
  */
-public final class HttpBearerAuthTrait extends AnnotationTrait {
+public final class HttpBearerAuthTrait extends AbstractTrait implements ToSmithyBuilder<HttpBearerAuthTrait>  {
 
     public static final ShapeId ID = ShapeId.from("smithy.api#httpBearerAuth");
+    public static final String BEARER_FORMAT = "bearerFormat";
 
-    public HttpBearerAuthTrait() {
-        this(Node.objectNode());
+    private final String bearerFormat;
+
+    private HttpBearerAuthTrait(Builder builder) {
+        super(ID, builder.getSourceLocation());
+        bearerFormat = builder.bearerFormat;
     }
 
-    public HttpBearerAuthTrait(ObjectNode node) {
-        super(ID, node);
+    /**
+     * Gets the bearer format.
+     *
+     * @return returns the optional bearer format.
+     */
+    public Optional<String> getBearerFormat() {
+        return Optional.ofNullable(bearerFormat);
     }
 
-    public static final class Provider extends AnnotationTrait.Provider<HttpBearerAuthTrait> {
+    @Override
+    public Builder toBuilder() {
+        return builder()
+                .sourceLocation(getSourceLocation())
+                .bearerFormat(bearerFormat);
+    }
+
+    @Override
+    protected Node createNode() {
+        return Node.objectNodeBuilder()
+                .withOptionalMember(BEARER_FORMAT, getBearerFormat().map(Node::from))
+                .build();
+    }
+
+    /**
+     * @return Returns a new HttpBearerAuthTrait builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a  used to create a HttpBearerAuthTrait.
+     */
+    public static final class Builder extends AbstractTraitBuilder<HttpBearerAuthTrait, Builder> {
+        private String bearerFormat;
+
+        private Builder() {}
+
+        @Override
+        public HttpBearerAuthTrait build() {
+            return new HttpBearerAuthTrait(this);
+        }
+
+        public Builder bearerFormat(String bearerFormat) {
+            this.bearerFormat = bearerFormat;
+            return this;
+        }
+    }
+
+    public static final class Provider extends AbstractTrait.Provider {
         public Provider() {
-            super(ID, HttpBearerAuthTrait::new);
+            super(ID);
+        }
+
+        @Override
+        public Trait createTrait(ShapeId target, Node value) {
+            Builder builder = builder().sourceLocation(value.getSourceLocation());
+            ObjectNode objectNode = value.expectObjectNode();
+            objectNode.getStringMember(BEARER_FORMAT)
+                    .map(StringNode::getValue)
+                    .ifPresent(builder::bearerFormat);
+            return builder.build();
         }
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/HttpBearerAuthTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/HttpBearerAuthTraitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -53,6 +53,25 @@ public class HttpBearerAuthTraitTest {
         HttpBearerAuthTrait auth = (HttpBearerAuthTrait) trait.get();
 
         assertThat(auth.getBearerFormat(), equalTo(Optional.empty()));
+        assertThat(auth.toNode(), equalTo(node));
+        assertThat(auth.toBuilder().build(), equalTo(auth));
+    }
+
+    @Test
+    public void defaultConstructor() {
+        ObjectNode node = Node.objectNode();
+        HttpBearerAuthTrait auth = new HttpBearerAuthTrait();
+        assertThat(auth.getBearerFormat(), equalTo(Optional.empty()));
+        assertThat(auth.toNode(), equalTo(node));
+        assertThat(auth.toBuilder().build(), equalTo(auth));
+    }
+
+    @Test
+    public void constructorWithObjectNode() {
+        ObjectNode node = Node.objectNode()
+                .withMember("bearerFormat", "JWT");
+        HttpBearerAuthTrait auth = new HttpBearerAuthTrait(node);
+        assertThat(auth.getBearerFormat(), equalTo(Optional.of("JWT")));
         assertThat(auth.toNode(), equalTo(node));
         assertThat(auth.toBuilder().build(), equalTo(auth));
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/HttpBearerAuthTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/HttpBearerAuthTraitTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import java.util.Optional;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class HttpBearerAuthTraitTest {
+    @Test
+    public void loadsTraitWithoutBearerFormat() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        ObjectNode node = Node.objectNode()
+                .withMember("bearerFormat", "JWT");
+        Optional<Trait> trait = provider.createTrait(
+                HttpBearerAuthTrait.ID, ShapeId.from("ns.qux#foo"), node);
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(HttpBearerAuthTrait.class));
+        HttpBearerAuthTrait auth = (HttpBearerAuthTrait) trait.get();
+
+        assertThat(auth.getBearerFormat(), equalTo(Optional.of("JWT")));
+        assertThat(auth.toNode(), equalTo(node));
+        assertThat(auth.toBuilder().build(), equalTo(auth));
+    }
+
+    @Test
+    public void loadsTraitWithBearerFormat() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        ObjectNode node = Node.objectNode();
+        Optional<Trait> trait = provider.createTrait(
+                HttpBearerAuthTrait.ID, ShapeId.from("ns.qux#foo"), node);
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(HttpBearerAuthTrait.class));
+        HttpBearerAuthTrait auth = (HttpBearerAuthTrait) trait.get();
+
+        assertThat(auth.getBearerFormat(), equalTo(Optional.empty()));
+        assertThat(auth.toNode(), equalTo(node));
+        assertThat(auth.toBuilder().build(), equalTo(auth));
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearerConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearerConverter.java
@@ -38,6 +38,7 @@ public final class HttpBearerConverter implements SecuritySchemeConverter<HttpBe
                 .type("http")
                 .scheme("Bearer")
                 .description("HTTP Bearer authentication")
+                .bearerFormat(trait.getBearerFormat().orElse(null))
                 .build();
     }
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearerConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearerConverterTest.java
@@ -1,0 +1,28 @@
+package software.amazon.smithy.openapi.fromsmithy.security;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.IoUtils;
+
+public class HttpBearerConverterTest {
+    @Test
+    public void addsHttpBearerAuth() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("http-bearer-security.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("http-bearer-security.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-bearer-security.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-bearer-security.json
@@ -1,0 +1,29 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#Service": {
+            "type": "service",
+            "version": "2006-03-01",
+            "operations": [
+                {
+                    "target": "smithy.example#Operation1"
+                }
+            ],
+            "traits": {
+                "aws.protocols#restJson1": {},
+                "smithy.api#httpBearerAuth": {
+                    "bearerFormat": "JWT"
+                }
+            }
+        },
+        "smithy.example#Operation1": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/",
+                    "method": "GET"
+                }
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-bearer-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-bearer-security.openapi.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "Operation1",
+        "responses": {
+          "200": {
+            "description": "Operation1 response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "smithy.api.httpBearerAuth": {
+        "type": "http",
+        "description": "HTTP Bearer authentication",
+        "scheme": "Bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [
+    {
+      "smithy.api.httpBearerAuth": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/awslabs/smithy/issues/825

*Description of changes:*
Add bearerFormat to httpBearerAuth trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
