### PR TITLE
add test for rpc protocol path preix

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_0/endpoint-paths.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/endpoint-paths.smithy
@@ -1,0 +1,24 @@
+// This file defines tests to ensure that implementations support endpoints with paths
+
+$version: "1.0"
+
+namespace aws.protocoltests.json10
+
+use aws.protocols#awsJson1_0
+use smithy.test#httpRequestTests
+
+@httpRequestTests([
+    {
+        id: "AwsJson10HostWithPath",
+        documentation: """
+                Custom endpoints supplied by users can have paths""",
+        protocol: awsJson1_0,
+        method: "POST",
+        uri: "/custom/",
+        body: "{}",
+        host: "example.com/custom",
+        appliesTo: "client"
+    }
+])
+
+operation HostWithPathOperation {}

--- a/smithy-aws-protocol-tests/model/awsJson1_0/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/main.smithy
@@ -25,5 +25,8 @@ service JsonRpc10 {
         // @endpoint and @hostLabel trait tests
         EndpointOperation,
         EndpointWithHostLabelOperation,
+
+        // custom endpoints with paths
+        HostWithPathOperation,
     ]
 }

--- a/smithy-aws-protocol-tests/model/awsJson1_1/endpoint-paths.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/endpoint-paths.smithy
@@ -1,0 +1,24 @@
+// This file defines tests to ensure that implementations support endpoints with paths
+
+$version: "1.0"
+
+namespace aws.protocoltests.json
+
+use aws.protocols#awsJson1_1
+use smithy.test#httpRequestTests
+
+@httpRequestTests([
+    {
+        id: "AwsJson11HostWithPath",
+        documentation: """
+                Custom endpoints supplied by users can have paths""",
+        protocol: awsJson1_1,
+        method: "POST",
+        uri: "/custom/",
+        body: "{}",
+        host: "example.com/custom",
+        appliesTo: "client"
+    }
+])
+
+operation HostWithPathOperation {}

--- a/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
@@ -33,6 +33,9 @@ service JsonProtocol {
         // @endpoint and @hostLabel trait tests
         EndpointOperation,
         EndpointWithHostLabelOperation,
+
+        // custom endpoints with paths
+        HostWithPathOperation,
     ],
 }
 

--- a/smithy-aws-protocol-tests/model/awsQuery/endpoint-paths.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/endpoint-paths.smithy
@@ -1,0 +1,24 @@
+// This file defines tests to ensure that implementations support endpoints with paths
+
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+
+@httpRequestTests([
+    {
+        id: "QueryHostWithPath",
+        documentation: """
+                Custom endpoints supplied by users can have paths""",
+        protocol: awsQuery,
+        method: "POST",
+        uri: "/custom/",
+        body: "Action=HostWithPathOperation&Version=2020-01-08",
+        host: "example.com/custom",
+        appliesTo: "client"
+    }
+])
+
+operation HostWithPathOperation {}

--- a/smithy-aws-protocol-tests/model/awsQuery/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/main.smithy
@@ -58,5 +58,8 @@ service AwsQuery {
         // @endpoint and @hostLabel trait tests
         EndpointOperation,
         EndpointWithHostLabelOperation,
+
+        // custom endpoints with paths
+        HostWithPathOperation,
     ]
 }

--- a/smithy-aws-protocol-tests/model/ec2Query/endpoint-paths.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/endpoint-paths.smithy
@@ -1,0 +1,24 @@
+// This file defines tests to ensure that implementations support endpoints with paths
+
+$version: "1.0"
+
+namespace aws.protocoltests.ec2
+
+use aws.protocols#ec2Query
+use smithy.test#httpRequestTests
+
+@httpRequestTests([
+    {
+        id: "Ec2QueryHostWithPath",
+        documentation: """
+                Custom endpoints supplied by users can have paths""",
+        protocol: ec2Query,
+        method: "POST",
+        uri: "/custom/",
+        body: "Action=HostWithPathOperation&Version=2020-01-08",
+        host: "example.com/custom",
+        appliesTo: "client"
+    }
+])
+
+operation HostWithPathOperation {}

--- a/smithy-aws-protocol-tests/model/ec2Query/main.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/main.smithy
@@ -74,5 +74,8 @@ service AwsEc2 {
         // @endpoint and @hostLabel trait tests
         EndpointOperation,
         EndpointWithHostLabelOperation,
+
+        // custom endpoints with paths
+        HostWithPathOperation,
     ]
 }


### PR DESCRIPTION
*Description of changes:*

Followup to https://github.com/awslabs/smithy-typescript/pull/406. Add protocol test for RPC protocols path prefix support.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
