### PR TITLE
Add David to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add core contributors to all prs by default
-* @kstich @JordonPhillips @mtdowling
+* @kstich @JordonPhillips @mtdowling @DavidOgunsAWS


### PR DESCRIPTION
This adds @DavidOgunsAWS to the codeowners so he'll be automatically added to PRs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
