### PR TITLE
Fail by default when a build plugin can't be found

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -49,6 +49,11 @@ The configuration file accepts the following properties:
       - Defines the plugins to apply to the model when building every
         projection. Plugins are a mapping of plugin names to an arbitrary
         plugin configuration object.
+    * - ignoreMissingPlugins
+      - ``bool``
+      - If a plugin can't be found, Smithy will by default fail the build. This
+        setting can be set to ``true`` to allow the build to progress even if
+        a plugin can't be found on the classpath.
 
 The following is an example ``smithy-build.json`` configuration:
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -362,9 +362,14 @@ final class SmithyBuildImpl {
         SmithyBuildPlugin resolved = pluginFactory.apply(pluginName).orElse(null);
 
         if (resolved == null) {
-            LOGGER.info(() -> String.format(
-                    "Unable to find a plugin for `%s` in the `%s` projection",
-                    pluginName, projectionName));
+            String message = "Unable to find a plugin named `" + pluginName + "` in the `" + projectionName + "` "
+                             + "projection. Is this the correct spelling? Are you missing a dependency? Is your "
+                             + "classpath configured correctly?";
+            if (config.isIgnoreMissingPlugins()) {
+                LOGGER.severe(message);
+            } else {
+                throw new SmithyBuildException(message);
+            }
         } else if (resolved.requiresValidModel() && modelResult.isBroken()) {
             LOGGER.fine(() -> String.format(
                     "Skipping `%s` plugin for `%s` projection because the model is broken",
@@ -411,7 +416,9 @@ final class SmithyBuildImpl {
 
             ProjectionTransformer transformer = transformFactory.apply(name)
                     .orElseThrow(() -> new UnknownTransformException(String.format(
-                            "Unable to find a transform for `%s` in the `%s` projection.", name, projectionName)));
+                            "Unable to find a transform named `%s` in the `%s` projection. Is this the correct "
+                            + "spelling? Are you missing a dependency? Is your classpath configured correctly?",
+                            name, projectionName)));
             resolved.add(Pair.of(transformConfig.getArgs(), transformer));
         }
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -187,9 +187,9 @@ public class SmithyBuildTest {
     }
 
     @Test
-    public void ignoresUnknownPlugins() throws Exception {
+    public void canIgnoreUnknownPlugins() throws Exception {
         SmithyBuildConfig config = SmithyBuildConfig.builder()
-                .load(Paths.get(getClass().getResource("unknown-plugin.json").toURI()))
+                .load(Paths.get(getClass().getResource("unknown-plugin-ignored.json").toURI()))
                 .outputDirectory(outputDirectory.toString())
                 .build();
         Model model = Model.assembler()
@@ -198,6 +198,25 @@ public class SmithyBuildTest {
                 .unwrap();
         SmithyBuild builder = new SmithyBuild(config).model(model);
         builder.build();
+    }
+
+    @Test
+    public void failsByDefaultForUnknownPlugins() throws Exception {
+        SmithyBuildConfig config = SmithyBuildConfig.builder()
+                .load(Paths.get(getClass().getResource("unknown-plugin.json").toURI()))
+                .outputDirectory(outputDirectory.toString())
+                .build();
+        Model model = Model.assembler()
+                .addImport(Paths.get(getClass().getResource("resource-model.json").toURI()))
+                .assemble()
+                .unwrap();
+
+        SmithyBuildException e = Assertions.assertThrows(SmithyBuildException.class, () -> {
+            SmithyBuild builder = new SmithyBuild(config).model(model);
+            builder.build();
+        });
+
+        assertThat(e.getMessage(), containsString("Unable to find a plugin named `unknown1`"));
     }
 
     @Test

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
@@ -157,4 +157,26 @@ public class SmithyBuildConfigTest {
             throw new RuntimeException(e);
         }
     }
+
+    @Test
+    public void convertingToBuilderRetainsIgnoreMissingPlugins() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder()
+                .version("1")
+                .ignoreMissingPlugins(true)
+                .build();
+
+        assertThat(a.toBuilder().build().isIgnoreMissingPlugins(), equalTo(true));
+    }
+
+    @Test
+    public void mergingTakesIgnoreMissingPluginsFromEither() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder()
+                .version("1")
+                .ignoreMissingPlugins(true)
+                .build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1").build();
+
+        assertThat(a.toBuilder().merge(b).build().isIgnoreMissingPlugins(), equalTo(true));
+        assertThat(b.toBuilder().merge(a).build().isIgnoreMissingPlugins(), equalTo(true));
+    }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/unknown-plugin-ignored.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/unknown-plugin-ignored.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.0",
+    "ignoreMissingPlugins": true,
+    "plugins": {
+        "unknown1": {}
+    },
+    "projections": {
+        "a": {
+            "plugins": {
+                "unknown2": {}
+            }
+        },
+        "b": {
+            "plugins": {
+                "unknown3": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
smithy-build previously just logged an info when a build plugin couldn't
be found on the classpath. This was a bad user experience for actually
using Smithy. The requirement to be able to ignore a missing build
plugin is really an edge case for build tools that want to be able to
build just models and ignore other plugins, so those tools should opt-in
to that behavior instead. Just logging was way too subtle for diagnosing
issues with config files and dependencies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
