### PR TITLE
Remove base64 padding parser assertion tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
@@ -33,7 +33,7 @@ apply MalformedBlob @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            value: ["blob", "\"xyz\"", "\"YmxvYg=\"", "[98, 108, 11, 98]",
+            value: ["blob", "[98, 108, 11, 98]",
                     "[\"b\", \"l\",\"o\",\"b\"]", "981081198", "true"]
         }
     },


### PR DESCRIPTION
This removes two malformed request tests, both of which enforce
validating that a base64 encoded blob is properly padded with the
`=` character to have a length that is a multiple of 4.

Padding isn't necessary when the size of the input data in
unambiguous. Between HTTPS and content-length validation, we can be
pretty certain we've got everything.

https://www.rfc-editor.org/rfc/rfc4648.html#section-3.2


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
