### PR TITLE
Update NodeMapper to handle Trait sourceLocation

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.Pair;
@@ -373,8 +374,8 @@ final class DefaultNodeDeserializers {
                 return false;
             }
 
-            // Must either return the target class itself (like a builder) or void.
-            if (method.getReturnType() != void.class && method.getReturnType() != type) {
+
+            if (!hasSetterReturnType(method, type, propertyName)) {
                 return false;
             }
 
@@ -389,6 +390,16 @@ final class DefaultNodeDeserializers {
             }
 
             return false;
+        }
+
+        private static boolean hasSetterReturnType(Method method, Class<?> type, String propertyName) {
+            // This is a hack to make source location work. Work needs to be done in resolveClassFromType to
+            // make sourceLocation work without a hack like this.
+            if (propertyName.equals("sourceLocation") && method.getReturnType() == AbstractTraitBuilder.class) {
+                return true;
+            }
+            // Must either return the target class itself (like a builder) or void.
+            return method.getReturnType() == void.class || method.getReturnType() == type;
         }
 
         private static Class<?> determineParameterizedType(Method setter) {
@@ -431,6 +442,7 @@ final class DefaultNodeDeserializers {
             } else if (type instanceof WildcardType) {
                 return resolveClassFromType(((WildcardType) type).getUpperBounds()[0]);
             } else if (type instanceof TypeVariable<?>) {
+                // TODO: implement this to enable sourceLocation setting without hacks
                 throw new IllegalArgumentException("TypeVariable targets are not implemented: " + type);
             } else if (type instanceof GenericArrayType) {
                 throw new IllegalArgumentException("GenericArrayType targets are not implemented: " + type);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeSerializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeSerializers.java
@@ -65,6 +65,7 @@ final class DefaultNodeSerializers {
                 return null;
             }
 
+            // TODO: make sure every instance of `toNode` is setting this
             return value.toNode();
         }
     };
@@ -362,7 +363,13 @@ final class DefaultNodeSerializers {
             // multiple times (like in a List<T>).
             serializedObjects.remove(value);
 
-            return new ObjectNode(mappings, SourceLocation.NONE);
+            // Pass on the source location if it is present.
+            SourceLocation sourceLocation = SourceLocation.NONE;
+            if (value instanceof FromSourceLocation) {
+                sourceLocation = ((FromSourceLocation) value).getSourceLocation();
+            }
+
+            return new ObjectNode(mappings, sourceLocation);
         }
 
         private boolean canSerialize(NodeMapper mapper, Node value) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
@@ -1215,7 +1215,7 @@ public class NodeMapperTest {
     }
 
     @Test
-    public void doesNotSerializeSourceLocationAsKey() {
+    public void serializesSourceLocationFromValue() {
         NodeMapper mapper = new NodeMapper();
         HasSourceLocation hs = new HasSourceLocation();
         SourceLocation sourceLocation = new SourceLocation("/foo/baz");
@@ -1224,12 +1224,13 @@ public class NodeMapperTest {
         Node result = mapper.serialize(hs);
 
         assertThat(result.expectObjectNode().getStringMap(), hasKey("foo"));
+        // The sourceLocation needs to be set on the node, not as a key.
         assertThat(result.expectObjectNode().getStringMap(), not(hasKey("sourceLocation")));
         assertThat(result.getSourceLocation(), equalTo(sourceLocation));
     }
 
     @Test
-    public void passesSourceLocationFromTrait() {
+    public void serializesSourceLocationFromTrait() {
         SourceLocation sourceLocation = new SourceLocation("/foo/baz");
         SourceLocationBearerTrait trait = SourceLocationBearerTrait.builder()
                 .sourceLocation(sourceLocation)
@@ -1238,6 +1239,7 @@ public class NodeMapperTest {
         Node result = trait.createNode();
 
         assertThat(result.expectObjectNode().getStringMap(), hasKey("foo"));
+        // The sourceLocation needs to be set on the node, not as a key.
         assertThat(result.expectObjectNode().getStringMap(), not(hasKey("sourceLocation")));
         assertThat(result.getSourceLocation(), equalTo(sourceLocation));
     }


### PR DESCRIPTION
This updates NodeMapper so that it can properly set source location on traits that use the AbstractTraitBuilder. Unfortunately the fix implemented here is a hack that looks for that specific case, and the same root cause may bite us elsewhere.

The true root cause is that our [default deserializer is unable to resolve generics](https://github.com/awslabs/smithy/blob/main/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java#L434). AbstractTraitBuilder generically defines the return value of the setter `sourceLocation` to `B extends AbstractTraitBuilder`. When we use reflection to look at the return type, all we see is `AbstractTraitBuilder`. We *can* also get the type variable, but actually resolving it will take a decent amount of effort as that functionality isn't built in.

This is related to #864 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
