### PR TITLE
Initial implementation of @httpMalformedRequestTests

### DIFF
--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestDefinition.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestDefinition.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Defines a request to be used by an HttpMalformedRequest test case.
+ */
+@SmithyUnstableApi
+public final class HttpMalformedRequestDefinition implements ToNode, ToSmithyBuilder<HttpMalformedRequestDefinition> {
+
+    private static final String BODY = "body";
+    private static final String HEADERS = "headers";
+    private static final String HOST = "host";
+    private static final String METHOD = "method";
+    private static final String QUERY_PARAMS = "queryParams";
+    private static final String URI = "uri";
+
+    private final String body;
+    private final Map<String, String> headers;
+    private final String host;
+    private final String method;
+    private final List<String> queryParams;
+    private final String uri;
+
+    private HttpMalformedRequestDefinition(Builder builder) {
+        body = builder.body;
+        host = builder.host;
+        headers = MapUtils.copyOf(builder.headers);
+        method = SmithyBuilder.requiredState(METHOD, builder.method);
+        queryParams = ListUtils.copyOf(builder.queryParams);
+        uri = builder.uri;
+    }
+
+    public Optional<String> getBody() {
+        return Optional.ofNullable(body);
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public Optional<String> getHost() {
+        return Optional.ofNullable(host);
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public List<String> getQueryParams() {
+        return queryParams;
+    }
+
+    public Optional<String> getUri() {
+        return Optional.ofNullable(uri);
+    }
+
+    public static HttpMalformedRequestDefinition fromNode(Node node) {
+        HttpMalformedRequestDefinition.Builder builder = builder();
+        ObjectNode o = node.expectObjectNode();
+        o.getStringMember(BODY).map(StringNode::getValue).ifPresent(builder::body);
+        o.getObjectMember(HEADERS).ifPresent(headers -> {
+            headers.getStringMap().forEach((k, v) -> {
+                builder.putHeader(k, v.expectStringNode().getValue());
+            });
+        });
+        o.getStringMember(HOST).ifPresent(stringNode -> builder.host(stringNode.getValue()));
+        builder.method(o.expectStringMember(METHOD).getValue());
+        o.getStringMember(URI).map(StringNode::getValue).ifPresent(builder::uri);
+        o.getArrayMember(QUERY_PARAMS).ifPresent(queryParams -> {
+            builder.queryParams(queryParams.getElementsAs(StringNode::getValue));
+        });
+        return builder.build();
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.objectNodeBuilder()
+                .withOptionalMember(BODY, getBody().map(Node::from))
+                .withOptionalMember(HEADERS,
+                        headers.isEmpty() ? Optional.empty() : Optional.of(ObjectNode.fromStringMap(getHeaders())))
+                .withOptionalMember(HOST, getHost().map(StringNode::from))
+                .withMember(METHOD, getMethod())
+                .withOptionalMember(URI, getUri().map(Node::from))
+                .withOptionalMember(QUERY_PARAMS,
+                        queryParams.isEmpty() ? Optional.empty() : Optional.of(ArrayNode.fromStrings(getQueryParams())))
+                .build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .headers(getHeaders())
+                .method(getMethod())
+                .queryParams(getQueryParams());
+        getBody().ifPresent(builder::body);
+        getHost().ifPresent(builder::host);
+        getUri().ifPresent(builder::uri);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a HttpRequestTestsTrait.
+     */
+    public static final class Builder implements SmithyBuilder<HttpMalformedRequestDefinition> {
+
+        private String body;
+        private String host;
+        private final Map<String, String> headers = new HashMap<>();
+        private String method;
+        private final List<String> queryParams = new ArrayList<>();
+        private String uri;
+
+        private Builder() {}
+
+        public Builder body(String body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers.clear();
+            this.headers.putAll(headers);
+            return this;
+        }
+
+        public Builder putHeader(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder method(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder queryParams(List<String> queryParams) {
+            this.queryParams.clear();
+            this.queryParams.addAll(queryParams);
+            return this;
+        }
+
+        public Builder uri(String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        @Override
+        public HttpMalformedRequestDefinition build() {
+            return new HttpMalformedRequestDefinition(this);
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.Tagged;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Defines a test case for malformed HTTP requests.
+ */
+@SmithyUnstableApi
+public final class HttpMalformedRequestTestCase implements Tagged, ToSmithyBuilder<HttpMalformedRequestTestCase> {
+
+    private static final String ID = "id";
+    private static final String PROTOCOL = "protocol";
+    private static final String REQUEST = "request";
+    private static final String RESPONSE = "response";
+
+    private final String documentation;
+    private final String id;
+    private final ShapeId protocol;
+    private final HttpMalformedRequestDefinition request;
+    private final HttpMalformedResponseDefinition response;
+    private final List<String> tags;
+
+    private HttpMalformedRequestTestCase(Builder builder) {
+        documentation = builder.documentation;
+        id = SmithyBuilder.requiredState(ID, builder.id);
+        protocol = SmithyBuilder.requiredState(PROTOCOL, builder.protocol);
+        request = SmithyBuilder.requiredState(REQUEST, builder.request);
+        response = SmithyBuilder.requiredState(RESPONSE, builder.response);
+        tags = ListUtils.copyOf(builder.tags);
+    }
+
+    public Optional<String> getDocumentation() {
+        return Optional.ofNullable(documentation);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public ShapeId getProtocol() {
+        return protocol;
+    }
+
+    public HttpMalformedRequestDefinition getRequest() {
+        return request;
+    }
+
+    public HttpMalformedResponseDefinition getResponse() {
+        return response;
+    }
+
+    @Override
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .id(getId())
+                .protocol(getProtocol())
+                .request(getRequest())
+                .response(getResponse())
+                .tags(getTags());
+        getDocumentation().ifPresent(builder::documentation);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a HttpMalformedRequestTestCase.
+     */
+    public static final class Builder implements SmithyBuilder<HttpMalformedRequestTestCase> {
+
+        private String documentation;
+        private String id;
+        private ShapeId protocol;
+        private HttpMalformedRequestDefinition request;
+        private HttpMalformedResponseDefinition response;
+        private final List<String> tags = new ArrayList<>();
+
+        private Builder() {}
+
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
+            return this;
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder protocol(ToShapeId protocol) {
+            this.protocol = protocol.toShapeId();
+            return this;
+        }
+
+        public Builder request(HttpMalformedRequestDefinition request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder response(HttpMalformedResponseDefinition response) {
+            this.response = response;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags.clear();
+            this.tags.addAll(tags);
+            return this;
+        }
+
+        @Override
+        public HttpMalformedRequestTestCase build() {
+            return new HttpMalformedRequestTestCase(this);
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsTrait.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.List;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Defines protocol tests for malformed HTTP request handling.
+ */
+@SmithyUnstableApi
+public final class HttpMalformedRequestTestsTrait extends AbstractTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.test#httpMalformedRequestTests");
+
+    private final List<ParameterizedHttpMalformedRequestTestCase> testCases;
+
+    public HttpMalformedRequestTestsTrait(List<ParameterizedHttpMalformedRequestTestCase> testCases) {
+        this(SourceLocation.NONE, testCases);
+    }
+
+    public HttpMalformedRequestTestsTrait(SourceLocation sourceLocation,
+                                          List<ParameterizedHttpMalformedRequestTestCase> testCases) {
+        super(ID, sourceLocation);
+        this.testCases = ListUtils.copyOf(testCases);
+    }
+
+    public static final class Provider extends AbstractTrait.Provider {
+        public Provider() {
+            super(ID);
+        }
+
+        @Override
+        public Trait createTrait(ShapeId target, Node value) {
+            ArrayNode values = value.expectArrayNode();
+            List<ParameterizedHttpMalformedRequestTestCase> testCases =
+                    values.getElementsAs(ParameterizedHttpMalformedRequestTestCase::fromNode);
+            return new HttpMalformedRequestTestsTrait(value.getSourceLocation(), testCases);
+        }
+    }
+
+    public List<HttpMalformedRequestTestCase> getTestCases() {
+        return testCases
+                .stream()
+                .map(ParameterizedHttpMalformedRequestTestCase::generateTestCasesFromParameters)
+                .flatMap(List::stream)
+                .collect(ListUtils.toUnmodifiableList());
+    }
+
+    /**
+     * This is not preferred for code generation. Use {@link #getTestCases()} instead.
+     * @return the parameterized test cases, as defined by the model author
+     */
+    List<ParameterizedHttpMalformedRequestTestCase> getParameterizedTestCases() {
+        return testCases;
+    }
+
+    @Override
+    protected Node createNode() {
+        return getParameterizedTestCases().stream().collect(ArrayNode.collect(getSourceLocation()));
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Ensures that parameters attached to @httpMalformedRequestTest cases are well-formed.
+ */
+@SmithyInternalApi
+public final class HttpMalformedRequestTestsValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        Stream.concat(model.shapes(OperationShape.class), model.shapes(StructureShape.class)).forEach(shape -> {
+            shape.getTrait(HttpMalformedRequestTestsTrait.class).ifPresent(trait -> {
+                trait.getParameterizedTestCases().forEach(testCase -> {
+                    if (!testCase.getTestParameters().isEmpty()) {
+                        Set<Integer> sizes = testCase.getTestParameters().values()
+                                .stream().map(List::size).collect(Collectors.toSet());
+                        if (sizes.size() != 1) {
+                            events.add(error(shape, trait.getSourceLocation(), "Each list associated to a key "
+                                    + "in `testParameters` must be of the same length."));
+                        }
+                    }
+                });
+            });
+        });
+        return events;
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedResponseBodyDefinition.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedResponseBodyDefinition.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Defines the response expected by an HttpMalformedRequest test case.
+ */
+@SmithyUnstableApi
+public final class HttpMalformedResponseBodyDefinition
+        implements ToNode, ToSmithyBuilder<HttpMalformedResponseBodyDefinition> {
+
+    private static final String ASSERTION = "assertion";
+    private static final String CONTENTS = "contents";
+    private static final String MEDIA_TYPE = "mediaType";
+    private static final String MESSAGE_REGEX = "messageRegex";
+
+    private final String contents;
+    private final String mediaType;
+    private final String messageRegex;
+
+    private HttpMalformedResponseBodyDefinition(Builder builder) {
+        contents = builder.contents;
+        mediaType = SmithyBuilder.requiredState(MEDIA_TYPE, builder.mediaType);
+        messageRegex = builder.messageRegex;
+    }
+
+    public Optional<String> getContents() {
+        return Optional.ofNullable(contents);
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public Optional<String> getMessageRegex() {
+        return Optional.ofNullable(messageRegex);
+    }
+
+    public static HttpMalformedResponseBodyDefinition fromNode(Node node) {
+        HttpMalformedResponseBodyDefinition.Builder builder = builder();
+        ObjectNode o = node.expectObjectNode();
+        builder.mediaType(o.expectStringMember(MEDIA_TYPE).getValue());
+        ObjectNode assertion = o.expectObjectMember(ASSERTION);
+        assertion.getStringMember(CONTENTS).ifPresent(stringNode -> builder.contents(stringNode.getValue()));
+        assertion.getStringMember(MESSAGE_REGEX).ifPresent(stringNode -> builder.messageRegex(stringNode.getValue()));
+        return builder.build();
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.objectNodeBuilder()
+                .withMember(MEDIA_TYPE, getMediaType())
+                .withMember(ASSERTION, ObjectNode.objectNodeBuilder()
+                        .withOptionalMember(CONTENTS, getContents().map(StringNode::from))
+                        .withOptionalMember(MESSAGE_REGEX, getMessageRegex().map(StringNode::from))
+                        .build())
+                .build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .mediaType(getMediaType());
+        getContents().ifPresent(builder::mediaType);
+        getMessageRegex().ifPresent(builder::messageRegex);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a HttpMalformedResponseBodyDefinition.
+     */
+    public static final class Builder implements SmithyBuilder<HttpMalformedResponseBodyDefinition> {
+
+        private String contents;
+        private String mediaType;
+        private String messageRegex;
+
+        private Builder() {}
+
+        public Builder contents(String contents) {
+            this.contents = contents;
+            return this;
+        }
+
+        public Builder mediaType(String mediaType) {
+            this.mediaType = mediaType;
+            return this;
+        }
+
+        public Builder messageRegex(String messageRegex) {
+            this.messageRegex = messageRegex;
+            return this;
+        }
+
+        @Override
+        public HttpMalformedResponseBodyDefinition build() {
+            return new HttpMalformedResponseBodyDefinition(this);
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedResponseDefinition.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedResponseDefinition.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Defines the response expected by an HttpMalformedRequest test case.
+ */
+@SmithyUnstableApi
+public final class HttpMalformedResponseDefinition implements ToNode, ToSmithyBuilder<HttpMalformedResponseDefinition> {
+
+    private static final String BODY = "body";
+    private static final String CODE = "code";
+    private static final String HEADERS = "headers";
+
+    private final HttpMalformedResponseBodyDefinition body;
+    private final int code;
+    private final Map<String, String> headers;
+
+    private HttpMalformedResponseDefinition(Builder builder) {
+        body = builder.body;
+        code = builder.code;
+        headers = MapUtils.copyOf(builder.headers);
+    }
+
+    public Optional<HttpMalformedResponseBodyDefinition> getBody() {
+        return Optional.ofNullable(body);
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public static HttpMalformedResponseDefinition fromNode(Node node) {
+        HttpMalformedResponseDefinition.Builder builder = builder();
+        ObjectNode o = node.expectObjectNode();
+        o.getObjectMember(BODY).ifPresent(body -> builder.body(HttpMalformedResponseBodyDefinition.fromNode(body)));
+        o.getNumberMember(CODE).ifPresent(numberNode -> builder.code(numberNode.getValue().intValue()));
+        o.getObjectMember(HEADERS).ifPresent(headers -> {
+            headers.getStringMap().forEach((k, v) -> {
+                builder.putHeader(k, v.expectStringNode().getValue());
+            });
+        });
+        return builder.build();
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.objectNodeBuilder()
+                .withOptionalMember(BODY, getBody().map(HttpMalformedResponseBodyDefinition::toNode))
+                .withMember(CODE, getCode())
+                .withOptionalMember(HEADERS,
+                        headers.isEmpty() ? Optional.empty() : Optional.of(ObjectNode.fromStringMap(getHeaders())))
+                .build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .headers(getHeaders())
+                .code(getCode());
+        getBody().ifPresent(builder::body);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a HttpMalformedResponseDefinition.
+     */
+    public static final class Builder implements SmithyBuilder<HttpMalformedResponseDefinition> {
+
+        private HttpMalformedResponseBodyDefinition body;
+        private int code;
+        private final Map<String, String> headers = new HashMap<>();
+
+        private Builder() {}
+
+        public Builder body(HttpMalformedResponseBodyDefinition body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder code(int code) {
+            this.code = code;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers.clear();
+            this.headers.putAll(headers);
+            return this;
+        }
+
+        public Builder putHeader(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        @Override
+        public HttpMalformedResponseDefinition build() {
+            return new HttpMalformedResponseDefinition(this);
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ParameterizedHttpMalformedRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ParameterizedHttpMalformedRequestTestCase.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.Tagged;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Defines a parameterized test case for malformed HTTP requests.
+ *
+ * This class is *not* preferred for code generation - use {@link HttpMalformedRequestTestCase}
+ * instances instead, retrieved from {@link HttpMalformedRequestTestsTrait#getTestCases()}.
+ */
+@SmithyUnstableApi
+final class ParameterizedHttpMalformedRequestTestCase
+        implements Tagged, ToNode, ToSmithyBuilder<ParameterizedHttpMalformedRequestTestCase> {
+
+    private static final String DOCUMENTATION = "documentation";
+    private static final String ID = "id";
+    private static final String PROTOCOL = "protocol";
+    private static final String REQUEST = "request";
+    private static final String RESPONSE = "response";
+    private static final String TAGS = "tags";
+    private static final String TEST_PARAMETERS = "testParameters";
+
+    private final String documentation;
+    private final String id;
+    private final ShapeId protocol;
+    private final HttpMalformedRequestDefinition request;
+    private final HttpMalformedResponseDefinition response;
+    private final List<String> tags;
+    private final Map<String, List<String>> testParameters;
+
+    private ParameterizedHttpMalformedRequestTestCase(Builder builder) {
+        documentation = builder.documentation;
+        id = SmithyBuilder.requiredState(ID, builder.id);
+        protocol = SmithyBuilder.requiredState(PROTOCOL, builder.protocol);
+        request = SmithyBuilder.requiredState(REQUEST, builder.request);
+        response = SmithyBuilder.requiredState(RESPONSE, builder.response);
+        tags = ListUtils.copyOf(builder.tags);
+        testParameters = MapUtils.copyOf(builder.testParameters);
+    }
+
+    public Optional<String> getDocumentation() {
+        return Optional.ofNullable(documentation);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public ShapeId getProtocol() {
+        return protocol;
+    }
+
+    public HttpMalformedRequestDefinition getRequest() {
+        return request;
+    }
+
+    public HttpMalformedResponseDefinition getResponse() {
+        return response;
+    }
+
+    @Override
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Map<String, List<String>> getTestParameters() {
+        return testParameters;
+    }
+
+    public List<HttpMalformedRequestTestCase> generateTestCasesFromParameters() {
+        if (testParameters.isEmpty()) {
+            HttpMalformedRequestTestCase.Builder builder = HttpMalformedRequestTestCase.builder()
+                    .id(getId())
+                    .protocol(getProtocol())
+                    .request(request)
+                    .response(response)
+                    .tags(getTags());
+            getDocumentation().ifPresent(builder::documentation);
+            return ListUtils.of(builder.build());
+        }
+
+        int paramLength = testParameters.values().stream().findFirst().map(List::size)
+                .orElseThrow(IllegalStateException::new);
+        final List<HttpMalformedRequestTestCase> testCases = new ArrayList<>(paramLength);
+        for (int i = 0; i < paramLength; i++) {
+            final CodeWriter writer = new CodeWriter();
+            for (Map.Entry<String, List<String>> e : testParameters.entrySet()) {
+                writer.putContext(e.getKey(), e.getValue().get(i));
+            }
+
+            HttpMalformedRequestTestCase.Builder builder = HttpMalformedRequestTestCase.builder()
+                    .id(String.format(getId() + "_case%d", i))
+                    .protocol(getProtocol())
+                    .tags(getTags().stream().map(writer::format).collect(Collectors.toList()));
+            getDocumentation().map(writer::format).ifPresent(builder::documentation);
+
+            testCases.add(builder.request(interpolateRequest(request, writer))
+                                 .response(interpolateResponse(response, writer))
+                                 .build());
+        }
+        return testCases;
+    }
+
+    private static HttpMalformedResponseDefinition interpolateResponse(HttpMalformedResponseDefinition response,
+                                                                       CodeWriter writer) {
+        HttpMalformedResponseDefinition.Builder responseBuilder =
+                response.toBuilder().headers(formatHeaders(writer, response.getHeaders()));
+        response.getBody()
+                .map(responseBody -> {
+                    HttpMalformedResponseBodyDefinition.Builder bodyBuilder = responseBody.toBuilder()
+                            .mediaType(writer.format(responseBody.getMediaType()));
+                    responseBody.getContents().map(writer::format).ifPresent(bodyBuilder::contents);
+                    responseBody.getMessageRegex().map(writer::format).ifPresent(bodyBuilder::messageRegex);
+                    return bodyBuilder.build();
+                })
+                .ifPresent(responseBuilder::body);
+        return responseBuilder.build();
+    }
+
+    private static HttpMalformedRequestDefinition interpolateRequest(HttpMalformedRequestDefinition request,
+                                                                     CodeWriter writer) {
+        HttpMalformedRequestDefinition.Builder requestBuilder = request.toBuilder()
+                .headers(formatHeaders(writer, request.getHeaders()))
+                .queryParams(request.getQueryParams().stream().map(writer::format).collect(Collectors.toList()));
+        request.getBody().map(writer::format).ifPresent(requestBuilder::body);
+        request.getUri().map(writer::format).ifPresent(requestBuilder::uri);
+        return requestBuilder.build();
+    }
+
+    private static Map<String, String> formatHeaders(CodeWriter writer, Map<String, String> headers) {
+        Map<String, String> newHeaders = new HashMap<>();
+        for (Map.Entry<String, String> headerEntry : headers.entrySet()) {
+            newHeaders.put(writer.format(headerEntry.getKey()), writer.format(headerEntry.getValue()));
+        }
+        return newHeaders;
+    }
+
+    public static ParameterizedHttpMalformedRequestTestCase fromNode(Node node) {
+        ParameterizedHttpMalformedRequestTestCase.Builder builder = builder();
+        ObjectNode o = node.expectObjectNode();
+        o.getStringMember(DOCUMENTATION).map(StringNode::getValue).ifPresent(builder::documentation);
+        builder.id(o.expectStringMember(ID).getValue());
+        builder.protocol(o.expectStringMember(PROTOCOL).expectShapeId());
+        builder.request(HttpMalformedRequestDefinition.fromNode(o.expectObjectMember(REQUEST)));
+        builder.response(HttpMalformedResponseDefinition.fromNode(o.expectObjectMember(RESPONSE)));
+        o.getArrayMember(TAGS).ifPresent(tags -> {
+            builder.tags(tags.getElementsAs(StringNode::getValue));
+        });
+        o.getObjectMember(TEST_PARAMETERS).ifPresent(params -> {
+            Map<String, List<String>> paramsMap = new HashMap<>();
+            for (Map.Entry<String, Node> e : params.getStringMap().entrySet()) {
+                paramsMap.put(e.getKey(),
+                              e.getValue().expectArrayNode().getElementsAs(n -> n.expectStringNode().getValue()));
+            }
+            builder.testParameters(paramsMap);
+        });
+        return builder.build();
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder()
+                .withOptionalMember(DOCUMENTATION, getDocumentation().map(Node::from))
+                .withMember(ID, getId())
+                .withMember(PROTOCOL, getProtocol().toString())
+                .withMember(REQUEST, getRequest().toNode())
+                .withMember(RESPONSE, getResponse().toNode());
+
+        if (!tags.isEmpty()) {
+            builder.withMember(TAGS, ArrayNode.fromStrings(getTags()));
+        }
+        if (!testParameters.isEmpty()) {
+            ObjectNode.Builder paramBuilder = ObjectNode.objectNodeBuilder();
+            for (Map.Entry<String, List<String>> e : getTestParameters().entrySet()) {
+                paramBuilder.withMember(e.getKey(), ArrayNode.fromStrings(e.getValue()));
+            }
+            builder.withMember(TEST_PARAMETERS, paramBuilder.build());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .id(getId())
+                .protocol(getProtocol())
+                .request(getRequest())
+                .response(getResponse())
+                .tags(getTags())
+                .testParameters(getTestParameters());
+        getDocumentation().ifPresent(builder::documentation);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a ParameterizedHttpMalformedRequestTestCase.
+     */
+    public static final class Builder implements SmithyBuilder<ParameterizedHttpMalformedRequestTestCase> {
+
+        private String documentation;
+        private String id;
+        private ShapeId protocol;
+        private HttpMalformedRequestDefinition request;
+        private HttpMalformedResponseDefinition response;
+        private final List<String> tags = new ArrayList<>();
+        private final Map<String, List<String>> testParameters = new HashMap<>();
+
+        private Builder() {}
+
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
+            return this;
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder protocol(ToShapeId protocol) {
+            this.protocol = protocol.toShapeId();
+            return this;
+        }
+
+        public Builder request(HttpMalformedRequestDefinition request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder response(HttpMalformedResponseDefinition response) {
+            this.response = response;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags.clear();
+            this.tags.addAll(tags);
+            return this;
+        }
+
+        public Builder testParameters(Map<String, List<String>> testParameters) {
+            this.testParameters.clear();
+            this.testParameters.putAll(testParameters);
+            return this;
+        }
+
+        @Override
+        public ParameterizedHttpMalformedRequestTestCase build() {
+            return new ParameterizedHttpMalformedRequestTestCase(this);
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -1,2 +1,3 @@
+software.amazon.smithy.protocoltests.traits.HttpMalformedRequestTestsTrait$Provider
 software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait$Provider
 software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait$Provider

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -2,3 +2,4 @@ software.amazon.smithy.protocoltests.traits.HttpRequestTestsInputValidator
 software.amazon.smithy.protocoltests.traits.HttpResponseTestsOutputValidator
 software.amazon.smithy.protocoltests.traits.HttpResponseTestsErrorValidator
 software.amazon.smithy.protocoltests.traits.UniqueProtocolTestCaseIdValidator
+software.amazon.smithy.protocoltests.traits.HttpMalformedRequestTestsValidator

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -18,7 +18,7 @@ structure HttpRequestTestCase {
     /// MUST match Smithy's `identifier` ABNF. No two `httpRequestTests`
     /// test cases can share the same ID.
     @required
-    @pattern("[A-Za-z_][A-Za-z0-9_]+")
+    @pattern("^[A-Za-z_][A-Za-z0-9_]+$")
     id: String,
 
     /// The name of the protocol to test.
@@ -178,7 +178,7 @@ structure HttpResponseTestCase {
     /// MUST match Smithy's `identifier` ABNF. No two `httpResponseTests`
     /// test cases can share the same ID.
     @required
-    @pattern("[A-Za-z_][A-Za-z0-9_]+")
+    @pattern("^[A-Za-z_][A-Za-z0-9_]+$")
     id: String,
 
     /// The shape ID of the protocol to test.

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -285,3 +285,131 @@ string NonEmptyString
     },
 ])
 string AppliesTo
+
+/// Define how a malformed HTTP request is rejected by a server given a specific protocol
+@trait(selector: "operation")
+@length(min: 1)
+@unstable
+list httpMalformedRequestTests {
+    member: HttpMalformedRequestTestCase
+}
+
+@private
+structure HttpMalformedRequestTestCase {
+    /// The identifier of the test case. This identifier can be used by
+    /// protocol test implementations to filter out unsupported test
+    /// cases by ID, to generate test case names, etc. The provided `id`
+    /// MUST match Smithy's `identifier` ABNF. No two `httpMalformedRequestTests`
+    /// test cases can share the same ID.
+    @required
+    @pattern("^[A-Za-z_][A-Za-z0-9_]+$")
+    id: String,
+
+    /// The name of the protocol to test.
+    @required
+    @idRef(selector: "[trait|protocolDefinition]", failWhenMissing: true)
+    protocol: String,
+
+    /// The malformed request to send.
+    @required
+    request: HttpMalformedRequestDefinition,
+
+    /// The expected response.
+    @required
+    response: HttpMalformedResponseDefinition,
+
+    /// A description of the test and what is being asserted.
+    documentation: String,
+
+    /// Applies a list of tags to the test.
+    tags: NonEmptyStringList,
+
+    /// An optional set of test parameters for parameterized testing.
+    testParameters: HttpMalformedRequestTestParametersDefinition,
+}
+
+@private
+structure HttpMalformedRequestDefinition {
+
+    /// The expected serialized HTTP request method.
+    @required
+    @length(min: 1)
+    method: String,
+
+    /// The request-target of the HTTP request, not including
+    /// the query string (for example, "/foo/bar").
+    @required
+    @length(min: 1)
+    uri: String,
+
+    /// The host / endpoint provided to the client, not including the path
+    /// or scheme (for example, "example.com").
+    host: String,
+
+    /// A list of the serialized query string parameters to include in the request.
+    ///
+    /// Each element in the list is a query string key value pair
+    /// that starts with the query string parameter name optionally
+    /// followed by "=", optionally followed by the query string
+    /// parameter value. For example, "foo=bar", "foo=", and "foo"
+    /// are all valid values. The query string parameter name and
+    /// the value MUST appear in the format in which it is expected
+    /// to be sent over the wire; if a key or value needs to be
+    /// percent-encoded, then it MUST appear percent-encoded in this list.
+    queryParams: StringList,
+
+    /// Defines a map HTTP headers to include in the request
+    headers: StringMap,
+
+    /// The HTTP message body to include in the request
+    body: String,
+}
+
+@private
+structure HttpMalformedResponseDefinition {
+
+    /// Defines a map of expected HTTP headers.
+    ///
+    /// Headers that are not listed in this map are ignored.
+    headers: StringMap,
+
+    /// Defines the HTTP response code.
+    @required
+    @range(min: 100, max: 599)
+    code: Integer,
+
+    /// The expected response body.
+    body: HttpMalformedResponseBodyDefinition,
+}
+
+@private
+structure HttpMalformedResponseBodyDefinition {
+    /// The assertion to execute against the response body.
+    @required
+    assertion: HttpMalformedResponseBodyAssertion,
+
+    /// The media type of the response body.
+    ///
+    /// This is used to help test runners to parse and evaluate
+    /// `contents' and `messageRegex` in the assertion
+    @required
+    mediaType: String
+}
+
+@private
+union HttpMalformedResponseBodyAssertion {
+    /// Defines the expected serialized response body, which will be matched
+    /// exactly.
+    contents: String,
+
+    /// A regex to evaluate against the `message` field in the body. For
+    /// responses that may have some variance from platform to platform,
+    /// such as those that include messages from a parser.
+    messageRegex: String
+}
+
+@private
+map HttpMalformedRequestTestParametersDefinition {
+    key: String,
+    value: StringList
+}

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-malformed-request-features.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-malformed-request-features.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#SayHello: This shape applies a trait that is unstable: smithy.test#httpMalformedRequestTests | UnstableTrait

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-malformed-request-features.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-malformed-request-features.smithy
@@ -1,0 +1,113 @@
+namespace smithy.example
+
+use smithy.test#httpMalformedRequestTests
+
+@trait
+@protocolDefinition
+structure testProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpMalformedRequestTests([
+    {
+        id: "bodyRegex",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "Hi",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "baz"},
+            body: {
+                assertion: {
+                    messageRegex: "Invalid JSON: .*"
+                },
+                mediaType: "application/json"
+            }
+        },
+        tags: ["foo", "bar"]
+    },
+    {
+        id: "body",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "Hi",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "baz"},
+            body: {
+                assertion: {
+                    contents: """
+                    {
+                        "message" : "Invalid JSON"
+                    }"""
+                },
+                mediaType: "application/json"
+            }
+        },
+        tags: ["foo", "bar"]
+    },
+    {
+        id: "noResponseBodyAssertion",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "Hi",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "baz"}
+        },
+        tags: ["foo", "bar"]
+    },
+    {
+        id: "parameterized",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "$foo:L",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "$bar:L"}
+        },
+        tags: ["foo", "bar"],
+        testParameters: {
+            "foo" : ["a", "b", "c"],
+            "bar" : ["d", "e", "f"]
+        }
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    @httpPayload
+    body: String,
+
+    @httpHeader("X-OmitMe")
+    header: String,
+}

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.errors
@@ -1,0 +1,2 @@
+[WARNING] smithy.example#SayHello: This shape applies a trait that is unstable: smithy.test#httpMalformedRequestTests | UnstableTrait
+[ERROR] smithy.example#SayHello: Each list associated to a key in `testParameters` must be of the same length. | HttpMalformedRequestTests

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.smithy
@@ -1,0 +1,50 @@
+namespace smithy.example
+
+use smithy.test#httpMalformedRequestTests
+
+@trait
+@protocolDefinition
+structure testProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpMalformedRequestTests([
+    {
+        id: "definesMismatchedTestParameters",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "$foo:L",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "baz"},
+            body: {
+                assertion: {
+                    messageRegex: "Invalid JSON: $bar:L"
+                },
+                mediaType: "application/json"
+            }
+        },
+        tags: ["foo", "bar"],
+        testParameters: {
+            foo: ["a", "b", "c"],
+            bar: ["d", "e"]
+        }
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    @httpPayload
+    body: String,
+
+    @httpHeader("X-OmitMe")
+    header: String,
+}

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-response.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-response.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#SayHello: Error creating trait `smithy.test#httpMalformedRequestTests`: Missing expected member `mediaType`. | Model

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-response.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-response.smithy
@@ -1,0 +1,45 @@
+namespace smithy.example
+
+use smithy.test#httpMalformedRequestTests
+
+@trait
+@protocolDefinition
+structure testProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpMalformedRequestTests([
+    {
+        id: "definesRegexButNotMediaType",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "Hi",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "baz"},
+            body: {
+                assertion: {
+                    messageRegex: "Invalid JSON: .*"
+                }
+            }
+        },
+        tags: ["foo", "bar"]
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    @httpPayload
+    body: String,
+
+    @httpHeader("X-OmitMe")
+    header: String,
+}


### PR DESCRIPTION
*Description of changes:*
Sets up the trait and serialization/deserialization of all of its members. This
trait allows server implementations to generate tests that reject invalid
requests before those requests are bound to a Smithy-generated implementation
class, or before the deserialized request is handed off to application code.

I'm going to keep this in draft mode for feedback while I work on generating tests from it to make sure this is actually useful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
