### PR TITLE
Malformed request tests for timestamps

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -106,6 +106,18 @@ service RestJson {
         MalformedShort,
         MalformedLong,
         MalformedFloat,
-        MalformedDouble
+        MalformedDouble,
+        MalformedTimestampPathDefault,
+        MalformedTimestampPathHttpDate,
+        MalformedTimestampPathEpoch,
+        MalformedTimestampQueryDefault,
+        MalformedTimestampQueryHttpDate,
+        MalformedTimestampQueryEpoch,
+        MalformedTimestampHeaderDefault,
+        MalformedTimestampHeaderDateTime,
+        MalformedTimestampHeaderEpoch,
+        MalformedTimestampBodyDefault,
+        MalformedTimestampBodyDateTime,
+        MalformedTimestampBodyHttpDate
     ]
 }

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-body.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-body.smithy
@@ -1,0 +1,327 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedTimestampBodyDefault", method: "POST")
+operation MalformedTimestampBodyDefault {
+    input: MalformedTimestampBodyDefaultInput
+}
+
+@http(uri: "/MalformedTimestampBodyDateTime", method: "POST")
+operation MalformedTimestampBodyDateTime {
+    input: MalformedTimestampBodyDateTimeInput
+}
+
+@http(uri: "/MalformedTimestampBodyHttpDate", method: "POST")
+operation MalformedTimestampBodyHttpDate {
+    input: MalformedTimestampBodyHttpDateInput
+}
+
+apply MalformedTimestampBodyDefault @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyTimestampDefaultRejectsDateTime",
+        documentation: """
+        By default, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDefault",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23:20:50.52Z",
+                       "1985-04-12T23:20:50Z",
+                       "1996-12-19T16:39:57-08:00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampDefaultRejectsStringifiedEpochSeconds",
+        documentation: """
+        By default, epoch second timestamps as strings are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDefault",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampDefaultRejectsMalformedEpochSeconds",
+        documentation: """
+        Invalid values for epoch seconds are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDefault",
+            body: """
+                  { "timestamp": $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["true", "1515531081ABC", "0x42", "1515531081.123.456",
+                       "Infinity", "\"Infinity\"", "-Infinity", "\"-Infinity\"", "NaN", "\"NaN\""]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampDefaultRejectsHttpDate",
+        documentation: """
+        By default, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDefault",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
+                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampBodyDateTime @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyTimestampDateTimeRejectsHttpDate",
+        documentation: """
+        When the format is date-time, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDateTime",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
+                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampDateTimeRejectsEpochSeconds",
+        documentation: """
+        When the format is date-time, epoch-seconds timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDateTime",
+            body: """
+                  { "timestamp": $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampDateTimeRejectsUTCOffsets",
+        documentation: """
+        When the format is date-time, RFC 3339 timestamps with a UTC offset are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDateTime",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1996-12-19T16:39:57-08:00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampDateTimeRejectsDifferent8601Formats",
+        documentation: """
+        When the format is date-time, maybe-valid ISO-8601 date-times not conforming to RFC 3339
+        are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyDateTime",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1996-12-19T16:39:57+00",
+                       "1996-12-19T16:39:57+00Z",
+                       "1996-12-19T16:39:57",
+                       "1996-12-19T163957",
+                       "19961219T163957Z",
+                       "19961219T163957",
+                       "19961219T16:39:57Z",
+                       "19961219T16:39:57",
+                       "1996-12-19T16:39Z",
+                       "1996-12-19T16:39",
+                       "1996-12-19T1639",
+                       "1996-12-19T16Z",
+                       "1996-12-19T16",
+                       "1996-12-19 16:39:57Z",
+                       "2011-12-03T10:15:30+01:00[Europe/Paris]"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampBodyHttpDate @httpMalformedRequestTests([
+    {
+        id: "RestJsonBodyTimestampHttpDateRejectsDateTime",
+        documentation: """
+        When the format is http-date, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyHttpDate",
+            body: """
+                  { "timestamp": $value:S }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23:20:50.52Z",
+                       "1985-04-12T23:20:50Z",
+                       "1996-12-19T16:39:57-08:00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonBodyTimestampHttpDateRejectsEpoch",
+        documentation: """
+        When the format is http-date, epoch-seconds timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampBodyHttpDate",
+            body: """
+                  { "timestamp": $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+structure MalformedTimestampBodyDefaultInput {
+    @required
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampBodyDateTimeInput {
+    @required
+    @timestampFormat("date-time")
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampBodyHttpDateInput {
+    @required
+    @timestampFormat("http-date")
+    timestamp: Timestamp,
+}

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-header.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-header.smithy
@@ -1,0 +1,262 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedTimestampHeaderDefault", method: "POST")
+operation MalformedTimestampHeaderDefault {
+    input: MalformedTimestampHeaderDefaultInput
+}
+
+@http(uri: "/MalformedTimestampHeaderDateTime", method: "POST")
+operation MalformedTimestampHeaderDateTime {
+    input: MalformedTimestampHeaderDateTimeInput
+}
+
+@http(uri: "/MalformedTimestampHeaderEpoch", method: "POST")
+operation MalformedTimestampHeaderEpoch {
+    input: MalformedTimestampHeaderEpochInput
+}
+
+apply MalformedTimestampHeaderDefault @httpMalformedRequestTests([
+    {
+        id: "RestJsonHeaderTimestampDefaultRejectsDateTime",
+        documentation: """
+        By default, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderDefault",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23:20:50.52Z",
+                       "1985-04-12T23:20:50Z",
+                       "1996-12-19T16:39:57-08:00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonHeaderTimestampDefaultRejectsEpochSeconds",
+        documentation: """
+        By default, epoch second timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderDefault",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampHeaderDateTime @httpMalformedRequestTests([
+    {
+        id: "RestJsonHeaderTimestampDateTimeRejectsHttpDate",
+        documentation: """
+        When the format is date-time, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderDateTime",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
+                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonHeaderTimestampDateTimeRejectsEpochSeconds",
+        documentation: """
+        When the format is date-time, epoch-seconds timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderDateTime",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonHeaderTimestampDateTimeRejectsDifferent8601Formats",
+        documentation: """
+        When the format is date-time, maybe-valid ISO-8601 date-times not conforming to RFC 3339
+        are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderDateTime",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1996-12-19T16:39:57+00",
+                       "1996-12-19T16:39:57+00Z",
+                       "1996-12-19T16:39:57",
+                       "1996-12-19T163957",
+                       "19961219T163957Z",
+                       "19961219T163957",
+                       "19961219T16:39:57Z",
+                       "19961219T16:39:57",
+                       "1996-12-19T16:39Z",
+                       "1996-12-19T16:39",
+                       "1996-12-19T1639",
+                       "1996-12-19T16Z",
+                       "1996-12-19T16",
+                       "1996-12-19 16:39:57Z",
+                       "2011-12-03T10:15:30+01:00[Europe/Paris]"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampHeaderEpoch @httpMalformedRequestTests([
+    {
+        id: "RestJsonHeaderTimestampEpochRejectsDateTime",
+        documentation: """
+        When the format is epoch-seconds, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderEpoch",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23:20:50.52Z",
+                       "1985-04-12T23:20:50Z",
+                       "1996-12-19T16:39:57-08:00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonHeaderTimestampEpochRejectsHttpDate",
+        documentation: """
+        When the format is epoch-seconds, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderEpoch",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
+                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonHeaderTimestampEpochRejectsMalformedValues",
+        documentation: """
+        Invalid values for epoch seconds are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampHeaderEpoch",
+            headers: {
+                "timestamp": "$value:L"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["true", "1515531081ABC", "0x42", "1515531081.123.456",
+                       "Infinity", "-Infinity", "NaN"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+structure MalformedTimestampHeaderDefaultInput {
+    @httpHeader("timestamp")
+    @required
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampHeaderDateTimeInput {
+    @httpHeader("timestamp")
+    @required
+    @timestampFormat("date-time")
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampHeaderEpochInput {
+    @httpHeader("timestamp")
+    @required
+    @timestampFormat("epoch-seconds")
+    timestamp: Timestamp,
+}

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-path.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-path.smithy
@@ -1,0 +1,257 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedTimestampPathDefault/{timestamp}", method: "POST")
+operation MalformedTimestampPathDefault {
+    input: MalformedTimestampPathDefaultInput
+}
+
+@http(uri: "/MalformedTimestampPathHttpDate/{timestamp}", method: "POST")
+operation MalformedTimestampPathHttpDate {
+    input: MalformedTimestampPathHttpDateInput
+}
+
+@http(uri: "/MalformedTimestampPathEpoch/{timestamp}", method: "POST")
+operation MalformedTimestampPathEpoch {
+    input: MalformedTimestampPathEpochInput
+}
+
+apply MalformedTimestampPathDefault @httpMalformedRequestTests([
+    {
+        id: "RestJsonPathTimestampDefaultRejectsHttpDate",
+        documentation: """
+        By default, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathDefault/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue%2C%2029%20Apr%202014%2018%3A30%3A38%20GMT",
+                       "Sun%2C%2002%20Jan%202000%2020%3A34%3A56.000%20GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonPathTimestampDefaultRejectsEpochSeconds",
+        documentation: """
+        By default, epoch second timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathDefault/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonPathTimestampDefaultRejectsUTCOffsets",
+        documentation: """
+        UTC offsets must be rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathDefault/1996-12-19T16%3A39%3A57-08%3A00"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonPathTimestampDefaultRejectsDifferent8601Formats",
+        documentation: """
+        By default, maybe-valid ISO-8601 date-times not conforming to RFC 3339
+        are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathDefault/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1996-12-19T16%3A39%3A57%2B00",
+                       "1996-12-19T16%3A39%3A57%2B00Z",
+                       "1996-12-19T16%3A39%3A57",
+                       "1996-12-19T163957",
+                       "19961219T163957Z",
+                       "19961219T163957",
+                       "19961219T16%3A39%3A57Z",
+                       "19961219T16%3A39%3A57",
+                       "1996-12-19T16%3A39Z",
+                       "1996-12-19T16%3A39",
+                       "1996-12-19T1639",
+                       "1996-12-19T16Z",
+                       "1996-12-19T16",
+                       "1996-12-19 16%3A39%3A57Z",
+                       "2011-12-03T10%3A15%3A30%2B01%3A00%5BEurope/Paris%5D"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampPathHttpDate @httpMalformedRequestTests([
+    {
+        id: "RestJsonPathTimestampHttpDateRejectsDateTime",
+        documentation: """
+        When the format is http-date, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathHttpDate/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23%3A20%3A50.52Z",
+                       "1985-04-12T23%3A20%3A50Z",
+                       "1996-12-19T16%3A39%3A57-08%3A00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonPathTimestampHttpDateRejectsEpochSeconds",
+        documentation: """
+        When the format is http-date,  epoch second timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathHttpDate/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampPathEpoch @httpMalformedRequestTests([
+    {
+        id: "RestJsonPathTimestampEpochRejectsDateTime",
+        documentation: """
+        When the format is epoch-seconds, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathEpoch/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23%3A20%3A50.52Z",
+                       "1985-04-12T23%3A20%3A50Z",
+                       "1996-12-19T16%3A39%3A57-08%3A00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonPathTimestampEpochRejectsHttpDate",
+        documentation: """
+        When the format is epoch-seconds, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathEpoch/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue%2C%2029%20Apr%202014%2018%3A30%3A38%20GMT",
+                       "Sun%2C%2002%20Jan%202000%2020%3A34%3A56.000%20GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonPathTimestampEpochRejectsMalformedValues",
+        documentation: """
+        Invalid values for epoch seconds are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampPathEpoch/$value:L"
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["true", "1515531081ABC", "0x42", "1515531081.123.456",
+                       "Infinity", "-Infinity", "NaN"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+structure MalformedTimestampPathDefaultInput {
+    @httpLabel
+    @required
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampPathHttpDateInput {
+    @httpLabel
+    @required
+    @timestampFormat("http-date")
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampPathEpochInput {
+    @httpLabel
+    @required
+    @timestampFormat("epoch-seconds")
+    timestamp: Timestamp,
+}
+

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-query.smithy
@@ -1,0 +1,284 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedTimestampQueryDefault", method: "POST")
+operation MalformedTimestampQueryDefault {
+    input: MalformedTimestampQueryDefaultInput
+}
+
+@http(uri: "/MalformedTimestampQueryHttpDate", method: "POST")
+operation MalformedTimestampQueryHttpDate {
+    input: MalformedTimestampQueryHttpDateInput
+}
+
+@http(uri: "/MalformedTimestampQueryEpoch", method: "POST")
+operation MalformedTimestampQueryEpoch {
+    input: MalformedTimestampQueryEpochInput
+}
+
+apply MalformedTimestampQueryDefault @httpMalformedRequestTests([
+    {
+        id: "RestJsonQueryTimestampDefaultRejectsHttpDate",
+        documentation: """
+        By default, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryDefault",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue%2C%2029%20Apr%202014%2018%3A30%3A38%20GMT",
+                       "Sun%2C%2002%20Jan%202000%2020%3A34%3A56.000%20GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonQueryTimestampDefaultRejectsEpochSeconds",
+        documentation: """
+        By default, epoch second timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryDefault",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonQueryTimestampDefaultRejectsUTCOffsets",
+        documentation: """
+        UTC offsets must be rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryDefault",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonQueryTimestampDefaultRejectsDifferent8601Formats",
+        documentation: """
+        By default, maybe-valid ISO-8601 date-times not conforming to RFC 3339
+        are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryDefault",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1996-12-19T16:39:57+00",
+                       "1996-12-19T16:39:57+00Z",
+                       "1996-12-19T16:39:57",
+                       "1996-12-19T163957",
+                       "19961219T163957Z",
+                       "19961219T163957",
+                       "19961219T16:39:57Z",
+                       "19961219T16:39:57",
+                       "1996-12-19T16:39Z",
+                       "1996-12-19T16:39",
+                       "1996-12-19T1639",
+                       "1996-12-19T16Z",
+                       "1996-12-19T16",
+                       "1996-12-19 16:39:57Z",
+                       "2011-12-03T10:15:30+01:00[Europe/Paris]"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampQueryHttpDate @httpMalformedRequestTests([
+    {
+        id: "RestJsonQueryTimestampHttpDateRejectsDateTime",
+        documentation: """
+        When the format is http-date, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryHttpDate",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23%3A20%3A50.52Z",
+                       "1985-04-12T23%3A20%3A50Z",
+                       "1996-12-19T16%3A39%3A57-08%3A00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonQueryTimestampHttpDateRejectsEpochSeconds",
+        documentation: """
+        When the format is http-date, epoch second timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryHttpDate",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1515531081.1234", "1515531081"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+apply MalformedTimestampQueryEpoch @httpMalformedRequestTests([
+    {
+        id: "RestJsonQueryTimestampEpochRejectsDateTime",
+        documentation: """
+        When the format is epoch-seconds, RFC3339 timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryEpoch",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["1985-04-12T23%3A20%3A50.52Z",
+                       "1985-04-12T23%3A20%3A50Z",
+                       "1996-12-19T16%3A39%3A57-08%3A00"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonQueryTimestampEpochRejectsHttpDate",
+        documentation: """
+        When the format is epoch-seconds, IMF-fixdate timestamps are rejected with a
+        400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryEpoch",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["Tue%2C%2029%20Apr%202014%2018%3A30%3A38%20GMT",
+                       "Sun%2C%2002%20Jan%202000%2020%3A34%3A56.000%20GMT"]
+        },
+        tags : ["timestamp"]
+    },
+    {
+        id: "RestJsonQueryTimestampEpochRejectsMalformedValues",
+        documentation: """
+        Invalid values for epoch seconds are rejected with a 400 SerializationException""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedTimestampQueryEpoch",
+            queryParams: [
+                "timestamp=$value:L"
+            ]
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            "value" : ["true", "1515531081ABC", "0x42", "1515531081.123.456",
+                       "Infinity", "-Infinity", "NaN"]
+        },
+        tags : ["timestamp"]
+    },
+])
+
+structure MalformedTimestampQueryDefaultInput {
+    @httpQuery("timestamp")
+    @required
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampQueryHttpDateInput {
+    @httpQuery("timestamp")
+    @required
+    @timestampFormat("http-date")
+    timestamp: Timestamp,
+}
+
+structure MalformedTimestampQueryEpochInput {
+    @httpQuery("timestamp")
+    @required
+    @timestampFormat("epoch-seconds")
+    timestamp: Timestamp,
+}
+


### PR DESCRIPTION
*Description of changes:*
This is basically a really verbose matrix test. There are four files: one for body, header, query, and path. Each has three operations: one for whatever the default is for that type of member, and two more for the other two formats that aren't the default. The tests are essentially the same in every location, modulo formatting and where the value is injected. This is probably overkill, but it ensures that we don't have a server implementation where the validation of timestamps varies based on location.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
