### PR TITLE
fix(docs): httpChecksum.response should be a list

### DIFF
--- a/docs/source/1.0/spec/core/behavior-traits.rst
+++ b/docs/source/1.0/spec/core/behavior-traits.rst
@@ -701,10 +701,10 @@ The ``httpChecksum`` trait is a structure that contains the following members:
                 { algorithm: "sha256", in: "header", name: "x-checksum-sha256"},
                 { algorithm: "crc32", in: "header", name: "x-checksum-crc32"}
             ],
-            response: {
+            response: [
                 { algorithm: "sha256", in: "header", name: "x-checksum-sha256"},
                 { algorithm: "crc32", in: "header", name: "x-checksum-crc32"}
-            }
+            ]
         )
         operation PutSomething {
             input: PutSomethingInput,


### PR DESCRIPTION
*Issue #, if available:*
Missed in https://github.com/awslabs/smithy/pull/843

*Description of changes:*
httpChecksum.response should be a list

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
