### PR TITLE
Add index of all traits

### DIFF
--- a/docs/smithy/__init__.py
+++ b/docs/smithy/__init__.py
@@ -8,10 +8,13 @@ from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
 from docutils.writers.html4css1 import HTMLTranslator as BaseTranslator
 
+from .traitindex import setup_smithy_trait_index
+
 
 def setup(app):
     app.set_translator('html', HTMLTranslator)
     app.add_directive("text-figure", TextFigure)
+    setup_smithy_trait_index(app)
 
 # Finds the href part of a header.
 HREF = re.compile('href="([^"]+)"')

--- a/docs/smithy/traitindex.py
+++ b/docs/smithy/traitindex.py
@@ -1,0 +1,116 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+from sphinx.locale import _
+
+SMITHY_TRAITS_ATTR = "smithy_traits"
+
+
+# Placeholder node that will be replaced with the trait index.
+class SmithyTraitIndexNode(nodes.General, nodes.Element):
+    pass
+
+
+# Directive that places a SmithyTraitIndexNode in the document.
+# Usage: .. smithy-trait-index::
+class SmithyTraitIndexDirective(Directive):
+    def run(self):
+        return [SmithyTraitIndexNode("")]
+
+
+# Directive that marks the location of a smithy trait in the docs.
+# Usage: .. smithy-trait: ns.example#shapeId
+class SmithyTraitDirective(Directive):
+
+    # Makes the shape id argument required
+    required_arguments = 1
+
+    def run(self):
+        env = self.state.document.settings.env
+        shape_id = self.arguments[0]
+
+        # Make the shape id url-friendly
+        stripped_shape_id = shape_id.strip().replace("#", "-").replace(".", "-").lower()
+
+        # Create a new target node that can be referenced
+        target_id = stripped_shape_id + "-trait"
+        target_node = nodes.target("", "", ids=[target_id])
+
+        # Add a list of the smithy trait targets to the envirnonment so that
+        # they can be referenced later when building the trait index.
+        if not hasattr(env, SMITHY_TRAITS_ATTR):
+            env.smithy_traits = []
+
+        env.smithy_traits.append(
+            {
+                "docname": env.docname,
+                "target": target_node,
+                "shape_id": shape_id,
+            }
+        )
+
+        return [target_node]
+
+
+# If the source file changes, remove any cached smithy traits for it. If there
+# are any remaining in the file itself, they'll be re-added in the normal way.
+def purge_smithy_traits(app, env, docname):
+    if not hasattr(env, SMITHY_TRAITS_ATTR):
+        return
+    env.smithy_traits = [t for t in env.smithy_traits if t["docname"] != docname]
+
+
+# In the case of a parallel build, there will be multiple envs. This handles
+# merging all the smithy traits into a single list at the end.
+def merge_smithy_traits(app, env, docnames, other):
+    if not hasattr(env, SMITHY_TRAITS_ATTR):
+        env.smithy_traits = []
+    if hasattr(other, SMITHY_TRAITS_ATTR):
+        env.smithy_traits.extend(other.smithy_traits)
+
+
+# Generates a list of links to known smithy traits, replacing any
+# SmithyTraitIndexNodes
+def process_smithy_nodes(app, doctree, fromdocname):
+    env = app.builder.env
+
+    if not hasattr(env, SMITHY_TRAITS_ATTR):
+        env.smithy_traits = []
+
+    for node in doctree.traverse(SmithyTraitIndexNode):
+        new_index_node = nodes.bullet_list()
+
+        smithy_traits = sorted(env.smithy_traits, key=lambda x: x["shape_id"])
+
+        for smithy_trait_info in smithy_traits:
+            shape_id = smithy_trait_info["shape_id"]
+
+            # Create a reference node, which becomes a link with the text being
+            # the shape id.
+            ref_node = nodes.reference("", "")
+            inner_node = nodes.emphasis(_(shape_id), _(shape_id))
+            ref_node["refdocname"] = smithy_trait_info["docname"]
+            ref_node["refuri"] = app.builder.get_relative_uri(
+                fromdocname, smithy_trait_info["docname"]
+            )
+            ref_node["refuri"] += "#" + smithy_trait_info["target"]["refid"]
+            ref_node.append(inner_node)
+
+            # Wrap the reference in a paragraph and construct a list item from it.
+            para = nodes.paragraph()
+            para += ref_node
+            list_item = nodes.list_item()
+            list_item += para
+
+            new_index_node.append(list_item)
+
+        node.replace_self(new_index_node)
+
+
+def setup_smithy_trait_index(app):
+    app.add_node(SmithyTraitIndexNode)
+    app.add_directive("smithy-trait", SmithyTraitDirective)
+    app.add_directive("smithy-trait-index", SmithyTraitIndexDirective)
+    app.connect("doctree-resolved", process_smithy_nodes)
+    app.connect("env-purge-doc", purge_smithy_traits)
+    app.connect("env-merge-info", merge_smithy_traits)

