### PR TITLE
Use team for CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add core contributors to all prs by default
-* @kstich @JordonPhillips @mtdowling @DavidOgunsAWS
+* @awslabs/smithy-developers


### PR DESCRIPTION
This updates the codeowners config to use a team so we don't have
to keep changing this file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
