### PR TITLE
Add removeUriPrefix to OpenAPI converter

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -492,6 +492,40 @@ jsonAdd (``Map<String, Node>``)
             }
         }
 
+
+.. _remove-path-prefix:
+
+removeUriPrefix (``string``)
+    Removes a prefix from paths derived from modeled Smithy operations. This
+    can be useful when operations in a Smithy model include a prefix in the
+    ``uri`` of the :ref:`http-trait` to specify a version or "stage" of the
+    API, but you need to integrate with gateways like Amazon API Gateway that
+    expect to own placing this prefix onto the paths defined in OpenAPI
+    models.
+
+    For example, if every operation in a Smithy model starts with "/v1", the
+    following configuration would strip "/v1" from the beginning of every
+    OpenAPI path generated from them:
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "removeUriPrefix": "/v1"
+                }
+            }
+        }
+
+    .. note::
+
+        This configuration option only removes prefixes from operations
+        modeled in Smithy. It does not affect OpenAPI paths defined through
+        things like ``jsonAdd``, ``schemaDocumentExtensions``, or other
+        OpenAPI plugins applied when converting Smithy to OpenAPI.
+
 .. _generate-openapi-setting-useIntegerType:
 
 useIntegerType (``boolean``)

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -86,6 +86,7 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private List<String> externalDocs = ListUtils.of(
             "Homepage", "API Reference", "User Guide", "Developer Guide", "Reference", "Guide");
     private boolean useIntegerType;