--- a/docs/source/1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source/1.0/spec/aws/amazon-apigateway.rst
@@ -11,6 +11,7 @@ schemes, and OpenAPI specifications.
     :backlinks: none
 
 
+.. smithy-trait:: aws.apigateway#apiKeySource
 .. _aws.apigateway#apiKeySource-trait:
 
 -------------------------------------
@@ -78,6 +79,7 @@ The following example sets the ``X-API-Key`` header as the API key source.
     customers.
 
 
+.. smithy-trait:: aws.apigateway#authorizers
 .. _aws.apigateway#authorizers-trait:
 
 ------------------------------------
@@ -217,6 +219,7 @@ An *authorizer* definition is a structure that supports the following members:
     customers.
 
 
+.. smithy-trait:: aws.apigateway#authorizer
 .. _aws.apigateway#authorizer-trait:
 
 -----------------------------------
@@ -242,6 +245,7 @@ Value type
     customers.
 
 
+.. smithy-trait:: aws.apigateway#requestValidator
 .. _aws.apigateway#requestValidator-trait:
 
 -----------------------------------------
@@ -313,6 +317,7 @@ Then following example enables request validation on a service:
     customers.
 
 
+.. smithy-trait:: aws.apigateway#integration
 .. _aws.apigateway#integration-trait:
 
 ------------------------------------
@@ -489,6 +494,7 @@ operation within the service.
     customers.
 
 
+.. smithy-trait:: aws.apigateway#mockIntegration
 .. _aws.apigateway#mockIntegration-trait:
 
 ----------------------------------------

--- a/docs/source/1.0/spec/aws/aws-auth.rst
+++ b/docs/source/1.0/spec/aws/aws-auth.rst
@@ -12,6 +12,7 @@ This document defines AWS authentication schemes.
     :backlinks: none
 
 
+.. smithy-trait:: aws.auth#sigv4
 .. _aws.auth#sigv4-trait:
 
 ------------------------
@@ -79,6 +80,7 @@ Trait value
         }
 
 
+.. smithy-trait:: aws.auth#unsignedPayload
 .. _aws.auth#unsignedPayload-trait:
 
 ----------------------------------
@@ -143,6 +145,7 @@ literal string ``UNSIGNED-PAYLOAD`` is used when constructing a
 `x-amz-content-sha256`_ header when sending an HTTP request.
 
 
+.. smithy-trait:: aws.auth#cognitoUserPools
 .. _aws.auth#cognitoUserPools-trait:
 
 -----------------------------------

--- a/docs/source/1.0/spec/aws/aws-cloudformation.rst
+++ b/docs/source/1.0/spec/aws/aws-cloudformation.rst
@@ -24,6 +24,7 @@ Interface`_ to build, register, and deploy `resource providers`_.
     :backlinks: none
 
 
+.. smithy-trait:: aws.cloudformation#cfnResource
 .. _aws.cloudformation#cfnResource-trait:
 
 ----------------------------------------
@@ -139,6 +140,7 @@ of these structures can be excluded by applying the :ref:`aws.cloudformation#cfn
     derived.
 
 
