### PR TITLE
Fix wording of sentence describing enheritance behavior of auth trait

### DIFF
--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -284,7 +284,7 @@ Value type
     shape.
 
 Operations that are not annotated with the ``auth`` trait inherit the ``auth``
-trait of the service they are bound to, and if the service is not annotated
+trait of the service they are bound to, and if the operation is not annotated
 with the ``auth`` trait, then the operation is expected to support each of
 the :ref:`authentication scheme traits <authDefinition-trait>` applied to the
 service. Each entry in the ``auth`` trait is a shape ID that MUST refer to an


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Update to auth docs that I believe mistakenly provide 'service' where 'operation' was intended.  If I misunderstood the point of the sentence kindly close the PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
