### PR TITLE
Some initial malformed request tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -92,5 +92,20 @@ service RestJson {
 
         // checksum(s)
         HttpChecksumRequired,
+
+        // malformed request tests
+        MalformedRequestBody,
+        MalformedInteger,
+        MalformedUnion,
+        MalformedBoolean,
+        MalformedSet,
+        MalformedList,
+        MalformedMap,
+        MalformedBlob,
+        MalformedByte,
+        MalformedShort,
+        MalformedLong,
+        MalformedFloat,
+        MalformedDouble
     ]
 }

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
@@ -1,0 +1,46 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedBlob", method: "POST")
+operation MalformedBlob {
+    input: MalformedBlobInput
+}
+
+apply MalformedBlob @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyMalformedBlobInvalidBase64",
+        documentation: """
+        When a blob member is not properly base64 encoded, or not encoded at
+        all, the response should be a 400 SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedBlob",
+            body: """
+            { "blob" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            value: ["blob", "\"xyz\"", "\"YmxvYg=\"", "[98, 108, 11, 98]",
+                    "[\"b\", \"l\",\"o\",\"b\"]", "981081198", "true"]
+        }
+    },
+])
+
+structure MalformedBlobInput {
+    blob: Blob,
+}
+
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-boolean.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-boolean.smithy
@@ -1,0 +1,145 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedBoolean/{booleanInPath}", method: "POST")
+operation MalformedBoolean {
+    input: MalformedBooleanInput
+}
+
+apply MalformedBoolean @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyBooleanStringCoercion",
+        documentation: """
+        Attempted string coercion should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedBoolean/true",
+            body: """
+            { "booleanInBody" : $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["true", "True", "TRUE", "y", "Y", "yes", "Yes", "YES", "1", "on", "On", "ON",
+                       "false", "False", "FALSE", "n", "N", "no", "No", "NO", "0", "off", "Off", "OFF"]
+        }
+    },
+    {
+        id: "RestJsonBodyBooleanBadLiteral",
+        documentation: """
+        YAML-style alternate boolean literals should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedBoolean/true",
+            body: """
+            { "booleanInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["True", "TRUE", "y", "Y", "yes", "Yes", "YES", "1", "on", "On", "ON",
+                       "False", "FALSE", "n", "N", "no", "No", "NO", "0", "off", "Off", "OFF"]
+        }
+    },
+    {
+        id: "RestJsonPathBooleanStringCoercion",
+        documentation: """
+        Attempted string coercion should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedBoolean/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["True", "TRUE", "y", "Y", "yes", "Yes", "YES", "1", "on", "On", "ON",
+                       "False", "FALSE", "n", "N", "no", "No", "NO", "0", "off", "Off", "OFF"]
+        }
+    },
+    {
+        id: "RestJsonQueryBooleanStringCoercion",
+        documentation: """
+        Attempted string coercion should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedBoolean/true",
+            queryParams: [
+                "booleanInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["True", "TRUE", "y", "Y", "yes", "Yes", "YES", "1", "on", "On", "ON",
+                       "False", "FALSE", "n", "N", "no", "No", "NO", "0", "off", "Off", "OFF"]
+        }
+    },
+    {
+        id: "RestJsonHeaderBooleanStringCoercion",
+        documentation: """
+        Attempted string coercion should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedBoolean/true",
+            headers: {
+                "booleanInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["True", "TRUE", "y", "Y", "yes", "Yes", "YES", "1", "on", "On", "ON",
+                       "False", "FALSE", "n", "N", "no", "No", "NO", "0", "off", "Off", "OFF"]
+        }
+    }
+])
+
+structure MalformedBooleanInput {
+    booleanInBody: Boolean,
+
+    @httpLabel
+    @required
+    booleanInPath: Boolean,
+
+    @httpQuery("booleanInQuery")
+    booleanInQuery: Boolean,
+
+    @httpHeader("booleanInHeader")
+    booleanInHeader: Boolean
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-byte.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-byte.smithy
@@ -1,0 +1,217 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedByte/{byteInPath}", method: "POST")
+operation MalformedByte {
+    input: MalformedByteInput
+}
+
+apply MalformedByte @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyByteUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/1",
+            body: """
+            { "byteInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["256", "-256", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonPathByteUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["256", "-256", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonQueryByteUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/1",
+            queryParams: [
+                "byteInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["256", "-256", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonHeaderByteUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/1",
+            headers: {
+               "byteInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["256", "-256", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonBodyByteMalformedValueRejected",
+        documentation: """
+        Malformed values in the body should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/1",
+            body: """
+            { "byteInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["\"123\"", "true", "1.001", "2ABC", "0x42",
+                       "Infinity", "\"Infinity\"", "-Infinity", "\"-Infinity\"", "NaN", "\"NaN\""],
+            "tag" : ["string_coercion", "boolean_coercion", "float_truncation", "trailing_chars", "hex",
+                       "inf", "string_inf", "negative_inf", "string_negative_inf", "nan", "string_nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonPathByteMalformedValueRejected",
+        documentation: """
+        Malformed values in the path should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonQueryByteMalformedValueRejected",
+        documentation: """
+        Malformed values in query parameters should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/1",
+            queryParams: [
+                "byteInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonHeaderByteMalformedValueRejected",
+        documentation: """
+        Malformed values in headers should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedByte/1",
+            headers: {
+               "byteInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+])
+
+structure MalformedByteInput {
+    byteInBody: Byte,
+
+    @httpLabel
+    @required
+    byteInPath: Byte,
+
+    @httpQuery("byteInQuery")
+    byteInQuery: Byte,
+
+    @httpHeader("byteInHeader")
+    byteInHeader: Byte
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-double.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-double.smithy
@@ -1,0 +1,124 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedDouble/{doubleInPath}", method: "POST")
+operation MalformedDouble {
+    input: MalformedDoubleInput
+}
+
+apply MalformedDouble @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyDoubleMalformedValueRejected",
+        documentation: """
+        Malformed values in the body should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedDouble/1",
+            body: """
+            { "doubleInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["\"123\"", "true", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["string_coercion", "boolean_coercion", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonPathDoubleMalformedValueRejected",
+        documentation: """
+        Malformed values in the path should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedDouble/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "2ABC", "0x42"],
+            "tag" : ["boolean_coercion", "trailing_chars", "hex"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonQueryDoubleMalformedValueRejected",
+        documentation: """
+        Malformed values in query parameters should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedDouble/1",
+            queryParams: [
+                "doubleInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "2ABC", "0x42"],
+            "tag" : ["boolean_coercion", "trailing_chars", "hex"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonHeaderDoubleMalformedValueRejected",
+        documentation: """
+        Malformed values in headers should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedDouble/1",
+            headers: {
+               "doubleInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "2ABC", "0x42"],
+            "tag" : ["boolean_coercion", "trailing_chars", "hex"]
+        },
+        tags: [ "$tag:L" ]
+    },
+])
+
+structure MalformedDoubleInput {
+    doubleInBody: Double,
+
+    @httpLabel
+    @required
+    doubleInPath: Double,
+
+    @httpQuery("doubleInQuery")
+    doubleInQuery: Double,
+
+    @httpHeader("doubleInHeader")
+    doubleInHeader: Double
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-float.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-float.smithy
@@ -1,0 +1,124 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedFloat/{floatInPath}", method: "POST")
+operation MalformedFloat {
+    input: MalformedFloatInput
+}
+
+apply MalformedFloat @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyFloatMalformedValueRejected",
+        documentation: """
+        Malformed values in the body should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedFloat/1",
+            body: """
+            { "floatInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["\"123\"", "true", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["string_coercion", "boolean_coercion", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonPathFloatMalformedValueRejected",
+        documentation: """
+        Malformed values in the path should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedFloat/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "2ABC", "0x42"],
+            "tag" : ["boolean_coercion", "trailing_chars", "hex"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonQueryFloatMalformedValueRejected",
+        documentation: """
+        Malformed values in query parameters should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedFloat/1",
+            queryParams: [
+                "floatInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "2ABC", "0x42"],
+            "tag" : ["boolean_coercion", "trailing_chars", "hex"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonHeaderFloatMalformedValueRejected",
+        documentation: """
+        Malformed values in headers should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedFloat/1",
+            headers: {
+               "floatInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "2ABC", "0x42"],
+            "tag" : ["boolean_coercion", "trailing_chars", "hex"]
+        },
+        tags: [ "$tag:L" ]
+    },
+])
+
+structure MalformedFloatInput {
+    floatInBody: Float,
+
+    @httpLabel
+    @required
+    floatInPath: Float,
+
+    @httpQuery("floatInQuery")
+    floatInQuery: Float,
+
+    @httpHeader("floatInHeader")
+    floatInHeader: Float
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-integer.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-integer.smithy
@@ -1,0 +1,217 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedInteger/{integerInPath}", method: "POST")
+operation MalformedInteger {
+    input: MalformedIntegerInput
+}
+
+apply MalformedInteger @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyIntegerUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/1",
+            body: """
+            { "integerInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : [ "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonPathIntegerUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : [ "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonQueryIntegerUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/1",
+            queryParams: [
+                "integerInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : [ "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonHeaderIntegerUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/1",
+            headers: {
+               "integerInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : [ "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonBodyIntegerMalformedValueRejected",
+        documentation: """
+        Malformed values in the body should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/1",
+            body: """
+            { "integerInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["\"123\"", "true", "1.001", "2ABC", "0x42",
+                       "Infinity", "\"Infinity\"", "-Infinity", "\"-Infinity\"", "NaN", "\"NaN\""],
+            "tag" : ["string_coercion", "boolean_coercion", "float_truncation", "trailing_chars", "hex",
+                       "inf", "string_inf", "negative_inf", "string_negative_inf", "nan", "string_nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonPathIntegerMalformedValueRejected",
+        documentation: """
+        Malformed values in the path should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonQueryIntegerMalformedValueRejected",
+        documentation: """
+        Malformed values in query parameters should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/1",
+            queryParams: [
+                "integerInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonHeaderIntegerMalformedValueRejected",
+        documentation: """
+        Malformed values in headers should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedInteger/1",
+            headers: {
+               "integerInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+])
+
+structure MalformedIntegerInput {
+    integerInBody: Integer,
+
+    @httpLabel
+    @required
+    integerInPath: Integer,
+
+    @httpQuery("integerInQuery")
+    integerInQuery: Integer,
+
+    @httpHeader("integerInHeader")
+    integerInHeader: Integer
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-list.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-list.smithy
@@ -1,0 +1,68 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedList", method: "POST")
+operation MalformedList {
+    input: MalformedListInput
+}
+
+apply MalformedList @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyMalformedListNullItem",
+        documentation: """
+        When a dense list contains null, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedList",
+            body: """
+            { "bodyList" : ["a", null, "b", "c"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonBodyMalformedListUnclosed",
+        documentation: """
+        When a list does not have a closing bracket, the response should be
+        a 400 SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedList",
+            body: """
+            { "bodyList" : ["a", "b", "c" }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+])
+
+structure MalformedListInput {
+    bodyList: SimpleList,
+}
+
+
+list SimpleList {
+    member: String
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-long.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-long.smithy
@@ -1,0 +1,217 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedLong/{longInPath}", method: "POST")
+operation MalformedLong {
+    input: MalformedLongInput
+}
+
+apply MalformedLong @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyLongUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/1",
+            body: """
+            { "longInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["-184467440737095500000", "184467440737095500000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonPathLongUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["-184467440737095500000", "184467440737095500000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonQueryLongUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/1",
+            queryParams: [
+                "longInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["-184467440737095500000", "184467440737095500000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonHeaderLongUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/1",
+            headers: {
+               "longInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["-184467440737095500000", "184467440737095500000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonBodyLongMalformedValueRejected",
+        documentation: """
+        Malformed values in the body should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/1",
+            body: """
+            { "longInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["\"123\"", "true", "1.001", "2ABC", "0x42",
+                       "Infinity", "\"Infinity\"", "-Infinity", "\"-Infinity\"", "NaN", "\"NaN\""],
+            "tag" : ["string_coercion", "boolean_coercion", "float_truncation", "trailing_chars", "hex",
+                       "inf", "string_inf", "negative_inf", "string_negative_inf", "nan", "string_nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonPathLongMalformedValueRejected",
+        documentation: """
+        Malformed values in the path should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonQueryLongMalformedValueRejected",
+        documentation: """
+        Malformed values in query parameters should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/1",
+            queryParams: [
+                "longInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonHeaderLongMalformedValueRejected",
+        documentation: """
+        Malformed values in headers should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedLong/1",
+            headers: {
+               "longInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+])
+
+structure MalformedLongInput {
+    longInBody: Long,
+
+    @httpLabel
+    @required
+    longInPath: Long,
+
+    @httpQuery("longInQuery")
+    longInQuery: Long,
+
+    @httpHeader("longInHeader")
+    longInHeader: Long
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-map.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-map.smithy
@@ -1,0 +1,69 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedMap", method: "POST")
+operation MalformedMap {
+    input: MalformedMapInput
+}
+
+apply MalformedList @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyMalformedMapNullKey",
+        documentation: """
+        When a map contains a null key, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedMap",
+            body: """
+            { "bodyMap" : { null: "abc" }  }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonBodyMalformedMapNullValue",
+        documentation: """
+        When a dense map contains a null value, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedMap",
+            body: """
+            { "bodyMap" : { "abc": null }  }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+])
+
+structure MalformedMapInput {
+    bodyMap: SimpleMap
+}
+
+
+map SimpleMap {
+    key: String,
+    value: String
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-request-body.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-request-body.smithy
@@ -1,0 +1,83 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedRequestBody", method: "POST")
+operation MalformedRequestBody {
+    input: MalformedRequestBodyInput
+}
+
+apply MalformedRequestBody @httpMalformedRequestTests([
+    {
+        id: "RestJsonInvalidJsonBody",
+        documentation: """
+        When the request body is not valid JSON, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedRequestBody",
+            body: "$value:L",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value": ["{[",
+                      "{ \"int\": 10 }abc",
+                      "abc{ \"int\": 10 }",
+                      """
+                      {
+                          "int": 10 // the integer should be 10
+                      }""",
+                      """
+                      {
+                          "int": 10 /* the integer should be 10 */
+                      }""",
+                      "{\"int\" :\u000c10}",
+                      "{'int': 10}",
+                      "{\"int\": 10,}",
+           ]
+        }
+    },
+    {
+        id: "RestJsonTechnicallyValidJsonBody",
+        documentation: """
+        When the request body is technically valid, but cannot map to a Smithy structure,
+        the response should be a 400 SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedRequestBody",
+            body: "$value:L",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            value: ["[{ \"int\": 10}]", "10", "null"]
+        },
+        tags: ["technically_valid_json_body"]
+    },
+])
+
+structure MalformedRequestBodyInput {
+    int: Integer,
+    float: Float
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-set.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-set.smithy
@@ -1,0 +1,68 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedSet", method: "POST")
+operation MalformedSet {
+    input: MalformedSetInput
+}
+
+apply MalformedSet @httpMalformedRequestTests([
+    {
+        id: "RestJsonMalformedSetDuplicateItems",
+        documentation: """
+        When the set has duplicated items, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "set" : ["a", "a", "b", "c"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedSetNullItem",
+        documentation: """
+        When the set contains null, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "set" : ["a", null, "b", "c"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+])
+
+structure MalformedSetInput {
+    set: SimpleSet
+}
+
+
+set SimpleSet {
+    member: String
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-short.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-short.smithy
@@ -1,0 +1,217 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedShort/{shortInPath}", method: "POST")
+operation MalformedShort {
+    input: MalformedShortInput
+}
+
+apply MalformedShort @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyShortUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/1",
+            body: """
+            { "shortInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["40000", "-40000", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonPathShortUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["40000", "-40000", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonQueryShortUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/1",
+            queryParams: [
+                "shortInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["40000", "-40000", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonHeaderShortUnderflowOverflow",
+        documentation: """
+        Underflow or overflow should result in SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/1",
+            headers: {
+               "shortInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["40000", "-40000", "-9223372000000000000", "9223372000000000000", "123000000000000000000000" ]
+        },
+        tags: ["underflow/overflow"]
+    },
+    {
+        id: "RestJsonBodyShortMalformedValueRejected",
+        documentation: """
+        Malformed values in the body should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/1",
+            body: """
+            { "shortInBody" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["\"123\"", "true", "1.001", "2ABC", "0x42",
+                       "Infinity", "\"Infinity\"", "-Infinity", "\"-Infinity\"", "NaN", "\"NaN\""],
+            "tag" : ["string_coercion", "boolean_coercion", "float_truncation", "trailing_chars", "hex",
+                       "inf", "string_inf", "negative_inf", "string_negative_inf", "nan", "string_nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonPathShortMalformedValueRejected",
+        documentation: """
+        Malformed values in the path should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonQueryShortMalformedValueRejected",
+        documentation: """
+        Malformed values in query parameters should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/1",
+            queryParams: [
+                "shortInQuery=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+    {
+        id: "RestJsonHeaderShortMalformedValueRejected",
+        documentation: """
+        Malformed values in headers should be rejected""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedShort/1",
+            headers: {
+               "shortInHeader" : "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters : {
+            "value" : ["true", "1.001", "2ABC", "0x42", "Infinity", "-Infinity", "NaN"],
+            "tag" : ["boolean_coercion", "float_truncation", "trailing_chars", "hex", "inf", "negative_inf", "nan"]
+        },
+        tags: [ "$tag:L" ]
+    },
+])
+
+structure MalformedShortInput {
+    shortInBody: Short,
+
+    @httpLabel
+    @required
+    shortInPath: Short,
+
+    @httpQuery("shortInQuery")
+    shortInQuery: Short,
+
+    @httpHeader("shortInHeader")
+    shortInHeader: Short
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-union.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-union.smithy
@@ -1,0 +1,113 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedUnion", method: "POST")
+operation MalformedUnion {
+    input: MalformedUnionInput
+}
+
+apply MalformedUnion @httpMalformedRequestTests([
+    {
+        id: "RestJsonMalformedUnionMultipleFieldsSet",
+        documentation: """
+        When the union has multiple fields set, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUnion",
+            body: """
+            { "union" : { "int": 2, "string": "three" } }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUnionKnownAndUnknownFieldsSet",
+        documentation: """
+        When the union has multiple fields set, even when only one is modeled,
+        the response should be a 400 SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUnion",
+            body: """
+            { "union" : { "int": 2, "unknownField": "three" } }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUnionNoFieldsSet",
+        documentation: """
+        When the union has no fields set, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUnion",
+            body: """
+            { "union" : { "int": null } }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUnionValueIsArray",
+        documentation: """
+        When the union value is actually an array, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUnion",
+            body: """
+            { "union" : ["int"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+])
+
+structure MalformedUnionInput {
+    union: SimpleUnion
+}
+
+union SimpleUnion {
+    int: Integer,
+
+    string: String
+}
+


### PR DESCRIPTION
*Description of changes:*
Most of the numeric type tests are based on each other; if you've read one integral one and one floating-point one, you've read them all.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
