### PR TITLE
Add malformed content-type / accept tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -28,6 +28,20 @@ apply NoInputAndNoOutput @httpRequestTests([
         method: "POST",
         uri: "/NoInputAndNoOutput",
         body: ""
+    },
+    {
+        id: "RestJsonNoInputAllowsAccept",
+        documentation: """
+                Servers should allow the accept header to be set to the
+                default content-type.""",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/NoInputAndNoOutput",
+        body: "",
+        headers: {
+            "Accept": "application/json"
+        },
+       appliesTo: "server",
     }
 ])
 
@@ -63,7 +77,10 @@ apply NoInputAndOutput @httpRequestTests([
         protocol: restJson1,
         method: "POST",
         uri: "/NoInputAndOutputOutput",
-        body: ""
+        body: "",
+        headers: {
+            "Accept": "application/json"
+        },
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -87,7 +87,45 @@ apply HttpPayloadTraits @httpResponseTests([
         params: {
             foo: "Foo"
         }
-    }
+    },
+    {
+        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllContentTypes",
+        documentation: """
+            Servers must accept any content type for blob inputs
+            without the media type trait.""",
+        protocol: restJson1,
+        code: 200,
+        body: "This is definitely a jpeg",
+        bodyMediaType: "application/octet-stream",
+        headers: {
+            "X-Foo": "Foo",
+            "Content-Type": "image/jpeg"
+        },
+        params: {
+            foo: "Foo",
+            blob: "This is definitely a jpeg"
+        },
+        appliesTo: "server",
+    },
+    {
+        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllAccepts",
+        documentation: """
+            Servers must accept any accept header for blob inputs
+            without the media type trait.""",
+        protocol: restJson1,
+        code: 200,
+        body: "This is definitely a jpeg",
+        bodyMediaType: "application/octet-stream",
+        headers: {
+            "X-Foo": "Foo",
+            "Accept": "image/jpeg"
+        },
+        params: {
+            foo: "Foo",
+            blob: "This is definitely a jpeg"
+        },
+        appliesTo: "server",
+    },
 ])
 
 structure HttpPayloadTraitsInputOutput {

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -123,7 +123,6 @@ service RestJson {
         MalformedContentTypeWithBody,
         MalformedContentTypeWithPayload,
         MalformedContentTypeWithGenericString,
-        MalformedAcceptWithoutBody,
         MalformedAcceptWithBody,
         MalformedAcceptWithPayload,
         MalformedAcceptWithGenericString,

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -118,6 +118,14 @@ service RestJson {
         MalformedTimestampHeaderEpoch,
         MalformedTimestampBodyDefault,
         MalformedTimestampBodyDateTime,
-        MalformedTimestampBodyHttpDate
+        MalformedTimestampBodyHttpDate,
+        MalformedContentTypeWithoutBody,
+        MalformedContentTypeWithBody,
+        MalformedContentTypeWithPayload,
+        MalformedContentTypeWithGenericString,
+        MalformedAcceptWithoutBody,
+        MalformedAcceptWithBody,
+        MalformedAcceptWithPayload,
+        MalformedAcceptWithGenericString,
     ]
 }

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
@@ -1,0 +1,133 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+use aws.protocoltests.shared#GreetingStruct
+use aws.protocoltests.shared#JpegBlob
+
+apply MalformedAcceptWithoutBody @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithoutBodyExpectsEmptyAccept",
+        documentation: """
+        When there is no modeled output, accept must not be set.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedAcceptWithoutBody",
+            headers: {
+                // this should be omitted
+                "accept": "application/json"
+            }
+        },
+        response: {
+            code: 406,
+            headers: {
+                "x-amzn-errortype": "NotAcceptableException"
+            }
+        },
+        tags: [ "accept" ]
+    }
+])
+
+apply MalformedAcceptWithBody @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithBodyExpectsApplicationJsonAccept",
+        documentation: """
+        When there is modeled output, the accept must be application/json""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedAcceptWithBody",
+            headers: {
+                // this should be application/json
+                "accept": "application/hal+json"
+            }
+        },
+        response: {
+            code: 406,
+            headers: {
+                "x-amzn-errortype": "NotAcceptableException"
+            }
+        },
+        tags: [ "accept" ]
+    }
+])
+
+apply MalformedAcceptWithPayload @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithPayloadExpectsModeledAccept",
+        documentation: """
+        When there is a payload with a mediaType trait, the accept must match.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedAcceptWithPayload",
+            headers: {
+                // this should be image/jpeg
+                "accept": "application/json"
+            }
+        },
+        response: {
+            code: 406,
+            headers: {
+                "x-amzn-errortype": "NotAcceptableException"
+            }
+        },
+        tags: [ "accept" ]
+    }
+])
+
+apply MalformedAcceptWithGenericString @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithPayloadExpectsImpliedAccept",
+        documentation: """
+        When there is a payload without a mediaType trait, the accept must match the
+        implied content type of the shape.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedAcceptWithPayload",
+            headers: {
+                // this should be text/plain
+                "accept": "application/json"
+            }
+        },
+        response: {
+            code: 406,
+            headers: {
+                "x-amzn-errortype": "NotAcceptableException"
+            }
+        },
+        tags: [ "accept" ]
+    }
+])
+
+@http(method: "POST", uri: "/MalformedAcceptWithoutBody")
+operation MalformedAcceptWithoutBody {}
+
+@http(method: "POST", uri: "/MalformedAcceptWithBody")
+operation MalformedAcceptWithBody {
+    output: GreetingStruct
+}
+
+@http(method: "POST", uri: "/MalformedAcceptWithPayload")
+operation MalformedAcceptWithPayload {
+    output: MalformedAcceptWithPayloadInput
+}
+
+structure MalformedAcceptWithPayloadInput {
+    @httpPayload
+    payload: JpegBlob
+}
+
+@http(method: "POST", uri: "/MalformedAcceptWithGenericString")
+operation MalformedAcceptWithGenericString {
+    input: MalformedAcceptWithGenericStringInput
+}
+
+structure MalformedAcceptWithGenericStringInput {
+    @httpPayload
+    payload: Blob
+}

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
@@ -7,30 +7,6 @@ use smithy.test#httpMalformedRequestTests
 use aws.protocoltests.shared#GreetingStruct
 use aws.protocoltests.shared#JpegBlob
 