+.. smithy-trait:: aws.cloudformation#cfnExcludeProperty
 .. _aws.cloudformation#cfnExcludeProperty-trait:
 
 -----------------------------------------------
@@ -330,6 +332,7 @@ The computed resource property mutabilities are:
       - + Specified in the ``create`` lifecycle via ``CreateFooRequest``.
 
 
+.. smithy-trait:: aws.cloudformation#cfnMutability
 .. _aws.cloudformation#cfnMutability-trait:
 
 ------------------------------------------
@@ -531,6 +534,7 @@ derivable ``secret`` and ``password`` properties as write only:
         }
 
 
+.. smithy-trait:: aws.cloudformation#cfnName
 .. _aws.cloudformation#cfnName-trait:
 
 ------------------------------------
@@ -573,6 +577,8 @@ the following property names are derived from it:
     "bar"
     "Tags"
 
+
+.. smithy-trait:: aws.cloudformation#cfnAdditionalIdentifier
 .. _aws.cloudformation#cfnAdditionalIdentifier-trait:
 
 ----------------------------------------------------

--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -11,6 +11,7 @@ AWS products like AWS CloudFormation and tools like the AWS SDKs.
     :backlinks: none
 
 
+.. smithy-trait:: aws.api#service
 .. _aws.api#service-trait:
 
 -------------------------
@@ -256,6 +257,7 @@ a static, unique identifier. :ref:`service-sdk-id` should be used for those
 purposes. Additionally, this value can be used to attempt to resolve endpoints.
 
 
+.. smithy-trait:: aws.api#arn
 .. _aws.api#arn-trait:
 
 ---------------------
@@ -492,6 +494,8 @@ resource.
             }
         }
 
+
+.. smithy-trait:: aws.api#arnReference
 .. _aws.api#arnReference-trait:
 
 ------------------------------
@@ -607,6 +611,8 @@ previous example:
             }
         }
 
+
+.. smithy-trait:: aws.api#data
 .. _aws.api#data-trait:
 
 ----------------------
@@ -739,6 +745,7 @@ applied through the ``aws.api#data`` trait.
         :ref:`sensitive-trait`.
 
 
+.. smithy-trait:: aws.api#controlPlane
 .. _aws.api#controlPlane-trait:
 
 ------------------------------
@@ -793,6 +800,8 @@ plane unless an operation or resource is marked with the
             }
         }
 
+
+.. smithy-trait:: aws.api#dataPlane
 .. _aws.api#dataPlane-trait:
 
 ---------------------------
@@ -860,6 +869,7 @@ automatically discover, cache, and connect to service endpoints. The
 following traits provide the information needed to perform this.
 
 
+.. smithy-trait:: aws.api#clientEndpointDiscovery
 .. _client-endpoint-discovery-trait:
 
 ``aws.api#clientEndpointDiscovery`` trait
@@ -908,6 +918,7 @@ The operation output MUST contain a member ``Endpoints`` that is a list of
 - a ``long`` member named ``CachePeriodInMinutes``
 
 
+.. smithy-trait:: aws.api#clientDiscoveredEndpoint
 .. _client-discovered-endpoint-trait:
 
 ``aws.api#clientDiscoveredEndpoint`` trait
@@ -940,6 +951,7 @@ following members:
         discover a more specific endpoint.
 
 
+.. smithy-trait:: aws.api#clientEndpointDiscoveryId
 .. _client-endpoint-discovery-id-trait:
 
 ``aws.api#clientEndpointDiscoveryId`` trait

--- a/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -12,6 +12,7 @@ This specification defines the ``aws.protocols#ec2`` protocol.
     :backlinks: none
 
 
+.. smithy-trait:: aws.protocols#ec2Query
 .. _aws.protocols#ec2Query-trait:
 
 --------------------------------
@@ -68,6 +69,7 @@ Value type
         }
 
 
+.. smithy-trait:: aws.protocols#ec2QueryName
 .. _aws.protocols#ec2QueryName-trait:
 
 ------------------------------------

