### PR TITLE
Add note about structurally exclusive for httpQueryParams

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -957,6 +957,8 @@ Conflicts with
    :ref:`httpLabel-trait`, :ref:`httpHeader-trait`, :ref:`httpQuery-trait`,
    :ref:`httpPrefixHeaders-trait`, :ref:`httpPayload-trait`,
    :ref:`httpResponseCode-trait`
+Structurally exclusive
+    Only a single structure member can be bound to ``httpQueryParams``.
 
 The following example defines an operation that optionally sends the
 target input map as query string parameters in an HTTP request:


### PR DESCRIPTION
Was missing here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
