### PR TITLE
Fix typo in docs about awsQueryError's trait selector

### DIFF
--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -508,7 +508,7 @@ Summary
 Trait selector
     ``structure [trait|error]``
 
-    The ``httpError`` trait can only be applied to :ref:`structure <structure>`
+    The ``awsQueryError`` trait can only be applied to :ref:`structure <structure>`
     shapes that also have the :ref:`error-trait`.
 Value type
     ``structure`` that supports the following members:


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