-apply MalformedAcceptWithoutBody @httpMalformedRequestTests([
-    {
-        id: "RestJsonWithoutBodyExpectsEmptyAccept",
-        documentation: """
-        When there is no modeled output, accept must not be set.""",
-        protocol: restJson1,
-        request: {
-            method: "POST",
-            uri: "/MalformedAcceptWithoutBody",
-            headers: {
-                // this should be omitted
-                "accept": "application/json"
-            }
-        },
-        response: {
-            code: 406,
-            headers: {
-                "x-amzn-errortype": "NotAcceptableException"
-            }
-        },
-        tags: [ "accept" ]
-    }
-])
-
 apply MalformedAcceptWithBody @httpMalformedRequestTests([
     {
         id: "RestJsonWithBodyExpectsApplicationJsonAccept",
@@ -103,9 +79,6 @@ apply MalformedAcceptWithGenericString @httpMalformedRequestTests([
         tags: [ "accept" ]
     }
 ])
-
-@http(method: "POST", uri: "/MalformedAcceptWithoutBody")
-operation MalformedAcceptWithoutBody {}
 
 @http(method: "POST", uri: "/MalformedAcceptWithBody")
 operation MalformedAcceptWithBody {

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy
@@ -1,0 +1,137 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+use aws.protocoltests.shared#GreetingStruct
+use aws.protocoltests.shared#JpegBlob
+
+apply MalformedContentTypeWithoutBody @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithoutBodyExpectsEmptyContentType",
+        documentation: """
+        When there is no modeled input, content type must not be set and the body must be empty.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedContentTypeWithoutBody",
+            body: "{}",
+            headers: {
+                // this should be omitted
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    }
+])
+
+apply MalformedContentTypeWithBody @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithBodyExpectsApplicationJsonContentType",
+        documentation: """
+        When there is modeled input, they content type must be application/json""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedContentTypeWithBody",
+            body: "{}",
+            headers: {
+                // this should be application/json
+                "content-type": "application/hal+json"
+            }
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    }
+])
+
+apply MalformedContentTypeWithPayload @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithPayloadExpectsModeledContentType",
+        documentation: """
+        When there is a payload with a mediaType trait, the content type must match.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedContentTypeWithPayload",
+            body: "{}",
+            headers: {
+                // this should be image/jpeg
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    }
+])
+
+apply MalformedContentTypeWithGenericString @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithPayloadExpectsImpliedContentType",
+        documentation: """
+        When there is a payload without a mediaType trait, the content type must match the
+        implied content type of the shape.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedContentTypeWithPayload",
+            body: "{}",
+            headers: {
+                // this should be text/plain
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    }
+])
+
+@http(method: "POST", uri: "/MalformedContentTypeWithoutBody")
+operation MalformedContentTypeWithoutBody {}
+
+@http(method: "POST", uri: "/MalformedContentTypeWithBody")
+operation MalformedContentTypeWithBody {
+    input: GreetingStruct
+}
+
+@http(method: "POST", uri: "/MalformedContentTypeWithPayload")
+operation MalformedContentTypeWithPayload {
+    input: MalformedContentTypeWithPayloadInput
+}
+
+structure MalformedContentTypeWithPayloadInput {
+    @httpPayload
+    payload: JpegBlob
+}
+
+@http(method: "POST", uri: "/MalformedContentTypeWithGenericString")
+operation MalformedContentTypeWithGenericString {
+    input: MalformedContentTypeWithGenericStringInput
+}
+
+structure MalformedContentTypeWithGenericStringInput {
+    @httpPayload
+    payload: String
+}

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -122,6 +122,9 @@ timestamp HttpDate
 @mediaType("text/plain")
 blob TextPlainBlob
 
+@mediaType("image/jpeg")
+blob JpegBlob
+
 structure GreetingStruct {
     hi: String,
 }


### PR DESCRIPTION
This adds malformed request tests for asserting content type and accept header behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
