### PR TITLE
Implement mixins

### DIFF
--- a/designs/mixins.md
+++ b/designs/mixins.md
@@ -114,35 +114,43 @@ structure CityResourceInput {
 }
 ```
 
-The `with` clause of a structure or union statement is used to merge the members
-of one or more mixins into a structure or union. Each shape ID in the `with`
-clause MUST target a shape marked with the `@mixin` trait. Structure shapes can
-only use structure mixins, and union shapes can only use union mixins.
+Adding a mixin to a structure or union shape causes the members and traits of
+a shape to be copied into the shape. Mixins can be added to a shape using
+`with` followed by any number of shape IDs. Each shape ID MUST target a
+shape marked with the `@mixin` trait. Structure shapes can only use structure
+mixins, and union shapes can only use union mixins.
 
 ```
-structure GetCityInput with CityResourceInput {}
+structure GetCityInput with CityResourceInput {
+    foo: String
+}
 ```
 
 Multiple mixins can be applied:
 
 ```
-structure GetCityInput with CityResourceInput, SomeOtherMixin {}
+structure GetAnotherCityInput with
+    CityResourceInput
+    SomeOtherMixin
+{
+    foo: String
+}
 ```
 
 Mixins can be composed of other mixins:
 
 ```
 @mixin
-structure A {
+structure MixinA {
     a: String
 }
 
 @mixin
-structure B with A {
+structure MixinB with MixinA {
     b: String
 }
 
-structure C with B {
+structure C with MixinB {
     c: String
 }
 ```
@@ -261,7 +269,9 @@ structure StructB {}
 /// C
 @threeTrait
 @mixin
-structure StructC with StructA, StructB {}
+structure StructC with
+    StructA
+    StructB {}
 
 /// D
 @fourTrait
@@ -339,14 +349,9 @@ can be referred to outside of `smithy.example`.
 
 The members and traits applied to members of a mixin are copied onto the target
 shape. It is sometimes necessary to provide a more specific trait value for a
-copied member or to add traits only to a specific copy of a member. This can be
-achieved in the following ways:
-
-* In the JSON AST using the `apply` type
-* In the Smithy IDL using `apply` statements
-* In the Smithy IDL by redefining a member and targeting the special
-  `(inherit)` keyword. This is simply syntactic sugar for using `apply`
-  statements.
+copied member or to add traits only to a specific copy of a member. Traits can
+be applied to these members in the JSON AST using the `apply` type and in the
+Smithy IDL using `apply` statements.
 
 > Note: using the `apply` type and `apply` statements on members that are
 copied from mixin members _do not_ merge the applied trait value with the
@@ -425,65 +430,6 @@ apply MyStruct$mixinMember @documentation("Specific docs")
 ```
 
 
-#### Redefining members in the IDL
-
-As part of this proposal, we will add syntactic sugar in the Smithy IDL for
-applying traits to copied mixin members. A mixin member can be redefined in
-the Smithy IDL by targeting a special new structure and union member target
-keyword named `(inherit)` that indicates the member redefines a mixin member
-and inherits its type from a mixin. Redefining a member in this way is simply
-syntactic sugar for using `apply` statements and carries no additional
-semantic meaning.
-
-For example, the previous example can be defined in the Smithy IDL by
-redefining the member instead of using `apply`:
-
-```
-$version: "1.1"
-namespace smithy.example
-
-@mixin
-structure MyMixin {
-    /// Generic docs
-    mixinMember: String
-}
-
-structure MyStruct with MyMixin {
-    /// Specific docs
-    mixinMember: (inherit)
-}
-```
-
-`MyStruct` is equivalent to the following flattened structure:
-
-```smithy
-structure MyStruct {
-    /// Specific docs
-    mixinMember: String
-}
-```
-
-To redefine a mixin member:
-
-1. The redefined member MUST have the exact same name as the mixin member.
-2. The redefined member MUST target a special keyword type named `(inherit)`
-   to indicate the member redefines and inherits its type from a mixin member.
-3. Just like replacing traits on the containing shape, any trait applied
-   to a redefined member completely replaces any resolved traits applied to
-   the mixin member.
-4. Redefining mixin members has no bearing on the ordering of members in
-   structures that use mixins.
-
-**`(inherit)` keyword**
-
-`(inherit)` is a special keyword for union and structure member targets
-available in the Smithy IDL. It can only be used when a structure or union
-member is defined by one of the mixins applied to the shape. It is an error
-to target this type in any other case. Note that `(inherit)` _is not_ a
-shape ID. It is a keyword supported only in the Smithy IDL and _is not_
-supported in the JSON AST.
-
-
 ### Mixins are not code generated
 
 Mixins are an implementation detail of models and are only intended to reduce
@@ -555,7 +501,9 @@ structure A2 {
     a: String
 }
 
-structure Invalid with A1, A2 {}
+structure Invalid with
+    A1
+    A2 {}
 ```
 
 The following model is also invalid, but not specifically because of mixins.
@@ -573,34 +521,27 @@ structure A2 {
     A: String
 }
 
-structure Invalid with A1, A2 {}
+structure Invalid with
+    A1
+    A2 {}
 ```
 
 
 ### Mixins in the IDL
 
 To support mixins, `structure_statement` and `union_statement` ABNF rules
-will be updated to contain an optional `with` clause that comes after the
-shape name and before `{`. If present, the `with` clause MUST contain one or
-more shape IDs, and each shape MUST target a valid shape marked with the
-`@mixin` trait. The `(inherit)` keyword also requires updating the Smithy
-IDL grammar for structure and union shapes.
+will be updated to contain an optional series of `add_mixin` productions
+that comes after the shape name and before `{`. Each `with` in the
+`add_mixin` MUST be followed by a single shape ID, and each shape MUST
+target a valid shape marked with the `@mixin` trait. Any number of mixins can
+be added to a shape.
 
 ```
-structure_statement = "structure" ws `identifier` ws [with_clause] structure_members
-structure_members: "{" `ws` *(`structure_members_kvp` `ws`) "}"
-structure_members_kvp: `trait_statements` `identifier` `ws`
-    ":" `ws` `structure_and_union_member_target` [`required_member_sugar`]
-
-with_clause = "with" ws 1*shape_id ws
-structure_and_union_member_target: `shape_id` / `inherit_keyword`
-inherit_keyword: "(inherit)"
-
-union_statement = "union" ws `identifier` ws [with_clause] union_members
-union_members: "{" `ws` *(`union_members_kvp` `ws`) "}"
-union_members_kvp: `trait_statements` `identifier` `ws`
-    ":" `ws` `structure_and_union_member_target`
+structure_statement = "structure" ws `identifier` ws *add_mixin structure_members
+union_statement = "union" ws `identifier` ws *add_mixin union_members
+add_mixin = "with" `ws` `shape_id`
 ```
+
 
 ### Mixins in the JSON AST
 
@@ -708,13 +649,8 @@ Both yield the following shapes, in any order:
 
 The order of structure and union members is important for languages like C
 that require a stable ABI. Mixins provide a deterministic member ordering.
-Members are ordered by:
-
-- Members inherited from mixins come before members defined directly in the
-  shape.
-- Members are inherited from mixins in the order in which they are first
-  applied to a shape. Redefining a member in the Smithy IDL using
-  `(inherit)` has no bearing on member order.
+Members inherited from mixins come before members defined directly in the
+shape.
 
 Members are ordered in a kind of depth-first, preorder traversal of mixins
 that are applied to a structure or union. To resolve the member order of a
@@ -741,7 +677,10 @@ structure PaginatedInput {
     pageSize: Integer
 }
 
-structure ListSomethingInput with PaginatedInput, FilteredByName {
+structure ListSomethingInput with
+    PaginatedInput
+    FilteredByName
+{
     sizeFilter: Integer
 }
 ```
@@ -800,13 +739,6 @@ in whatever way works best). For example, when calling `Shape#getAllMembers`,
 both mixin members and members local to the shape are returned. This reduces
 the complexity of code generators and will prevent issues with code generators
 forgetting to traverse mixins to resolve members.
-
-When loading Smithy IDL models that use `(inherit)`, the model loader should
-treat the member exactly like an `apply` statement.
-
-When serializing a Smithy model using the IDL, the serialized IDL should
-use the redefined member syntax rather than `apply` statements to make the
-serialized model more readable.
 
 The reference implementation will contain a model transformation that can
 "flatten" mixins out of a model so that they do not need to be accounted for
@@ -933,15 +865,15 @@ structure FooMixin {
 structure ApplicationOfFooMixin with FooMixin {
     // Remove the required trait from this member.
     @override([omitTraits: [required]])
-    someMember: (inherit)
+    someMember: String
 }
 ```
 
 While this could work, it is not strictly required and presents two
 tradeoffs: the application of the mixin has significantly more verbose, it
-requires introducing an `@override` trait that communicates exactly what
-`(inherit)` already communicates, and filtering traits adds more complex
-requirements to Smithy implementations that resolve the traits of a structure.
+requires introducing an `@override` trait, and filtering traits adds more
+complex requirements to Smithy implementations that resolve the traits of a
+structure.
 
 Alternatively, multiple levels of mixins can be used in many cases to allow
 for reuse with more flexibility. For example:
@@ -954,10 +886,8 @@ structure FooMixinOptional {
 }
 
 @mixin
-structure FooMixinRequired with FooMixinOptional {
-    @required
-    someMember: (inherit)
-}
+structure FooMixinRequired with FooMixinOptional {}
+apply FooMixinRequired$someMember @required
 ```
 
 

--- a/designs/mixins.md
+++ b/designs/mixins.md
@@ -530,16 +530,15 @@ structure Invalid with
 ### Mixins in the IDL
 
 To support mixins, `structure_statement` and `union_statement` ABNF rules
-will be updated to contain an optional series of `add_mixin` productions
-that comes after the shape name and before `{`. Each `with` in the
-`add_mixin` MUST be followed by a single shape ID, and each shape MUST
-target a valid shape marked with the `@mixin` trait. Any number of mixins can
-be added to a shape.
+will be updated to contain an optional `mixins` production
+that comes after the shape name and before `{`. Each shape ID referenced in
+the `mixins` production MUST target a shape of the same type as the
+shape being defined and MUST be marked with the `@mixin` trait.
 
 ```
-structure_statement = "structure" ws `identifier` ws *add_mixin structure_members
-union_statement = "union" ws `identifier` ws *add_mixin union_members
-add_mixin = "with" `ws` `shape_id`
+structure_statement = "structure" ws identifier ws [mixins ws] structure_members
+union_statement = "union" ws identifier ws [mixins ws] union_members
+mixins = "with" 1*(ws shape_id)
 ```
 
 

--- a/docs/source/1.0/guides/style-guide.rst
+++ b/docs/source/1.0/guides/style-guide.rst
@@ -47,6 +47,24 @@ Smithy models SHOULD resemble the following example:
     @trait(selector: "string")
     structure myTrait {}
 
+    // Structures with no members place the braces on the same line.
+    @mixin
+    structure MyMixin {}
+
+    // When using a single mixin, place "with" and the shape on the same line
+    structure UsesMixin with MyMixin {
+        foo: String
+    }
+
+    // When using multiple mixins, place each shape ID on its own line,
+    // followed by a line that contains the opening brace.
+    structure UsesMixin with
+        MyMixin
+        SomeOtherMixin
+    {
+        foo: String
+    }
+
 * Each statement should appear on its own line.
 
 

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConverter.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConverter.java
@@ -67,7 +67,12 @@ public final class JsonSchemaConverter implements ToSmithyBuilder<JsonSchemaConv
         mappers.addAll(builder.mappers);
         config = SmithyBuilder.requiredState("config", builder.config);
         propertyNamingStrategy = SmithyBuilder.requiredState("propertyNamingStrategy", builder.propertyNamingStrategy);
-        model = SmithyBuilder.requiredState("model", builder.model);
+
+        // Flatten mixins out of the model before using the model at all. Mixins are
+        // not relevant to JSON Schema documents.
+        Model builderModel = SmithyBuilder.requiredState("model", builder.model);
+        model = ModelTransformer.create().flattenAndRemoveMixins(builderModel);
+
         shapePredicate = builder.shapePredicate;
 
         LOGGER.fine("Building filtered JSON schema shape index");

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/model-with-mixins.smithy
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/model-with-mixins.smithy
@@ -1,0 +1,12 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure Mixin {
+    foo: String
+}
+
+structure UsesMixin with Mixin {
+    baz: String
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AbstractMutableModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AbstractMutableModelFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 package software.amazon.smithy.model.loader;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.node.Node;
@@ -31,7 +35,9 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitFactory;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.Validator;
 
 /**
  * Base class used for mutable model files.
@@ -40,8 +46,10 @@ abstract class AbstractMutableModelFile implements ModelFile {
 
     protected final TraitContainer traitContainer;
 
-    // A LinkedHashMap is used to maintain member order.
+    private final Set<ShapeId> allShapeIds = new HashSet<>();
     private final Map<ShapeId, AbstractShapeBuilder<?, ?>> shapes = new LinkedHashMap<>();
+    private final Map<ShapeId, Map<String, MemberShape.Builder>> members = new HashMap<>();
+    private final Map<ShapeId, Set<ShapeId>> shapesPendings = new HashMap<>();
     private final List<ValidationEvent> events = new ArrayList<>();
     private final MetadataContainer metadata = new MetadataContainer(events);
     private final TraitFactory traitFactory;
@@ -60,15 +68,33 @@ abstract class AbstractMutableModelFile implements ModelFile {
      * @param builder Shape builder to register.
      */
     void onShape(AbstractShapeBuilder<?, ?> builder) {
-        if (shapes.containsKey(builder.getId())) {
-            AbstractShapeBuilder<?, ?> previous = shapes.get(builder.getId());
-            // Duplicate shapes in the same model file are not allowed.
-            ValidationEvent event = LoaderUtils.onShapeConflict(builder.getId(), builder.getSourceLocation(),
-                                                                previous.getSourceLocation());
-            throw new SourceException(event.getMessage(), event.getSourceLocation());
-        }
+        allShapeIds.add(builder.getId());
 
-        shapes.put(builder.getId(), builder);
+        if (builder instanceof MemberShape.Builder) {
+            String memberName = builder.getId().getMember().get();
+            ShapeId containerId = builder.getId().withoutMember();
+            if (!members.containsKey(containerId)) {
+                members.put(containerId, new LinkedHashMap<>());
+            } else if (members.get(containerId).containsKey(memberName)) {
+                throw onConflict(builder, members.get(containerId).get(memberName));
+            }
+            members.get(containerId).put(memberName, (MemberShape.Builder) builder);
+        } else if (shapes.containsKey(builder.getId())) {
+            throw onConflict(builder, shapes.get(builder.getId()));
+        } else {
+            shapes.put(builder.getId(), builder);
+        }
+    }
+
+    void addPendingMixin(ShapeId shape, ShapeId mixin) {
+        shapesPendings.computeIfAbsent(shape, id -> new LinkedHashSet<>()).add(mixin);
+    }
+
+    private SourceException onConflict(AbstractShapeBuilder<?, ?> builder, AbstractShapeBuilder<?, ?> previous) {
+        // Duplicate shapes in the same model file are not allowed.
+        ValidationEvent event = LoaderUtils.onShapeConflict(builder.getId(), builder.getSourceLocation(),
+                                                            previous.getSourceLocation());
+        return new SourceException(event.getMessage(), event.getSourceLocation());
     }
 
     /**
@@ -114,16 +140,31 @@ abstract class AbstractMutableModelFile implements ModelFile {
 
     @Override
     public final Set<ShapeId> shapeIds() {
-        return shapes.keySet();
+        return allShapeIds;
     }
 
     @Override
-    public final Collection<Shape> createShapes(TraitContainer resolvedTraits) {
-        List<Shape> resolved = new ArrayList<>(shapes.size());
+    public final ShapeType getShapeType(ShapeId id) {
+        return shapes.containsKey(id) ? shapes.get(id).getShapeType() : null;
+    }
+
+    @Override
+    public final CreatedShapes createShapes(TraitContainer resolvedTraits) {
+        List<Shape> resolvedShapes = new ArrayList<>(shapes.size());
+        List<PendingShape> pendingMixins = new ArrayList<>();
+
+        for (Map.Entry<ShapeId, Set<ShapeId>> entry : shapesPendings.entrySet()) {
+            ShapeId subject = entry.getKey();
+            Set<ShapeId> mixins = entry.getValue();
+            AbstractShapeBuilder<?, ?> builder = shapes.get(entry.getKey());
+            Map<String, MemberShape.Builder> builderMembers = claimMembersOfContainer(builder.getId());
+            shapes.remove(entry.getKey());
+            pendingMixins.add(createPendingShape(subject, builder, builderMembers, mixins, traitContainer));
+        }
 
         // Build members and add them to top-level shapes.
-        for (AbstractShapeBuilder<?, ?> builder : shapes.values()) {
-            if (builder instanceof MemberShape.Builder) {
+        for (Map<String, MemberShape.Builder> memberBuilders : members.values()) {
+            for (MemberShape.Builder builder : memberBuilders.values()) {
                 ShapeId id = builder.getId();
                 AbstractShapeBuilder<?, ?> container = shapes.get(id.withoutMember());
                 if (container == null) {
@@ -132,31 +173,83 @@ abstract class AbstractMutableModelFile implements ModelFile {
                 for (Trait trait : resolvedTraits.getTraitsForShape(id).values()) {
                     builder.addTrait(trait);
                 }
-                container.addMember((MemberShape) builder.build());
+                container.addMember(builder.build());
             }
         }
 
-        // Build top-level shapes.
+        // Build top-level shapes that don't use mixins.
         for (AbstractShapeBuilder<?, ?> builder : shapes.values()) {
-            if (!(builder instanceof MemberShape.Builder)) {
-                // Try/catch since shapes could have problems building, like an invalid Shape ID.
-                try {
-                    for (Trait trait : resolvedTraits.getTraitsForShape(builder.getId()).values()) {
-                        builder.addTrait(trait);
-                    }
-                    resolved.add(builder.build());
-                } catch (SourceException e) {
-                    events.add(ValidationEvent.fromSourceException(e).toBuilder()
-                                       .shapeId(builder.getId()).build());
-                }
-            }
+            buildShape(builder, resolvedTraits).ifPresent(resolvedShapes::add);
         }
 
-        return resolved;
+        return new CreatedShapes(resolvedShapes, pendingMixins);
     }
 
-    @Override
-    public final ShapeType getShapeType(ShapeId id) {
-        return shapes.containsKey(id) ? shapes.get(id).getShapeType() : null;
+    private Map<String, MemberShape.Builder> claimMembersOfContainer(ShapeId id) {
+        Map<String, MemberShape.Builder> result = members.remove(id);
+        return result == null ? Collections.emptyMap() : result;
+    }
+
+    private PendingShape createPendingShape(
+            ShapeId subject,
+            AbstractShapeBuilder<?, ?> builder,
+            Map<String, MemberShape.Builder> builderMembers,
+            Set<ShapeId> mixins,
+            TraitContainer resolvedTraits
+    ) {
+        return PendingShape.create(subject, builder, mixins, shapeMap -> {
+            // Build normal members first.
+            for (MemberShape.Builder memberBuilder : builderMembers.values()) {
+                buildShape(memberBuilder, resolvedTraits).ifPresent(builder::addMember);
+            }
+            // Add each mixin and ensure there are no member conflicts.
+            for (ShapeId mixin : mixins) {
+                Shape mixinShape = shapeMap.get(mixin);
+                // Members cannot be redefined.
+                for (MemberShape member : mixinShape.members()) {
+                    if (builderMembers.containsKey(member.getMemberName())) {
+                        MemberShape.Builder conflict = builderMembers.get(member.getMemberName());
+                        events.add(ValidationEvent.builder()
+                                .severity(Severity.ERROR)
+                                .id(Validator.MODEL_ERROR)
+                                .shapeId(conflict.getId())
+                                .sourceLocation(conflict.getSourceLocation())
+                                .message("Member conflicts with an inherited mixin member: " + member.getId())
+                                .build());
+                    } else {
+                        // Build local member copies before adding mixins if traits
+                        // were introduced to inherited mixin members.
+                        ShapeId targetId = builder.getId().withMember(member.getMemberName());
+                        Map<ShapeId, Trait> introducedTraits = traitContainer.getTraitsForShape(targetId);
+                        if (!introducedTraits.isEmpty()) {
+                            builder.addMember(member.toBuilder()
+                                    .id(targetId)
+                                    .addTraits(introducedTraits.values())
+                                    .clearMixins()
+                                    .addMixin(member)
+                                    .build());
+                        }
+                    }
+                }
+                builder.addMixin(mixinShape);
+            }
+            buildShape(builder, resolvedTraits).ifPresent(result -> shapeMap.put(result.getId(), result));
+        });
+    }
+
+    private <S extends Shape, B extends AbstractShapeBuilder<? extends B, S>> Optional<S> buildShape(
+            B builder,
+            TraitContainer resolvedTraits
+    ) {
+        try {
+            for (Trait trait : resolvedTraits.getTraitsForShape(builder.getId()).values()) {
+                builder.addTrait(trait);
+            }
+            return Optional.of(builder.build());
+        } catch (SourceException e) {
+            events.add(ValidationEvent.fromSourceException(e).toBuilder().shapeId(builder.getId()).build());
+            resolvedTraits.clearTraitsForShape(builder.getId());
+            return Optional.empty();
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AbstractMutableModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AbstractMutableModelFile.java
@@ -222,10 +222,11 @@ abstract class AbstractMutableModelFile implements ModelFile {
                         ShapeId targetId = builder.getId().withMember(member.getMemberName());
                         Map<ShapeId, Trait> introducedTraits = traitContainer.getTraitsForShape(targetId);
                         if (!introducedTraits.isEmpty()) {
-                            builder.addMember(member.toBuilder()
+                            builder.addMember(MemberShape.builder()
                                     .id(targetId)
+                                    .target(member.getTarget())
+                                    .source(member.getSourceLocation())
                                     .addTraits(introducedTraits.values())
-                                    .clearMixins()
                                     .addMixin(member)
                                     .build());
                         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import software.amazon.smithy.model.SourceException;
+import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
@@ -68,11 +69,12 @@ enum AstModelLoader {
     private static final String TRAITS = "traits";
     private static final String TYPE = "type";
     private static final String TARGET = "target";
+    private static final String MIXINS = "mixins";
 
     private static final List<String> TOP_LEVEL_PROPERTIES = ListUtils.of("smithy", SHAPES, METADATA);
     private static final List<String> APPLY_PROPERTIES = ListUtils.of(TYPE, TRAITS);
     private static final List<String> SIMPLE_PROPERTY_NAMES = ListUtils.of(TYPE, TRAITS);
-    private static final List<String> STRUCTURE_AND_UNION_PROPERTY_NAMES = ListUtils.of(TYPE, MEMBERS, TRAITS);
+    private static final List<String> STRUCTURE_AND_UNION_PROPERTY_NAMES = ListUtils.of(TYPE, MEMBERS, TRAITS, MIXINS);
     private static final List<String> COLLECTION_PROPERTY_NAMES = ListUtils.of(TYPE, "member", TRAITS);
     private static final List<String> MAP_PROPERTY_NAMES = ListUtils.of(TYPE, "key", "value", TRAITS);
     private static final Set<String> MEMBER_PROPERTIES = SetUtils.of(TARGET, TRAITS);
@@ -322,6 +324,11 @@ enum AstModelLoader {
         ObjectNode memberObject = node.getObjectMember(MEMBERS).orElse(Node.objectNode());
         for (Map.Entry<String, Node> entry : memberObject.getStringMap().entrySet()) {
             loadMember(modelFile, id.withMember(entry.getKey()), entry.getValue().expectObjectNode());
+        }
+
+        ArrayNode mixins = node.getArrayMember(MIXINS).orElse(Node.arrayNode());
+        for (ObjectNode mixin : mixins.getElementsAs(ObjectNode.class)) {
+            modelFile.addPendingMixin(id, loadReferenceBody(modelFile, id, mixin));
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/CompositeModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/CompositeModelFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package software.amazon.smithy.model.loader;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -41,7 +42,7 @@ final class CompositeModelFile implements ModelFile {
 
     private final TraitFactory traitFactory;
     private final List<ModelFile> modelFiles;
-    private final List<ValidationEvent> mergeEvents = new ArrayList<>();
+    private final List<ValidationEvent> events = new ArrayList<>();
 
     CompositeModelFile(TraitFactory traitFactory, List<ModelFile> modelFiles) {
         this.traitFactory = traitFactory;
@@ -70,7 +71,7 @@ final class CompositeModelFile implements ModelFile {
 
     @Override
     public Map<String, Node> metadata() {
-        MetadataContainer metadata = new MetadataContainer(mergeEvents);
+        MetadataContainer metadata = new MetadataContainer(events);
         for (ModelFile modelFile : modelFiles) {
             for (Map.Entry<String, Node> entry : modelFile.metadata().entrySet()) {
                 metadata.putMetadata(entry.getKey(), entry.getValue());
@@ -81,7 +82,7 @@ final class CompositeModelFile implements ModelFile {
 
     @Override
     public TraitContainer resolveShapes(Set<ShapeId> ids, Function<ShapeId, ShapeType> typeProvider) {
-        TraitContainer.TraitHashMap traitValues = new TraitContainer.TraitHashMap(traitFactory, mergeEvents);
+        TraitContainer.TraitHashMap traitValues = new TraitContainer.TraitHashMap(traitFactory, events);
         for (ModelFile modelFile : modelFiles) {
             TraitContainer other = modelFile.resolveShapes(ids, typeProvider);
             for (Map.Entry<ShapeId, Map<ShapeId, Trait>> entry : other.traits().entrySet()) {
@@ -95,34 +96,80 @@ final class CompositeModelFile implements ModelFile {
     }
 
     @Override
-    public Collection<Shape> createShapes(TraitContainer resolvedTraits) {
-        // Merge all shapes together, resolve conflicts, and warn for acceptable conflicts.
-        Map<ShapeId, Shape> shapes = new HashMap<>();
+    public List<ValidationEvent> events() {
+        List<ValidationEvent> result = new ArrayList<>(events);
         for (ModelFile modelFile : modelFiles) {
-            for (Shape shape : modelFile.createShapes(resolvedTraits)) {
-                Shape previous = shapes.get(shape.getId());
-                if (previous == null) {
-                    shapes.put(shape.getId(), shape);
-                } else if (!previous.equals(shape)) {
-                    mergeEvents.add(LoaderUtils.onShapeConflict(shape.getId(), shape.getSourceLocation(),
-                                                                previous.getSourceLocation()));
-                } else if (!LoaderUtils.isSameLocation(shape, previous)) {
-                    LOGGER.warning(() -> "Ignoring duplicate but equivalent shape definition: " + previous.getId()
-                                         + " defined at " + shape.getSourceLocation() + " and "
-                                         + previous.getSourceLocation());
+            result.addAll(modelFile.events());
+        }
+        return result;
+    }
+
+    @Override
+    public CreatedShapes createShapes(TraitContainer resolvedTraits) {
+        Map<ShapeId, Shape> createdShapes = new ResolvedShapeMap();
+        Map<ShapeId, PendingShape> pendingShapes = new PendingShapeMap();
+        TopologicalShapeSort sorter = new TopologicalShapeSort();
+
+        for (ModelFile modelFile : modelFiles) {
+            CreatedShapes created = modelFile.createShapes(resolvedTraits);
+            for (Shape shape : created.getCreatedShapes()) {
+                createdShapes.put(shape.getId(), shape);
+                // Optimization: Only need to add created shapes that are mixins to the queue.
+                if (shape.hasTrait(MixinTrait.class)) {
+                    sorter.enqueue(shape);
+                }
+            }
+            for (PendingShape pending : created.getPendingShapes()) {
+                sorter.enqueue(pending.getId(), pending.getPendingShapes());
+                pendingShapes.put(pending.getId(), pending);
+            }
+        }
+
+        try {
+            for (ShapeId id : sorter.dequeueSortedShapes()) {
+                if (pendingShapes.containsKey(id)) {
+                    // Build pending shapes, which in turn populates the createShapes map.
+                    pendingShapes.get(id).buildShapes(createdShapes);
+                }
+            }
+        } catch (TopologicalShapeSort.CycleException e) {
+            // Emit useful, per shape, error messages.
+            for (PendingShape pending : pendingShapes.values()) {
+                if (e.getUnresolved().contains(pending.getId())) {
+                    events.addAll(pending.unresolved(createdShapes, pendingShapes));
+                    resolvedTraits.getTraitsForShape(pending.getId()).clear();
                 }
             }
         }
 
-        return shapes.values();
+        return new CreatedShapes(createdShapes.values(), Collections.emptyList());
     }
 
-    @Override
-    public List<ValidationEvent> events() {
-        List<ValidationEvent> events = new ArrayList<>(mergeEvents);
-        for (ModelFile modelFile : modelFiles) {
-            events.addAll(modelFile.events());
+    private final class ResolvedShapeMap extends HashMap<ShapeId, Shape> {
+        @Override
+        public Shape put(ShapeId key, Shape value) {
+            Shape old = get(key);
+            if (old == null) {
+                return super.put(key, value);
+            } else if (!old.equals(value)) {
+                events.add(LoaderUtils.onShapeConflict(key, value.getSourceLocation(), old.getSourceLocation()));
+            } else if (!LoaderUtils.isSameLocation(value, old)) {
+                LOGGER.warning(() -> "Ignoring duplicate but equivalent shape definition: " + old.getId()
+                                     + " defined at " + value.getSourceLocation() + " and "
+                                     + old.getSourceLocation());
+            }
+            return old;
         }
-        return events;
+    }
+
+    private static final class PendingShapeMap extends HashMap<ShapeId, PendingShape> {
+        @Override
+        public PendingShape put(ShapeId key, PendingShape pending) {
+            PendingShape old = get(key);
+            if (old != null) {
+                pending = PendingShape.mergeIntoLeft(old, pending);
+            }
+            return super.put(key, pending);
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -543,7 +543,7 @@ final class IdlModelParser extends SimpleParser {
     private void parseStructuredShape(
             ShapeId id,
             SourceLocation location,
-            AbstractShapeBuilder builder,
+            AbstractShapeBuilder<?, ?> builder,
             boolean structureMember
     ) {
         // Register the structure/union with the loader before parsing members.
@@ -552,6 +552,22 @@ final class IdlModelParser extends SimpleParser {
         // would otherwise result in cryptic error messages like:
         // "Member `foo.baz#Foo$Baz` cannot be added to software.amazon.smithy.model.shapes.OperationShape$Builder"
         modelFile.onShape(builder.id(id).source(location));
+
+        // Parse optional "with" statements to add mixins.
+        ws();
+        if (peek() == 'w') {
+            expect('w');
+            expect('i');
+            expect('t');
+            expect('h');
+            ws();
+            do {
+                String target = ParserUtils.parseShapeId(this);
+                modelFile.addForwardReference(target, resolved -> modelFile.addPendingMixin(id, resolved));
+                ws();
+            } while (peek() != '{');
+        }
+
         parseMembers(id, Collections.emptySet(), structureMember);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ImmutablePreludeModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ImmutablePreludeModelFile.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.model.loader;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,7 @@ final class ImmutablePreludeModelFile implements ModelFile {
     }
 
     @Override
-    public Collection<Shape> createShapes(TraitContainer resolvedTraits) {
+    public CreatedShapes createShapes(TraitContainer resolvedTraits) {
         // Create error events for each trait applied outside of the prelude.
         Map<ShapeId, Map<ShapeId, Trait>> invalidTraits = resolvedTraits.getTraitsAppliedToPrelude();
 
@@ -80,7 +79,7 @@ final class ImmutablePreludeModelFile implements ModelFile {
             }
         }
 
-        return prelude.toSet();
+        return new CreatedShapes(prelude.toSet());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -558,7 +558,7 @@ public final class ModelAssembler {
             TraitContainer traits = files.resolveShapes(files.shapeIds(), files::getShapeType);
             Model model = Model.builder()
                     .metadata(files.metadata())
-                    .addShapes(files.createShapes(traits))
+                    .addShapes(files.createShapes(traits).getCreatedShapes())
                     .build();
             return validate(model, traits, files.events());
         } catch (SourceException e) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.loader;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,7 +81,7 @@ interface ModelFile {
      * @param resolvedTraits Traits to apply to the shapes in the ModelFile.
      * @return Returns the created shapes.
      */
-    Collection<Shape> createShapes(TraitContainer resolvedTraits);
+    CreatedShapes createShapes(TraitContainer resolvedTraits);
 
     /**
      * Gets a mutable list of {@link ValidationEvent} objects encountered when
@@ -89,4 +90,40 @@ interface ModelFile {
      * @return Returns the list of events.
      */
     List<ValidationEvent> events();
+
+    /**
+     * Return value of creating shapes from a {@link ModelFile}.
+     */
+    final class CreatedShapes {
+
+        private final Collection<Shape> shapes;
+        private final List<PendingShape> pending;
+
+        CreatedShapes(Collection<Shape> shapes, List<PendingShape> pending) {
+            this.shapes = shapes;
+            this.pending = pending;
+        }
+
+        CreatedShapes(Collection<Shape> shapes) {
+            this(shapes, Collections.emptyList());
+        }
+
+        /**
+         * Gets the shapes that were created.
+         *
+         * @return Returns created shapes.
+         */
+        Collection<Shape> getCreatedShapes() {
+            return shapes;
+        }
+
+        /**
+         * Gets the shapes that are pending other shapes to resolve as mixins.
+         *
+         * @return Returns the pending shapes.
+         */
+        List<PendingShape> getPendingShapes() {
+            return pending;
+        }
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ParserUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ParserUtils.java
@@ -105,7 +105,7 @@ public final class ParserUtils {
     }
 
     /**
-     * Expects and returns a parsed absolute Smithy Shape ID.
+     * Expects and returns a parsed relative or absolute Smithy Shape ID.
      *
      * @param parser Parser to consume tokens from.
      * @return Returns the parsed Shape ID as a string.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/PendingShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/PendingShape.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Consumer;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.Validator;
+
+/**
+ * Represents a shape that is pending other shapes in order to be created.
+ */
+interface PendingShape {
+
+    /**
+     * Create a singular pending shape.
+     *
+     * @param id ID of the shape.
+     * @param sourceLocation Where the shape was defined.
+     * @param mixins Mixins the shape is waiting on to resolve.
+     * @param creator The factory used to create the resolved shape.
+     * @return Returns the created pending shape.
+     */
+    static PendingShape create(
+            ShapeId id,
+            FromSourceLocation sourceLocation,
+            Set<ShapeId> mixins,
+            Consumer<Map<ShapeId, Shape>> creator
+    ) {
+        return new Singular(id, sourceLocation, mixins, creator);
+    }
+
+    /**
+     * Merge {@code right} into {@code left} and the updated value.
+     *
+     * @param left  Left value to merge into.
+     * @param right Right value to merge into left.
+     * @return Returns the merged value.
+     */
+    static PendingConflict mergeIntoLeft(PendingShape left, PendingShape right) {
+        if (!left.getId().equals(right.getId())) {
+            throw new IllegalArgumentException("Cannot merge conflicting shapes with different IDs");
+        }
+
+        PendingConflict result;
+        if (left instanceof PendingConflict) {
+            result = (PendingConflict) left;
+        } else {
+            result = new PendingConflict(left);
+        }
+
+        result.pendingDelegates.add(right);
+        result.pendingShapes.addAll(right.getPendingShapes());
+
+        return result;
+    }
+
+    /**
+     * Gets the shape ID of the shape to create.
+     *
+     * @return Returns the shape ID.
+     */
+    ShapeId getId();
+
+    /**
+     * Gets the set of shapes that are pending.
+     *
+     * @return Returns the set of pending shape IDs.
+     */
+    Set<ShapeId> getPendingShapes();
+
+    /**
+     * Builds the shape, and populates the built shape and any members into the
+     * given mutable shapeMap.
+     *
+     * <p>Any conflicts that occurs between shapes is handled implicitly in the
+     * given {@code shapeMap}. There is no need to account for conflicts when
+     * implementing {@code buildShapes}.
+     *
+     * @param shapeMap Mutable map of shapes to populate with the created shapes.
+     */
+    void buildShapes(Map<ShapeId, Shape> shapeMap);
+
+    /**
+     * Creates validation events for any shapes that are still unresolved.
+     *
+     * @param resolved     The map of shapes that have been resolved.
+     * @param otherPending The map of other shapes that were not resolved.
+     * @return Returns the validation events to emit.
+     */
+    List<ValidationEvent> unresolved(Map<ShapeId, Shape> resolved, Map<ShapeId, PendingShape> otherPending);
+
+    /**
+     * A singular pending shape to resolve.
+     */
+    class Singular implements PendingShape {
+        private final ShapeId id;
+        private final SourceLocation sourceLocation;
+        private final Set<ShapeId> mixins;
+        private final Set<ShapeId> pending;
+        private final Consumer<Map<ShapeId, Shape>> creator;
+
+        Singular(
+                ShapeId id,
+                FromSourceLocation sourceLocation,
+                Set<ShapeId> mixins,
+                Consumer<Map<ShapeId, Shape>> creator
+        ) {
+            this.id = id;
+            this.sourceLocation = sourceLocation.getSourceLocation();
+            this.mixins = mixins;
+            this.pending = new HashSet<>(mixins);
+            this.creator = creator;
+        }
+
+        @Override
+        public ShapeId getId() {
+            return id;
+        }
+
+        @Override
+        public Set<ShapeId> getPendingShapes() {
+            return pending;
+        }
+
+        @Override
+        public void buildShapes(Map<ShapeId, Shape> shapeMap) {
+            creator.accept(shapeMap);
+        }
+
+        @Override
+        public List<ValidationEvent> unresolved(Map<ShapeId, Shape> resolved, Map<ShapeId, PendingShape> pending) {
+            // A rare case when there are conflicting shapes, and only some are unresolved.
+            if (getPendingShapes().isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            List<ShapeId> nonMixinDependencies = new ArrayList<>();
+            List<ShapeId> notFoundShapes = new ArrayList<>();
+            List<ShapeId> missingTransitive = new ArrayList<>();
+            List<ShapeId> cycles = new ArrayList<>();
+            for (ShapeId id : getPendingShapes()) {
+                if (resolved.containsKey(id)) {
+                    nonMixinDependencies.add(id);
+                } else if (!pending.containsKey(id)) {
+                    notFoundShapes.add(id);
+                } else if (anyMissingTransitiveDependencies(id, resolved, pending, new HashSet<>())) {
+                    missingTransitive.add(id);
+                } else {
+                    cycles.add(id);
+                }
+            }
+
+            StringJoiner message = new StringJoiner(" ");
+            message.add("Unable to resolve mixins;");
+
+            if (!nonMixinDependencies.isEmpty()) {
+                message.add("attempted to mixin shapes with no mixin trait: " + nonMixinDependencies);
+            }
+
+            if (!notFoundShapes.isEmpty()) {
+                message.add("attempted to mixin shapes that are not in the model: " + notFoundShapes);
+            }
+
+            if (!missingTransitive.isEmpty()) {
+                message.add("unable to resolve due to missing transitive mixins: " + missingTransitive);
+            }
+
+            if (!cycles.isEmpty()) {
+                message.add("cycles detected between this shape and " + cycles);
+            }
+
+            return Collections.singletonList(ValidationEvent.builder()
+                    .id(Validator.MODEL_ERROR)
+                    .severity(Severity.ERROR)
+                    .shapeId(getId())
+                    .sourceLocation(sourceLocation)
+                    .message(message.toString())
+                    .build());
+        }
+
+        private boolean anyMissingTransitiveDependencies(
+                ShapeId current,
+                Map<ShapeId, Shape> resolved,
+                Map<ShapeId, PendingShape> otherPending,
+                Set<ShapeId> visited
+        ) {
+            if (resolved.containsKey(current)) {
+                return false;
+            } else if (!otherPending.containsKey(current)) {
+                return true;
+            } else if (visited.contains(current)) {
+                visited.remove(current);
+                return false;
+            }
+
+            visited.add(current);
+            for (ShapeId next : otherPending.get(current).getPendingShapes()) {
+                if (anyMissingTransitiveDependencies(next, resolved, otherPending, visited)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Aggregates together one or more shapes to implicitly handle aggregating and
+     * resolving the dependencies of conflicting shapes defined in the model.
+     *
+     * <p>Smithy allows conflicting shapes to be defined, and only emits errors if
+     * the shapes are not exactly equivalent. It's not possible to know if the
+     * shapes are equivalent until they are fully built, so that has to be deferred
+     * until all conflicts are built - hence this class.
+     */
+    class PendingConflict implements PendingShape {
+        private final List<PendingShape> pendingDelegates = new ArrayList<>();
+        private final Set<ShapeId> pendingShapes;
+
+        PendingConflict(PendingShape pending) {
+            this.pendingDelegates.add(pending);
+            this.pendingShapes = new HashSet<>(pending.getPendingShapes());
+        }
+
+        @Override
+        public ShapeId getId() {
+            return pendingDelegates.get(0).getId();
+        }
+
+        @Override
+        public Set<ShapeId> getPendingShapes() {
+            return pendingShapes;
+        }
+
+        @Override
+        public void buildShapes(Map<ShapeId, Shape> shapeMap) {
+            for (PendingShape p : pendingDelegates) {
+                p.buildShapes(shapeMap);
+            }
+        }
+
+        @Override
+        public List<ValidationEvent> unresolved(Map<ShapeId, Shape> resolved, Map<ShapeId, PendingShape> pending) {
+            List<ValidationEvent> events = new ArrayList<>();
+            for (PendingShape p : pendingDelegates) {
+                events.addAll(p.unresolved(resolved, pending));
+            }
+            return events;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Topologically sorts shapes based on their dependencies (i.e., mixins).
+ *
+ * <p>While this class is reusable, is is also stateful; shapes and edges
+ * are enqueued, and when sorted, all shapes and edges are dequeued.
+ */
+public final class TopologicalShapeSort {
+
+    private final Map<ShapeId, Set<ShapeId>> forwardDependencies = new HashMap<>();
+    private final Queue<ShapeId> satisfiedShapes = new LinkedList<>();
+
+    /**
+     * Add a shape to the sort queue, and automatically extract dependencies.
+     *
+     * @param shape Shape to add.
+     */
+    public void enqueue(Shape shape) {
+        enqueue(shape.getId(), shape.getMixins());
+    }
+
+    /**
+     * Add a shape to the sort queue, and provide an explicit dependencies list.
+     *
+     * @param shape Shape to add.
+     * @param dependencies Dependencies of the shape.
+     */
+    public void enqueue(ShapeId shape, Collection<ShapeId> dependencies) {
+        forwardDependencies.put(shape, new LinkedHashSet<>(dependencies));
+    }
+
+    /**
+     * Sort the shapes and returns the ordered list of shape IDs.
+     *
+     * @return Returns the topologically sorted list of shape IDs.
+     * @throws CycleException if cycles exist between shapes.
+     */
+    public List<ShapeId> dequeueSortedShapes() {
+        Map<ShapeId, Set<ShapeId>> reverseDependencies = new HashMap<>();
+
+        for (Map.Entry<ShapeId, Set<ShapeId>> entry : forwardDependencies.entrySet()) {
+            if (entry.getValue().isEmpty()) {
+                satisfiedShapes.offer(entry.getKey());
+            } else {
+                for (ShapeId dependent : entry.getValue()) {
+                    reverseDependencies.computeIfAbsent(dependent, unused -> new HashSet<>()).add(entry.getKey());
+                }
+            }
+        }
+
+        return topologicalSort(reverseDependencies);
+    }
+
+    private List<ShapeId> topologicalSort(Map<ShapeId, Set<ShapeId>> reverseDependencies) {
+        List<ShapeId> result = new ArrayList<>();
+
+        while (!satisfiedShapes.isEmpty()) {
+            ShapeId current = satisfiedShapes.poll();
+            forwardDependencies.remove(current);
+            result.add(current);
+
+            for (ShapeId dependent : reverseDependencies.getOrDefault(current, Collections.emptySet())) {
+                Set<ShapeId> dependentDependencies = forwardDependencies.get(dependent);
+                dependentDependencies.remove(current);
+                if (dependentDependencies.isEmpty()) {
+                    satisfiedShapes.add(dependent);
+                }
+            }
+        }
+
+        if (!forwardDependencies.isEmpty()) {
+            throw new CycleException(new TreeSet<>(forwardDependencies.keySet()));
+        }
+
+        return result;
+    }
+
+    /**
+     * Thrown when cycles exist between shapes.
+     */
+    public static final class CycleException extends RuntimeException {
+        private final Set<ShapeId> unresolved;
+
+        public CycleException(Set<ShapeId> unresolved) {
+            super("Mixin cycles detected among " + unresolved);
+            this.unresolved = unresolved;
+        }
+
+        /**
+         * Gets the entire set of shapes that could not be resolved.
+         *
+         * @return Returns the set of unresolved shapes.
+         */
+        public Set<ShapeId> getUnresolved() {
+            return unresolved;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TraitContainer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TraitContainer.java
@@ -52,6 +52,11 @@ public interface TraitContainer {
         }
 
         @Override
+        public void clearTraitsForShape(ShapeId shape) {
+            // Do nothing.
+        }
+
+        @Override
         public Map<ShapeId, Map<ShapeId, Trait>> getTraitsAppliedToPrelude() {
             return Collections.emptyMap();
         }
@@ -79,6 +84,17 @@ public interface TraitContainer {
      * @return Returns the traits of the shape.
      */
     Map<ShapeId, Trait> getTraitsForShape(ShapeId shape);
+
+    /**
+     * Clears the traits applied to a shape.
+     *
+     * <p>This is useful in the event of errors that occur while attempting to
+     * create a shape so that validation events about traits applied to shapes
+     * that couldn't be created are not emitted.
+     *
+     * @param shape Shape to clear the traits for.
+     */
+    void clearTraitsForShape(ShapeId shape);
 
     /**
      * Gets all traits applied to the prelude.
@@ -132,6 +148,11 @@ public interface TraitContainer {
         @Override
         public Map<ShapeId, Trait> getTraitsForShape(ShapeId shape) {
             return targetToTraits.getOrDefault(shape, Collections.emptyMap());
+        }
+
+        @Override
+        public void clearTraitsForShape(ShapeId shape) {
+            targetToTraits.remove(shape);
         }
 
         @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -186,6 +186,9 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
     @Override
     public List<Relationship> structureShape(StructureShape shape) {
         List<Relationship> result = new ArrayList<>();
+        for (ShapeId mixin : shape.getMixins()) {
+            result.add(relationship(shape, RelationshipType.MIXIN, mixin));
+        }
         for (MemberShape member : shape.getAllMembers().values()) {
             result.add(Relationship.create(shape, RelationshipType.STRUCTURE_MEMBER, member));
         }
@@ -195,6 +198,9 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
     @Override
     public List<Relationship> unionShape(UnionShape shape) {
         List<Relationship> result = new ArrayList<>();
+        for (ShapeId mixin : shape.getMixins()) {
+            result.add(relationship(shape, RelationshipType.MIXIN, mixin));
+        }
         for (MemberShape member : shape.getAllMembers().values()) {
             result.add(Relationship.create(shape, RelationshipType.UNION_MEMBER, member));
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipType.java
@@ -201,7 +201,13 @@ public enum RelationshipType {
      * with {@link NeighborProvider#withTraitRelationships(Model, NeighborProvider)}
      * in order to yield trait relationships.
      */
-    TRAIT("trait", RelationshipDirection.DIRECTED);
+    TRAIT("trait", RelationshipDirection.DIRECTED),
+
+    /**
+     * Relationship that exists between a structure or union and a mixin applied
+     * to the shape.
+     */
+    MIXIN("mixin", RelationshipDirection.DIRECTED);
 
     private String selectorLabel;
     private RelationshipDirection direction;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/StringNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/StringNode.java
@@ -32,7 +32,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 /**
  * Represents a string node.
  */
-public final class StringNode extends Node {
+public final class StringNode extends Node implements Comparable<StringNode> {
     private String value;
 
     /**
@@ -181,5 +181,10 @@ public final class StringNode extends Node {
     @Override
     public String toString() {
         return value;
+    }
+
+    @Override
+    public int compareTo(StringNode o) {
+        return getValue().compareTo(o.getValue());
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
@@ -276,6 +276,15 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<B, S>,
         return (B) this;
     }
 
+    /**
+     * Removes mixins from a shape and flattens them into the shape.
+     *
+     * <p>Flattening a mixin into a shape copies the traits and members of a
+     * mixin onto the shape, effectively resulting in the same shape but with
+     * no trace of the mixin relationship.
+     *
+     * @return Returns the updated builder.
+     */
     @SuppressWarnings("unchecked")
     public B flattenMixins() {
         if (mixins != null) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
 
 package software.amazon.smithy.model.shapes;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -31,12 +35,13 @@ import software.amazon.smithy.utils.SmithyBuilder;
  * @param <B> Concrete builder type.
  * @param <S> Shape being created.
  */
-public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S extends Shape>
+public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<B, S>, S extends Shape>
         implements SmithyBuilder<S>, FromSourceLocation {
 
     private ShapeId id;
     private Map<ShapeId, Trait> traits;
     private SourceLocation source = SourceLocation.none();
+    private Map<ShapeId, Shape> mixins;
 
     AbstractShapeBuilder() {}
 
@@ -80,7 +85,6 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
      * @return Returns the builder.
      * @throws ShapeIdSyntaxException if the shape ID is invalid.
      */
-    @SuppressWarnings("unchecked")
     public final B id(String shapeId) {
         return id(ShapeId.from(shapeId));
     }
@@ -108,7 +112,6 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
      * @param column Column number of the line where the shape was defined.
      * @return Returns the builder.
      */
-    @SuppressWarnings("unchecked")
     public final B source(String filename, int line, int column) {
         return source(new SourceLocation(filename, line, column));
     }
@@ -120,9 +123,11 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
      * @return Returns the builder.
      */
     @SuppressWarnings("unchecked")
-    public final B traits(Collection<Trait> traitsToSet) {
+    public final B traits(Collection<? extends Trait> traitsToSet) {
         clearTraits();
-        traitsToSet.forEach(this::addTrait);
+        for (Trait trait : traitsToSet) {
+            addTrait(trait);
+        }
         return (B) this;
     }
 
@@ -134,8 +139,10 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
      * @return Returns the builder.
      */
     @SuppressWarnings("unchecked")
-    public final B addTraits(Collection<Trait> traitsToAdd) {
-        traitsToAdd.forEach(this::addTrait);
+    public final B addTraits(Collection<? extends Trait> traitsToAdd) {
+        for (Trait trait : traitsToAdd) {
+            addTrait(trait);
+        }
         return (B) this;
     }
 
@@ -147,9 +154,7 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
      */
     @SuppressWarnings("unchecked")
     public final B addTrait(Trait trait) {
-        if (trait == null) {
-            throw new IllegalArgumentException("trait must not be null");
-        }
+        Objects.requireNonNull(trait, "trait must not be null");
 
         if (traits == null) {
             traits = new HashMap<>();
@@ -193,26 +198,8 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
      */
     @SuppressWarnings("unchecked")
     public final B clearTraits() {
-        if (traits != null) {
-            traits.clear();
-        }
+        traits = null;
         return (B) this;
-    }
-
-    /**
-     * Configures the builder with the properties of the given shape.
-     *
-     * <p>This should be overridden in subclasses when the shape being
-     * build has more properties than those captured in the method below.
-     *
-     * @param shape Shape to extract values and populate the builder with.
-     * @return Returns the builder.
-     */
-    @SuppressWarnings("unchecked")
-    final B from(S shape) {
-        return (B) id(shape.getId())
-                .source(shape.getSourceLocation())
-                .addTraits(shape.getAllTraits().values());
     }
 
     /**
@@ -227,7 +214,92 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S ext
                 "Member `%s` cannot be added to %s", member.getId(), getClass().getName()));
     }
 
-    Map<ShapeId, Trait> copyTraits() {
-        return traits == null ? Collections.emptyMap() : MapUtils.copyOf(traits);
+    /**
+     * Adds a mixin to the shape.
+     *
+     * @param shape Mixin to add.
+     * @return Returns the builder.
+     */
+    @SuppressWarnings("unchecked")
+    public B addMixin(Shape shape) {
+        if (mixins == null) {
+            mixins = new LinkedHashMap<>();
+        }
+
+        mixins.put(shape.getId(), shape);
+        return (B) this;
+    }
+
+    /**
+     * Replaces the mixins of the shape.
+     *
+     * @param mixins Mixins to add.
+     * @return Returns the builder.
+     */
+    @SuppressWarnings("unchecked")
+    public B mixins(Collection<? extends Shape> mixins) {
+        for (Shape shape : mixins) {
+            addMixin(shape);
+        }
+        return (B) this;
+    }
+
+    /**
+     * Removes a mixin from the shape by shape or ID.
+     *
+     * @param shape Shape or shape ID to remove.
+     * @return Returns the builder.
+     */
+    @SuppressWarnings("unchecked")
+    public B removeMixin(ToShapeId shape) {
+        if (mixins != null) {
+            mixins.remove(shape.toShapeId());
+        }
+
+        return (B) this;
+    }
+
+    /**
+     * Removes all mixins.
+     *
+     * @return Returns the builder.
+     */
+    @SuppressWarnings("unchecked")
+    public B clearMixins() {
+        if (mixins != null) {
+            // Avoid concurrent modification.
+            List<ShapeId> mixinIds = new ArrayList<>(mixins.keySet());
+            for (ShapeId id : mixinIds) {
+                removeMixin(id);
+            }
+        }
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public B flattenMixins() {
+        if (mixins != null) {
+            for (Shape mixin : mixins.values()) {
+                // Only inherit non-local traits that aren't already on the shape.
+                Map<ShapeId, Trait> nonLocalTraits = MixinTrait.getNonLocalTraitsFromMap(mixin.getAllTraits());
+                for (Map.Entry<ShapeId, Trait> entry : nonLocalTraits.entrySet()) {
+                    if (traits == null || !traits.containsKey(entry.getKey())) {
+                        addTrait(entry.getValue());
+                    }
+                }
+            }
+            // Don't call clearMixins here because its side effects are unwanted.
+            mixins.clear();
+        }
+
+        return (B) this;
+    }
+
+    Map<ShapeId, Shape> getMixins() {
+        return mixins == null ? Collections.emptyMap() : mixins;
+    }
+
+    Map<ShapeId, Trait> getTraits() {
+        return traits == null ? Collections.emptyMap() : traits;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigDecimalShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigDecimalShape.java
@@ -33,7 +33,7 @@ public final class BigDecimalShape extends NumberShape implements ToSmithyBuilde
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigIntegerShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigIntegerShape.java
@@ -33,7 +33,7 @@ public final class BigIntegerShape extends NumberShape implements ToSmithyBuilde
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BlobShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BlobShape.java
@@ -33,7 +33,7 @@ public final class BlobShape extends SimpleShape implements ToSmithyBuilder<Blob
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BooleanShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BooleanShape.java
@@ -33,7 +33,7 @@ public final class BooleanShape extends SimpleShape implements ToSmithyBuilder<B
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ByteShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ByteShape.java
@@ -33,7 +33,7 @@ public final class ByteShape extends NumberShape implements ToSmithyBuilder<Byte
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
@@ -63,7 +63,7 @@ public abstract class CollectionShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
-    public abstract static class Builder<B extends Builder, S extends CollectionShape>
+    public abstract static class Builder<B extends Builder<B, S>, S extends CollectionShape>
             extends AbstractShapeBuilder<B, S> {
 
         private MemberShape member;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DocumentShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DocumentShape.java
@@ -33,7 +33,7 @@ public final class DocumentShape extends SimpleShape implements ToSmithyBuilder<
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DoubleShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DoubleShape.java
@@ -33,7 +33,7 @@ public final class DoubleShape extends NumberShape implements ToSmithyBuilder<Do
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
@@ -85,8 +85,7 @@ public abstract class EntityShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
-    @SuppressWarnings("rawtypes")
-    public abstract static class Builder<B extends Builder, S extends EntityShape>
+    public abstract static class Builder<B extends Builder<B, S>, S extends EntityShape>
             extends AbstractShapeBuilder<B, S> {
 
         private final Set<ShapeId> resources = new LinkedHashSet<>();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/FloatShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/FloatShape.java
@@ -33,7 +33,7 @@ public final class FloatShape extends NumberShape implements ToSmithyBuilder<Flo
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntegerShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntegerShape.java
@@ -33,7 +33,7 @@ public final class IntegerShape extends NumberShape implements ToSmithyBuilder<I
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ListShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ListShape.java
@@ -25,6 +25,7 @@ public final class ListShape extends CollectionShape implements ToSmithyBuilder<
 
     private ListShape(Builder builder) {
         super(builder);
+        validateMemberShapeIds();
     }
 
     public static Builder builder() {
@@ -33,7 +34,7 @@ public final class ListShape extends CollectionShape implements ToSmithyBuilder<
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this).member(getMember());
+        return updateBuilder(builder()).member(getMember());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/LongShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/LongShape.java
@@ -33,7 +33,7 @@ public final class LongShape extends NumberShape implements ToSmithyBuilder<Long
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
@@ -35,20 +35,7 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
         super(builder, false);
         key = SmithyBuilder.requiredState("key", builder.key);
         value = SmithyBuilder.requiredState("value", builder.value);
-
-        ShapeId expectedKey = getId().withMember("key");
-        if (!key.getId().equals(expectedKey)) {
-            throw new IllegalArgumentException(String.format(
-                    "Expected the key member of `%s` to have an ID of `%s` but found `%s`",
-                    getId(), expectedKey, key.getId()));
-        }
-
-        ShapeId expectedValue = getId().withMember("value");
-        if (!value.getId().equals(expectedValue)) {
-            throw new IllegalArgumentException(String.format(
-                    "Expected the value member of `%s` to have an ID of `%s` but found `%s`",
-                    getId(), expectedValue, value.getId()));
-        }
+        validateMemberShapeIds();
     }
 
     public static Builder builder() {
@@ -57,7 +44,7 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this).key(key).value(value);
+        return updateBuilder(builder()).key(key).value(value);
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
@@ -15,8 +15,10 @@
 
 package software.amazon.smithy.model.shapes;
 
+import java.util.Collection;
 import java.util.Optional;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -36,13 +38,21 @@ public final class MemberShape extends Shape implements ToSmithyBuilder<MemberSh
         this.memberName = getId().getMember().orElse("");
     }
 
+    @Override
+    protected void validateMixins(Collection<ShapeId> mixins) {
+        // This can only happen by manipulating the semantic model in code.
+        if (mixins.size() > 1) {
+            throw new SourceException("Members must not have more than one mixin: " + getId(), this);
+        }
+    }
+
     public static Builder builder() {
         return new Builder();
     }
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this).target(target);
+        return updateBuilder(builder()).target(target);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 package software.amazon.smithy.model.shapes;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -30,31 +35,63 @@ import software.amazon.smithy.utils.MapUtils;
  * <p>The order of members in structures and unions are the same as the
  * order that they are defined in the model.
  */
-abstract class NamedMembersShape extends Shape {
+public abstract class NamedMembersShape extends Shape {
 
     private final Map<String, MemberShape> members;
     private volatile List<String> memberNames;
 
     NamedMembersShape(NamedMembersShape.Builder<?, ?> builder) {
         super(builder, false);
-        assert builder.members != null;
 
-        // Copy the members to make them immutable and ensure that each
-        // member has a valid ID that is prefixed with the shape ID.
-        members = MapUtils.orderedCopyOf(builder.members);
-
-        for (MemberShape member : members.values()) {
-            if (!member.getId().toString().startsWith(getId().toString())) {
-                ShapeId expected = getId().withMember(member.getMemberName());
-                throw new IllegalArgumentException(String.format(
-                        "Expected the `%s` member of `%s` to have an ID of `%s` but found `%s`",
-                        member.getMemberName(), getId(), expected, member.getId()));
+        if (getMixins().isEmpty()) {
+            members = MapUtils.orderedCopyOf(builder.members);
+        } else {
+            // Compute mixin members of this shape that inherit traits from mixin members.
+            Map<String, MemberShape> computedMembers = new LinkedHashMap<>();
+            for (Shape shape : builder.getMixins().values()) {
+                for (MemberShape member : shape.members()) {
+                    String name = member.getMemberName();
+                    if (builder.members.containsKey(name)) {
+                        MemberShape localMember = builder.members.get(name);
+                        // Rebuild the member with the proper inherited mixin if needed.
+                        // This catches errant cases where a member is added to a structure/union
+                        // but omits the mixin members of parent shapes. Arguably, that's way too
+                        // nuanced and error-prone to _not_ try to smooth over.
+                        if (localMember.getMixins().isEmpty() || !builder.getMixins().containsKey(member.getId())) {
+                            localMember = localMember.toBuilder().clearMixins().addMixin(member).build();
+                        }
+                        computedMembers.put(name, localMember);
+                    } else {
+                        computedMembers.put(name, MemberShape.builder()
+                                .id(getId().withMember(name))
+                                .target(member.getTarget())
+                                .source(getSourceLocation())
+                                .addMixin(member)
+                                .build());
+                    }
+                }
             }
+
+            // Add members local to the structure after inherited members.
+            for (MemberShape member : builder.members.values()) {
+                if (!computedMembers.containsKey(member.getMemberName())) {
+                    computedMembers.put(member.getMemberName(), member);
+                }
+            }
+
+            members = Collections.unmodifiableMap(computedMembers);
         }
+
+        validateMemberShapeIds();
+    }
+
+    @Override
+    protected void validateMixins(Collection<ShapeId> mixins) {
+        // do nothing. Mixins are allowed on structures and unions.
     }
 
     /**
-     * Gets the members of the shape.
+     * Gets the members of the shape, including mixin members.
      *
      * @return Returns the immutable member map.
      */
@@ -64,7 +101,7 @@ abstract class NamedMembersShape extends Shape {
 
     /**
      * Returns an ordered list of member names based on the order they are
-     * defined in the model.
+     * defined in the model, including mixin members.
      *
      * @return Returns an immutable list of member names.
      */
@@ -109,9 +146,10 @@ abstract class NamedMembersShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
-    abstract static class Builder<B extends Builder, S extends NamedMembersShape> extends AbstractShapeBuilder<B, S> {
+    public abstract static class Builder<B extends Builder<B, S>, S extends NamedMembersShape>
+            extends AbstractShapeBuilder<B, S> {
 
-        Map<String, MemberShape> members = new LinkedHashMap<>();
+        private final Map<String, MemberShape> members = new LinkedHashMap<>();
 
         @Override
         public final B id(ShapeId shapeId) {
@@ -130,7 +168,7 @@ abstract class NamedMembersShape extends Shape {
          */
         @SuppressWarnings("unchecked")
         public B members(Collection<MemberShape> members) {
-            this.members.clear();
+            clearMembers();
             for (MemberShape member : members) {
                 addMember(member);
             }
@@ -148,12 +186,6 @@ abstract class NamedMembersShape extends Shape {
             return (B) this;
         }
 
-        /**
-         * Adds a member to the builder.
-         *
-         * @param member Shape targeted by the member.
-         * @return Returns the builder.
-         */
         @Override
         @SuppressWarnings("unchecked")
         public B addMember(MemberShape member) {
@@ -197,6 +229,10 @@ abstract class NamedMembersShape extends Shape {
         /**
          * Removes a member by name.
          *
+         * <p>Note that removing a member that was added by a mixin results in
+         * an inconsistent model. It's best to use ModelTransform to ensure
+         * that the model remains consistent when removing members.
+         *
          * @param member Member name to remove.
          * @return Returns the builder.
          */
@@ -204,6 +240,93 @@ abstract class NamedMembersShape extends Shape {
         public B removeMember(String member) {
             members.remove(member);
             return (B) this;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public B addMixin(Shape shape) {
+            if (getId() == null) {
+                throw new IllegalStateException("An id must be set before adding a mixin");
+            }
+
+            super.addMixin(shape);
+
+            // Clean up members that were previously mixed in by the given shape but
+            // are no longer present on the given shape.
+            members.values().removeIf(member -> {
+                if (!isMemberMixedInFromShape(shape.getId(), member)) {
+                    return false;
+                }
+                for (MemberShape mixinMember : shape.members()) {
+                    if (mixinMember.getMemberName().equals(member.getMemberName())) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+
+            return (B) this;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public B removeMixin(ToShapeId shape) {
+            super.removeMixin(shape);
+            ShapeId id = shape.toShapeId();
+            // Remove members that have a mixin where the ID equals the given ID or
+            // the mixin ID without a member equals the given ID.
+            members.values().removeIf(member -> isMemberMixedInFromShape(id, member));
+            return (B) this;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public B flattenMixins() {
+            if (getMixins().isEmpty()) {
+                return (B) this;
+            }
+
+            // Ensure that the members are ordered, mixin members first, followed by local members.
+            Set<MemberShape> orderedMembers = new LinkedHashSet<>();
+
+            // Copy members from mixins onto the shape.
+            for (Shape mixin : getMixins().values()) {
+                for (MemberShape member : mixin.members()) {
+                    SourceLocation location = getSourceLocation();
+                    Collection<Trait> localTraits = Collections.emptyList();
+                    MemberShape existing = members.remove(member.getMemberName());
+                    if (existing != null) {
+                        localTraits = existing.getIntroducedTraits().values();
+                        location = existing.getSourceLocation();
+                    }
+                    orderedMembers.add(MemberShape.builder()
+                            .id(getId().withMember(member.getMemberName()))
+                            .target(member.getTarget())
+                            .addTraits(member.getAllTraits().values())
+                            .addTraits(localTraits)
+                            .source(location)
+                            .build());
+                }
+            }
+
+            // Add any local members _after_ mixin members. LinkedHashSet will keep insertion
+            // order, so no need to check for non-mixin members first.
+            orderedMembers.addAll(members.values());
+            members(orderedMembers);
+
+            return super.flattenMixins();
+        }
+
+        private boolean isMemberMixedInFromShape(ShapeId check, MemberShape member) {
+            if (member.getMixins().contains(check)) {
+                return true;
+            }
+            for (ShapeId memberMixin : member.getMixins()) {
+                if (memberMixin.withoutMember().equals(check)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -44,7 +44,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this)
+        return updateBuilder(builder())
                 .input(input)
                 .output(output)
                 .errors(errors);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -70,7 +70,7 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder().from(this)
+        Builder builder = updateBuilder(builder())
                 .identifiers(getIdentifiers())
                 .put(put)
                 .create(create)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -43,7 +43,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder().from(this).version(version);
+        Builder builder = updateBuilder(builder()).version(version);
         getOperations().forEach(builder::addOperation);
         getResources().forEach(builder::addResource);
         builder.rename(rename);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SetShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SetShape.java
@@ -25,6 +25,7 @@ public final class SetShape extends CollectionShape implements ToSmithyBuilder<S
 
     private SetShape(Builder builder) {
         super(builder);
+        validateMemberShapeIds();
     }
 
     public static Builder builder() {
@@ -33,7 +34,7 @@ public final class SetShape extends CollectionShape implements ToSmithyBuilder<S
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this).member(getMember());
+        return updateBuilder(builder()).member(getMember());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShortShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShortShape.java
@@ -33,7 +33,7 @@ public final class ShortShape extends NumberShape implements ToSmithyBuilder<Sho
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -70,7 +70,7 @@ public final class SmithyIdlModelSerializer {
         OMIT_REQUIRED,
 
         /** Inline documentation traits with other traits as opposed to using /// syntax. */
-        INLINE_DOCUMENTATION;
+        NO_SPECIAL_DOCS_SYNTAX;
 
         /**
          * Checks if the current enum value is present in an array of enum values.
@@ -412,12 +412,12 @@ public final class SmithyIdlModelSerializer {
                         // Use short form for a single trait, and block form for multiple traits.
                         if (member.getIntroducedTraits().size() == 1) {
                             codeWriter.writeInline("apply $I ", member.getId());
-                            serializeTraits(member.getIntroducedTraits(), TraitFeature.INLINE_DOCUMENTATION);
+                            serializeTraits(member.getIntroducedTraits(), TraitFeature.NO_SPECIAL_DOCS_SYNTAX);
                             codeWriter.write("");
                         } else {
                             codeWriter.openBlock("apply $I {", "}", member.getId(), () -> {
                                 // Only serialize local traits, and don't use special documentation syntax here.
-                                serializeTraits(member.getIntroducedTraits(), TraitFeature.INLINE_DOCUMENTATION);
+                                serializeTraits(member.getIntroducedTraits(), TraitFeature.NO_SPECIAL_DOCS_SYNTAX);
                             }).write("");
                         }
                     }
@@ -430,11 +430,11 @@ public final class SmithyIdlModelSerializer {
         }
 
         private void serializeTraits(Map<ShapeId, Trait> traits, TraitFeature... traitFeatures) {
-            boolean inlineDocumentation = TraitFeature.INLINE_DOCUMENTATION.hasFeature(traitFeatures);
+            boolean noSpecialDocsSyntax = TraitFeature.NO_SPECIAL_DOCS_SYNTAX.hasFeature(traitFeatures);
             boolean omitRequired = TraitFeature.OMIT_REQUIRED.hasFeature(traitFeatures);
 
             // The documentation trait always needs to be serialized first since it uses special syntax.
-            if (!inlineDocumentation && traits.containsKey(DocumentationTrait.ID)) {
+            if (!noSpecialDocsSyntax && traits.containsKey(DocumentationTrait.ID)) {
                 Trait documentation = traits.get(DocumentationTrait.ID);
                 if (traitFilter.test(documentation)) {
                     serializeDocumentation(documentation.toNode().expectStringNode().getValue());
@@ -442,7 +442,7 @@ public final class SmithyIdlModelSerializer {
             }
 
             traits.values().stream()
-                    .filter(trait -> inlineDocumentation || !(trait instanceof DocumentationTrait))
+                    .filter(trait -> noSpecialDocsSyntax || !(trait instanceof DocumentationTrait))
                     .filter(trait -> !(omitRequired && trait.toShapeId().equals(RequiredTrait.ID)))
                     .filter(traitFilter)
                     .sorted(Comparator.comparing(Trait::toShapeId))

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StringShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StringShape.java
@@ -33,7 +33,7 @@ public final class StringShape extends SimpleShape implements ToSmithyBuilder<St
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
@@ -36,7 +36,7 @@ public final class StructureShape extends NamedMembersShape implements ToSmithyB
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this).members(getAllMembers().values());
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/TimestampShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/TimestampShape.java
@@ -32,7 +32,7 @@ public final class TimestampShape extends SimpleShape implements ToSmithyBuilder
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this);
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
@@ -33,7 +33,7 @@ public final class UnionShape extends NamedMembersShape implements ToSmithyBuild
 
     @Override
     public Builder toBuilder() {
-        return builder().from(this).members(getAllMembers().values());
+        return updateBuilder(builder());
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/MixinTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/MixinTrait.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class MixinTrait extends AbstractTrait implements ToSmithyBuilder<MixinTrait> {
+    public static final ShapeId ID = ShapeId.from("smithy.api#mixin");
+
+    private final Set<ShapeId> localTraits;
+
+    private MixinTrait(Builder builder) {
+        super(ID, builder.sourceLocation);
+        this.localTraits = SetUtils.orderedCopyOf(builder.localTraits);
+    }
+
+    /**
+     * Gets the mixin local traits.
+     *
+     * @return returns the mixin local traits.
+     */
+    public Set<ShapeId> getLocalTraits() {
+        return localTraits;
+    }
+
+    @Override
+    protected Node createNode() {
+        // smithy.api#mixin is always present, so no need to serialize it.
+        if (localTraits.size() <= 1) {
+            return Node.objectNode();
+        }
+
+        List<Node> nonImplicitValues = new ArrayList<>();
+        for (ShapeId trait : localTraits) {
+            if (!trait.equals(ID)) {
+                nonImplicitValues.add(Node.from(trait.toString()));
+            }
+        }
+
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
+                .withMember("localTraits", Node.fromNodes(nonImplicitValues))
+                .build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder()
+                .sourceLocation(getSourceLocation())
+                .localTraits(localTraits);
+    }
+
+    /**
+     * Helper method used to filter out non-local traits from a map of traits.
+     *
+     * <p>If the map is empty or does not contain a mixin trait, then it is
+     * returned as-is. If the map does contain the mixin trait, then a new map
+     * is created that does not contain any of the localTraits specified on
+     * the trait.
+     *
+     * @param traits Traits to filter based on the localTraits property of the mixin.
+     * @return Returns the filtered traits.
+     */
+    public static Map<ShapeId, Trait> getNonLocalTraitsFromMap(Map<ShapeId, Trait> traits) {
+        if (traits.isEmpty() || !traits.containsKey(ID)) {
+            return traits;
+        }
+
+        Map<ShapeId, Trait> filtered = new HashMap<>(traits);
+
+        // Technically the trait could be a dynamic trait is some wacky,
+        // hand-made model that isn't sent through the assembler. That is
+        // so beyond unlikely, that a hard cast here works fine.
+        MixinTrait mixinTrait = (MixinTrait) traits.get(MixinTrait.ID);
+
+        for (ShapeId toRemove : mixinTrait.getLocalTraits()) {
+            filtered.remove(toRemove);
+        }
+
+        return filtered;
+    }
+
+    /**
+     * @return Returns a new MixinTrait builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a MixinTrait.
+     */
+    public static final class Builder extends AbstractTraitBuilder<MixinTrait, Builder> {
+        private final Set<ShapeId> localTraits = new LinkedHashSet<>();
+
+        @Override
+        public MixinTrait build() {
+            // The mixin trait is always implicitly local.
+            localTraits.add(ID);
+            return new MixinTrait(this);
+        }
+
+        public Builder localTraits(Collection<ShapeId> traits) {
+            localTraits.clear();
+            localTraits.addAll(traits);
+            return this;
+        }
+
+        public Builder addLocalTrait(ShapeId trait) {
+            localTraits.add(trait);
+            return this;
+        }
+    }
+
+    public static final class Provider implements TraitService {
+        @Override
+        public ShapeId getShapeId() {
+            return ID;
+        }
+
+        @Override
+        public MixinTrait createTrait(ShapeId target, Node value) {
+            Builder builder = builder().sourceLocation(value);
+            ObjectNode objectNode = value.expectObjectNode();
+            objectNode.getArrayMember("localTraits").ifPresent(values -> {
+                for (StringNode entry : values.getElementsAs(StringNode.class)) {
+                    builder.addLocalTrait(entry.expectShapeId());
+                }
+            });
+            return builder.build();
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/MixinTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/MixinTrait.java
@@ -93,7 +93,7 @@ public final class MixinTrait extends AbstractTrait implements ToSmithyBuilder<M
 
         Map<ShapeId, Trait> filtered = new HashMap<>(traits);
 
-        // Technically the trait could be a dynamic trait is some wacky,
+        // Technically the trait could be a dynamic trait in some wacky,
         // hand-made model that isn't sent through the assembler. That is
         // so beyond unlikely, that a hard cast here works fine.
         MixinTrait mixinTrait = (MixinTrait) traits.get(MixinTrait.ID);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/FlattenAndRemoveMixins.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/FlattenAndRemoveMixins.java
@@ -25,7 +25,7 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.MixinTrait;
 
 /**
- * Flattens out mixins out of the model.
+ * Flattens mixins out of the model.
  */
 final class FlattenAndRemoveMixins {
     Model transform(ModelTransformer transformer, Model model) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/FlattenAndRemoveMixins.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/FlattenAndRemoveMixins.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.MixinTrait;
+
+/**
+ * Flattens out mixins out of the model.
+ */
+final class FlattenAndRemoveMixins {
+    Model transform(ModelTransformer transformer, Model model) {
+        List<Shape> updatedShapes = new ArrayList<>();
+        List<Shape> toRemove = new ArrayList<>();
+
+        Stream.concat(model.shapes(StructureShape.class), model.shapes(UnionShape.class)).forEach(shape -> {
+            if (shape.hasTrait(MixinTrait.class)) {
+                toRemove.add(shape);
+            } else if (!shape.getMixins().isEmpty()) {
+                updatedShapes.add(Shape.shapeToBuilder(shape).flattenMixins().build());
+            }
+        });
+
+        if (!updatedShapes.isEmpty()) {
+            Model.Builder builder = model.toBuilder();
+            updatedShapes.forEach(builder::addShape);
+            model = builder.build();
+        }
+
+        if (!toRemove.isEmpty()) {
+            model = transformer.removeShapes(model, toRemove);
+        }
+
+        return model;
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -455,4 +455,14 @@ public final class ModelTransformer {
     public Model sortMembers(Model model, Comparator<MemberShape> comparator) {
         return new SortMembers(comparator).transform(this, model);
     }
+
+    /**
+     * Flattens mixins out of the model and removes them from the model.
+     *
+     * @param model Model to flatten.
+     * @return Returns the flattened model.
+     */
+    public Model flattenAndRemoveMixins(Model model) {
+        return new FlattenAndRemoveMixins().transform(this, model);
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveShapes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ReplaceShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ReplaceShapes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.TopologicalShapeSort;
+import software.amazon.smithy.model.shapes.AbstractShapeBuilder;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -36,6 +40,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.Pair;
 import software.amazon.smithy.utils.SetUtils;
@@ -53,6 +58,8 @@ import software.amazon.smithy.utils.SetUtils;
  *     updated in the model.</li>
  *     <li>When a member is removed from a structure or union,
  *     ensures that the member is removed from the model.</li>
+ *     <li>When a mixin is updated, ensures that all shapes that use the
+ *     mixin are updated.</li>
  * </ul>
  *
  * <p>Only shapes that are not currently in a model or shapes that are
@@ -72,7 +79,7 @@ import software.amazon.smithy.utils.SetUtils;
  * attempt to change the type of a shape will throw an exception.
  */
 final class ReplaceShapes {
-    private Collection<Shape> replacements;
+    private final Collection<Shape> replacements;
 
     ReplaceShapes(Collection<Shape> replacements) {
         this.replacements = Objects.requireNonNull(replacements);
@@ -86,6 +93,9 @@ final class ReplaceShapes {
 
         assertNoShapeChangedType(model, shouldReplace);
         Model.Builder builder = createReplacedModelBuilder(model, shouldReplace);
+
+        // Update shapes that relied on mixins that were updated.
+        updateMixins(model, builder, shouldReplace);
 
         // If a member shape changes, then ensure that the containing shape
         // is also updated to reference the updated member. Note that the updated container
@@ -143,6 +153,53 @@ final class ReplaceShapes {
             builder.addShapes(shape.members());
         });
         return builder;
+    }
+
+    private void updateMixins(Model model, Model.Builder builder, List<Shape> replacements) {
+        // Create a map to function as a mutable kind of intermediate model index so that as
+        // shapes are updated and built, they're used as mixins in shapes that depend on it.
+        Map<ShapeId, Shape> updatedShapes = new HashMap<>();
+        for (Shape replaced : replacements) {
+            updatedShapes.put(replaced.getId(), replaced);
+        }
+
+        // Topologically sort the updated shapes to ensure shapes are updated in order.
+        TopologicalShapeSort sorter = new TopologicalShapeSort();
+
+        // Add structure and union shapes that are mixins or use mixins.
+        Stream.concat(model.shapes(StructureShape.class), model.shapes(UnionShape.class)).forEach(shape -> {
+            if (shape.hasTrait(MixinTrait.class) || !shape.getMixins().isEmpty()) {
+                sorter.enqueue(shape);
+            }
+        });
+
+        // Add _all_ of the replacements in case mixins or the Mixin trait were removed from updated shapes.
+        for (Shape shape : replacements) {
+            sorter.enqueue(shape);
+        }
+
+        List<ShapeId> sorted = sorter.dequeueSortedShapes();
+        for (ShapeId toRebuild : sorted) {
+            Shape shape = updatedShapes.containsKey(toRebuild)
+                    ? updatedShapes.get(toRebuild)
+                    : model.expectShape(toRebuild);
+            if (!shape.getMixins().isEmpty()) {
+                // We don't clear mixins here because a shape might have an inherited
+                // mixin member that was updated with an applied trait. Clearing mixins
+                // would remove this member but not re-add it properly. Re-adding already
+                // present mixins, however, will update members in-place.
+                AbstractShapeBuilder<?, ?> shapeBuilder = Shape.shapeToBuilder(shape);
+                for (ShapeId mixin : shape.getMixins()) {
+                    Shape mixinShape = updatedShapes.containsKey(mixin)
+                            ? updatedShapes.get(mixin)
+                            : model.expectShape(mixin);
+                    shapeBuilder.addMixin(mixinShape);
+                }
+                Shape rebuilt = shapeBuilder.build();
+                builder.addShape(rebuilt);
+                updatedShapes.put(rebuilt.getId(), rebuilt);
+            }
+        }
     }
 
     private Set<Shape> getShapesToRemove(Model model, List<Shape> shouldReplace) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveMixins.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveMixins.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform.plugins;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.AbstractShapeBuilder;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.MixinTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.transform.ModelTransformerPlugin;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Removes mixins from shapes when a mixin is removed from the model.
+ */
+@SmithyInternalApi
+public final class RemoveMixins implements ModelTransformerPlugin {
+    @Override
+    public Model onRemove(ModelTransformer transformer, Collection<Shape> shapes, Model model) {
+        Map<Shape, Set<Shape>> mixinShapesToRemove = new HashMap<>();
+
+        for (Shape removedShape : shapes) {
+            if (removedShape.hasTrait(MixinTrait.class) && !removedShape.isMemberShape()) {
+                // Remove the mixin from any shape that uses it.
+                Stream.concat(model.shapes(StructureShape.class), model.shapes(UnionShape.class)).forEach(shape -> {
+                    if (shape.getMixins().contains(removedShape.getId())) {
+                        mixinShapesToRemove.computeIfAbsent(shape, s -> new HashSet<>()).add(removedShape);
+                    }
+                });
+            }
+        }
+
+        if (mixinShapesToRemove.isEmpty()) {
+            return model;
+        }
+
+        List<Shape> toReplace = new ArrayList<>(mixinShapesToRemove.size());
+        for (Map.Entry<Shape, Set<Shape>> entry : mixinShapesToRemove.entrySet()) {
+            AbstractShapeBuilder<?, ?> builder = Shape.shapeToBuilder(entry.getKey());
+            for (Shape mixin : entry.getValue()) {
+                builder.removeMixin(mixin);
+            }
+            toReplace.add(builder.build());
+        }
+
+        // The replace transform handles ensuring that any updated mixins as a result
+        // of removing mixins are reflected in inherited shapes.
+        return transformer.replaceShapes(model, toReplace);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MixinValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MixinValidator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.validators;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Ensures that mixins do no introduce conflicting members across
+ * mixin closures.
+ *
+ * <p>The kinds of errors detected by this validator are not actually
+ * possible when loading models via the IDL or JSON, but are possible
+ * when creating models manually.
+ */
+@SmithyInternalApi
+public final class MixinValidator extends AbstractValidator {
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        for (StructureShape shape : model.toSet(StructureShape.class)) {
+            validateShape(model, shape, events);
+        }
+        for (UnionShape shape : model.toSet(UnionShape.class)) {
+            validateShape(model, shape, events);
+        }
+        return events;
+    }
+
+    private void validateShape(Model model, Shape shape, List<ValidationEvent> events) {
+        if (!shape.getMixins().isEmpty()) {
+            validateMemberSources(model, shape, events);
+        }
+    }
+
+    private void validateMemberSources(Model model, Shape shape, List<ValidationEvent> events) {
+        Map<String, Set<ShapeId>> memberSources = new HashMap<>();
+
+        // Add non-mixin members to start the map.
+        for (MemberShape member : shape.members()) {
+            if (member.getMixins().isEmpty()) {
+                Set<ShapeId> self = new TreeSet<>();
+                self.add(shape.getId());
+                memberSources.put(member.getMemberName(), self);
+            }
+        }
+
+        // Add each mixin member.
+        for (ShapeId mixin : shape.getMixins()) {
+            model.getShape(mixin).ifPresent(mixinShape -> {
+                for (MemberShape member : mixinShape.members()) {
+                    memberSources.computeIfAbsent(member.getMemberName(), name -> new TreeSet<>()).add(mixin);
+                }
+            });
+        }
+
+        // Remove entries that have no conflicts.
+        memberSources.entrySet().removeIf(e -> e.getValue().size() <= 1);
+
+        if (!memberSources.isEmpty()) {
+            for (Map.Entry<String, Set<ShapeId>> entry : memberSources.entrySet()) {
+                String memberName = entry.getKey();
+                Set<ShapeId> conflicts = entry.getValue();
+                String message = String.format(
+                        "Member `%s` conflicts with members defined in the following mixins: %s",
+                        memberName, conflicts);
+                events.add(error(shape, message));
+            }
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MixinValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MixinValidator.java
@@ -32,7 +32,7 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
- * Ensures that mixins do no introduce conflicting members across
+ * Ensures that mixins do not introduce conflicting members across
  * mixin closures.
  *
  * <p>The kinds of errors detected by this validator are not actually

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -34,6 +34,7 @@ software.amazon.smithy.model.traits.InternalTrait$Provider
 software.amazon.smithy.model.traits.JsonNameTrait$Provider
 software.amazon.smithy.model.traits.LengthTrait$Provider
 software.amazon.smithy.model.traits.MediaTypeTrait$Provider
+software.amazon.smithy.model.traits.MixinTrait$Provider
 software.amazon.smithy.model.traits.NoReplaceTrait$Provider
 software.amazon.smithy.model.traits.OptionalAuthTrait$Provider
 software.amazon.smithy.model.traits.PaginatedTrait$Provider

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.transform.ModelTransformerPlugin
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.transform.ModelTransformerPlugin
@@ -4,4 +4,5 @@ software.amazon.smithy.model.transform.plugins.CleanResourceReferences
 software.amazon.smithy.model.transform.plugins.CleanServiceRenames
 software.amazon.smithy.model.transform.plugins.CleanStructureAndUnionMembers
 software.amazon.smithy.model.transform.plugins.CleanTraitDefinitions
+software.amazon.smithy.model.transform.plugins.RemoveMixins
 software.amazon.smithy.model.transform.plugins.RemoveTraits

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -18,6 +18,7 @@ software.amazon.smithy.model.validation.validators.HttpResponseCodeSemanticsVali
 software.amazon.smithy.model.validation.validators.HttpUriConflictValidator
 software.amazon.smithy.model.validation.validators.LengthTraitValidator
 software.amazon.smithy.model.validation.validators.MediaTypeValidator
+software.amazon.smithy.model.validation.validators.MixinValidator
 software.amazon.smithy.model.validation.validators.NoInlineDocumentSupportValidator
 software.amazon.smithy.model.validation.validators.PaginatedTraitValidator
 software.amazon.smithy.model.validation.validators.PrivateAccessValidator

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -803,3 +803,24 @@ structure httpChecksumProperty {
     },
 ])
 string HttpChecksumLocation
+
+/// Makes a structure or union a mixin.
+@trait(selector: ":is(structure, union)")
+structure mixin {
+    localTraits: LocalMixinTraitList
+}
+
+@private
+list LocalMixinTraitList {
+    member: LocalMixinTrait
+}
+
+@idRef(
+    selector: "[trait|trait]",
+    failWhenMissing: true,
+    errorMessage: """
+            Strings provided to the localTraits property of a mixin trait
+            must target a valid trait.""")
+@private
+string LocalMixinTrait
+

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -67,6 +67,7 @@ import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.SuppressTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.model.validation.ValidatedResultException;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.Validator;
 import software.amazon.smithy.model.validation.ValidatorFactory;
@@ -658,5 +659,45 @@ public class ModelAssemblerTest {
                 .unwrap();
 
         assertThat(collectedEvents, equalTo(toEmit));
+    }
+
+    @Test
+    public void loadsMixinMembersInCorrectOrderAndWithTraits() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("mixins/mixins-can-override-traits.smithy"))
+                .assemble()
+                .unwrap();
+
+        StructureShape f = model.expectShape(ShapeId.from("smithy.example#F"), StructureShape.class);
+
+        assertThat(f.getMemberNames(), contains("a", "b", "c", "d", "e", "f"));
+        assertThat(f.getMember("a").get().expectTrait(DocumentationTrait.class).getValue(), equalTo("I've changed"));
+        assertThat(f.getMember("c").get().expectTrait(DocumentationTrait.class).getValue(), equalTo("I've changed"));
+    }
+
+    @Test
+    public void ignoresAcceptableMixinConflicts() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("mixins/mixin-conflict-acceptable-1.smithy"))
+                .addImport(getClass().getResource("mixins/mixin-conflict-acceptable-2.smithy"))
+                .assemble()
+                .unwrap();
+
+        StructureShape a = model.expectShape(ShapeId.from("smithy.example#A"), StructureShape.class);
+
+        assertThat(a.getMemberNames(), contains("b", "a"));
+    }
+
+    @Test
+    public void failsWhenMixinsConflictAndAreNotEquivalent() {
+        ValidatedResultException e = Assertions.assertThrows(ValidatedResultException.class, () -> {
+            Model.assembler()
+                    .addImport(getClass().getResource("mixins/mixin-conflict-acceptable-1.smithy"))
+                    .addImport(getClass().getResource("mixins/mixin-conflict-error.smithy"))
+                    .assemble()
+                    .unwrap();
+        });
+
+        assertThat(e.getMessage(), containsString("Conflicting shape definition for `smithy.example#A`"));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/PendingShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/PendingShapeTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.SetUtils;
+
+public class PendingShapeTest {
+    @Test
+    public void cannotMergeIncompatibleShapes() {
+        PendingShape a = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(),
+                (created) -> {});
+        PendingShape b = PendingShape.create(
+                ShapeId.from("test#B"),
+                SourceLocation.NONE,
+                SetUtils.of(),
+                (created) -> {});
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            PendingShape.mergeIntoLeft(a, b);
+        });
+    }
+
+    @Test
+    public void mergesIntoExistingPendingConflict() {
+        PendingShape a = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(ShapeId.from("test#X")),
+                (created) -> {});
+        PendingShape b = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(ShapeId.from("test#Y")),
+                (created) -> {});
+
+        PendingShape merged = PendingShape.mergeIntoLeft(PendingShape.mergeIntoLeft(a, b), a);
+
+        assertThat(merged.getPendingShapes(), containsInAnyOrder(ShapeId.from("test#X"), ShapeId.from("test#Y")));
+    }
+
+    @Test
+    public void callsOnlyTheFirstMergedBuilder() {
+        Set<String> called = new HashSet<>();
+        PendingShape a = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(ShapeId.from("test#X")),
+                (created) -> called.add("a"));
+        PendingShape b = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(ShapeId.from("test#Y")),
+                (created) -> called.add("b"));
+        PendingShape merged = PendingShape.mergeIntoLeft(a, b);
+        merged.buildShapes(Collections.emptyMap());
+
+        assertThat(called, contains("a", "b"));
+    }
+
+    @Test
+    public void findsUnresolvedShapesForEachPendingShape() {
+        PendingShape a = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(ShapeId.from("test#X")),
+                (created) -> {});
+        PendingShape b = PendingShape.create(
+                ShapeId.from("test#A"),
+                SourceLocation.NONE,
+                SetUtils.of(ShapeId.from("test#Y")),
+                (created) -> {});
+        PendingShape merged = PendingShape.mergeIntoLeft(a, b);
+
+        List<ValidationEvent> events = merged.unresolved(Collections.emptyMap(), Collections.emptyMap());
+
+        assertThat(events, hasSize(2));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static software.amazon.smithy.model.shapes.ShapeId.from;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.Pair;
+import software.amazon.smithy.utils.SetUtils;
+
+public class TopologicalShapeSortTest {
+
+    @Test
+    public void topologicallySorts() {
+        List<Pair<ShapeId, Set<ShapeId>>> input = new ArrayList<>();
+        input.add(Pair.of(from("test#A"), SetUtils.of(from("test#B"), from("test#C"))));
+        input.add(Pair.of(from("test#B"), SetUtils.of(from("test#C"), from("test#D"))));
+        input.add(Pair.of(from("test#C"), SetUtils.of(from("test#E"))));
+        input.add(Pair.of(from("test#D"), SetUtils.of()));
+        input.add(Pair.of(from("test#E"), SetUtils.of()));
+
+        for (int i = 0; i < 100; i++) {
+            Collections.shuffle(input);
+            TopologicalShapeSort sort = new TopologicalShapeSort();
+            input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
+            List<ShapeId> result = sort.dequeueSortedShapes();
+
+            assertTrue("test#D".equals(result.get(0).toString()) || "test#E".equals(result.get(0).toString()));
+            assertTrue("test#D".equals(result.get(1).toString()) || "test#E".equals(result.get(1).toString()));
+            assertThat("test#C", equalTo(result.get(2).toString()));
+            assertThat("test#B", equalTo(result.get(3).toString()));
+            assertThat("test#A", equalTo(result.get(4).toString()));
+        }
+    }
+
+    @Test
+    public void detectsCycles() {
+        List<Pair<ShapeId, Set<ShapeId>>> input = new ArrayList<>();
+        input.add(Pair.of(from("test#A"), SetUtils.of(from("test#B"), from("test#C"))));
+        input.add(Pair.of(from("test#B"), SetUtils.of(from("test#C"), from("test#D"))));
+        input.add(Pair.of(from("test#C"), SetUtils.of(from("test#E"))));
+        input.add(Pair.of(from("test#D"), SetUtils.of()));
+        input.add(Pair.of(from("test#E"), SetUtils.of(from("test#A"))));
+
+        for (int i = 0; i < 100; i++) {
+            Collections.shuffle(input);
+            TopologicalShapeSort sort = new TopologicalShapeSort();
+            input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
+            try {
+                sort.dequeueSortedShapes();
+                throw new IllegalArgumentException("should have detected a cycle");
+            } catch (TopologicalShapeSort.CycleException e) {
+                assertThat(e.getUnresolved(),
+                           containsInAnyOrder(from("test#A"), from("test#B"), from("test#C"), from("test#E")));
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
@@ -37,8 +37,11 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.IdempotentTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
 
 public class NeighborVisitorTest {
 
@@ -153,6 +156,34 @@ public class NeighborVisitorTest {
         assertThat(relationships, containsInAnyOrder(
                 Relationship.create(struct, RelationshipType.STRUCTURE_MEMBER, member1Target),
                 Relationship.create(struct, RelationshipType.STRUCTURE_MEMBER, member2Target)));
+    }
+
+    @Test
+    public void structureShapeWithMixins() {
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#TestMixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addTrait(DeprecatedTrait.builder().build())
+                .addMember("a", string.getId(), builder -> builder.addTrait(new SensitiveTrait()))
+                .addMember("b", string.getId())
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addTrait(new SensitiveTrait())
+                .addMixin(mixin1)
+                .addMember("b", string.getId(), builder -> builder.addTrait(DeprecatedTrait.builder().build()))
+                .addMember("c", string.getId())
+                .build();
+        Model model = Model.builder().addShapes(mixin1, concrete, string).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
+        List<Relationship> relationships = concrete.accept(neighborVisitor);
+
+        assertThat(relationships, containsInAnyOrder(
+                Relationship.create(concrete, RelationshipType.STRUCTURE_MEMBER, concrete.getMember("a").get()),
+                Relationship.create(concrete, RelationshipType.STRUCTURE_MEMBER, concrete.getMember("b").get()),
+                Relationship.create(concrete, RelationshipType.STRUCTURE_MEMBER, concrete.getMember("c").get()),
+                Relationship.create(concrete, RelationshipType.MIXIN, mixin1)));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -1026,4 +1026,30 @@ public class SelectorTest {
 
         assertThat(matches, equalTo(matches2));
     }
+
+    @Test
+    public void selectsStructuresWithMixins() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("structure-with-mixins.smithy"))
+                .assemble()
+                .unwrap();
+        Selector hasMixins = Selector.parse("structure :test(-[mixin]->)");
+        Selector isUsedMixin = Selector.parse("structure -[mixin]->");
+        Selector noMixins = Selector.parse("structure[id|namespace='smithy.example'] :not(-[mixin]->)");
+        Selector unusedMixin = Selector.parse("[trait|mixin][id|namespace='smithy.example'] :not(<-[mixin]-)");
+
+        assertThat(hasMixins.select(model).stream().map(Shape::toShapeId).collect(Collectors.toSet()),
+                   containsInAnyOrder(ShapeId.from("smithy.example#Mixin2"), ShapeId.from("smithy.example#Concrete")));
+
+        assertThat(isUsedMixin.select(model).stream().map(Shape::toShapeId).collect(Collectors.toSet()),
+                   containsInAnyOrder(ShapeId.from("smithy.example#Mixin1"), ShapeId.from("smithy.example#Mixin2")));
+
+        assertThat(noMixins.select(model).stream().map(Shape::toShapeId).collect(Collectors.toSet()),
+                   containsInAnyOrder(ShapeId.from("smithy.example#Mixin1"),
+                                      ShapeId.from("smithy.example#NoMixins"),
+                                      ShapeId.from("smithy.example#UnusedMixin")));
+
+        assertThat(unusedMixin.select(model).stream().map(Shape::toShapeId).collect(Collectors.toSet()),
+                   contains(ShapeId.from("smithy.example#UnusedMixin")));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
@@ -21,10 +21,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.SourceException;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.InternalTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 
 public class StructureShapeTest {
@@ -116,5 +121,156 @@ public class StructureShapeTest {
                 .build();
 
         assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void supportsMixinTraits() {
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#Mixin1")
+                .addTrait(new SensitiveTrait())
+                .build();
+        StructureShape mixin2 = StructureShape.builder()
+                .id("smithy.example#Mixin2")
+                .addTrait(DeprecatedTrait.builder().build())
+                .build();
+        StructureShape mixin3 = StructureShape.builder()
+                .id("smithy.example#Mixin3")
+                .addMixin(mixin2)
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addMixin(mixin1)
+                .addMixin(mixin3)
+                .addTrait(new DocumentationTrait("hi"))
+                .build();
+
+        assertTrue(concrete.hasTrait(SensitiveTrait.class));
+        assertTrue(concrete.hasTrait(DeprecatedTrait.class));
+        assertTrue(concrete.hasTrait(DocumentationTrait.class));
+    }
+
+    @Test
+    public void reordersMixinMembersAutomatically() {
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#Mixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId())
+                .build();
+        StructureShape mixin2 = StructureShape.builder()
+                .id("smithy.example#Mixin2")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("b", string.getId())
+                .build();
+        StructureShape mixin3 = StructureShape.builder()
+                .id("smithy.example#Mixin3")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("c", string.getId())
+                .addMixin(mixin2)
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                // Note that d is added before mixins, but the builder tracks this
+                // and handles ordering appropriately when building the shape.
+                .addMember("d", string.getId())
+                .addMixin(mixin1)
+                .addMixin(mixin3)
+                .build();
+
+        assertThat(concrete.getMemberNames(), contains("a", "b", "c", "d"));
+    }
+
+    @Test
+    public void mixinMembersCanBeModifiedJustLikeNormalMembers() {
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#Mixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId())
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addMixin(mixin1)
+                .build();
+
+        // Just like you'd do with a normal member, you first get the member,
+        // then convert it to a builder to update it, then build it. Then the
+        // member is added to a new container shape and rebuilt. The workflow
+        // is exactly the same as a normal structure with no mixin members.
+        MemberShape updatedA = concrete.getMember("a").get().toBuilder()
+                .addTrait(new SensitiveTrait())
+                .build();
+        StructureShape updated = concrete.toBuilder().addMember(updatedA).build();
+
+        assertThat(updated.getMemberNames(), contains("a"));
+        assertTrue(updated.getMember("a").get().hasTrait(SensitiveTrait.class));
+        assertThat(updated.getMember("a").get().getMixins(), contains(mixin1.getMember("a").get().getId()));
+    }
+
+    @Test
+    public void structuresAccountForMissingMixinsOnLocalMembers() {
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#TestMixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId(), builder -> builder.addTrait(new SensitiveTrait()))
+                .addMember("b", string.getId())
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                // The missing mixin is automatically added to the computed members because the mixin
+                // is added after the member is added. If the member is added after the mixin, then
+                // this safeguard doesn't work.
+                .addMember(MemberShape.builder().id("smithy.example#Concrete$a").target(string).build())
+                // Note that b becomes a local member because it introduces a new trait.
+                .addMember("b", string.getId(), builder -> builder.addTrait(new SensitiveTrait()))
+                .addMixin(mixin1)
+                .build();
+
+        assertTrue(concrete.getMember("a").get().hasTrait(SensitiveTrait.class));
+        assertThat(concrete.getMember("a").get().getMixins(), contains(mixin1.getMember("a").get().getId()));
+
+        assertTrue(concrete.getMember("b").get().hasTrait(SensitiveTrait.class));
+        assertThat(concrete.getMember("b").get().getMixins(), contains(mixin1.getMember("b").get().getId()));
+    }
+
+    @Test
+    public void flattensMixins() {
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#TestMixin1")
+                .addTrait(MixinTrait.builder().addLocalTrait(InternalTrait.ID).build())
+                .addTrait(DeprecatedTrait.builder().build())
+                .addTrait(new InternalTrait()) // local and not copied.
+                .addMember("a", string.getId(), builder -> builder.addTrait(new SensitiveTrait()))
+                .addMember("b", string.getId())
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addTrait(new SensitiveTrait())
+                .addMixin(mixin1)
+                .addMember("b", string.getId(), builder -> builder.addTrait(DeprecatedTrait.builder().build()))
+                .addMember("c", string.getId())
+                .build();
+
+        StructureShape flattened = concrete.toBuilder().flattenMixins().build();
+        StructureShape expected = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addTrait(new SensitiveTrait())
+                .addTrait(DeprecatedTrait.builder().build())
+                .addMember("a", string.getId(), builder -> builder.addTrait(new SensitiveTrait()))
+                .addMember("b", string.getId(), builder -> builder.addTrait(DeprecatedTrait.builder().build()))
+                .addMember("c", string.getId())
+                .build();
+
+        assertThat(flattened, equalTo(expected));
+        assertThat(flattened.getMemberNames(), contains("a", "b", "c"));
+    }
+
+    @Test
+    public void flatteningStructureWithNoMixinsDoesNothing() {
+        StructureShape shape = StructureShape.builder().id("smithy.example#A").flattenMixins().build();
+
+        assertThat(shape, equalTo(StructureShape.builder().id("smithy.example#A").build()));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/MixinTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/MixinTraitTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class MixinTraitTest {
+
+    @Test
+    public void loadsEmptyTrait() {
+        Node node = Node.objectNode();
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#mixin"), ShapeId.from("ns.qux#foo"), node);
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(MixinTrait.class));
+        MixinTrait mixinTrait = (MixinTrait) trait.get();
+
+        // Returns MixinTrait.ID by default.
+        assertThat(mixinTrait.getLocalTraits(), contains(MixinTrait.ID));
+
+        // But doesn't serialize it since it's implied.
+        assertThat(mixinTrait.toNode(), equalTo(node));
+    }
+
+    @Test
+    public void retainsSourceLocation() {
+        SourceLocation source = new SourceLocation("/foo", 0, 0);
+        MixinTrait trait = MixinTrait.builder().sourceLocation(source).build();
+        MixinTrait rebuilt = trait.toBuilder().build();
+
+        assertThat(trait.getSourceLocation(), equalTo(rebuilt.getSourceLocation()));
+    }
+
+    @Test
+    public void retainsMixinLocalTraits() {
+        MixinTrait trait = MixinTrait.builder().addLocalTrait(SensitiveTrait.ID).build();
+        MixinTrait rebuilt = trait.toBuilder().build();
+        assertThat(trait.getLocalTraits(), hasItem(SensitiveTrait.ID));
+        assertThat(trait.getLocalTraits(), equalTo(rebuilt.getLocalTraits()));
+
+        assertThat(rebuilt, equalTo(trait));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ModelTransformerTest.java
@@ -18,20 +18,36 @@ package software.amazon.smithy.model.transform;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Predicate;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
 
 public class ModelTransformerTest {
+
+    private Model createTestModel() {
+        return Model.assembler()
+                .addImport(ModelTransformerTest.class.getResource("test-model.json"))
+                .assemble()
+                .unwrap();
+    }
 
     @Test
     public void discoversOnRemoveClassesWithSpi() {
@@ -78,10 +94,81 @@ public class ModelTransformerTest {
         assertThat(nonTraitShapes.getShape(EnumTrait.ID), Matchers.equalTo(Optional.empty()));
     }
 
-    private Model createTestModel() {
-        return Model.assembler()
-                .addImport(ModelTransformerTest.class.getResource("test-model.json"))
+    @Test
+    public void canFilterAndRemoveMixinsWhenNoMixinsArePresent() {
+        ModelTransformer transformer = ModelTransformer.create();
+        Model model = createTestModel();
+
+        assertThat(transformer.flattenAndRemoveMixins(model), Matchers.equalTo(model));
+    }
+
+    @Test
+    public void canFilterAndRemoveMixinsWhenMixinsArePresent() {
+        ModelTransformer transformer = ModelTransformer.create();
+        Model.Builder builder = Model.builder();
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#Mixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId())
+                .build();
+        StructureShape mixin2 = StructureShape.builder()
+                .id("smithy.example#Mixin2")
+                .addMember("b", string.getId())
+                .addTrait(MixinTrait.builder().build())
+                .build();
+        StructureShape mixin3 = StructureShape.builder()
+                .id("smithy.example#Mixin3")
+                .addMember("c", string.getId())
+                .addTrait(MixinTrait.builder().build())
+                .addMixin(mixin2)
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addMember("d", string.getId())
+                .addMixin(mixin1)
+                .addMixin(mixin3)
+                .build();
+        builder.addShapes(mixin1, mixin2, mixin3, concrete);
+        Model model = builder.build();
+        Model result = transformer.flattenAndRemoveMixins(model);
+
+        assertThat(result.toSet(), Matchers.not(Matchers.hasItem(mixin1)));
+        assertThat(result.toSet(), Matchers.not(Matchers.hasItem(mixin2)));
+        assertThat(result.toSet(), Matchers.not(Matchers.hasItem(mixin3)));
+        assertThat(result.getShape(concrete.getId()).get(),
+                   Matchers.equalTo(concrete.toBuilder().flattenMixins().build()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("flattenShapesData")
+    public void flattenShapes(String name) {
+        Model original = Model.assembler()
+                .addImport(Model.class.getResource("loader/valid/mixins/" + name + ".smithy"))
                 .assemble()
                 .unwrap();
+        Model expectedModel = Model.assembler()
+                .addImport(Model.class.getResource("loader/valid/mixins/" + name + ".flattened.smithy"))
+                .assemble()
+                .unwrap();
+        Model flattened = ModelTransformer.create().flattenAndRemoveMixins(original);
+
+        Node result = ModelSerializer.builder().build().serialize(flattened);
+        Node expected = ModelSerializer.builder().build().serialize(expectedModel);
+
+        try {
+            Node.assertEquals(result, expected);
+        } catch (ExpectationNotMetException e) {
+            fail(name + ": " + e.getMessage());
+        }
+    }
+
+    public static String[] flattenShapesData() {
+        return new String[] {
+            "loads-mixins",
+            "mixins-with-members",
+            "mixins-with-members-and-traits",
+            "mixins-with-mixin-local-traits"
+        };
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RemoveShapesTest.java
@@ -17,18 +17,28 @@ package software.amazon.smithy.model.transform;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -38,12 +48,22 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.AuthDefinitionTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.ProtocolDefinitionTrait;
 import software.amazon.smithy.model.traits.ReadonlyTrait;
 
 public class RemoveShapesTest {
 
     private static final ShapeId STRING_TARGET = ShapeId.from("ns.foo#String");
+    private static Model mixinsModel;
+
+    @BeforeAll
+    public static void before() {
+        mixinsModel = Model.assembler()
+                .addImport(RemoveShapesTest.class.getResource("mixin-removal/model.smithy"))
+                .assemble()
+                .unwrap();
+    }
 
     private void assertContainerMembersAreRemoved(Shape container, List<Shape> members) {
         Model.Builder builder = Model.builder()
@@ -199,5 +219,89 @@ public class RemoveShapesTest {
         ServiceShape updatedService = result.expectShape(service.getId(), ServiceShape.class);
 
         assertThat(updatedService.getRename().keySet(), empty());
+    }
+
+    @Test
+    public void removingMixinsRemovesThemFromShapes() {
+        ModelTransformer transformer = ModelTransformer.create();
+        Model.Builder builder = Model.builder();
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#Mixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId())
+                .build();
+        StructureShape mixin2 = StructureShape.builder()
+                .id("smithy.example#Mixin2")
+                .addMember("b", string.getId())
+                .addTrait(MixinTrait.builder().build())
+                .build();
+        StructureShape mixin3 = StructureShape.builder()
+                .id("smithy.example#Mixin3")
+                .addMember("c", string.getId())
+                .addTrait(MixinTrait.builder().build())
+                .addMixin(mixin2)
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addMember("d", string.getId())
+                .addMixin(mixin1)
+                .addMixin(mixin3)
+                .build();
+        builder.addShapes(mixin1, mixin2, mixin3, concrete);
+        Model model = builder.build();
+
+        Model result1 = transformer.removeShapes(model, Collections.singletonList(mixin3));
+        assertThat(result1.expectShape(concrete.getId(), StructureShape.class).getAllMembers(), not(hasKey("c")));
+        assertThat(result1.expectShape(concrete.getId(), StructureShape.class).getAllMembers(), not(hasKey("b")));
+        assertThat(result1.expectShape(concrete.getId(), StructureShape.class).getAllMembers(), hasKey("a"));
+        assertThat(result1.expectShape(concrete.getId(), StructureShape.class).getAllMembers(), hasKey("d"));
+        assertThat(result1.getShape(mixin3.getId()), equalTo(Optional.empty()));
+        assertThat(result1.getShape(mixin2.getId()), equalTo(Optional.of(mixin2)));
+
+        Model result2 = transformer.removeShapes(model, Collections.singletonList(mixin2));
+        assertThat(result2.getShape(mixin2.getId()), equalTo(Optional.empty()));
+
+        Model result3 = transformer.removeShapes(model, Collections.singletonList(mixin1));
+        assertThat(result3.getShape(mixin1.getId()), equalTo(Optional.empty()));
+        assertThat(result3.expectShape(concrete.getId(), StructureShape.class).getAllMembers(), not(hasKey("a")));
+        assertThat(result3.expectShape(concrete.getId(), StructureShape.class).getAllMembers(), hasKey("d"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("removeMixinData")
+    public void RemoveMixinsTest(String mixinFile, String[] shapeNamesToRemove) {
+        Model start = mixinsModel;
+
+        Collection<Shape> shapesToRemove = new ArrayList<>(shapeNamesToRemove.length);
+        for (String name : shapeNamesToRemove) {
+            shapesToRemove.add(start.expectShape(ShapeId.from("smithy.example#" + name)));
+        }
+
+        Model result = ModelTransformer.create().removeShapes(start, shapesToRemove);
+        Model expected = Model.assembler()
+                .addImport(RemoveShapesTest.class.getResource("mixin-removal/" + mixinFile))
+                .assemble()
+                .unwrap();
+        ModelSerializer serializer = ModelSerializer.builder().build();
+
+        Node.assertEquals(serializer.serialize(result), serializer.serialize(expected));
+    }
+
+    public static Collection<Object[]> removeMixinData() {
+        return Arrays.asList(new Object[][] {
+            { "without-a.smithy", new String[] {"A"}},
+            { "without-a2.smithy", new String[] {"A2"}},
+            { "without-a3.smithy", new String[] {"A3"}},
+            { "without-a-a2.smithy", new String[] {"A", "A2"}},
+            { "without-a-a2-a3.smithy", new String[] {"A", "A2", "A3"}},
+            { "without-a-a2-a3-b-b2-b3.smithy", new String[] {"A", "A2", "A3", "B", "B2", "B3"}},
+            { "without-a-b.smithy", new String[] {"A", "B"}},
+            { "without-b.smithy", new String[] {"B"}},
+            { "without-b2.smithy", new String[] {"B2"}},
+            { "without-b3.smithy", new String[] {"B3"}},
+            { "without-c.smithy", new String[] {"C"}},
+            { "without-d.smithy", new String[] {"D"}}
+        });
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/MixinValidatorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/MixinValidatorTest.java
@@ -1,0 +1,42 @@
+package software.amazon.smithy.model.validation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.MixinTrait;
+import software.amazon.smithy.model.validation.validators.MixinValidator;
+
+public class MixinValidatorTest {
+    @Test
+    public void ensuresManuallyBuiltModelsAreValid() {
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#mixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("foo", ShapeId.from("smithy.api#String"))
+                .build();
+        StructureShape mixin2 = StructureShape.builder()
+                .id("smithy.example#mixin2")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("foo", ShapeId.from("smithy.api#String"))
+                .build();
+        StructureShape invalid = StructureShape.builder()
+                .id("smithy.example#invalid")
+                .addMixin(mixin1)
+                .addMixin(mixin2)
+                .build();
+        Model model = Model.builder().addShapes(mixin1, mixin2, invalid).build();
+
+        MixinValidator validator = new MixinValidator();
+        List<ValidationEvent> events = validator.validate(model);
+
+        assertThat(events, hasSize(1));
+        assertThat(events.get(0).getMessage(),
+                   equalTo("Member `foo` conflicts with members defined in the following mixins: [smithy.example#mixin1, smithy.example#mixin2]"));
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles1.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles1.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#Mixin: Unable to resolve mixins; cycles detected between this shape and [smithy.example#UsesMixin] | Model
+[ERROR] smithy.example#UsesMixin: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin] | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles1.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles1.json
@@ -1,0 +1,23 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#Mixin": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#UsesMixin"}
+            ]
+        },
+        "smithy.example#UsesMixin": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#Mixin"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles2.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles2.errors
@@ -1,0 +1,4 @@
+[ERROR] smithy.example#Mixin1: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Bad] | Model
+[ERROR] smithy.example#Mixin2: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin1] | Model
+[ERROR] smithy.example#Mixin3: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin2] | Model
+[ERROR] smithy.example#Bad: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin3] | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles2.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles2.json
@@ -1,0 +1,35 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#Mixin1": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#Bad"}
+            ]
+        },
+        "smithy.example#Mixin2": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#Mixin1"}
+            ]
+        },
+        "smithy.example#Mixin3": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#Mixin2"}
+            ]
+        },
+        "smithy.example#Bad": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#Mixin3"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles3.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles3.errors
@@ -1,0 +1,8 @@
+[ERROR] smithy.example#Mixin1A: Unable to resolve mixins; cycles detected between this shape and [smithy.example#BadA] | Model
+[ERROR] smithy.example#Mixin2A: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin1A] | Model
+[ERROR] smithy.example#Mixin3A: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin2A] | Model
+[ERROR] smithy.example#BadA: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin3A] | Model
+[ERROR] smithy.example#Mixin1B: Unable to resolve mixins; cycles detected between this shape and [smithy.example#BadB] | Model
+[ERROR] smithy.example#Mixin2B: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin1B] | Model
+[ERROR] smithy.example#Mixin3B: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin2B] | Model
+[ERROR] smithy.example#BadB: Unable to resolve mixins; cycles detected between this shape and [smithy.example#Mixin3B] | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles3.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-cycles3.json
@@ -1,0 +1,65 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#Mixin1A": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#BadA"}
+            ]
+        },
+        "smithy.example#Mixin2A": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#Mixin1A"}
+            ]
+        },
+        "smithy.example#Mixin3A": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#Mixin2A"}
+            ]
+        },
+        "smithy.example#BadA": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#Mixin3A"}
+            ]
+        },
+        "smithy.example#Mixin1B": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#BadB"}
+            ]
+        },
+        "smithy.example#Mixin2B": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#Mixin1B"}
+            ]
+        },
+        "smithy.example#Mixin3B": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#Mixin2B"}
+            ]
+        },
+        "smithy.example#BadB": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#Mixin3B"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-invalid-mixin.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-invalid-mixin.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#B: Unable to resolve mixins; attempted to mixin shapes with no mixin trait: [smithy.example#A] | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-invalid-mixin.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-invalid-mixin.json
@@ -1,0 +1,17 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#A": {
+            "type": "structure"
+        },
+        "smithy.example#B": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#A"}
+            ],
+            "traits": {
+                "smithy.api#documentation": "This documentation does not raise a validation error even though smithy.example#B cannot be built."
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-missing-transitive.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-missing-transitive.errors
@@ -1,0 +1,3 @@
+[ERROR] smithy.example#A: Unable to resolve mixins; attempted to mixin shapes that are not in the model: [smithy.example#Missing] | Model
+[ERROR] smithy.example#B: Unable to resolve mixins; unable to resolve due to missing transitive mixins: [smithy.example#A] | Model
+[ERROR] smithy.example#C: Unable to resolve mixins; unable to resolve due to missing transitive mixins: [smithy.example#B] | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-missing-transitive.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/mixins-detects-missing-transitive.json
@@ -1,0 +1,29 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#A": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#Missing"}
+            ]
+        },
+        "smithy.example#B": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#A"}
+            ]
+        },
+        "smithy.example#C": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#B"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/structure-warns-additional-properties.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/structure-warns-additional-properties.errors
@@ -1,1 +1,1 @@
-[WARNING] smithy.example#Hi: Expected an object with possible properties of `members`, `traits`, `type`, but found additional properties: `foo` | Model
+[WARNING] smithy.example#Hi: Expected an object with possible properties of `members`, `mixins`, `traits`, `type`, but found additional properties: `foo` | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-illegal-redefined-member.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-illegal-redefined-member.errors
@@ -1,0 +1,3 @@
+[ERROR] smithy.example#Baz$foo: Member conflicts with an inherited mixin member: smithy.example#Foo$foo | Model
+[ERROR] smithy.example#Bam$foo: Member conflicts with an inherited mixin member: smithy.example#Foo$foo | Model
+[ERROR] smithy.example#Boo$foo: Member conflicts with an inherited mixin member: smithy.example#Bam$foo | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-illegal-redefined-member.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-illegal-redefined-member.smithy
@@ -1,0 +1,21 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure Foo {
+    foo: String
+}
+
+structure Baz with Foo {
+    foo: String // cannot redefine mixin members!
+}
+
+@mixin
+structure Bam with Foo {
+    foo: String // cannot redefine mixin members!
+}
+
+structure Boo with Bam {
+    foo: String // cannot redefine mixin members!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-trait-applied.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-trait-applied.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#InvalidUseOfMixinTrait: Trait `smithy.example#mixinTrait` is a mixin and cannot be applied to `smithy.example#InvalidUseOfMixinTrait`. | TraitTarget

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-trait-applied.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-trait-applied.smithy
@@ -1,0 +1,15 @@
+$version: "1.1"
+namespace smithy.example
+
+@mixin
+@trait
+structure mixinTrait {}
+
+// This is fine, and it makes this shape a trait!
+structure usesMixinTrait with mixinTrait {}
+
+@usesMixinTrait
+structure FineUseOfTrait {}
+
+@mixinTrait // cannot apply a trait with a mixin as a trait.
+structure InvalidUseOfMixinTrait {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-used-in-illegal-relationship.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-used-in-illegal-relationship.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#Baz$invalid: Illegal MEMBER_TARGET reference to mixin `smithy.example#Foo`; shapes marked with the mixin trait can only be referenced to apply them as a mixin. | Target

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-used-in-illegal-relationship.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/mixin-used-in-illegal-relationship.smithy
@@ -1,0 +1,12 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure Foo {
+    foo: String
+}
+
+structure Baz {
+    invalid: Foo // this is not allowed because Foo is a mixin
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/dangling-with.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/dangling-with.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 5, column 1 near ``: Expected a valid identifier character, but found ''
+namespace com.foo
+
+structure Foo with

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-resource.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-resource.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 15 near `with`: Expected: '{', but found 'w'
+namespace com.foo
+
+resource Test with X {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-string.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-string.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 21 near ` X`: Unexpected shape type: with
+namespace com.foo
+
+string MyString with X

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-statement-after-structure-name.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-statement-after-structure-name.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 15 near `Baz`: Expected: '{', but found 'B'
+namespace com.foo
+
+structure Foo Baz {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/missing-rest-of-with-word.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/missing-rest-of-with-word.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 18 near ` Baz`: Expected: 'h', but found ' '
+namespace com.foo
+
+structure Foo wit Baz {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/with-but-no-ids.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/with-but-no-ids.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 20 near `{}`: Expected a valid identifier character, but found '{'
+namespace com.foo
+
+structure Foo with {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixin-conflict-acceptable-1.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixin-conflict-acceptable-1.smithy
@@ -1,0 +1,13 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A with B {
+    a: String
+}
+
+@mixin
+structure B {
+    b: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixin-conflict-acceptable-2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixin-conflict-acceptable-2.smithy
@@ -1,0 +1,8 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A with B {
+    a: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixin-conflict-error.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixin-conflict-error.smithy
@@ -1,0 +1,9 @@
+// This should fail when also loaded with mixin-conflict-acceptable.smithy
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A with B {
+    a: Integer
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixins-can-override-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixins-can-override-traits.smithy
@@ -1,0 +1,55 @@
+namespace smithy.example
+
+/// A
+@sensitive
+@mixin
+structure A {
+    /// A.a
+    a: String
+}
+
+/// B
+@deprecated
+@mixin
+structure B with A {
+    /// B.b
+    b: String
+}
+
+/// C
+@mixin
+@tags(["a"])
+structure C {
+    /// C.c
+    c: String
+}
+
+/// D
+@mixin
+@externalDocumentation(web: "http://example.com")
+structure D with C {
+    /// D.d
+    d: String
+}
+
+// Override traits on the inherited member.
+apply D$c @sensitive
+apply D$c @documentation("I've changed")
+
+/// E
+@since("X")
+@mixin
+structure E with D {
+    /// E.e
+    e: String
+}
+
+/// F
+@internal
+structure F with B, E {
+    /// F.f
+    f: String
+}
+
+// Override the docs of a on F
+apply F$a @documentation("I've changed")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins-with-whitespace.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins-with-whitespace.json
@@ -1,0 +1,24 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#A": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#B": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#C": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#A"},
+                {"target": "smithy.example#B"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins-with-whitespace.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins-with-whitespace.smithy
@@ -1,0 +1,15 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {}
+
+@mixin
+structure B {}
+
+structure C with
+   A ,,,
+
+
+   ,    B ,,, ,     {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.flattened.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.flattened.smithy
@@ -1,0 +1,7 @@
+$version: "1.1"
+
+namespace smithy.example
+
+structure B {}
+
+structure F {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.json
@@ -1,0 +1,48 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#A": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#B": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#A"}
+            ]
+        },
+        "smithy.example#C": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#D": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#C"}
+            ],
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#E": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {}
+            },
+            "mixins": [
+                {"target": "smithy.example#D"}
+            ]
+        },
+        "smithy.example#F": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#A"},
+                {"target": "smithy.example#E"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.smithy
@@ -1,0 +1,19 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {}
+
+structure B with A {}
+
+@mixin
+structure C {}
+
+@mixin
+structure D with C {}
+
+@mixin
+structure E with D {}
+
+structure F with A, E {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members-and-traits.flattened.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members-and-traits.flattened.smithy
@@ -1,0 +1,31 @@
+$version: "1.1"
+
+namespace smithy.example
+
+/// F
+@internal
+@deprecated
+@externalDocumentation(web: "http://example.com")
+@sensitive
+@since("X")
+@tags(["a"])
+structure F {
+    /// I've changed
+    a: String,
+
+    /// B.b
+    b: String,
+
+    /// I've changed
+    @sensitive
+    c: String,
+
+    /// D.d
+    d: String,
+
+    /// E.e
+    e: String,
+
+    /// F.f
+    f: String,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members-and-traits.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members-and-traits.json
@@ -1,0 +1,138 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#A": {
+            "type": "structure",
+            "members": {
+                "a": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "A.a"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "A",
+                "smithy.api#mixin": {},
+                "smithy.api#sensitive": {}
+            }
+        },
+        "smithy.example#B": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#A"
+                }
+            ],
+            "members": {
+                "b": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "B.b"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "B",
+                "smithy.api#deprecated": {},
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#C": {
+            "type": "structure",
+            "members": {
+                "c": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "C.c"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "C",
+                "smithy.api#mixin": {},
+                "smithy.api#tags": ["a"]
+            }
+        },
+        "smithy.example#D": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#C"
+                }
+            ],
+            "members": {
+                "d": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "D.d"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "D",
+                "smithy.api#mixin": {},
+                "smithy.api#externalDocumentation": {
+                    "web": "http://example.com"
+                }
+            }
+        },
+        "smithy.example#D$c": {
+            "type": "apply",
+            "traits": {
+                "smithy.api#documentation": "I've changed",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "smithy.example#E": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#D"
+                }
+            ],
+            "members": {
+                "e": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "E.e"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "E",
+                "smithy.api#mixin": {},
+                "smithy.api#since": "X"
+            }
+        },
+        "smithy.example#F": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#B"
+                },
+                {
+                    "target": "smithy.example#E"
+                }
+            ],
+            "members": {
+                "f": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "F.f"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "F",
+                "smithy.api#internal": {}
+            }
+        },
+        "smithy.example#F$a": {
+            "type": "apply",
+            "traits": {
+                "smithy.api#documentation": "I've changed"
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members-and-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members-and-traits.smithy
@@ -1,0 +1,57 @@
+$version: "1.1"
+
+namespace smithy.example
+
+/// A
+@sensitive
+@mixin
+structure A {
+    /// A.a
+    a: String
+}
+
+/// B
+@deprecated
+@mixin
+structure B with A {
+    /// B.b
+    b: String
+}
+
+/// C
+@mixin
+@tags(["a"])
+structure C {
+    /// C.c
+    c: String
+}
+
+/// D
+@mixin
+@externalDocumentation(web: "http://example.com")
+structure D with C {
+    /// D.d
+    d: String
+}
+
+// Override traits on the inherited member.
+apply D$c @sensitive
+apply D$c @documentation("I've changed")
+
+/// E
+@since("X")
+@mixin
+structure E with D {
+    /// E.e
+    e: String
+}
+
+/// F
+@internal
+structure F with B, E {
+    /// F.f
+    f: String
+}
+
+// Override the docs of a on F
+apply F$a @documentation("I've changed")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members.flattened.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members.flattened.smithy
@@ -1,0 +1,12 @@
+$version: "1.1"
+
+namespace smithy.example
+
+structure F {
+    a: String,
+    b: String,
+    c: String,
+    d: String,
+    e: String,
+    f: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members.json
@@ -1,0 +1,91 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#A": {
+            "type": "structure",
+            "members": {
+                "a": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#B": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#A"
+                }
+            ],
+            "members": {
+                "b": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#C": {
+            "type": "structure",
+            "members": {
+                "c": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#D": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#C"
+                }
+            ],
+            "members": {
+                "d": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#E": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#D"
+                }
+            ],
+            "members": {
+                "e": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#F": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#B"
+                },
+                {
+                    "target": "smithy.example#E"
+                }
+            ],
+            "members": {
+                "f": {
+                    "target": "smithy.api#String"
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-members.smithy
@@ -1,0 +1,32 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    a: String
+}
+
+@mixin
+structure B with A {
+    b: String
+}
+
+@mixin
+structure C {
+    c: String
+}
+
+@mixin
+structure D with C {
+    d: String
+}
+
+@mixin
+structure E with D {
+    e: String
+}
+
+structure F with B, E {
+    f: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-mixin-local-traits.flattened.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-mixin-local-traits.flattened.smithy
@@ -1,0 +1,8 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@sensitive
+structure PublicShape {
+    foo: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-mixin-local-traits.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-mixin-local-traits.json
@@ -1,0 +1,27 @@
+{
+    "smithy": "1.1",
+    "shapes": {
+        "smithy.example#PrivateMixin": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#mixin": {
+                    "localTraits": ["smithy.api#private", "smithy.api#documentation"]
+                },
+                "smithy.api#private": {},
+                "smithy.api#documentation": "This mixin is used to make things have a foo member,\nbut it can't be used outside of this namespace.",
+                "smithy.api#sensitive": {}
+            },
+            "members": {
+                "foo": {
+                    "target": "smithy.api#String"
+                }
+            }
+        },
+        "smithy.example#PublicShape": {
+            "type": "structure",
+            "mixins": [
+                {"target": "smithy.example#PrivateMixin"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-mixin-local-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/mixins-with-mixin-local-traits.smithy
@@ -1,0 +1,14 @@
+$version: "1.1"
+
+namespace smithy.example
+
+/// This mixin is used to make things have a foo member,
+/// but it can't be used outside of this namespace.
+@private
+@sensitive
+@mixin(localTraits: [private, documentation])
+structure PrivateMixin {
+    foo: String
+}
+
+structure PublicShape with PrivateMixin {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/structure-with-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/structure-with-mixins.smithy
@@ -1,0 +1,16 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure Mixin1 {}
+
+@mixin
+structure Mixin2 with Mixin1 {}
+
+structure Concrete with Mixin2 {}
+
+structure NoMixins {}
+
+@mixin
+structure UnusedMixin {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/mixins.smithy
@@ -1,0 +1,63 @@
+$version: "1.1"
+
+namespace smithy.example
+
+/// A
+@mixin
+@sensitive
+structure A {
+    /// A.a
+    a: String
+}
+
+/// B
+@deprecated
+@mixin
+structure B with A {
+    /// B.b
+    b: String
+}
+
+/// C
+@mixin
+@tags([
+    "a"
+])
+structure C {
+    /// C.c
+    c: String
+}
+
+/// D
+@externalDocumentation(
+    web: "http://example.com"
+)
+@mixin
+structure D with C {
+    /// D.d
+    d: String
+}
+
+apply D$c {
+    @documentation("I've changed")
+    @sensitive
+}
+
+/// E
+@mixin
+@since("X")
+structure E with D {
+    /// E.e
+    e: String
+}
+
+/// F
+@internal
+structure F with B, E {
+    /// F.f
+    f: String
+}
+
+apply F$a {
+    @documentation("I've changed")
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/mixins.smithy
@@ -53,11 +53,25 @@ structure E with D {
 
 /// F
 @internal
-structure F with B, E {
+structure F with
+    B
+    E
+{
     /// F.f
     f: String
 }
 
 apply F$a {
     @documentation("I've changed")
+    @sensitive
 }
+
+apply F$e @sensitive
+
+structure G with
+    B
+    E {}
+
+structure H with B {}
+
+structure I {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/model.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/model.smithy
@@ -1,0 +1,51 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+apply A3$a @documentation("A3")
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+apply C$a @documentation("C")
+
+structure D with C {
+    d: String
+}
+
+apply D$a @documentation("D")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-a2-a3-b-b2-b3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-a2-a3-b-b2-b3.smithy
@@ -1,0 +1,12 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure C {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-a2-a3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-a2-a3.smithy
@@ -1,0 +1,27 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with B3 {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-a2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-a2.smithy
@@ -1,0 +1,32 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A3 {
+    a3: String
+}
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-b.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a-b.smithy
@@ -1,0 +1,32 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A2 {
+    a2: String
+}
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+@mixin
+structure B2 {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a.smithy
@@ -1,0 +1,37 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A2 {
+    a2: String
+}
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a2.smithy
@@ -1,0 +1,38 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A3 {
+    a3: String
+}
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-a3.smithy
@@ -1,0 +1,40 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with B3 {
+    c: String
+}
+
+structure D with C {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-b.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-b.smithy
@@ -1,0 +1,46 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+apply A3$a @documentation("A3")
+
+@mixin
+structure B2 {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+apply C$a @documentation("C")
+
+structure D with C {
+    d: String
+}
+
+apply D$a @documentation("D")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-b2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-b2.smithy
@@ -1,0 +1,46 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+apply A3$a @documentation("A3")
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B3 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+apply C$a @documentation("C")
+
+structure D with C {
+    d: String
+}
+
+apply D$a @documentation("D")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-b3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-b3.smithy
@@ -1,0 +1,46 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+apply A3$a @documentation("A3")
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure C with A3 {
+    c: String
+}
+
+apply C$a @documentation("C")
+
+structure D with C {
+    d: String
+}
+
+apply D$a @documentation("D")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-c.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-c.smithy
@@ -1,0 +1,45 @@
+// Removing "C" will update D such that D has no mixins, D no longer has
+// a2, a3, b, b2, or b3. D still has a because a trait was added to the
+// inherited a member of D to update the documentation to "D".
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+apply A3$a @documentation("A3")
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+structure D {
+    d: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-d.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/mixin-removal/without-d.smithy
@@ -1,0 +1,47 @@
+// Removing "D" has no effect on other shapes, even shapes that are mixins
+// that D used. Those shapes aren't dependent on D.
+$version: "1.1"
+
+namespace smithy.example
+
+@mixin
+structure A {
+    /// A
+    a: String
+}
+
+@mixin
+structure A2 with A {
+    a2: String
+}
+
+apply A2$a @documentation("A2")
+
+@mixin
+structure A3 with A2 {
+    a3: String
+}
+
+apply A3$a @documentation("A3")
+
+@mixin
+structure B {
+    b: String
+}
+
+@mixin
+structure B2 with B {
+    b2: String
+}
+
+@mixin
+structure B3 with B2 {
+    b3: String
+}
+
+@mixin
+structure C with A3, B3 {
+    c: String
+}
+
+apply C$a @documentation("C")

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -47,6 +47,7 @@ import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.TitleTrait;
 import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.model.validation.ValidationUtils;
 import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.OpenApiException;
@@ -172,6 +173,9 @@ public final class OpenApiConverter {
         if (serviceShapeId == null) {
             throw new OpenApiException("openapi is missing required property, `service`");
         }
+
+        // Remove mixins from the model.
+        model = ModelTransformer.create().flattenAndRemoveMixins(model);
 
         JsonSchemaConverter.Builder jsonSchemaConverterBuilder = JsonSchemaConverter.builder();
         jsonSchemaConverterBuilder.model(model);

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -498,4 +498,23 @@ public class OpenApiConverterTest {
 
         Node.assertEquals(result, expectedNode);
     }
+
+    @Test
+    public void removesMixins() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("model-with-mixins.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#HasMixin"));
+        config.setProtocol(ShapeId.from("aws.protocols#restJson1"));
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("model-with-mixins.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/model-with-mixins.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/model-with-mixins.openapi.json
@@ -1,0 +1,41 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "HasMixin",
+        "version": "2021-08-12"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "Greeting",
+                "responses": {
+                    "200": {
+                        "description": "Greeting 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GreetingResponseContent"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "GreetingResponseContent": {
+                "type": "object",
+                "properties": {
+                    "greeting": {
+                        "type": "string"
+                    },
+                    "language": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/model-with-mixins.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/model-with-mixins.smithy
@@ -1,0 +1,24 @@
+$version: "1.1"
+
+namespace smithy.example
+
+@aws.protocols#restJson1
+service HasMixin {
+    version: "2021-08-12",
+    operations: [Greeting]
+}
+
+@http(method: "GET", uri: "/")
+@readonly
+operation Greeting {
+    output: Output
+}
+
+@mixin
+structure Mixin {
+    greeting: String
+}
+
+structure Output with Mixin {
+    language: String
+}

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/ListUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/ListUtils.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.utils;
 
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,6 +61,34 @@ public final class ListUtils {
      */
     public static <T> List<T> of(T value) {
         return Collections.singletonList(value);
+    }
+
+    /**
+     * Returns an unmodifiable list containing two entries.
+     *
+     * @param value1 The first value.
+     * @param value2 The second value.
+     * @param <T> the List's value type.
+     * @return a List containing the specified values.
+     */
+    @SuppressWarnings("varargs")
+    public static <T> List<T> of(T value1, T value2) {
+        // Note that AbstractList is immutable by default.
+        return new AbstractList<T>() {
+            @Override
+            public T get(int index) {
+                switch (index) {
+                    case 0: return value1;
+                    case 1: return value2;
+                    default: throw new IndexOutOfBoundsException("Index: " + index + ", Size: 2");
+                }
+            }
+
+            @Override
+            public int size() {
+                return 2;
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
This massive PR implements the mixins proposal, but with the following
change that will be updated as a followup on the proposal:

The idea of redefining inherited members was removed, along with the
special `(inherit)` syntax. Feedback on this syntax was that it was
awkward. Redefining a member is now prohibited. Instead, only apply is
allowed. To make it easier to apply multiple traits to a single shape,
particularly a member, a block form of apply was added in a previous
commit.

This change adds:
1. The ability to create mixins using the `@mixin` trait.
2. The ability to restrict which members are inherited by shapes that
   use a mixin using `localTraits` on the `@mixin` trait.
3. The ability to use a mixin with a shape in the IDL using `with`.
4. The ability to use a mixin in the JSON AST using `mixins`.
5. The ability to serialize mixins in the IDL and AST.
6. The ability to query mixin relationships in selectors using the
   `mixin` relationship. This also ensures that mixins are considered
   part of a service closure.
7. The ability to remove mixins from a model, and update all shapes that
   depend on the mixin.
8. The ability to "flatten" mixins out of the model, meaning that the
   mixin is removed, but any members or traits it provides to shapes
   that use it are copied onto those shapes.
9. Validation to ensure no mixin cycles or "with" statements are added
   that point to shapes that don't exist or that aren't marked with
   the `@mixin` trait.
10. Mixins are flattened out of models when converting to JSON Schema
    and to OpenAPI.
11. When a mixin is updated, any shape that uses that mixin is also
    updated.

Implementation notes:
* Mixins were added to the Shape type. This made it far easier to
  implement everything rather than introducing something like a
  `HasMixins` interface implemented on structure, union, and member
  shapes or using visitors. This design decision is similar to what was
  already done with the `members()` method on `Shape`, which just makes
  `Shape` generally easir to use.
* Shapes implicitly hold on to references to their mixins, but the mixin
  shapes are not directly exposed in the shape's API (only ShapeIds).
  This ensures that if we need to do any refactoring later, we can
  without making that a hard design requirement (it isn't so far!).
* Missing validation about member shapes matching their container IDs
  was added because it was needed to ensure mixin members were added
  correctly.
* An updated ListUtils.of() method was added for the case when there are
  two items. This was done because the `members()` method is now used
  each time a shape is created, which previously created an ArrayList
  each time the members of MapShape were requested.

  Followups:
  * Add specifications around mixins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
