### PR TITLE
Fix sourceLocation propagation in Traits

### DIFF
--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
@@ -101,7 +101,7 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
 
     @Override
     public Builder toBuilder() {
-        return builder().authorizers(authorizers);
+        return builder().sourceLocation(getSourceLocation()).authorizers(authorizers);
     }
 
     @Override

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
@@ -108,7 +108,8 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
     protected Node createNode() {
         return authorizers.entrySet().stream()
                 .sorted(Comparator.comparing(Map.Entry::getKey))
-                .collect(ObjectNode.collectStringKeys(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(ObjectNode.collectStringKeys(Map.Entry::getKey, Map.Entry::getValue))
+                .toBuilder().sourceLocation(getSourceLocation()).build();
     }
 
     /**

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -88,6 +88,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // TODO: sourceLocation?
             return new NodeMapper().deserialize(value, IntegrationTrait.class);
         }
     }
@@ -336,7 +337,8 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         NodeMapper mapper = new NodeMapper();
         mapper.disableToNodeForClass(IntegrationTrait.class);
         mapper.setOmitEmptyValues(true);
-        return mapper.serialize(this).expectObjectNode();
+        ObjectNode.Builder builder = mapper.serialize(this).expectObjectNode().toBuilder();
+        return builder.sourceLocation(getSourceLocation()).build();
     }
 
     @Override

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -342,6 +342,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
     @Override
     public Builder toBuilder() {
         return builder()
+                .sourceLocation(getSourceLocation())
                 .type(type)
                 .uri(uri)
                 .credentials(credentials)

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -88,7 +88,6 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // TODO: sourceLocation?
             return new NodeMapper().deserialize(value, IntegrationTrait.class);
         }
     }

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -336,8 +336,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         NodeMapper mapper = new NodeMapper();
         mapper.disableToNodeForClass(IntegrationTrait.class);
         mapper.setOmitEmptyValues(true);
-        ObjectNode.Builder builder = mapper.serialize(this).expectObjectNode().toBuilder();
-        return builder.sourceLocation(getSourceLocation()).build();
+        return mapper.serialize(this).expectObjectNode();
     }
 
     @Override

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
@@ -56,7 +56,6 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // TODO: sourceLocation?
             return new NodeMapper().deserialize(value, MockIntegrationTrait.class);
         }
     }

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
@@ -163,6 +163,7 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
     @Override
     public Builder toBuilder() {
         return builder()
+                .sourceLocation(getSourceLocation())
                 .passThroughBehavior(passThroughBehavior)
                 .contentHandling(contentHandling)
                 .requestParameters(requestParameters)

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
@@ -157,8 +157,7 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
         NodeMapper mapper = new NodeMapper();
         mapper.disableToNodeForClass(MockIntegrationTrait.class);
         mapper.setOmitEmptyValues(true);
-        ObjectNode.Builder builder = mapper.serialize(this).expectObjectNode().toBuilder();
-        return builder.sourceLocation(getSourceLocation()).build();
+        return mapper.serialize(this).expectObjectNode();
     }
 
     @Override

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
@@ -56,6 +56,7 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // TODO: sourceLocation?
             return new NodeMapper().deserialize(value, MockIntegrationTrait.class);
         }
     }
@@ -157,7 +158,8 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
         NodeMapper mapper = new NodeMapper();
         mapper.disableToNodeForClass(MockIntegrationTrait.class);
         mapper.setOmitEmptyValues(true);
-        return mapper.serialize(this).expectObjectNode();
+        ObjectNode.Builder builder = mapper.serialize(this).expectObjectNode().toBuilder();
+        return builder.sourceLocation(getSourceLocation()).build();
     }
 
     @Override

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -71,7 +72,8 @@ public final class CfnResourceTrait extends AbstractTrait
         NodeMapper mapper = new NodeMapper();
         mapper.disableToNodeForClass(CfnResourceTrait.class);
         mapper.setOmitEmptyValues(true);
-        return mapper.serialize(this).expectObjectNode();
+        ObjectNode.Builder builder = mapper.serialize(this).expectObjectNode().toBuilder();
+        return builder.sourceLocation(getSourceLocation()).build();
     }
 
     @Override
@@ -86,6 +88,7 @@ public final class CfnResourceTrait extends AbstractTrait
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // TODO: sourceLocation?
             return new NodeMapper().deserialize(value, CfnResourceTrait.class);
         }
     }

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
-import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -72,8 +71,7 @@ public final class CfnResourceTrait extends AbstractTrait
         NodeMapper mapper = new NodeMapper();
         mapper.disableToNodeForClass(CfnResourceTrait.class);
         mapper.setOmitEmptyValues(true);
-        ObjectNode.Builder builder = mapper.serialize(this).expectObjectNode().toBuilder();
-        return builder.sourceLocation(getSourceLocation()).build();
+        return mapper.serialize(this).expectObjectNode();
     }
 
     @Override

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
@@ -76,7 +76,7 @@ public final class CfnResourceTrait extends AbstractTrait
 
     @Override
     public SmithyBuilder<CfnResourceTrait> toBuilder() {
-        return builder().name(name).additionalSchemas(additionalSchemas);
+        return builder().sourceLocation(getSourceLocation()).name(name).additionalSchemas(additionalSchemas);
     }
 
     public static final class Provider extends AbstractTrait.Provider {

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
@@ -88,7 +88,6 @@ public final class CfnResourceTrait extends AbstractTrait
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // TODO: sourceLocation?
             return new NodeMapper().deserialize(value, CfnResourceTrait.class);
         }
     }

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
@@ -53,8 +53,7 @@ public final class DefineConditionKeysTrait extends AbstractTrait implements ToS
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
-            Builder builder = builder();
+            Builder builder = builder().sourceLocation(value);
             for (Map.Entry<StringNode, Node> entry : value.expectObjectNode().getMembers().entrySet()) {
                 ConditionKeyDefinition definition = ConditionKeyDefinition.fromNode(
                         entry.getValue().expectObjectNode());

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
@@ -53,6 +53,7 @@ public final class DefineConditionKeysTrait extends AbstractTrait implements ToS
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             Builder builder = builder();
             for (Map.Entry<StringNode, Node> entry : value.expectObjectNode().getMembers().entrySet()) {
                 ConditionKeyDefinition definition = ConditionKeyDefinition.fromNode(
@@ -87,7 +88,8 @@ public final class DefineConditionKeysTrait extends AbstractTrait implements ToS
         return conditionKeys.entrySet().stream()
                 .map(entry -> new AbstractMap.SimpleImmutableEntry<>(
                         Node.from(entry.getKey()), entry.getValue().toNode()))
-                .collect(ObjectNode.collect(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(ObjectNode.collect(Map.Entry::getKey, Map.Entry::getValue))
+                .toBuilder().sourceLocation(getSourceLocation()).build();
     }
 
     @Override

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnReferenceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnReferenceTrait.java
@@ -53,9 +53,8 @@ public final class ArnReferenceTrait extends AbstractTrait implements ToSmithyBu
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            //BUG: sourcelocation
             ObjectNode objectNode = value.expectObjectNode();
-            Builder builder = builder();
+            Builder builder = builder().sourceLocation(value);
             objectNode.getStringMember(TYPE)
                     .map(StringNode::getValue)
                     .ifPresent(builder::type);

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnReferenceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnReferenceTrait.java
@@ -53,6 +53,7 @@ public final class ArnReferenceTrait extends AbstractTrait implements ToSmithyBu
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            //BUG: sourcelocation
             ObjectNode objectNode = value.expectObjectNode();
             Builder builder = builder();
             objectNode.getStringMember(TYPE)
@@ -110,10 +111,12 @@ public final class ArnReferenceTrait extends AbstractTrait implements ToSmithyBu
 
     @Override
     protected Node createNode() {
-        return Node.objectNode()
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
                 .withOptionalMember(TYPE, getType().map(Node::from))
                 .withOptionalMember(SERVICE, getService().map(ShapeId::toString).map(Node::from))
-                .withOptionalMember(RESOURCE, getResource().map(ShapeId::toString).map(Node::from));
+                .withOptionalMember(RESOURCE, getResource().map(ShapeId::toString).map(Node::from))
+                .build();
     }
 
     /** Builder for {@link ArnReferenceTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
@@ -70,6 +70,7 @@ public final class ArnTrait extends AbstractTrait implements ToSmithyBuilder<Arn
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             Builder builder = builder();
             ObjectNode objectNode = value.expectObjectNode();
             builder.template(objectNode.expectStringMember(TEMPLATE).getValue());
@@ -133,11 +134,13 @@ public final class ArnTrait extends AbstractTrait implements ToSmithyBuilder<Arn
 
     @Override
     protected Node createNode() {
-        return Node.objectNode()
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
                 .withMember(TEMPLATE, Node.from(getTemplate()))
                 .withMember(ABSOLUTE, Node.from(isAbsolute()))
                 .withMember(NO_ACCOUNT, Node.from(isNoAccount()))
-                .withMember(NO_REGION, Node.from(isNoRegion()));
+                .withMember(NO_REGION, Node.from(isNoRegion()))
+                .build();
     }
 
     @Override

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
@@ -70,9 +70,8 @@ public final class ArnTrait extends AbstractTrait implements ToSmithyBuilder<Arn
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
-            Builder builder = builder();
             ObjectNode objectNode = value.expectObjectNode();
+            Builder builder = builder().sourceLocation(value);
             builder.template(objectNode.expectStringMember(TEMPLATE).getValue());
             builder.absolute(objectNode.getBooleanMemberOrDefault(ABSOLUTE));
             builder.noRegion(objectNode.getBooleanMemberOrDefault(NO_REGION));

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -60,6 +60,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // BUG sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             Builder builder = builder();
             String sdkId = objectNode.getStringMember("sdkId")
@@ -169,12 +170,14 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
 
     @Override
     protected Node createNode() {
-        return Node.objectNode()
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
                 .withMember("sdkId", Node.from(sdkId))
                 .withMember("arnNamespace", Node.from(getArnNamespace()))
                 .withMember("cloudFormationName", Node.from(getCloudFormationName()))
                 .withMember("cloudTrailEventSource", Node.from(getCloudTrailEventSource()))
-                .withMember("endpointPrefix", Node.from(getEndpointPrefix()));
+                .withMember("endpointPrefix", Node.from(getEndpointPrefix()))
+                .build();
     }
 
     /** Builder for {@link ServiceTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -60,9 +60,8 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // BUG sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
-            Builder builder = builder();
+            Builder builder = builder().sourceLocation(value);
             String sdkId = objectNode.getStringMember("sdkId")
                     .map(StringNode::getValue)
                     .orElseThrow(() -> new SourceException(String.format(

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
@@ -51,6 +51,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             return builder()
                     .providerArns(objectNode.expectArrayMember(PROVIDER_ARNS).getElementsAs(StringNode::getValue))
@@ -81,8 +82,10 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
     @Override
     protected Node createNode() {
-        return Node.objectNode()
-                .withMember(PROVIDER_ARNS, providerArns.stream().map(Node::from).collect(ArrayNode.collect()));
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
+                .withMember(PROVIDER_ARNS, providerArns.stream().map(Node::from).collect(ArrayNode.collect()))
+                .build();
     }
 
     /** Builder for {@link CognitoUserPoolsTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
@@ -51,9 +51,9 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             return builder()
+                    .sourceLocation(value)
                     .providerArns(objectNode.expectArrayMember(PROVIDER_ARNS).getElementsAs(StringNode::getValue))
                     .build();
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
@@ -76,7 +76,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
     @Override
     public Builder toBuilder() {
-        return builder().providerArns(providerArns);
+        return builder().sourceLocation(getSourceLocation()).providerArns(providerArns);
     }
 
     @Override

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/SigV4Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/SigV4Trait.java
@@ -59,7 +59,7 @@ public final class SigV4Trait extends AbstractTrait implements ToSmithyBuilder<S
 
     @Override
     protected Node createNode() {
-        return Node.objectNode().withMember(NAME, getName());
+        return Node.objectNodeBuilder().sourceLocation(getSourceLocation()).withMember(NAME, getName()).build();
     }
 
     public static final class Builder extends AbstractTraitBuilder<SigV4Trait, Builder> {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
@@ -61,7 +61,7 @@ public final class ClientDiscoveredEndpointTrait extends AbstractTrait
 
     @Override
     public SmithyBuilder<ClientDiscoveredEndpointTrait> toBuilder() {
-        return builder().required(required);
+        return builder().sourceLocation(getSourceLocation()).required(required);
     }
 
     /** Builder for {@link ClientDiscoveredEndpointTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
@@ -56,7 +56,10 @@ public final class ClientDiscoveredEndpointTrait extends AbstractTrait
 
     @Override
     protected Node createNode() {
-        return Node.objectNode().withMember(REQUIRED, Node.from(isRequired()));
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
+                .withMember(REQUIRED, Node.from(isRequired()))
+                .build();
     }
 
     @Override
@@ -88,6 +91,7 @@ public final class ClientDiscoveredEndpointTrait extends AbstractTrait
 
         @Override
         public ClientDiscoveredEndpointTrait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             return builder()
                     .required(objectNode.getBooleanMemberOrDefault(REQUIRED, true))

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
@@ -91,9 +91,9 @@ public final class ClientDiscoveredEndpointTrait extends AbstractTrait
 
         @Override
         public ClientDiscoveredEndpointTrait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             return builder()
+                    .sourceLocation(value)
                     .required(objectNode.getBooleanMemberOrDefault(REQUIRED, true))
                     .build();
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
@@ -91,7 +91,8 @@ public final class ClientEndpointDiscoveryTrait extends AbstractTrait
     @Override
     public Builder toBuilder() {
         return new Builder()
-                .operation(getOperation())
+                .sourceLocation(getSourceLocation())
+                .operation(operation)
                 .error(error);
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
@@ -146,9 +146,10 @@ public final class ClientEndpointDiscoveryTrait extends AbstractTrait
 
         @Override
         public ClientEndpointDiscoveryTrait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
-            Builder builder = builder().operation(objectNode.expectStringMember(OPERATION).expectShapeId());
+            Builder builder = builder()
+                    .sourceLocation(value)
+                    .operation(objectNode.expectStringMember(OPERATION).expectShapeId());
             objectNode.getStringMember(ERROR).ifPresent(error -> builder.error(error.expectShapeId()));
             return builder.build();
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
@@ -83,9 +83,11 @@ public final class ClientEndpointDiscoveryTrait extends AbstractTrait
 
     @Override
     protected Node createNode() {
-        return Node.objectNode()
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
                 .withMember(OPERATION, Node.from(getOperation().toString()))
-                .withOptionalMember(ERROR, getOptionalError().map(error -> Node.from(error.toString())));
+                .withOptionalMember(ERROR, getOptionalError().map(error -> Node.from(error.toString())))
+                .build();
     }
 
     @Override
@@ -144,6 +146,7 @@ public final class ClientEndpointDiscoveryTrait extends AbstractTrait
 
         @Override
         public ClientEndpointDiscoveryTrait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             Builder builder = builder().operation(objectNode.expectStringMember(OPERATION).expectShapeId());
             objectNode.getStringMember(ERROR).ifPresent(error -> builder.error(error.expectShapeId()));

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsProtocolTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsProtocolTrait.java
@@ -68,6 +68,7 @@ public abstract class AwsProtocolTrait extends AbstractTrait {
     @Override
     protected Node createNode() {
         ObjectNode.Builder builder = Node.objectNodeBuilder();
+        builder.sourceLocation(getSourceLocation());
 
         if (!getHttp().isEmpty()) {
             builder.withMember(HTTP, Node.fromStrings(getHttp()));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
@@ -53,16 +53,16 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
 
     @Override
     protected Node createNode() {
-        if (traits.isEmpty()) {
-            return Node.objectNode();
-        }
-
-        ArrayNode ids = traits.stream()
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        builder.sourceLocation(getSourceLocation());
+        if (!traits.isEmpty()) {
+            ArrayNode ids = traits.stream()
                 .map(ShapeId::toString)
                 .map(Node::from)
                 .collect(ArrayNode.collect());
-
-        return Node.objectNode().withMember("traits", ids);
+            builder.withMember("traits", ids);
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
@@ -60,6 +60,7 @@ public final class AuthTrait extends AbstractTrait {
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             List<ShapeId> values = new ArrayList<>();
             for (StringNode node : value.expectArrayNode().getElementsAs(StringNode.class)) {
                 values.add(node.expectShapeId());
@@ -70,6 +71,7 @@ public final class AuthTrait extends AbstractTrait {
 
     @Override
     protected Node createNode() {
-        return getValues().stream().map(ShapeId::toString).map(Node::from).collect(ArrayNode.collect());
+        return getValues().stream().map(ShapeId::toString).map(Node::from)
+                .collect(ArrayNode.collect(getSourceLocation()));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
@@ -60,7 +60,6 @@ public final class AuthTrait extends AbstractTrait {
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
             List<ShapeId> values = new ArrayList<>();
             for (StringNode node : value.expectArrayNode().getElementsAs(StringNode.class)) {
                 values.add(node.expectShapeId());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
@@ -101,7 +101,7 @@ public final class EndpointTrait extends AbstractTrait implements ToSmithyBuilde
 
     @Override
     public Builder toBuilder() {
-        return new Builder().hostPrefix(hostPrefix.toString());
+        return new Builder().sourceLocation(getSourceLocation()).hostPrefix(hostPrefix.toString());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
@@ -74,7 +74,7 @@ public final class EnumTrait extends AbstractTrait implements ToSmithyBuilder<En
 
     @Override
     protected Node createNode() {
-        return definitions.stream().map(EnumDefinition::toNode).collect(ArrayNode.collect());
+        return definitions.stream().map(EnumDefinition::toNode).collect(ArrayNode.collect(getSourceLocation()));
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExternalDocumentationTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExternalDocumentationTrait.java
@@ -66,7 +66,7 @@ public final class ExternalDocumentationTrait extends AbstractTrait
 
     @Override
     protected Node createNode() {
-        return ObjectNode.fromStringMap(urls);
+        return ObjectNode.fromStringMap(urls).toBuilder().sourceLocation(getSourceLocation()).build();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java
@@ -57,6 +57,7 @@ public final class HttpApiKeyAuthTrait extends AbstractTrait implements ToSmithy
     @Override
     protected Node createNode() {
         return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
                 .withMember("name", getName())
                 .withMember("in", getIn().toString())
                 .build();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpErrorTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpErrorTrait.java
@@ -45,6 +45,7 @@ public final class HttpErrorTrait extends AbstractTrait {
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            // BUG: sourcelocation
             return new HttpErrorTrait(value.expectNumberNode().getValue().intValue(), value.getSourceLocation());
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpErrorTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpErrorTrait.java
@@ -45,7 +45,6 @@ public final class HttpErrorTrait extends AbstractTrait {
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            // BUG: sourcelocation
             return new HttpErrorTrait(value.expectNumberNode().getValue().intValue(), value.getSourceLocation());
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpTrait.java
@@ -89,7 +89,7 @@ public final class HttpTrait extends AbstractTrait implements ToSmithyBuilder<Ht
 
     @Override
     public HttpTrait.Builder toBuilder() {
-        return new Builder().method(method).uri(uri).code(code);
+        return new Builder().sourceLocation(getSourceLocation()).method(method).uri(uri).code(code);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdRefTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdRefTrait.java
@@ -78,15 +78,16 @@ public final class IdRefTrait extends AbstractTrait implements ToSmithyBuilder<I
 
     @Override
     protected Node createNode() {
-        ObjectNode result = Node.objectNode()
+        ObjectNode.Builder builder = Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
                 .withOptionalMember(
                         SELECTOR_MEMBER_ID,
                         Optional.ofNullable(selector).map(Selector::toString).map(Node::from))
                 .withOptionalMember(ERROR_MESSAGE, getErrorMessage().map(Node::from));
         if (failWhenMissing) {
-            result = result.withMember(FAIL_WHEN_MISSING_MEMBER, Node.from(true));
+            builder = builder.withMember(FAIL_WHEN_MISSING_MEMBER, Node.from(true));
         }
-        return result;
+        return builder.build();
     }
 
     public static Builder builder() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
@@ -109,6 +109,7 @@ public final class LengthTrait extends AbstractTrait implements ToSmithyBuilder<
 
         @Override
         public LengthTrait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             Long minValue = objectNode.getMember("min")
                     .map(v -> v.expectNumberNode().getValue().longValue()).orElse(null);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
@@ -109,7 +109,6 @@ public final class LengthTrait extends AbstractTrait implements ToSmithyBuilder<
 
         @Override
         public LengthTrait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             Long minValue = objectNode.getMember("min")
                     .map(v -> v.expectNumberNode().getValue().longValue()).orElse(null);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
@@ -67,22 +67,19 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
 
     @Override
     protected Node createNode() {
-        if (traits.isEmpty()) {
-            return Node.objectNode();
-        }
-
         ObjectNode.Builder builder = Node.objectNodeBuilder();
+        builder.sourceLocation(getSourceLocation());
+        if (!traits.isEmpty()) {
+            ArrayNode ids = traits.stream()
+                    .map(ShapeId::toString)
+                    .map(Node::from)
+                    .collect(ArrayNode.collect());
+            builder.withMember(TRAITS, ids);
 
-        ArrayNode ids = traits.stream()
-                .map(ShapeId::toString)
-                .map(Node::from)
-                .collect(ArrayNode.collect());
-        builder.withMember(TRAITS, ids);
-
-        if (noInlineDocumentSupport) {
-            builder.withMember(NO_INLINE_DOCUMENT_SUPPORT, true);
+            if (noInlineDocumentSupport) {
+                builder.withMember(NO_INLINE_DOCUMENT_SUPPORT, true);
+            }
         }
-
         return builder.build();
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
@@ -80,7 +80,7 @@ public final class RangeTrait extends AbstractTrait implements ToSmithyBuilder<R
     }
 
     /**
-     * Builder used to create a LongTrait.
+     * Builder used to create a RangeTrait.
      */
     public static final class Builder extends AbstractTraitBuilder<RangeTrait, Builder> {
         private BigDecimal min;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
@@ -110,6 +110,7 @@ public final class RangeTrait extends AbstractTrait implements ToSmithyBuilder<R
 
         @Override
         public RangeTrait createTrait(ShapeId target, Node value) {
+            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             BigDecimal minValue = objectNode.getMember("min")
                     .map(node -> new BigDecimal(node.expectNumberNode().getValue().toString())).orElse(null);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
@@ -110,7 +110,6 @@ public final class RangeTrait extends AbstractTrait implements ToSmithyBuilder<R
 
         @Override
         public RangeTrait createTrait(ShapeId target, Node value) {
-            // BUG: sourceLocation
             ObjectNode objectNode = value.expectObjectNode();
             BigDecimal minValue = objectNode.getMember("min")
                     .map(node -> new BigDecimal(node.expectNumberNode().getValue().toString())).orElse(null);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReferencesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReferencesTrait.java
@@ -75,7 +75,7 @@ public final class ReferencesTrait extends AbstractTrait implements ToSmithyBuil
 
     @Override
     protected Node createNode() {
-        return references.stream().map(Reference::toNode).collect(ArrayNode.collect());
+        return references.stream().map(Reference::toNode).collect(ArrayNode.collect(getSourceLocation()));
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RetryableTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RetryableTrait.java
@@ -52,12 +52,16 @@ public final class RetryableTrait extends AbstractTrait implements ToSmithyBuild
 
     @Override
     public Builder toBuilder() {
-        return builder().throttling(throttling);
+        return builder().sourceLocation(getSourceLocation()).throttling(throttling);
     }
 
     @Override
     protected Node createNode() {
-        return throttling ? Node.objectNode().withMember(THROTTLING, true) : Node.objectNode();
+        ObjectNode.Builder nodeBuilder = Node.objectNodeBuilder().sourceLocation(getSourceLocation());
+        if (throttling) {
+            nodeBuilder.withMember(THROTTLING, true);
+        }
+        return nodeBuilder.build();
     }
 
     public static final class Provider implements TraitService {
@@ -69,7 +73,8 @@ public final class RetryableTrait extends AbstractTrait implements ToSmithyBuild
         @Override
         public RetryableTrait createTrait(ShapeId target, Node value) {
             ObjectNode node = value.expectObjectNode();
-            return builder().throttling(node.getBooleanMemberOrDefault(THROTTLING)).build();
+            Builder builder = builder().sourceLocation(value.getSourceLocation());
+            return builder.throttling(node.getBooleanMemberOrDefault(THROTTLING)).build();
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
@@ -72,7 +72,10 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder().selector(selector).structurallyExclusive(structurallyExclusive);
+        Builder builder = builder()
+                .sourceLocation(getSourceLocation())
+                .selector(selector)
+                .structurallyExclusive(structurallyExclusive);
         conflicts.forEach(builder::addConflict);
         return builder;
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/RetryableTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/RetryableTraitTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import java.util.Optional;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class RetryableTraitTest {
+    @Test
+    public void loadsTraitWithDefault() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        SourceLocation sourceLocation = new SourceLocation("fileA");
+        Node node = Node.objectNodeBuilder().sourceLocation(sourceLocation).build();
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#retryable"), ShapeId.from("ns.qux#foo"), node);
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(RetryableTrait.class));
+        RetryableTrait retryableTrait = (RetryableTrait) trait.get();
+        assertThat(retryableTrait.getSourceLocation(), equalTo(sourceLocation));
+        assertFalse(retryableTrait.getThrottling());
+        assertThat(retryableTrait.toNode(), equalTo(node));
+        assertThat(retryableTrait.toNode().getSourceLocation(), equalTo(sourceLocation));
+        assertThat(retryableTrait.toBuilder().build(), equalTo(retryableTrait));
+        assertThat(retryableTrait.toBuilder().build().getSourceLocation(), equalTo(sourceLocation));
+    }
+
+    @Test
+    public void loadsTraitWithThrottling() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Node node = Node.objectNodeBuilder().withMember("throttling", true).build();
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#retryable"), ShapeId.from("ns.qux#foo"), node);
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(RetryableTrait.class));
+        RetryableTrait retryableTrait = (RetryableTrait) trait.get();
+        assertTrue(retryableTrait.getThrottling());
+        assertThat(retryableTrait.toNode(), equalTo(node));
+        assertThat(retryableTrait.toBuilder().build(), equalTo(retryableTrait));
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestsTrait.java
@@ -78,6 +78,6 @@ public final class HttpRequestTestsTrait extends AbstractTrait {
 
     @Override
     protected Node createNode() {
-        return getTestCases().stream().collect(ArrayNode.collect());
+        return getTestCases().stream().collect(ArrayNode.collect(getSourceLocation()));
     }
 }


### PR DESCRIPTION
The sourceLocation should propogate from
1. TraitService.createTrait -> Trait
2. Trait -> createNode
3. Trait -> toBuilder

Across traits, this wasn't done consistently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
