### PR TITLE
Move accept/content-type protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -56,6 +56,46 @@ apply HttpPayloadTraits @httpRequestTests([
             foo: "Foo"
         }
     },
+    {
+        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllContentTypes",
+        documentation: """
+            Servers must accept any content type for blob inputs
+            without the media type trait.""",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/HttpPayloadTraits",
+        body: "This is definitely a jpeg",
+        bodyMediaType: "application/octet-stream",
+        headers: {
+            "X-Foo": "Foo",
+            "Content-Type": "image/jpeg"
+        },
+        params: {
+            foo: "Foo",
+            blob: "This is definitely a jpeg"
+        },
+        appliesTo: "server",
+    },
+    {
+        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllAccepts",
+        documentation: """
+            Servers must accept any accept header for blob inputs
+            without the media type trait.""",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/HttpPayloadTraits",
+        body: "This is definitely a jpeg",
+        bodyMediaType: "application/octet-stream",
+        headers: {
+            "X-Foo": "Foo",
+            "Accept": "image/jpeg"
+        },
+        params: {
+            foo: "Foo",
+            blob: "This is definitely a jpeg"
+        },
+        appliesTo: "server",
+    },
 ])
 
 apply HttpPayloadTraits @httpResponseTests([
@@ -87,44 +127,6 @@ apply HttpPayloadTraits @httpResponseTests([
         params: {
             foo: "Foo"
         }
-    },
-    {
-        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllContentTypes",
-        documentation: """
-            Servers must accept any content type for blob inputs
-            without the media type trait.""",
-        protocol: restJson1,
-        code: 200,
-        body: "This is definitely a jpeg",
-        bodyMediaType: "application/octet-stream",
-        headers: {
-            "X-Foo": "Foo",
-            "Content-Type": "image/jpeg"
-        },
-        params: {
-            foo: "Foo",
-            blob: "This is definitely a jpeg"
-        },
-        appliesTo: "server",
-    },
-    {
-        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllAccepts",
-        documentation: """
-            Servers must accept any accept header for blob inputs
-            without the media type trait.""",
-        protocol: restJson1,
-        code: 200,
-        body: "This is definitely a jpeg",
-        bodyMediaType: "application/octet-stream",
-        headers: {
-            "X-Foo": "Foo",
-            "Accept": "image/jpeg"
-        },
-        params: {
-            foo: "Foo",
-            blob: "This is definitely a jpeg"
-        },
-        appliesTo: "server",
     },
 ])
 


### PR DESCRIPTION
This moves a pair of protocol tests from response to request, where they should have been from the start. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
