### PR TITLE
Remove warning when PATCH is idempotent

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
@@ -58,7 +58,7 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
             "POST", new HttpMethodSemantics(false, null, true),
             "DELETE", new HttpMethodSemantics(false, true, false),
             "PUT", new HttpMethodSemantics(false, true, true),
-            "PATCH", new HttpMethodSemantics(false, false, true));
+            "PATCH", new HttpMethodSemantics(false, null, true));
 
     @Override
     public List<ValidationEvent> validate(Model model) {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-method-semantics-validator.json
@@ -172,6 +172,16 @@
                     "target": "smithy.api#String"
                 }
             }
+        },
+        "ns.foo#N": {
+            "type": "operation",
+            "traits": {
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/E"
+                },
+                "smithy.api#idempotent": {}
+            }
         }
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

https://datatracker.ietf.org/doc/html/rfc5789#section-2

> PATCH is neither safe nor idempotent as defined by [RFC2616], Section
   9.1.

 >A PATCH request can be issued in such a way as to be idempotent,
   which also helps prevent bad outcomes from collisions between two
   PATCH requests on the same resource in a similar time frame.
   Collisions from multiple PATCH requests may be more dangerous than
   PUT collisions because some patch formats need to operate from a
   known base-point or else they will corrupt the resource.  Clients
   using this kind of patch application SHOULD use a conditional request
   such that the request will fail if the resource has been updated
   since the client last accessed the resource.  For example, the client
   can use a strong ETag [RFC2616] in an If-Match header on the PATCH
   request.