+    private String removeUriPrefix;
 
     public OpenApiConfig() {
         super();
@@ -328,6 +329,24 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setUseIntegerType(boolean useIntegerType) {
         this.useIntegerType = useIntegerType;
+    }
+
+    public String getRemoveUriPrefix() {
+        return removeUriPrefix;
+    }
+
+    /**
+     * Sets a prefix string that is removed from every modeled Smithy operation.
+     *
+     * <p>Only OpenAPI operations derived from Smithy operations are affected by
+     * this configuration setting. Operations defined through jsonAdd, schemaExtensions,
+     * or added through other plugins are not affected.
+     *
+     * @param removeUriPrefix Set to a non-null string to remove from the start of
+     *                        every operation defined in Smithy.
+     */
+    public void setRemoveUriPrefix(String removeUriPrefix) {
+        this.removeUriPrefix = removeUriPrefix;
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/CoreExtension.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/CoreExtension.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.openapi.fromsmithy.mappers.OpenApiJsonAdd;
 import software.amazon.smithy.openapi.fromsmithy.mappers.OpenApiJsonSubstitutions;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveEmptyComponents;
 import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveUnusedComponents;
+import software.amazon.smithy.openapi.fromsmithy.mappers.RemoveUriPrefix;
 import software.amazon.smithy.openapi.fromsmithy.mappers.UnsupportedTraits;
 import software.amazon.smithy.openapi.fromsmithy.protocols.AwsRestJson1Protocol;
 import software.amazon.smithy.openapi.fromsmithy.security.AwsV4Converter;
@@ -56,6 +57,7 @@ public final class CoreExtension implements Smithy2OpenApiExtension {
     @Override
     public List<OpenApiMapper> getOpenApiMappers() {
         return ListUtils.of(
+                new RemoveUriPrefix(),
                 new CheckForGreedyLabels(),
                 new CheckForPrefixHeaders(),
                 new OpenApiJsonSubstitutions(),

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiMapper.java
@@ -58,6 +58,20 @@ public interface OpenApiMapper {
     }
 
     /**
+     * Preprocesses the provided Smithy model before the conversion is
+     * performed, and returns a new model.
+     *
+     * <p>This method is invoked before {@link #updateDefaultSettings}.
+     *
+     * @param model Model being converted to OpenAPI.
+     * @param config OpenAPI configuration object.
+     * @return Returns the model, or an updated model.
+     */
+    default Model preprocessModel(Model model, OpenApiConfig config) {
+        return model;
+    }
+
+    /**
      * Sets default values on the OpenAPI configuration object.
      *
      * <p>Use this method <strong>and not {@link #before}</strong>
@@ -278,6 +292,14 @@ public interface OpenApiMapper {
                 for (OpenApiMapper plugin : sorted) {
                     plugin.updateDefaultSettings(model, config);
                 }
+            }
+
+            @Override
+            public Model preprocessModel(Model model, OpenApiConfig config) {
+                for (OpenApiMapper plugin : sorted) {
+                    model = plugin.preprocessModel(model, config);
+                }
+                return model;
             }
 
             @Override

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUriPrefix.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUriPrefix.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.openapi.fromsmithy.mappers;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.pattern.UriPattern;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.HttpTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Removes a configurable prefix from every Smithy operation defined
+ * in the model.
+ *
+ * <p>This plugin only works on operations that have the http trait.
+ * It does not affect any other kind of modeled operation nor does it
+ * affect OpenAPI paths created by other means like jsonAdd,
+ * schemaExtensions, or other plugins.
+ */
+@SmithyInternalApi
+public class RemoveUriPrefix implements OpenApiMapper {
+    @Override
+    public Model preprocessModel(Model model, OpenApiConfig config) {
+        String removeUriPrefix = config.getRemoveUriPrefix();
+        if (StringUtils.isEmpty(removeUriPrefix)) {
+            return model;
+        }
+
+        return ModelTransformer.create().mapShapes(model, shape -> {
+            return shape.asOperationShape().map(operation -> {
+                if (operation.hasTrait(HttpTrait.class)) {
+                    HttpTrait httpTrait = operation.expectTrait(HttpTrait.class);
+                    if (httpTrait.getUri().toString().startsWith(removeUriPrefix)) {
+                        String updatedUri = httpTrait.getUri().toString().substring(removeUriPrefix.length());
+                        if (!updatedUri.startsWith("/")) {
+                            updatedUri = "/" + updatedUri;
+                        }
+                        UriPattern uriPattern = UriPattern.parse(updatedUri);
+                        operation = operation.toBuilder()
+                                .addTrait(httpTrait.toBuilder().uri(uriPattern).build())
+                                .build();
+                    }
+                }
+                return (Shape) operation;
+            }).orElse(shape);
+        });
+    }
+}

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUriPrefixTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUriPrefixTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.openapi.fromsmithy.mappers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.openapi.OpenApiConfig;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
+import software.amazon.smithy.openapi.model.OpenApi;
+import software.amazon.smithy.utils.MapUtils;
+
+public class RemoveUriPrefixTest {
+    @Test
+    public void removesPrefixFromModeledOperations() {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setRemoveUriPrefix("/v1");
+        config.setService(ShapeId.from("smithy.example#Example"));
+
+        Model model = Model.assembler()
+                .addImport(RemoveUriPrefixTest.class.getResource("remove-uri-prefix.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApi result = OpenApiConverter.create().config(config).convert(model);
+
+        assertThat(result.getPaths().keySet(), hasItem("/item/more-nesting"));
+    }
+
+    @Test
+    public void doesNotRemovePrefixFromUnmodeledOperations() {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setRemoveUriPrefix("/v1");
+        config.setService(ShapeId.from("smithy.example#Example"));
+        // Create a place holder operation to prove these aren't affected.
+        config.setJsonAdd(MapUtils.of("/paths/~1v1~1foo/get", Node.objectNode()));
+
+        Model model = Model.assembler()
+                .addImport(RemoveUriPrefixTest.class.getResource("remove-uri-prefix.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+
+        Set<String> paths = result.expectObjectNode().expectObjectMember("paths").getStringMap().keySet();
+        assertThat(paths, hasItem("/v1/foo"));
+        assertThat(paths, hasItem("/item/more-nesting"));
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/remove-uri-prefix.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/remove-uri-prefix.smithy
@@ -1,0 +1,32 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use aws.api#service
+use aws.auth#sigv4
+use aws.protocols#restJson1
+
+@sigv4(name: "Example")
+@restJson1
+service Example {
+    version: "2020-09-11",
+    operations: [GetItem, PutItem],
+}
+
+@http(uri: "/v1/item/more-nesting", method: "GET")
+@readonly
+operation GetItem {
+    input: GetItemRequest,
+    output: GetItemResponse,
+}
+
+structure GetItemRequest {}
+
+structure GetItemResponse {}
+
+@http(uri: "/v1/item/more-nesting", method: "PUT")
+@idempotent
+operation PutItem {
+    input: PutItemRequest
+}
+structure PutItemRequest {}


### PR DESCRIPTION
Removes a prefix from paths derived from modeled Smithy operations. This can be useful when operations in a Smithy model include a prefix in the `uri` of the `http` trait to specify a version or "stage" of the API, but you need to integrate with gateways like Amazon API Gateway that expect to own placing this prefix onto the paths defined in OpenAPI models.

For example, if every operation in a Smithy model starts with "/v1", the following configuration would strip "/v1" from the beginning of every OpenAPI path generated from them:

```json
{
    "version": "1.0",
    "plugins": {
        "openapi": {
            "service": "smithy.example#Weather",
            "removeUriPrefix": "/v1"
        }
    }
}
```