### PR TITLE
Add more base64 malformed request tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -107,6 +107,7 @@ service RestJson {
         MalformedLong,
         MalformedFloat,
         MalformedDouble,
+        MalformedString,
         MalformedTimestampPathDefault,
         MalformedTimestampPathHttpDate,
         MalformedTimestampPathEpoch,

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
@@ -34,7 +34,7 @@ apply MalformedBlob @httpMalformedRequestTests([
         },
         testParameters: {
             value: ["blob", "\"xyz\"", "\"YmxvYg=\"", "[98, 108, 11, 98]",
-                    "[\"b\", \"l\",\"o\",\"b\"]", "981081198", "true"]
+                    "[\"b\", \"l\",\"o\",\"b\"]", "981081198", "true", "[][]", "-_=="]
         }
     },
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-string.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-string.smithy
@@ -1,0 +1,59 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
+
+@http(uri: "/MalformedString", method: "POST")
+operation MalformedString {
+    input: MalformedStringInput
+}
+
+apply MalformedString @httpMalformedRequestTests([
+    {
+        id: "RestJsonHeaderMalformedStringInvalidBase64MediaType",
+        documentation: """
+        When string with the mediaType trait is bound to a header, its value
+        must be base64 encoded. The server should reject values that aren't
+        valid base64 out of hand.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedString",
+            body: """
+            { "blob" : $value:L }""",
+            headers: {
+                "content-type": "application/json",
+                "amz-media-typed-header": "$value:L",
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        },
+        testParameters: {
+            value: [
+                // Insufficient padding
+                "xyz",
+                // Extant, but also insufficient padding
+                "YmxvYg=",
+                // Invalid characters
+                "[][]",
+                // Invalid characters which are commonly used as filename-safe
+                // alternatives to + and /
+                "-_=="
+            ]
+        }
+    },
+])
+
+structure MalformedStringInput {
+    @httpHeader("x-media-typed-header")
+    blob: JsonHeaderString,
+}
+
+@mediaType("application/json")
+string JsonHeaderString


### PR DESCRIPTION
This adds more base64 tests, including ones for strings that use
mediaType in places where they need to be encoded.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