--- a/docs/source/1.0/spec/aws/aws-iam.rst
+++ b/docs/source/1.0/spec/aws/aws-iam.rst
@@ -23,6 +23,7 @@ more information, see :ref:`deriving-condition-keys`.
     :backlinks: none
 
 
+.. smithy-trait:: aws.iam#actionPermissionDescription
 .. _aws.iam#actionPermissionDescription-trait:
 
 ---------------------------------------------
@@ -62,6 +63,8 @@ Value type
             }
         }
 
+
+.. smithy-trait:: aws.iam#conditionKeys
 .. _aws.iam#conditionKeys-trait:
 
 -------------------------------
@@ -169,6 +172,7 @@ The following example's ``MyResource`` resource has the
     without being defined on the service.
 
 
+.. smithy-trait:: aws.iam#defineConditionKeys
 .. _aws.iam#defineConditionKeys-trait:
 
 -------------------------------------
@@ -312,6 +316,7 @@ Condition keys in IAM policies can be evaluated with `condition operators`_.
       - An unordered list of String types.
 
 
+.. smithy-trait:: aws.iam#disableConditionKeyInference
 .. _aws.iam#disableConditionKeyInference-trait:
 
 ----------------------------------------------
@@ -392,6 +397,8 @@ condition key inference disabled.
             }
         }
 
+
+.. smithy-trait:: aws.iam#requiredActions
 .. _aws.iam#requiredActions-trait:
 
 ---------------------------------

--- a/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_0-protocol.rst
@@ -12,6 +12,7 @@ This specification defines the ``aws.protocols#awsJson1_0`` protocol.
     :backlinks: none
 
 
+.. smithy-trait:: aws.protocols#awsJson1_0
 .. _aws.protocols#awsJson1_0-trait:
 
 ----------------------------------

--- a/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-json-1_1-protocol.rst
@@ -12,6 +12,7 @@ This specification defines the ``aws.protocols#awsJson1_1`` protocol.
     :backlinks: none
 
 
+.. smithy-trait:: aws.protocols#awsJson1_1
 .. _aws.protocols#awsJson1_1-trait:
 
 ----------------------------------

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -441,6 +441,7 @@ following process:
 2. The :token:`shape name <identifier>` of the error's :ref:`shape-id`.
 
 
+.. smithy-trait:: aws.protocols#awsQuery
 .. _aws.protocols#awsQuery-trait:
 
 --------------------------------
@@ -491,6 +492,8 @@ See
             }
         }
 
+
+.. smithy-trait:: aws.protocols#awsQueryError
 .. _aws.protocols#awsQueryError-trait:
 
 -------------------------------------

--- a/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
@@ -15,6 +15,7 @@ status codes.
     :backlinks: none
 
 
+.. smithy-trait:: aws.protocols#restJson1
 .. _aws.protocols#restJson1-trait:
 
 ---------------------------------

--- a/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restxml-protocol.rst
@@ -12,6 +12,7 @@ This specification defines the ``aws.protocols#restXml`` protocol.
     :backlinks: none
 
 
+.. smithy-trait:: aws.protocols#restXml
 .. _aws.protocols#restXml-trait:
 
 -------------------------------

--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -12,6 +12,7 @@ Authentication traits define how a client authenticates with a service.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#authDefinition
 .. _authDefinition-trait:
 
 ------------------------
@@ -113,6 +114,7 @@ can also support configuration settings.
     }
 
 
+.. smithy-trait:: smithy.api#httpBasicAuth
 .. _httpBasicAuth-trait:
 
 -----------------------
@@ -135,6 +137,7 @@ Value type
     }
 
 
+.. smithy-trait:: smithy.api#httpDigestAuth
 .. _httpDigestAuth-trait:
 
 ------------------------
@@ -157,6 +160,7 @@ Value type
     }
 
 
+.. smithy-trait:: smithy.api#httpBearerAuth
 .. _httpBearerAuth-trait:
 
 ------------------------
@@ -179,6 +183,7 @@ Value type
     }
 
 
