### PR TITLE
Fix how the CLI logs

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+/**
+ * Package-private utilities for configuring CLI logging.
+ */
+final class LoggingUtil {
+
+    private static final SimpleDateFormat FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
+
+    private LoggingUtil() {}
+
+    static void configureLogging(boolean debug, Level level) {
+        Logger rootLogger = Logger.getLogger("");
+        removeConsoleHandler(rootLogger);
+        addCliHandler(debug, level, rootLogger);
+    }
+
+    private static void addCliHandler(boolean debug, Level level, Logger rootLogger) {
+        if (level != Level.OFF) {
+            Handler handler = debug
+                    // Debug ignores the given logging level and just logs everything.
+                    ? new CliLogHandler(new DebugFormatter())
+                    : new CliLogHandler(new BasicFormatter());
+            handler.setLevel(level);
+            rootLogger.addHandler(handler);
+        }
+
+        rootLogger.setLevel(level);
+        for (Handler h : rootLogger.getHandlers()) {
+            h.setLevel(level);
+        }
+    }
+
+    private static void removeConsoleHandler(Logger rootLogger) {
+        for (Handler handler : rootLogger.getHandlers()) {
+            if (handler instanceof ConsoleHandler) {
+                // Remove any console log handlers.
+                rootLogger.removeHandler(handler);
+            }
+        }
+    }
+
+    private static final class BasicFormatter extends SimpleFormatter {
+        @Override
+        public synchronized String format(LogRecord r) {
+            return FORMAT.format(new Date(r.getMillis()))
+                   + " " + r.getLevel().getLocalizedName() + " - "
+                   + r.getMessage();
+        }
+    }
+
+    private static final class DebugFormatter extends SimpleFormatter {
+        @Override
+        public synchronized String format(LogRecord r) {
+            return FORMAT.format(new Date(r.getMillis()))
+                   + " [" + Thread.currentThread().getName() + "] "
+                   + r.getLevel().getLocalizedName() + " "
+                   + r.getLoggerName() + " - "
+                   + r.getMessage();
+        }
+    }
+
+    /**
+     * Logs messages to the CLI's redirect stderr.
+     */
+    private static final class CliLogHandler extends Handler {
+        private final Formatter formatter;
+
+        CliLogHandler(Formatter formatter) {
+            this.formatter = formatter;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (isLoggable(record)) {
+                Cli.stderr(formatter.format(record));
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -32,6 +32,7 @@ public final class SmithyCli {
     public static final String SEVERITY = "--severity";
 
     private ClassLoader classLoader = getClass().getClassLoader();
+    private boolean configureLogging;
 
     private SmithyCli() {}
 
@@ -51,7 +52,9 @@ public final class SmithyCli {
      */
     public static void main(String... args) {
         try {
-            SmithyCli.create().run(args);
+            SmithyCli cli = SmithyCli.create();
+            cli.configureLogging = true;
+            cli.run(args);
         } catch (CliError e) {
             System.exit(e.code);
         } catch (Exception e) {
@@ -85,12 +88,17 @@ public final class SmithyCli {
      * @param args Arguments to parse and execute.
      */
     public void run(String... args) {
+        createCliRunner().run(args);
+    }
+
+    private Cli createCliRunner() {
         Cli cli = new Cli("smithy", classLoader);
         cli.addCommand(new ValidateCommand());
         cli.addCommand(new BuildCommand());
         cli.addCommand(new DiffCommand());
         cli.addCommand(new SelectCommand());
         cli.addCommand(new AstCommand());
-        cli.run(args);
+        cli.setConfigureLogging(configureLogging);
+        return cli;
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -95,5 +96,82 @@ public class CliTest {
         String help = outputStream.toString("UTF-8");
 
         assertThat(help, containsString("Unknown command or argument"));
+    }
+
+    @Test
+    public void canDisableLogging() throws Exception {
+        Cli cli = new Cli("mytest");
+        cli.addCommand(new BuildCommand());
+        PrintStream err = System.err;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+
+        try {
+            System.setErr(printStream);
+            cli.run(new String[]{"build", "--logging", "OFF"});
+            String result = outputStream.toString("UTF-8");
+
+            assertThat(result, not(containsString("INFO -")));
+        } finally {
+            System.setErr(err);
+        }
+    }
+
+    @Test
+    public void canEnableLoggingViaLogLevel() throws Exception {
+        Cli cli = new Cli("mytest");
+        cli.addCommand(new BuildCommand());
+        PrintStream err = System.err;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+
+        try {
+            System.setErr(printStream);
+            cli.run(new String[]{"build", "--logging", "INFO"});
+            String result = outputStream.toString("UTF-8");
+
+            assertThat(result, containsString("INFO -"));
+        } finally {
+            System.setErr(err);
+        }
+    }
+
+    @Test
+    public void canEnableLogging() throws Exception {
+        Cli cli = new Cli("mytest");
+        cli.setConfigureLogging(true);
+        cli.addCommand(new BuildCommand());
+        PrintStream err = System.err;
+
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream printStream = new PrintStream(outputStream);
+            System.setErr(printStream);
+            cli.run(new String[]{"build"});
+            String result = outputStream.toString("UTF-8");
+
+            assertThat(result, containsString("INFO -"));
+        } finally {
+            System.setErr(err);
+        }
+    }
+
+    @Test
+    public void canEnableDebugLogging() throws Exception {
+        Cli cli = new Cli("mytest");
+        cli.addCommand(new BuildCommand());
+        PrintStream err = System.err;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+
+        try {
+            System.setErr(printStream);
+            cli.run(new String[]{"build", "--debug"});
+            String result = outputStream.toString("UTF-8");
+
+            assertThat(result, containsString("FINE -"));
+        } finally {
+            System.setErr(err);
+        }
     }
 }


### PR DESCRIPTION
This commit updates the CLI to use a nicer log message format, and to
also properly configure JUL when a logging level is given. We need to
later make changes to the Gradle plugin to enable configuring the CLI
loggers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
