### PR TITLE
Fix escaping in malformed request test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-path.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-path.smithy
@@ -113,7 +113,7 @@ apply MalformedTimestampPathDefault @httpMalformedRequestTests([
                        "1996-12-19T16Z",
                        "1996-12-19T16",
                        "1996-12-19 16%3A39%3A57Z",
-                       "2011-12-03T10%3A15%3A30%2B01%3A00%5BEurope/Paris%5D"]
+                       "2011-12-03T10%3A15%3A30%2B01%3A00%5BEurope%2FParis%5D"]
         },
         tags : ["timestamp"]
     },


### PR DESCRIPTION
*Description of changes:*
In attempting to test rejection of a named timezone in a path parameter,
[Europe/Paris], the slash was accidentally left unencoded, which turned
it into a test of the URI matcher, instead of the timestamp deserializer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