+.. smithy-trait:: smithy.api#httpApiKeyAuth
 .. _httpApiKeyAuth-trait:
 
 ------------------------
@@ -223,6 +228,7 @@ HTTP header:
     }
 
 
+.. smithy-trait:: smithy.api#optionalAuth
 .. _optionalAuth-trait:
 
 ----------------------
@@ -261,6 +267,7 @@ The following example defines an operation that does not support
     operation SomeUnauthenticatedOperation {}
 
 
+.. smithy-trait:: smithy.api#auth
 .. _auth-trait:
 
 --------------

--- a/docs/source/1.0/spec/core/behavior-traits.rst
+++ b/docs/source/1.0/spec/core/behavior-traits.rst
@@ -10,6 +10,7 @@ Behavior traits are used to alter the behavior of operations.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#idempotencyToken
 .. _idempotencyToken-trait:
 
 --------------------------
@@ -55,6 +56,7 @@ member if and only if the member is not explicitly provided.
         }
 
 
+.. smithy-trait:: smithy.api#idempotent
 .. _idempotent-trait:
 
 --------------------
@@ -88,6 +90,7 @@ Conflicts with
     idempotent.
 
 
+.. smithy-trait:: smithy.api#readonly
 .. _readonly-trait:
 
 ------------------
@@ -114,6 +117,7 @@ Conflicts with
         }
 
 
+.. smithy-trait:: smithy.api#retryable
 .. _retryable-trait:
 
 -------------------
@@ -159,6 +163,7 @@ The retryable trait is a structure that contains the following members:
 
 .. _pagination:
 
+.. smithy-trait:: smithy.api#paginated
 .. _paginated-trait:
 
 -------------------
@@ -629,6 +634,7 @@ The following changes are considered backward compatible:
 .. _UUID: https://tools.ietf.org/html/rfc4122
 
 
+.. smithy-trait:: smithy.api#httpChecksumRequired
 .. _httpChecksumRequired-trait:
 
 ------------------------------
@@ -657,6 +663,7 @@ See
         }
 
 
+.. smithy-trait:: smithy.api#httpChecksum
 .. _httpChecksum-trait:
 
 ----------------------

--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -11,6 +11,7 @@ for a shape.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#enum
 .. _enum-trait:
 
 --------------
@@ -157,6 +158,7 @@ The following example defines an enum of valid string values for ``MyString``.
         }
 
 
+.. smithy-trait:: smithy.api#idRef
 .. _idref-trait:
 
 ---------------
@@ -385,6 +387,8 @@ blob         The size of the blob in bytes
             }
         }
 
+
+.. smithy-trait:: smithy.api#pattern
 .. _pattern-trait:
 
 -----------------
@@ -444,6 +448,7 @@ languages.
         }
 
 
+.. smithy-trait:: smithy.api#private
 .. _private-trait:
 
 -----------------
@@ -464,6 +469,7 @@ access from within the model itself and SHOULD NOT influence code-generation
 of the targeted shape.
 
 
+.. smithy-trait:: smithy.api#range
 .. _range-trait:
 
 ---------------
@@ -527,6 +533,7 @@ of the targeted numeric shape to which it is applied.
         }
 
 
+.. smithy-trait:: smithy.api#required
 .. _required-trait:
 
 ------------------
@@ -583,6 +590,7 @@ in a response.
    :ref:`recommended-trait`
 
 
+.. smithy-trait:: smithy.api#uniqueItems
 .. _uniqueItems:
 
 ---------------------

--- a/docs/source/1.0/spec/core/documentation-traits.rst
+++ b/docs/source/1.0/spec/core/documentation-traits.rst
@@ -13,6 +13,7 @@ in a way that does not materially affect the semantics of the model.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#deprecated
 .. _deprecated-trait:
 
 --------------------
@@ -77,6 +78,7 @@ The ``deprecated`` trait is a structure that supports the following members:
         }
 
 
+.. smithy-trait:: smithy.api#documentation
 .. _documentation-trait:
 
 -----------------------
