### PR TITLE
Allow replacement of simple shape types in ModelTransformer

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -16,20 +16,23 @@
 package software.amazon.smithy.model.transform;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -41,14 +44,85 @@ import software.amazon.smithy.model.traits.SensitiveTrait;
 public class ReplaceShapesTest {
 
     @Test
-    public void cannotChangeShapeTypes() {
-        Assertions.assertThrows(RuntimeException.class, () -> {
+    public void cannotChangeComplexShapeTypes() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
             ShapeId shapeId = ShapeId.from("ns.foo#id1");
             StringShape shape = StringShape.builder().id(shapeId).build();
-            Model model = Model.builder().addShape(shape).build();
+            Model model = Model.builder()
+                    .addShape(shape)
+                    .addShape(LongShape.builder().id("ns.foo#id2").build())
+                    .build();
             ModelTransformer transformer = ModelTransformer.create();
-            transformer.mapShapes(model, s -> IntegerShape.builder().id(shapeId).build());
+            transformer.mapShapes(model, s -> {
+                if (s.getId().equals(shapeId)) {
+                    return StructureShape.builder()
+                        .id(shapeId)
+                        .addMember(
+                                MemberShape.builder()
+                                        .id(ShapeId.from("ns.foo#id1$member1"))
+                                        .target("ns.foo#id2")
+                                        .build()
+                        ).build();
+                }
+                return s;
+            });
         });
+        assertEquals("Cannot change the type of ns.foo#id1 from string to structure", ex.getMessage());
+    }
+
+    @Test
+    public void canChangeSimpleShapeTypes() {
+        ShapeId shapeId = ShapeId.from("ns.foo#id1");
+        IntegerShape shape = IntegerShape.builder().id(shapeId).build();
+        Model model = Model.builder().addShape(shape).build();
+        ModelTransformer transformer = ModelTransformer.create();
+        transformer.mapShapes(model, s -> LongShape.builder().id(shapeId).build());
+    }
+
+    @Test
+    public void canExchangeSimilarListCollectionTypes() {
+        ShapeId shapeId = ShapeId.from("ns.foo#id1");
+        ListShape shape = ListShape.builder().id(shapeId).member(ShapeId.from("smithy.api#Long")).build();
+        Model model = Model.builder()
+                .addShape(shape)
+                .addShape(LongShape.builder().id(ShapeId.from("smithy.api#Long")).build())
+                .build();
+        ModelTransformer transformer = ModelTransformer.create();
+        transformer.mapShapes(model, s -> {
+            if (s.getId().equals(shapeId)) {
+                return SetShape.builder().id(shapeId).member(ShapeId.from("smithy.api#Long")).build();
+            }
+            return s;
+        });
+    }
+
+    @Test
+    public void canNotExchangeListCollectionTypesWithNonReplaceableMembers() {
+        ShapeId shapeId = ShapeId.from("ns.foo#id1");
+        ShapeId structId = ShapeId.from("ns.foo#id2");
+        ListShape shape = ListShape.builder().id(shapeId).member(ShapeId.from("smithy.api#Long")).build();
+        Model model = Model.builder()
+                .addShape(shape)
+                .addShape(LongShape.builder().id(ShapeId.from("smithy.api#Long")).build())
+                .addShape(StructureShape.builder()
+                        .id(structId)
+                        .addMember(
+                                MemberShape.builder()
+                                        .id(structId.withMember("member1"))
+                                        .target("smithy.api#Long")
+                                        .build()
+                        ).build())
+                .build();
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+            ModelTransformer transformer = ModelTransformer.create();
+            transformer.mapShapes(model, s -> {
+                if (s.getId().equals(shapeId)) {
+                    return SetShape.builder().id(shapeId).member(structId).build();
+                }
+                return s;
+            });
+        });
+        assertEquals("Cannot change the type of ns.foo#id1$member from long to structure", ex.getMessage());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* No issue

*Description of changes:*

The AWS Rust SDK needs to customize S3's `Size` shape to be a `LongShape` instead of an `IntegerShape` so that larger files can be successfully represented in responses (see https://github.com/awslabs/aws-sdk-rust/issues/209). This change updates `ReplaceShapes` to allow simple shape changes like this, as well as `ListShape <-> SetShape` changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