@@ -161,6 +163,7 @@ the effective documentation of ``Foo$baz`` resolves to "Member documentation",
 ``Baz`` resolves to "Shape documentation", and ``Foo`` is not documented.
 
 
+.. smithy-trait:: smithy.api#examples
 .. _examples-trait:
 
 ------------------
@@ -237,6 +240,7 @@ These values use the same semantics and format as
         ])
 
 
+.. smithy-trait:: smithy.api#externalDocumentation
 .. _externalDocumentation-trait:
 
 -------------------------------
@@ -264,6 +268,7 @@ Value type
         }
 
 
+.. smithy-trait:: smithy.api#internal
 .. _internal-trait:
 
 ------------------
@@ -296,6 +301,7 @@ filtered version of the model.
         }
 
 
+.. smithy-trait:: smithy.api#recommended
 .. _recommended-trait:
 
 ---------------------
@@ -338,6 +344,7 @@ Conflicts with
         }
 
 
+.. smithy-trait:: smithy.api#sensitive
 .. _sensitive-trait:
 
 -------------------
@@ -366,6 +373,7 @@ output. Application of this trait SHOULD NOT affect wire logging
         string MyString
 
 
+.. smithy-trait:: smithy.api#since
 .. _since-trait:
 
 ---------------
@@ -381,6 +389,7 @@ Value type
     ``string`` representing the date it was added.
 
 
+.. smithy-trait:: smithy.api#tags
 .. _tags-trait:
 
 --------------
@@ -407,6 +416,7 @@ tags trait are arbitrary and up to the model author.
         string SomeStructure {}
 
 
+.. smithy-trait:: smithy.api#title
 .. _title-trait:
 
 ---------------
@@ -436,6 +446,7 @@ Value type
         }
 
 
+.. smithy-trait:: smithy.api#unstable
 .. _unstable-trait:
 
 ------------------

--- a/docs/source/1.0/spec/core/endpoint-traits.rst
+++ b/docs/source/1.0/spec/core/endpoint-traits.rst
@@ -13,6 +13,7 @@ request endpoints.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#endpoint
 .. _endpoint-trait:
 
 ------------------
@@ -389,6 +390,7 @@ the expanded ``hostPrefix`` evaluates to ``abc.data.`` AND the ``X-Foo`` HTTP
 header will contain the value ``abc``.
 
 
+.. smithy-trait:: smithy.api#hostLabel
 .. _hostLabel-trait:
 
 -------------------

--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -18,6 +18,7 @@ and error structures are considered when serializing HTTP messages.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#http
 .. _http-trait:
 
 ``http`` trait
@@ -449,6 +450,7 @@ following rules are in place:
      ``hostPrefix``.
 
 
+.. smithy-trait:: smithy.api#httpError
 .. _httpError-trait:
 
 ``httpError`` trait
@@ -487,6 +489,7 @@ HTTP status code of the :ref:`error-trait`.
 * ``500`` is used for "server" errors
 
 
+.. smithy-trait:: smithy.api#httpHeader
 .. _httpHeader-trait:
 
 ``httpHeader`` trait
@@ -588,6 +591,7 @@ Various HTTP headers are highly discouraged for the ``httpHeader`` and
         need to be modeled.
 
 
+.. smithy-trait:: smithy.api#httpLabel
 .. _httpLabel-trait:
 
 ``httpLabel`` trait
@@ -677,6 +681,7 @@ of an operation, then those members are sent as part of the
 the body of the response.
 
 
+.. smithy-trait:: smithy.api#httpPayload
 .. _httpPayload-trait:
 
 ``httpPayload`` trait
@@ -758,6 +763,7 @@ or :ref:`httpPrefixHeaders-trait`.
    document that is sent as the body of the message.
 
 
+.. smithy-trait:: smithy.api#httpPrefixHeaders
 .. _httpPrefixHeaders-trait:
 
 ``httpPrefixHeaders`` trait
@@ -838,6 +844,7 @@ start with the same prefix provided in ``httpPrefixHeaders`` trait. If
 bound to ``headers``.
 
 
+.. smithy-trait:: smithy.api#httpQuery
 .. _httpQuery-trait:
 
 ``httpQuery`` trait
@@ -934,6 +941,8 @@ many HTTP client and server implementations enforce limits in practice.
 Carefully consider the maximum allowed length of each member that is bound to
 an HTTP query string or path.
 
+
+.. smithy-trait:: smithy.api#httpQueryParams
 .. _httpQueryParams-trait:
 
 ``httpQueryParams`` trait
@@ -1044,6 +1053,8 @@ An example HTTP request would be serialized as:
     POST /things?thingId=realId&otherTag=value
     Host: <server>
 
+
+.. smithy-trait:: smithy.api#httpResponseCode
 .. _httpResponseCode-trait:
 
 ``httpResponseCode`` trait
@@ -1082,6 +1093,8 @@ input structure of an operation, then those members are sent as part of the
 :ref:`protocol-specific document <http-protocol-document-payloads>` sent in
 the body of the request.
 
+
+.. smithy-trait:: smithy.api#cors
 .. _cors-trait:
 
 ``cors`` trait

--- a/docs/source/1.0/spec/core/protocol-traits.rst
+++ b/docs/source/1.0/spec/core/protocol-traits.rst
@@ -11,6 +11,7 @@ the wire.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#protocolDefinition
 .. _protocolDefinition-trait:
 
 ----------------------------
@@ -133,6 +134,7 @@ support configuration settings.
     }
 
 
+.. smithy-trait:: smithy.api#jsonName
 .. _jsonName-trait:
 
 ------------------
@@ -202,6 +204,7 @@ following document:
     }
 
 
+.. smithy-trait:: smithy.api#mediaType
 .. _mediaType-trait:
 
 -------------------
@@ -267,6 +270,7 @@ document types when the exact bytes of a value are required for an
 application to function.
 
 
+.. smithy-trait:: smithy.api#timestampFormat
 .. _timestampFormat-trait:
 
 -------------------------

--- a/docs/source/1.0/spec/core/resource-traits.rst
+++ b/docs/source/1.0/spec/core/resource-traits.rst
@@ -10,6 +10,7 @@ Resource traits augment resources and resource operation semantics.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#noReplace
 .. _noReplace-trait:
 
 -------------------
@@ -76,6 +77,7 @@ to call ``CreateTable`` on a table that already exists will return an error.
         }
 
 
+.. smithy-trait:: smithy.api#references
 .. _references-trait:
 
 --------------------
@@ -264,6 +266,7 @@ conditions:
    names that target string shapes.
 
 
+.. smithy-trait:: smithy.api#resourceIdentifier
 .. _resourceIdentifier-trait:
 
 ----------------------------

--- a/docs/source/1.0/spec/core/stream-traits.rst
+++ b/docs/source/1.0/spec/core/stream-traits.rst
@@ -13,6 +13,7 @@ once. This includes both streaming binary data and event streams.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#streaming
 .. _streaming-trait:
 
 -------------------
@@ -59,6 +60,7 @@ Validation
         blob StreamingBlob
 
 
+.. smithy-trait:: smithy.api#requiresLength
 .. _requiresLength-trait:
 
 ------------------------
@@ -643,6 +645,7 @@ based protocol, the event payload is serialized as a JSON object:
 Event stream traits
 ===================
 
+.. smithy-trait:: smithy.api#eventHeader
 .. _eventheader-trait:
 
 ``eventHeader`` trait
@@ -708,6 +711,8 @@ The following example defines multiple event headers:
             }
         }
 
+
+.. smithy-trait:: smithy.api#eventPayload
 .. _eventpayload-trait:
 
 ``eventPayload`` trait

--- a/docs/source/1.0/spec/core/type-refinement-traits.rst
+++ b/docs/source/1.0/spec/core/type-refinement-traits.rst
@@ -11,6 +11,7 @@ the type of a shape.
     :backlinks: none
 
 
+.. smithy-trait:: smithy.api#box
 .. _box-trait:
 
 -------------
@@ -66,6 +67,7 @@ The :ref:`prelude <prelude>` contains predefined simple shapes that can be
 used in all Smithy models, including boxed and unboxed shapes.
 
 
+.. smithy-trait:: smithy.api#error
 .. _error-trait:
 
 ---------------
@@ -136,6 +138,7 @@ in Java).
         }
 
 
+.. smithy-trait:: smithy.api#sparse
 .. _sparse-trait:
 
 ----------------

--- a/docs/source/1.0/spec/core/xml-traits.rst
+++ b/docs/source/1.0/spec/core/xml-traits.rst
@@ -594,6 +594,7 @@ The XML serialization of ``Choice`` is:
     </Choice>
 
 
+.. smithy-trait:: smithy.api#xmlAttribute
 .. _xmlAttribute-trait:
 
 ----------------------
@@ -698,6 +699,7 @@ The XML serialization is:
     <MyStructure NotFoo="example"/>
 
 
+.. smithy-trait:: smithy.api#xmlFlattened
 .. _xmlFlattened-trait:
 
 ----------------------
@@ -850,6 +852,7 @@ The XML serialization is:
     </Foo>
 
 
+.. smithy-trait:: smithy.api#xmlName
 .. _xmlName-trait:
 
 -----------------
@@ -934,6 +937,7 @@ The XML serialization is:
     </AnotherStructure>
 
 
+.. smithy-trait:: smithy.api#xmlNamespace
 .. _xmlNamespace-trait:
 
 ----------------------

--- a/docs/source/1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/1.0/spec/http-protocol-compliance-tests.rst
@@ -56,6 +56,7 @@ constraints:
   ``00000000-0000-4000-8000-000000000000``.
 
 
+.. smithy-trait:: smithy.test#httpRequestTests
 .. _httpRequestTests-trait:
 
 ----------------
@@ -350,6 +351,7 @@ that uses :ref:`HTTP binding traits <http-traits>`.
         }
 
 
+.. smithy-trait:: smithy.test#httpResponseTests
 .. _httpResponseTests-trait:
 
 -----------------

--- a/docs/source/1.0/spec/index.rst
+++ b/docs/source/1.0/spec/index.rst
@@ -43,3 +43,12 @@ AWS specifications
     :maxdepth: 2
 
     aws/index
+
+
+-----------
+Trait Index
+-----------
+
+The following is a list of all traits across all of the above specifications.
+
+.. smithy-trait-index::

--- a/docs/source/1.0/spec/mqtt.rst
+++ b/docs/source/1.0/spec/mqtt.rst
@@ -169,6 +169,7 @@ MQTT topic templates MUST adhere to the following constraints:
   in the topic template.
 
 
+.. smithy-trait:: smithy.mqtt#publish
 .. _smithy.mqtt#publish-trait:
 
 -----------------------------
@@ -274,6 +275,7 @@ Publish validation
   the resolved MQTT topics of subscribe operations.
 
 
+.. smithy-trait:: smithy.mqtt#subscribe
 .. _smithy.mqtt#subscribe-trait:
 
 -------------------------------
@@ -421,6 +423,7 @@ Subscribe validation
   custom headers to messages.
 
 
+.. smithy-trait:: smithy.mqtt#topicLabel
 .. _smithy.mqtt#topicLabel-trait:
 
 --------------------------------

--- a/docs/source/1.0/spec/waiters.rst
+++ b/docs/source/1.0/spec/waiters.rst
@@ -26,6 +26,7 @@ following client pseudocode:
             .wait();
 
 
+.. smithy-trait:: smithy.waiters#waitable
 .. _smithy.waiters#waitable-trait:
 
 ``smithy.waiters#waitable`` trait


### PR DESCRIPTION
This adds an index of all existing traits to the specifications page. This makes it way easier to find the docs for a trait you know about without having to figure out what class of trait it is, or whether it lives in aws or somewhere else.

If you wanna see what it looks like, reminder that the doc build ci thing uploads the docs it built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
