### PR TITLE
Fix NodeMapper handling of generic params

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -248,6 +248,56 @@ Applies the transforms defined in the given projection names.
         }
 
 
+.. _changeTypes:
+
+changeTypes
+-----------
+
+Changes the types of shapes.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - shapeTypes
+      - ``Map<ShapeId, String>``
+      - A map of shape IDs to the type to assign to the shape.
+
+Only the following shape type changes are supported:
+
+* Any simple type to any other simple type
+* List to set
+* Set to list
+* Structure to union
+* Union to structure
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "changeTypes",
+                            "args": {
+                                "shapeTypes": {
+                                    "smithy.example#Foo": "string",
+                                    "smithy.example#Baz": "union"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+
 .. _excludeShapesByTag-transform:
 
 excludeShapesByTag

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ChangeTypes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ChangeTypes.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+/**
+ * {@code changeType} is used to change the type of one or more shapes.
+ */
+public final class ChangeTypes extends ConfigurableProjectionTransformer<ChangeTypes.Config> {
+
+    /**
+     * {@code flattenNamespaces} configuration settings.
+     */
+    public static final class Config {
+
+        private final Map<ShapeId, ShapeType> shapeTypes = new LinkedHashMap<>();
+
+        /**
+         * Sets the map of shape IDs to shape types to set.
+         *
+         * @param shapeTypes Map of shape ID to shape type.
+         */
+        public void setShapeTypes(Map<ShapeId, ShapeType> shapeTypes) {
+            this.shapeTypes.clear();
+            this.shapeTypes.putAll(shapeTypes);
+        }
+
+        public Map<ShapeId, ShapeType> getShapeTypes() {
+            return shapeTypes;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    public String getName() {
+        return "changeTypes";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        if (config.getShapeTypes().isEmpty()) {
+            throw new SmithyBuildException(getName() + ": shapeTypes must not be empty");
+        }
+
+        return context.getTransformer().changeShapeType(context.getModel(), config.getShapeTypes());
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ChangeTypesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ChangeTypesTest.java
@@ -1,0 +1,32 @@
+package software.amazon.smithy.build.transforms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+public class ChangeTypesTest {
+    @Test
+    public void changesShapeTypes() {
+        StringShape a = StringShape.builder().id("ns.foo#a").build();
+        StructureShape b = StructureShape.builder().id("ns.foo#b").build();
+        Model model = Model.assembler().addShapes(a, b).assemble().unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("shapeTypes", Node.objectNode()
+                        .withMember("ns.foo#a", "boolean")
+                        .withMember("ns.foo#b", "union")))
+                .build();
+        Model result = new ChangeTypes().transform(context);
+
+        assertThat(result.expectShape(ShapeId.from("ns.foo#a")).getType(), is(ShapeType.BOOLEAN));
+        assertThat(result.expectShape(ShapeId.from("ns.foo#b")).getType(), is(ShapeType.UNION));
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
@@ -59,18 +59,44 @@ import software.amazon.smithy.utils.StringUtils;
  */
 final class DefaultNodeDeserializers {
 
+    // These are the kinds of types that can come back.
+    // This was informed by various other mappers, including jackson-jr:
+    // https://github.com/FasterXML/jackson-jr/blob/ac845b88702a1f1b1b5a75a4791b08577f74e94d/jr-objects/src/main/java/com/fasterxml/jackson/jr/type/TypeResolver.java#L79
+    static Class<?> classFromType(Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        } else if (type instanceof ParameterizedType) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        } else if (type instanceof WildcardType) {
+            return classFromType(((WildcardType) type).getUpperBounds()[0]);
+        } else if (type instanceof TypeVariable<?>) {
+            // TODO: implement this to enable improved builder detection
+            throw new IllegalArgumentException("TypeVariable targets are not implemented: " + type);
+        } else if (type instanceof GenericArrayType) {
+            throw new IllegalArgumentException("GenericArrayType targets are not implemented: " + type);
+        } else {
+            return null;
+        }
+    }
+
     // Deserialize an exact type if it matches (i.e., the setter expects a Node value).
     private static final ObjectCreatorFactory EXACT_CREATOR_FACTORY = (nodeType, targetType, nodeMapper) -> {
-        return Node.class.isAssignableFrom(targetType) && targetType.isAssignableFrom(nodeType.getNodeClass())
-               ? (node, target, param, pointer, mapper) -> node
-               : null;
+        Class<?> targetClass = classFromType(targetType);
+        if (targetClass != null
+                && Node.class.isAssignableFrom(targetClass)
+                && targetClass.isAssignableFrom(nodeType.getNodeClass())) {
+            return (node, target, pointer, mapper) -> node;
+        } else {
+            return null;
+        }
     };
 
     // Creates booleans from BooleanNodes.
     private static final ObjectCreatorFactory BOOLEAN_CREATOR_FACTORY = (nodeType, targetType, nodeMapper) -> {
         if (nodeType == NodeType.BOOLEAN) {
-            if (targetType == Boolean.class || targetType == boolean.class || targetType == Object.class) {
-                return (node, target, param, pointer, mapper) -> node.expectBooleanNode().getValue();
+            Class<?> targetClass = classFromType(targetType);
+            if (targetClass == Boolean.class || targetClass == boolean.class || targetClass == Object.class) {
+                return (node, target, pointer, mapper) -> node.expectBooleanNode().getValue();
             }
         }
         return null;
@@ -79,24 +105,25 @@ final class DefaultNodeDeserializers {
     // Null nodes always return null values.
     private static final ObjectCreatorFactory NULL_CREATOR = (nodeType, targetType, nodeMapper) -> {
         if (nodeType == NodeType.NULL) {
-            return (node, target, param, pointer, mapper) -> null;
+            return (node, target, pointer, mapper) -> null;
         }
         return null;
     };
 
     // String nodes can create java.land.String or a Smithy ShapeId.
-    private static final ObjectCreatorFactory STRING_CREATOR = (nodeType, into, nodeMapper) -> {
+    private static final ObjectCreatorFactory STRING_CREATOR = (nodeType, targetType, nodeMapper) -> {
         if (nodeType == NodeType.STRING) {
-            if (into == String.class || into == Object.class) {
-                return (node, target, param, pointer, mapper) -> node.expectStringNode().getValue();
-            } else if (into == ShapeId.class) {
-                return (node, target, param, pointer, mapper) -> node.expectStringNode().expectShapeId();
+            Class<?> targetClass = classFromType(targetType);
+            if (targetClass == String.class || targetClass == Object.class) {
+                return (node, target, pointer, mapper) -> node.expectStringNode().getValue();
+            } else if (targetClass == ShapeId.class) {
+                return (node, target, pointer, mapper) -> node.expectStringNode().expectShapeId();
             }
         }
         return null;
     };
 
-    private static final Map<Class, Function<Number, Object>> NUMBER_MAPPERS = new HashMap<>();
+    private static final Map<Type, Function<Number, Object>> NUMBER_MAPPERS = new HashMap<>();
 
     static {
         NUMBER_MAPPERS.put(Object.class, n -> n);
@@ -119,10 +146,11 @@ final class DefaultNodeDeserializers {
     // Creates numbers from NumberNodes.
     private static final ObjectCreatorFactory NUMBER_CREATOR = (nodeType, targetType, nodeMapper) -> {
         if (nodeType == NodeType.NUMBER) {
-            if (NUMBER_MAPPERS.containsKey(targetType)) {
-                return (node, target, param, pointer, mapper) -> {
+            Class<?> targetClass = classFromType(targetType);
+            if (NUMBER_MAPPERS.containsKey(targetClass)) {
+                return (node, target, pointer, mapper) -> {
                     Number value = node.expectNumberNode().getValue();
-                    return NUMBER_MAPPERS.get(target).apply(value);
+                    return NUMBER_MAPPERS.get(targetClass).apply(value);
                 };
             }
         }
@@ -136,18 +164,17 @@ final class DefaultNodeDeserializers {
     // Deserialize an ArrayNode into a Collection.
     private static final ObjectCreatorFactory COLLECTION_CREATOR = new ObjectCreatorFactory() {
         @Override
-        public NodeMapper.ObjectCreator getCreator(NodeType nodeType, Class<?> target, NodeMapper nodeMapper) {
+        public NodeMapper.ObjectCreator getCreator(NodeType nodeType, Type target, NodeMapper nodeMapper) {
             if (nodeType != NodeType.ARRAY) {
                 return null;
             }
 
             ReflectiveSupplier<Collection<Object>> ctor = createSupplier(target);
-
             if (ctor == null) {
                 return null;
             }
 
-            return (node, targetType, param, pointer, mapper) -> {
+            return (node, targetType, pointer, mapper) -> {
                 Collection<Object> collection;
 
                 try {
@@ -157,32 +184,44 @@ final class DefaultNodeDeserializers {
                     throw NodeDeserializationException.fromReflectiveContext(targetType, pointer, node, e, message);
                 }
 
+                // Extract out the expected generic type of the collection.
+                Type memberType = Object.class;
+                if (targetType instanceof ParameterizedType) {
+                    Type[] genericTypes = ((ParameterizedType) targetType).getActualTypeArguments();
+                    if (genericTypes.length > 0) {
+                        memberType = genericTypes[0];
+                    }
+                }
+
                 int i = 0;
                 for (Node entry : node.expectArrayNode().getElements()) {
-                    Object nextValue = mapper.deserializeNext(
-                            entry, pointer + "/" + i++, param, Object.class, mapper);
+                    Object nextValue = mapper.deserializeNext(entry, pointer + "/" + i++, memberType, mapper);
                     collection.add(nextValue);
                 }
                 return collection;
             };
         }
 
-        private ReflectiveSupplier<Collection<Object>> createSupplier(Class<?> targetType) {
-            // Create an ArrayList for most cases of lists or iterables.
-            if (targetType.equals(List.class)
-                    || targetType.equals(Collection.class)
-                    || targetType.equals(Object.class)
-                    || targetType.equals(ArrayList.class)
-                    || targetType.equals(Iterable.class)) {
-                return ArrayList::new;
-            } else if (targetType.equals(Set.class)
-                    || targetType.equals(HashSet.class)
-                    || targetType.equals(LinkedHashSet.class)) {
-                // Special casing for Set or HashSet.
-                return LinkedHashSet::new;
-            } else if (Collection.class.isAssignableFrom(targetType)) {
-                return createSupplierFromReflection(targetType);
+        private ReflectiveSupplier<Collection<Object>> createSupplier(Type targetType) {
+            Class<?> targetClass = classFromType(targetType);
+            if (targetClass != null) {
+                // Create an ArrayList for most cases of lists or iterables.
+                if (targetClass == List.class
+                        || targetClass == Collection.class
+                        || targetClass == Object.class
+                        || targetClass == ArrayList.class
+                        || targetClass == Iterable.class) {
+                    return ArrayList::new;
+                } else if (targetClass == Set.class
+                           || targetClass == HashSet.class
+                           || targetClass == LinkedHashSet.class) {
+                    // Special casing for Set or HashSet.
+                    return LinkedHashSet::new;
+                } else if (Collection.class.isAssignableFrom(targetClass)) {
+                    return createSupplierFromReflection(targetClass);
+                }
             }
+
             return null;
         }
 
@@ -190,8 +229,8 @@ final class DefaultNodeDeserializers {
         private ReflectiveSupplier<Collection<Object>> createSupplierFromReflection(Class<?> into) {
             try {
                 // Create the collection type by assuming it has a public, zero-arg constructor.
-                Class<Collection> collectionTarget = (Class<Collection>) into;
-                Constructor<Collection> classCtor = collectionTarget.getDeclaredConstructor();
+                Class<Collection<Object>> collectionTarget = (Class<Collection<Object>>) into;
+                Constructor<Collection<Object>> classCtor = collectionTarget.getDeclaredConstructor();
                 classCtor.setAccessible(true);
                 return classCtor::newInstance;
             } catch (NoSuchMethodException e) {
@@ -212,19 +251,19 @@ final class DefaultNodeDeserializers {
     // Deserialize an ObjectNode into a Map.
     private static final ObjectCreatorFactory MAP_CREATOR = new ObjectCreatorFactory() {
         @Override
-        public NodeMapper.ObjectCreator getCreator(NodeType nodeType, Class<?> target, NodeMapper nodeMapper) {
+        public NodeMapper.ObjectCreator getCreator(NodeType nodeType, Type target, NodeMapper nodeMapper) {
             if (nodeType != NodeType.OBJECT) {
                 return null;
             }
 
-            ReflectiveSupplier<Map<String, Object>> ctor = createSupplier(target);
+            ReflectiveSupplier<Map<Object, Object>> ctor = createSupplier(target);
 
             if (ctor == null) {
                 return null;
             }
 
-            return (node, targetType, param, pointer, mapper) -> {
-                Map<String, Object> map;
+            return (node, targetType, pointer, mapper) -> {
+                Map<Object, Object> map;
 
                 try {
                     map = ctor.get();
@@ -233,11 +272,26 @@ final class DefaultNodeDeserializers {
                     throw NodeDeserializationException.fromReflectiveContext(targetType, pointer, node, e, message);
                 }
 
+                // Extract out the expected generic types of the collection.
+                Type keyType = Object.class;
+                Type valueType = Object.class;
+                if (targetType instanceof ParameterizedType) {
+                    Type[] genericTypes = ((ParameterizedType) targetType).getActualTypeArguments();
+                    if (genericTypes.length > 0) {
+                        keyType = genericTypes[0];
+                    }
+                    if (genericTypes.length > 1) {
+                        valueType = genericTypes[1];
+                    }
+                }
+
                 ObjectNode objectNode = node.expectObjectNode();
-                for (Map.Entry<String, Node> entry : objectNode.getStringMap().entrySet()) {
-                    String key = entry.getKey();
+                for (Map.Entry<StringNode, Node> entry : objectNode.getMembers().entrySet()) {
+                    String keyValue = entry.getKey().getValue();
+                    Object key = mapper.deserializeNext(
+                            entry.getKey(), pointer + "/(key:" + keyValue + ")", keyType, mapper);
                     Object value = mapper.deserializeNext(
-                            entry.getValue(), pointer + "/" + key, param, Object.class, mapper);
+                            entry.getValue(), pointer + "/" + keyValue, valueType, mapper);
                     map.put(key, value);
                 }
 
@@ -245,21 +299,24 @@ final class DefaultNodeDeserializers {
             };
         }
 
-        private ReflectiveSupplier<Map<String, Object>> createSupplier(Class<?> into) {
-            if (into == Object.class || into == Map.class || into == HashMap.class) {
-                return HashMap::new;
-            } else if (Map.class.isAssignableFrom(into)) {
-                return createSupplierFromReflection(into);
+        private ReflectiveSupplier<Map<Object, Object>> createSupplier(Type into) {
+            Class<?> targetClass = classFromType(into);
+            if (targetClass != null) {
+                if (targetClass == Object.class || targetClass == Map.class || targetClass == HashMap.class) {
+                    return HashMap::new;
+                } else if (Map.class.isAssignableFrom(targetClass)) {
+                    return createSupplierFromReflection(targetClass);
+                }
             }
             return null;
         }
 
         @SuppressWarnings("unchecked")
-        private ReflectiveSupplier<Map<String, Object>> createSupplierFromReflection(Class<?> into) {
+        private ReflectiveSupplier<Map<Object, Object>> createSupplierFromReflection(Class<?> into) {
             try {
                 // Try to create the map from an empty constructor.
-                Class<Map<String, Object>> collectionTarget = (Class<Map<String, Object>>) into;
-                Constructor<Map<String, Object>> mapCtor = collectionTarget.getDeclaredConstructor();
+                Class<Map<Object, Object>> collectionTarget = (Class<Map<Object, Object>>) into;
+                Constructor<Map<Object, Object>> mapCtor = collectionTarget.getDeclaredConstructor();
                 return mapCtor::newInstance;
             } catch (NoSuchMethodException e) {
                 // We *could* pass here and try to let the next deserializer take a crack, but that would
@@ -273,14 +330,16 @@ final class DefaultNodeDeserializers {
 
     // Creates an object from any type of Node using the #fromNode factory method.
     private static final ObjectCreatorFactory FROM_NODE_CREATOR = (nodeType, target, nodeMapper) -> {
-        if (!nodeMapper.getDisableFromNode().contains(target)) {
-            for (Method method : target.getMethods()) {
+        Class<?> targetClass = classFromType(target);
+
+        if (targetClass != null && !nodeMapper.getDisableFromNode().contains(targetClass)) {
+            for (Method method : targetClass.getMethods()) {
                 if ((method.getName().equals("fromNode"))
-                        && target.isAssignableFrom(method.getReturnType())
+                        && targetClass.isAssignableFrom(method.getReturnType())
                         && method.getParameters().length == 1
                         && Node.class.isAssignableFrom(method.getParameters()[0].getType())
                         && Modifier.isStatic(method.getModifiers())) {
-                    return (node, targetType, paramType, pointer, mapper) -> {
+                    return (node, targetType, pointer, mapper) -> {
                         try {
                             return method.invoke(null, node);
                         } catch (ReflectiveOperationException e) {
@@ -296,47 +355,46 @@ final class DefaultNodeDeserializers {
     };
 
     static final class BeanMapper {
-        // Cache of Pair<types, member-name> to a Pair<Method, Parameterized type of input type>
-        private static final ConcurrentMap<Pair<Class<?>, String>, Pair<Method, Class>> SETTER_CACHE
-                = new ConcurrentHashMap<>();
+        // Cache of Pair<types, member-name> to a setter Method.
+        private static final ConcurrentMap<Pair<Class<?>, String>, Method> SETTER_CACHE = new ConcurrentHashMap<>();
 
         static void apply(
                 Object value,
                 Node node,
-                Class<?> target,
+                Type target,
                 String pointer,
                 NodeMapper mapper
         ) throws ReflectiveOperationException {
             for (Map.Entry<String, Node> entry : node.expectObjectNode().getStringMap().entrySet()) {
-                Pair<Method, Class> setterPair = findSetter(target, entry.getKey());
-                if (setterPair == null) {
+                Method setter = findSetter(target, entry.getKey());
+                if (setter == null) {
                     mapper.getWhenMissingSetter().handle(target, pointer, entry.getKey(), entry.getValue());
                 } else {
-                    Method method = setterPair.getLeft();
-                    Class parameterizedType = setterPair.getRight();
                     Object member = mapper.deserializeNext(
                             entry.getValue(),
                             pointer + "/" + entry.getKey(),
-                            method.getParameters()[0].getType(),
-                            parameterizedType,
+                            setter.getParameters()[0].getParameterizedType(),
                             mapper);
-                    method.invoke(value, member);
+                    setter.invoke(value, member);
                 }
             }
         }
 
-        // Return value is null or a pair of (the method to invoke, the generic collection parameter).
-        private static Pair<Method, Class> findSetter(Class<?> type, String memberName) {
-            return SETTER_CACHE.computeIfAbsent(Pair.of(type, memberName), pair -> {
+        // Return value is null or a setter method to invoke.
+        private static Method findSetter(Type type, String memberName) {
+            Class<?> targetType = classFromType(type);
+
+            if (targetType == null) {
+                return null;
+            }
+
+            return SETTER_CACHE.computeIfAbsent(Pair.of(targetType, memberName), pair -> {
                 String sanitized = sanitizePropertyName(pair.right);
-                if (sanitized == null) {
-                    return null;
-                }
-                Class target = pair.left;
-                for (Method method : target.getMethods()) {
-                    if (isBeanOrBuilderSetter(method, target, sanitized)) {
-                        Class parameterizedType = determineParameterizedType(method);
-                        return Pair.of(method, parameterizedType);
+                if (sanitized != null) {
+                    for (Method method : targetType.getMethods()) {
+                        if (isBeanOrBuilderSetter(method, targetType, sanitized)) {
+                            return method;
+                        }
                     }
                 }
                 return null;
@@ -394,71 +452,23 @@ final class DefaultNodeDeserializers {
 
             return false;
         }
-
-        private static Class<?> determineParameterizedType(Method setter) {
-            Type genericParameters = setter.getGenericParameterTypes()[0];
-            Class<?> containingType = setter.getParameterTypes()[0];
-
-            if (genericParameters instanceof ParameterizedType) {
-                Type[] parameterArgTypes = ((ParameterizedType) genericParameters).getActualTypeArguments();
-                if (isSupportedCollectionType(containingType, parameterArgTypes)) {
-                    // Return the collection value type.
-                    return resolveClassFromType(parameterArgTypes[0]);
-                } else if (isSupportedMapType(containingType, parameterArgTypes)) {
-                    // Return the Map value type.
-                    return resolveClassFromType(parameterArgTypes[1]);
-                }
-            }
-
-            return Object.class;
-        }
-
-        private static boolean isSupportedCollectionType(Class<?> containingType, Type[] parameterArgTypes) {
-            return parameterArgTypes.length == 1
-                   && Collection.class.isAssignableFrom(containingType);
-        }
-
-        private static boolean isSupportedMapType(Class<?> containingType, Type[] parameterArgTypes) {
-            return parameterArgTypes.length == 2
-                   && Map.class.isAssignableFrom(containingType)
-                   && parameterArgTypes[0] == String.class;
-        }
-
-        // These are the kinds of types that can come back.
-        // This was informed by various other mappers, including jackson-jr:
-        // https://github.com/FasterXML/jackson-jr/blob/ac845b88702a1f1b1b5a75a4791b08577f74e94d/jr-objects/src/main/java/com/fasterxml/jackson/jr/type/TypeResolver.java#L79
-        private static Class<?> resolveClassFromType(Type type) {
-            if (type instanceof Class) {
-                return (Class) type;
-            } else if (type instanceof ParameterizedType) {
-                return (Class) ((ParameterizedType) type).getRawType();
-            } else if (type instanceof WildcardType) {
-                return resolveClassFromType(((WildcardType) type).getUpperBounds()[0]);
-            } else if (type instanceof TypeVariable<?>) {
-                // TODO: implement this to enable improved builder detection
-                throw new IllegalArgumentException("TypeVariable targets are not implemented: " + type);
-            } else if (type instanceof GenericArrayType) {
-                throw new IllegalArgumentException("GenericArrayType targets are not implemented: " + type);
-            } else {
-                throw new IllegalArgumentException("Unable to determine target Class from " + type);
-            }
-        }
     }
 
     // Creates an object from any type of Node using the #builder factory method.
     @SuppressWarnings("unchecked")
     private static final ObjectCreatorFactory FROM_BUILDER_CREATOR = (nodeType, target, nodeMapper) -> {
-        if (nodeType != NodeType.OBJECT) {
+        Class<?> targetClass = classFromType(target);
+        if (nodeType != NodeType.OBJECT || targetClass == null) {
             return null;
         }
 
-        for (Method method : target.getMethods()) {
+        for (Method method : targetClass.getMethods()) {
             if ((method.getName().equals("builder"))
                     && SmithyBuilder.class.isAssignableFrom(method.getReturnType())
                     && method.getParameters().length == 0
                     && Modifier.isStatic(method.getModifiers())) {
                 method.setAccessible(true);
-                return (node, targetType, paramType, pointer, mapper) -> {
+                return (node, targetType, pointer, mapper) -> {
                     try {
                         SmithyBuilder<Object> builder = ((SmithyBuilder<Object>) method.invoke(null));
                         BeanMapper.apply(builder, node, builder.getClass(), pointer, mapper);
@@ -476,29 +486,30 @@ final class DefaultNodeDeserializers {
 
     private static void applySourceLocation(Object object, FromSourceLocation sourceLocation)
             throws ReflectiveOperationException {
-        Pair<Method, Class> setter = BeanMapper.findSetter(object.getClass(), "sourceLocation");
+        Method setter = BeanMapper.findSetter(object.getClass(), "sourceLocation");
         if (setter != null) {
-            setter.left.invoke(object, sourceLocation.getSourceLocation());
+            setter.invoke(object, sourceLocation.getSourceLocation());
         }
     }
 
     // Attempts to create a Bean style POJO using a zero-value constructor.
     private static final ObjectCreatorFactory BEAN_CREATOR = (nodeType, target, nodeMapper) -> {
-        if (nodeType != NodeType.OBJECT) {
+        Class<?> targetClass = classFromType(target);
+        if (nodeType != NodeType.OBJECT || targetClass == null) {
             return null;
         }
 
         try {
             // TODO: we could potentially add support for this if it's not too complicated.
-            if (target.getEnclosingClass() != null && !Modifier.isStatic(target.getModifiers())) {
+            if (targetClass.getEnclosingClass() != null && !Modifier.isStatic(targetClass.getModifiers())) {
                 throw new NodeDeserializationException(
-                        "Cannot create non-static inner class: " + target.getCanonicalName(), SourceLocation.NONE);
+                        "Cannot create non-static inner class: " + targetClass.getCanonicalName(), SourceLocation.NONE);
             }
 
-            Constructor<?> ctor = target.getDeclaredConstructor();
+            Constructor<?> ctor = targetClass.getDeclaredConstructor();
             ctor.setAccessible(true);
 
-            return (node, targetType, parameterizedType, pointer, mapper) -> {
+            return (node, targetType, pointer, mapper) -> {
                 try {
                     Object value = ctor.newInstance();
                     BeanMapper.apply(value, node, targetType, pointer, mapper);
@@ -520,13 +531,15 @@ final class DefaultNodeDeserializers {
     // Mimic's Jackson's behavior when using READ_ENUMS_USING_TO_STRING
     // See https://github.com/FasterXML/jackson-databind/wiki/Deserialization-Features
     private static final ObjectCreatorFactory ENUM_CREATOR = (nodeType, target, nodeMapper) -> {
-        if (nodeType != NodeType.STRING || !Enum.class.isAssignableFrom(target)) {
+        Class<?> targetClass = classFromType(target);
+
+        if (nodeType != NodeType.STRING || targetClass == null || !Enum.class.isAssignableFrom(targetClass)) {
             return null;
         }
 
-        return (node, targetType, parameterizedType, pointer, mapper) -> {
+        return (node, targetType, pointer, mapper) -> {
             String name = node.expectStringNode().getValue();
-            for (Object constant : targetType.getEnumConstants()) {
+            for (Object constant : targetClass.getEnumConstants()) {
                 if (constant.toString().equals(name)) {
                     return constant;
                 }
@@ -534,11 +547,11 @@ final class DefaultNodeDeserializers {
 
             // Give an error message with suggestions.
             List<String> names = new ArrayList<>();
-            for (Object constant : targetType.getEnumConstants()) {
+            for (Object constant : targetClass.getEnumConstants()) {
                 names.add(constant.toString());
             }
 
-            throw NodeDeserializationException.fromContext(targetType, pointer, node, null,
+            throw NodeDeserializationException.fromContext(targetClass, pointer, node, null,
                     "Expected one of the following enum strings: " + names);
         };
     };
@@ -550,7 +563,7 @@ final class DefaultNodeDeserializers {
     // These types have special, built-in handling.
     // This mirrors the simpler behaviors allowed in Jackson.
     // See https://github.com/FasterXML/jackson-databind/blob/ab583fb2319ee33ef6b548b720afec84265d40a7/src/main/java/com/fasterxml/jackson/databind/deser/std/FromStringDeserializer.java
-    private static final Map<Class, FromStringClassFactory> FROM_STRING_CLASSES = MapUtils.of(
+    private static final Map<Type, FromStringClassFactory> FROM_STRING_CLASSES = MapUtils.of(
             URL.class, URL::new,
             URI.class, URI::new,
             Pattern.class, Pattern::compile,
@@ -564,13 +577,12 @@ final class DefaultNodeDeserializers {
         }
 
         FromStringClassFactory factory = FROM_STRING_CLASSES.get(target);
-        return (node, targetType, parameterizedType, pointer, mapper) -> {
+        return (node, targetType, pointer, mapper) -> {
             String value = node.expectStringNode().getValue();
             try {
                 return factory.create(value);
             } catch (Exception e) {
-                throw NodeDeserializationException.fromContext(
-                        targetType, pointer, node, e, e.getMessage());
+                throw NodeDeserializationException.fromContext(targetType, pointer, node, e, e.getMessage());
             }
         };
     };
@@ -609,10 +621,11 @@ final class DefaultNodeDeserializers {
 
     // Creates an ObjectCreatorFactory that caches the result of finding ObjectCreators.
     private static ObjectCreatorFactory cachedCreator(ObjectCreatorFactory delegate) {
-        ConcurrentMap<Pair<NodeType, Class>, NodeMapper.ObjectCreator> cache = new ConcurrentHashMap<>();
+        ConcurrentMap<String, NodeMapper.ObjectCreator> cache = new ConcurrentHashMap<>();
         return (nodeType, target, nodeMapper) -> {
-            return cache.computeIfAbsent(Pair.of(nodeType, target), pair -> {
-                return delegate.getCreator(pair.left, pair.right, nodeMapper);
+            String key = nodeType.getNodeClass() + ":" + target.getTypeName();
+            return cache.computeIfAbsent(key, pair -> {
+                return delegate.getCreator(nodeType, target, nodeMapper);
             });
         };
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeDeserializationException.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeDeserializationException.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.model.node;
 
+import java.lang.reflect.Type;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.SourceLocation;
 
@@ -41,7 +42,7 @@ public class NodeDeserializationException extends SourceException {
      * @return Returns the created exception.
      */
     static NodeDeserializationException fromReflectiveContext(
-            Class<?> into,
+            Type into,
             String pointer,
             Node node,
             ReflectiveOperationException previous,
@@ -65,7 +66,7 @@ public class NodeDeserializationException extends SourceException {
      * @return Returns the created exception.
      */
     static NodeDeserializationException fromContext(
-            Class<?> into,
+            Type into,
             String pointer,
             Node node,
             Throwable previous,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeMapper.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeMapper.java
@@ -18,6 +18,8 @@ package software.amazon.smithy.model.node;
 import static java.lang.String.format;
 
 import java.io.File;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
@@ -58,7 +60,7 @@ public final class NodeMapper {
          * Throws an exception when attempting to deserialize an unknown property.
          */
         FAIL {
-            public void handle(Class<?> into, String pointer, String property, Node value) {
+            public void handle(Type into, String pointer, String property, Node value) {
                 String message = createMessage(property, pointer, into, value);
                 throw new NodeDeserializationException(message, value.getSourceLocation());
             }
@@ -68,7 +70,7 @@ public final class NodeMapper {
          * Warns when attempting to deserialize an unknown property.
          */
         WARN {
-            public void handle(Class<?> into, String pointer, String property, Node value) {
+            public void handle(Type into, String pointer, String property, Node value) {
                 LOGGER.warning(createMessage(property, pointer, into, value));
             }
         },
@@ -77,7 +79,7 @@ public final class NodeMapper {
          * Ignores unknown properties.
          */
         INGORE {
-            public void handle(Class<?> into, String pointer, String property, Node value) {
+            public void handle(Type into, String pointer, String property, Node value) {
             }
         };
 
@@ -89,14 +91,14 @@ public final class NodeMapper {
          * @param property The property that was unknown to the type.
          * @param value The Node being deserialized.
          */
-        public abstract void handle(Class<?> into, String pointer, String property, Node value);
+        public abstract void handle(Type into, String pointer, String property, Node value);
 
-        private static String createMessage(String property, String pointer, Class<?> into, Node node) {
+        private static String createMessage(String property, String pointer, Type into, Node node) {
             String location = node.getSourceLocation() == SourceLocation.NONE
                     ? ""
                     : " " + node.getSourceLocation().toString().trim();
             return format("Deserialization error at %s%s: unable to find setter method for `%s` on %s",
-                          getNormalizedPointer(pointer), location, property, into.getCanonicalName());
+                          getNormalizedPointer(pointer), location, property, into.getTypeName());
         }
     }
 
@@ -139,14 +141,13 @@ public final class NodeMapper {
          * Creates an Object from the given {@code Node} into the given {@code target}.
          *
          * @param node Node to convert into {@code target}.
-         * @param target Type to create.
-         * @param param The nullable parametric type of a {@link Collection} or {@link Map}.
+         * @param type Type to create.
          * @param pointer The JSON pointer to the current serialization context.
          * @param mapper Mapper to invoke to recursively deserialize values.
          * @return Returns the created {@code target} instance.
          * @throws NodeDeserializationException when unable to deserialize a value.
          */
-        Object create(Node node, Class<?> target, Class<?> param, String pointer, NodeMapper mapper);
+        Object create(Node node, Type type, String pointer, NodeMapper mapper);
     }
 
     /**
@@ -168,13 +169,17 @@ public final class NodeMapper {
          * @return Returns the {@code ObjectCreator} or {@code null} if the factory cannot handle the given arguments.
          * @throws NodeDeserializationException when unable to create a factory.
          */
+        ObjectCreator getCreator(NodeType nodeType, Type target, NodeMapper nodeMapper);
+    }
+
+    interface ObjectClassCreatorFactory {
         ObjectCreator getCreator(NodeType nodeType, Class<?> target, NodeMapper nodeMapper);
     }
 
     private static final Logger LOGGER = Logger.getLogger(NodeMapper.class.getName());
     private WhenMissing whenMissing = WhenMissing.WARN;
-    private final Set<Class> disableToNode = new HashSet<>();
-    private final Set<Class> disableFromNode = new HashSet<>();
+    private final Set<Type> disableToNode = new HashSet<>();
+    private final Set<Type> disableFromNode = new HashSet<>();
     private boolean serializeNullValues = false;
     private boolean omitEmptyValues;
 
@@ -225,7 +230,7 @@ public final class NodeMapper {
      *
      * @param type Class to disable the {@code toNode} method serialization for.
      */
-    public void disableToNodeForClass(Class type) {
+    public void disableToNodeForClass(Type type) {
         disableToNode.add(type);
     }
 
@@ -235,7 +240,7 @@ public final class NodeMapper {
      *
      * @param type Class to enable the {@code toNode} method serialization for.
      */
-    public void enableToNodeForClass(Class type) {
+    public void enableToNodeForClass(Type type) {
         disableToNode.remove(type);
     }
 
@@ -244,7 +249,7 @@ public final class NodeMapper {
      *
      * @return Returns the disabled classes.
      */
-    public Set<Class> getDisableToNode() {
+    public Set<Type> getDisableToNode() {
         return disableToNode;
     }
 
@@ -260,7 +265,7 @@ public final class NodeMapper {
      *
      * @param type Class to disable the {@code fromNode} method deserialization for.
      */
-    public void disableFromNodeForClass(Class type) {
+    public void disableFromNodeForClass(Type type) {
         disableFromNode.add(type);
     }
 
@@ -270,7 +275,7 @@ public final class NodeMapper {
      *
      * @param type Class to enable the {@code fromNode} method deserialization for.
      */
-    public void enableFromNodeForClass(Class type) {
+    public void enableFromNodeForClass(Type type) {
         disableFromNode.remove(type);
     }
 
@@ -279,7 +284,7 @@ public final class NodeMapper {
      *
      * @return Returns the disabled classes.
      */
-    public Set<Class> getDisableFromNode() {
+    public Set<Type> getDisableFromNode() {
         return disableFromNode;
     }
 
@@ -432,7 +437,7 @@ public final class NodeMapper {
      * @see #deserializeMap(Node, Class, Class)
      */
     public <T> T deserialize(Node value, Class<T> into) {
-        return deserializeNext(value, "", into, Object.class, this);
+        return deserializeNext(value, "", into, this);
     }
 
     /**
@@ -470,13 +475,29 @@ public final class NodeMapper {
      * @throws NodeDeserializationException on error.
      * @see #deserialize(Node, Class)
      */
-    @SuppressWarnings("unchecked")
-    public <T extends Collection, U, V extends Collection<? extends U>> V deserializeCollection(
+    public <T extends Collection<?>, U, V extends Collection<? extends U>> V deserializeCollection(
             Node value,
             Class<T> into,
             Class<U> members
     ) {
-        return (V) deserializeNext(value, "", into, members, this);
+        ParameterizedType type = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[]{members};
+            }
+
+            @Override
+            public Type getRawType() {
+                return into;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        return deserializeNext(value, "", type, this);
     }
 
     /**
@@ -495,12 +516,29 @@ public final class NodeMapper {
      * @throws NodeDeserializationException on error.
      * @see #deserialize(Node, Class)
      */
-    @SuppressWarnings("unchecked")
-    public <T extends Map, U, V extends Map<String, ? extends U>> V deserializeMap(
-            Node value, Class<T> into,
+    public <T extends Map<?, ?>, U, V extends Map<String, ? extends U>> V deserializeMap(
+            Node value,
+            Class<T> into,
             Class<U> members
     ) {
-        return (V) deserializeNext(value, "", into, members, this);
+        ParameterizedType type = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[]{String.class, members};
+            }
+
+            @Override
+            public Type getRawType() {
+                return into;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        return deserializeNext(value, "", type, this);
     }
 
     /**
@@ -513,23 +551,15 @@ public final class NodeMapper {
      * @param value Node value to deserialize.
      * @param pointer The JSON Pointer to the location of the value being deserialized.
      * @param into The type being created.
-     * @param parametricType The parametric type of {@link Collection} or {@link Map} targets.
      * @param mapper The {@code Mapper} that can be invoked to recursively deserialize.
      * @param <T> The type of value to create.
      * @return Returns the created value.
      */
     @SuppressWarnings("unchecked")
-    <T> T deserializeNext(
-            Node value,
-            String pointer,
-            Class<?> into,
-            Class<?> parametricType,
-            NodeMapper mapper
-    ) {
+    <T> T deserializeNext(Node value, String pointer, Type into, NodeMapper mapper) {
         Objects.requireNonNull(value, "Deserialization value cannot be null");
         Objects.requireNonNull(pointer, "Deserialization pointer cannot be null");
         Objects.requireNonNull(into, "Deserialization into cannot be null");
-        Objects.requireNonNull(parametricType, "Deserialization parametricType cannot be null");
         Objects.requireNonNull(mapper, "Deserialization mapper cannot be null");
 
         try {
@@ -537,7 +567,7 @@ public final class NodeMapper {
             if (creator == null) {
                 throw createError(into, pointer, value, null, null);
             }
-            return (T) creator.create(value, into, parametricType, pointer, mapper);
+            return (T) creator.create(value, into, pointer, mapper);
         } catch (NodeDeserializationException e) {
             // Rethrow already formatted exceptions.
             throw e;
@@ -548,7 +578,7 @@ public final class NodeMapper {
     }
 
     private static NodeDeserializationException createError(
-            Class<?> into,
+            Type into,
             String pointer,
             Node node,
             String message,
@@ -558,10 +588,10 @@ public final class NodeMapper {
         return new NodeDeserializationException(errorMessage, node.getSourceLocation(), cause);
     }
 
-    static String createErrorMessage(Class<?> into, String pointer, Node node, String message) {
+    static String createErrorMessage(Type into, String pointer, Node node, String message) {
         String formatted = String.format(
                 "Deserialization error at %s: unable to create %s from %s",
-                getNormalizedPointer(pointer), into.getCanonicalName(), Node.printJson(node));
+                getNormalizedPointer(pointer), into.getTypeName(), Node.printJson(node));
         if (message != null) {
             formatted += ": " + message;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
@@ -31,7 +31,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
  * @param <B> Concrete builder type.
  * @param <S> Shape being created.
  */
-public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder, S extends Shape>
+public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<?, ?>, S extends Shape>
         implements SmithyBuilder<S>, FromSourceLocation {
 
     private ShapeId id;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
@@ -63,7 +63,7 @@ public abstract class CollectionShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
-    public abstract static class Builder<B extends Builder, S extends CollectionShape>
+    public abstract static class Builder<B extends Builder<?, ?>, S extends CollectionShape>
             extends AbstractShapeBuilder<B, S> {
 
         private MemberShape member;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
@@ -85,8 +85,7 @@ public abstract class EntityShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
-    @SuppressWarnings("rawtypes")
-    public abstract static class Builder<B extends Builder, S extends EntityShape>
+    public abstract static class Builder<B extends Builder<?, ?>, S extends EntityShape>
             extends AbstractShapeBuilder<B, S> {
 
         private final Set<ShapeId> resources = new LinkedHashSet<>();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
@@ -109,7 +109,8 @@ abstract class NamedMembersShape extends Shape {
      * @param <B> Concrete builder type.
      * @param <S> Shape type being created.
      */
-    abstract static class Builder<B extends Builder, S extends NamedMembersShape> extends AbstractShapeBuilder<B, S> {
+    abstract static class Builder<B extends Builder<?, ?>, S extends NamedMembersShape>
+            extends AbstractShapeBuilder<B, S> {
 
         Map<String, MemberShape> members = new LinkedHashMap<>();
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -20,35 +20,41 @@ import java.util.Optional;
 /** An enumeration of the different types in a model. */
 public enum ShapeType {
 
-    BLOB("blob", BlobShape.class),
-    BOOLEAN("boolean", BooleanShape.class),
-    STRING("string", StringShape.class),
-    TIMESTAMP("timestamp", TimestampShape.class),
-    BYTE("byte", ByteShape.class),
-    SHORT("short", ShortShape.class),
-    INTEGER("integer", IntegerShape.class),
-    LONG("long", LongShape.class),
-    FLOAT("float", FloatShape.class),
-    DOCUMENT("document", DocumentShape.class),
-    DOUBLE("double", DoubleShape.class),
-    BIG_DECIMAL("bigDecimal", BigDecimalShape.class),
-    BIG_INTEGER("bigInteger", BigIntegerShape.class),
-    LIST("list", ListShape.class),
-    SET("set", SetShape.class),
-    MAP("map", MapShape.class),
-    STRUCTURE("structure", StructureShape.class),
-    UNION("union", UnionShape.class),
-    SERVICE("service", ServiceShape.class),
-    RESOURCE("resource", ResourceShape.class),
-    OPERATION("operation", OperationShape.class),
-    MEMBER("member", MemberShape.class);
+    BLOB("blob", BlobShape.class, Category.SIMPLE),
+    BOOLEAN("boolean", BooleanShape.class, Category.SIMPLE),
+    STRING("string", StringShape.class, Category.SIMPLE),
+    TIMESTAMP("timestamp", TimestampShape.class, Category.SIMPLE),
+    BYTE("byte", ByteShape.class, Category.SIMPLE),
+    SHORT("short", ShortShape.class, Category.SIMPLE),
+    INTEGER("integer", IntegerShape.class, Category.SIMPLE),
+    LONG("long", LongShape.class, Category.SIMPLE),
+    FLOAT("float", FloatShape.class, Category.SIMPLE),
+    DOCUMENT("document", DocumentShape.class, Category.SIMPLE),
+    DOUBLE("double", DoubleShape.class, Category.SIMPLE),
+    BIG_DECIMAL("bigDecimal", BigDecimalShape.class, Category.SIMPLE),
+    BIG_INTEGER("bigInteger", BigIntegerShape.class, Category.SIMPLE),
+
+    LIST("list", ListShape.class, Category.AGGREGATE),
+    SET("set", SetShape.class, Category.AGGREGATE),
+    MAP("map", MapShape.class, Category.AGGREGATE),
+    STRUCTURE("structure", StructureShape.class, Category.AGGREGATE),
+    UNION("union", UnionShape.class, Category.AGGREGATE),
+    MEMBER("member", MemberShape.class, Category.AGGREGATE),
+
+    SERVICE("service", ServiceShape.class, Category.SERVICE),
+    RESOURCE("resource", ResourceShape.class, Category.SERVICE),
+    OPERATION("operation", OperationShape.class, Category.SERVICE);
+
+    public enum Category { SIMPLE, AGGREGATE, SERVICE }
 
     private final String stringValue;
     private final Class<? extends Shape> shapeClass;
+    private final Category category;
 
-    ShapeType(String stringValue, Class<? extends Shape> shapeClass) {
+    ShapeType(String stringValue, Class<? extends Shape> shapeClass, Category categry) {
         this.stringValue = stringValue;
         this.shapeClass = shapeClass;
+        this.category = categry;
     }
 
     @Override
@@ -66,6 +72,16 @@ public enum ShapeType {
     }
 
     /**
+     * Returns the category of the shape type, as defined in the Smithy
+     * specification (one of SIMPLE, AGGREGATE, or SERVICE).
+     *
+     * @return Returns the category of the type.
+     */
+    public Category getCategory() {
+        return category;
+    }
+
+    /**
      * Create a new Shape.Type from a string.
      *
      * @param text Text to convert into a Shape.Type
@@ -79,5 +95,61 @@ public enum ShapeType {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Creates a shape builder that corresponds to the shape type.
+     *
+     * @return Returns a shape builder corresponding to the type.
+     */
+    public AbstractShapeBuilder<?, ?> createBuilderForType() {
+        switch (this) {
+            case BLOB:
+                return BlobShape.builder();
+            case BOOLEAN:
+                return BooleanShape.builder();
+            case STRING:
+                return StringShape.builder();
+            case TIMESTAMP:
+                return TimestampShape.builder();
+            case BYTE:
+                return ByteShape.builder();
+            case SHORT:
+                return ShortShape.builder();
+            case INTEGER:
+                return IntegerShape.builder();
+            case LONG:
+                return LongShape.builder();
+            case FLOAT:
+                return FloatShape.builder();
+            case DOCUMENT:
+                return DocumentShape.builder();
+            case DOUBLE:
+                return DoubleShape.builder();
+            case BIG_DECIMAL:
+                return BigDecimalShape.builder();
+            case BIG_INTEGER:
+                return BigIntegerShape.builder();
+            case LIST:
+                return ListShape.builder();
+            case SET:
+                return SetShape.builder();
+            case MAP:
+                return MapShape.builder();
+            case STRUCTURE:
+                return StructureShape.builder();
+            case UNION:
+                return UnionShape.builder();
+            case SERVICE:
+                return ServiceShape.builder();
+            case RESOURCE:
+                return ResourceShape.builder();
+            case OPERATION:
+                return OperationShape.builder();
+            case MEMBER:
+                return MemberShape.builder();
+            default:
+                throw new IllegalStateException("Invalid shape type: " + this);
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ChangeShapeType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ChangeShapeType.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.Map;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.AbstractShapeBuilder;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+
+final class ChangeShapeType {
+
+    private final Map<ShapeId, ShapeType> shapeToType;
+
+    ChangeShapeType(Map<ShapeId, ShapeType> shapeToType) {
+        this.shapeToType = shapeToType;
+    }
+
+    Model transform(ModelTransformer transformer, Model model) {
+        return transformer.mapShapes(model, shape -> {
+            if (shapeToType.containsKey(shape.getId())) {
+                return shape.accept(new Retype(shapeToType.get(shape.getId())));
+            } else {
+                return shape;
+            }
+        });
+    }
+
+    private static final class Retype extends ShapeVisitor.Default<Shape> {
+        private final ShapeType to;
+
+        Retype(ShapeType to) {
+            this.to = to;
+        }
+
+        @Override
+        protected Shape getDefault(Shape shape) {
+            throw invalidType(shape, to, shape.getType() + " cannot be retyped.");
+        }
+
+        @Override
+        public Shape blobShape(BlobShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape booleanShape(BooleanShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape byteShape(ByteShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape shortShape(ShortShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape integerShape(IntegerShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape longShape(LongShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape floatShape(FloatShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape doubleShape(DoubleShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape documentShape(DocumentShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape bigIntegerShape(BigIntegerShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape bigDecimalShape(BigDecimalShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape stringShape(StringShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape timestampShape(TimestampShape shape) {
+            return copyToSimpleShape(to, shape);
+        }
+
+        @Override
+        public Shape listShape(ListShape shape) {
+            if (to != ShapeType.SET) {
+                throw invalidType(shape, to, "Lists can only be converted to sets.");
+            }
+            SetShape.Builder builder = SetShape.builder();
+            copySharedPartsToShape(shape, builder);
+            return builder.build();
+        }
+
+        @Override
+        public Shape setShape(SetShape shape) {
+            if (to != ShapeType.LIST) {
+                throw invalidType(shape, to, "Sets can only be converted to lists.");
+            }
+            ListShape.Builder builder = ListShape.builder();
+            copySharedPartsToShape(shape, builder);
+            return builder.build();
+        }
+
+        @Override
+        public Shape structureShape(StructureShape shape) {
+            if (to != ShapeType.UNION) {
+                throw invalidType(shape, to, "Structures can only be converted to unions.");
+            }
+            UnionShape.Builder builder = UnionShape.builder();
+            copySharedPartsToShape(shape, builder);
+            return builder.build();
+        }
+
+        @Override
+        public Shape unionShape(UnionShape shape) {
+            if (to != ShapeType.STRUCTURE) {
+                throw invalidType(shape, to, "Unions can only be converted to structures.");
+            }
+            StructureShape.Builder builder = StructureShape.builder();
+            copySharedPartsToShape(shape, builder);
+            return builder.build();
+        }
+
+        private void copySharedPartsToShape(Shape source, AbstractShapeBuilder<?, ?> builder) {
+            builder.traits(source.getAllTraits().values());
+            builder.id(source.getId());
+            builder.source(source.getSourceLocation());
+
+            for (MemberShape member : source.members()) {
+                builder.addMember(member);
+            }
+        }
+
+        private Shape copyToSimpleShape(ShapeType to, Shape shape) {
+            if (to.getCategory() != ShapeType.Category.SIMPLE) {
+                throw invalidType(shape, to, "Simple types can only be converted to other simple types.");
+            }
+
+            AbstractShapeBuilder<?, ?> shapeBuilder = to.createBuilderForType();
+            copySharedPartsToShape(shape, shapeBuilder);
+            return shapeBuilder.build();
+        }
+
+        private IllegalArgumentException invalidType(Shape shape, ShapeType to, String message) {
+            return new IllegalArgumentException("Cannot convert " + shape + " to " + to + ". " + message);
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MapShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MapShapes.java
@@ -45,7 +45,7 @@ final class MapShapes {
                     if (mapped.equals(shape)) {
                         return Stream.empty();
                     } else if (!mapped.getId().equals(shape.getId())) {
-                        throw new RuntimeException(String.format(
+                        throw new ModelTransformException(String.format(
                                 "Mapped shapes must have the same shape ID. Expected %s, but found %s",
                                 shape.getId(), mapped.getId()));
                     } else {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformException.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+/**
+ * Exception thrown when a model transformation error occurs.
+ */
+public final class ModelTransformException extends RuntimeException {
+    public ModelTransformException(String message) {
+        super(message);
+    }
+
+    public ModelTransformException(String message, Throwable previous) {
+        super(message, previous);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -35,6 +35,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.utils.FunctionalUtils;
@@ -454,5 +455,27 @@ public final class ModelTransformer {
      */
     public Model sortMembers(Model model, Comparator<MemberShape> comparator) {
         return new SortMembers(comparator).transform(this, model);
+    }
+
+    /**
+     * Changes the type of each given shape.
+     *
+     * <p>The following transformations are permitted:
+     *
+     * <ul>
+     *     <li>Any simple type to any simple type</li>
+     *     <li>List to set</li>
+     *     <li>Set to list</li>
+     *     <li>Structure to union</li>
+     *     <li>Union to structure</li>
+     * </ul>
+     *
+     * @param model Model to transform.
+     * @param shapeToType Map of shape IDs to the new type to use for the shape.
+     * @return Returns the transformed model.
+     * @throws ModelTransformException if an incompatible type transform is attempted.
+     */
+    public Model changeShapeType(Model model, Map<ShapeId, ShapeType> shapeToType) {
+        return new ChangeShapeType(shapeToType).transform(this, model);
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -33,12 +34,12 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.AbstractTrait;
-import software.amazon.smithy.model.traits.AbstractTrait.Provider;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.RangeTrait;
-import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -462,7 +463,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/inner/inner) [1, 59]: unable to find setter method for `noSetter!` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.Baz"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$Baz"));
     }
 
     private static final class SimpleString {
@@ -486,7 +487,7 @@ public class NodeMapperTest {
                 () -> mapper.deserialize(Node.objectNode(), FailingFromNode.class));
 
         assertThat(e.getMessage(), equalTo(
-                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest.FailingFromNode "
+                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest$FailingFromNode "
                 + "from {}: Unable to deserialize Node using fromNode method: nope"));
     }
 
@@ -508,7 +509,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to find setter method for `foo` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.BadTypeFromNode"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$BadTypeFromNode"));
     }
 
     private static final class BadTypeFromNode {
@@ -529,7 +530,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to find setter method for `foo` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.NonStaticFromNode"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$NonStaticFromNode"));
     }
 
     private static final class NonStaticFromNode {
@@ -550,7 +551,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to find setter method for `foo` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.NonNodeFromNode"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$NonNodeFromNode"));
     }
 
     private static final class NonNodeFromNode {
@@ -571,7 +572,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to find setter method for `foo` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.MultiArgFromNode"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$MultiArgFromNode"));
     }
 
     private static final class MultiArgFromNode {
@@ -608,7 +609,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), startsWith(
                 "Deserialization error at (/): unable to create "
-                + "software.amazon.smithy.model.node.NodeMapperTest.ClassThrowingBuilderMethod from "
+                + "software.amazon.smithy.model.node.NodeMapperTest$ClassThrowingBuilderMethod from "
                 + "{\"foo\":\"foo\"}: Unable to deserialize Node using a builder: nope"));
     }
 
@@ -637,7 +638,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/) [1, 9]: unable to find setter method for `foo` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.NonStaticBuilderMethod"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$NonStaticBuilderMethod"));
     }
 
     private static final class NonStaticBuilderMethod {
@@ -665,7 +666,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/) [1, 9]: unable to find setter method for `foo` on "
-                + "software.amazon.smithy.model.node.NodeMapperTest.BuilderBadReturnType"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$BuilderBadReturnType"));
     }
 
     private static final class BuilderBadReturnType {
@@ -870,7 +871,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to create "
-                + "software.amazon.smithy.model.node.NodeMapperTest.PojoWithCollection from [\"a\",\"b\"]"));
+                + "software.amazon.smithy.model.node.NodeMapperTest$PojoWithCollection from [\"a\",\"b\"]"));
     }
 
     @Test
@@ -883,7 +884,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to create "
-                + "software.amazon.smithy.model.node.NodeMapperTest.ThrowingCollectionOnAdd from [\"a\",\"b\"]: "
+                + "software.amazon.smithy.model.node.NodeMapperTest$ThrowingCollectionOnAdd from [\"a\",\"b\"]: "
                 + "Cannot add a"));
     }
 
@@ -904,7 +905,7 @@ public class NodeMapperTest {
 
         assertThat(e.getMessage(), equalTo(
                 "Deserialization error at (/): unable to create "
-                + "software.amazon.smithy.model.node.NodeMapperTest.ThrowingCollectionOnCreate from [\"a\",\"b\"]: "
+                + "software.amazon.smithy.model.node.NodeMapperTest$ThrowingCollectionOnCreate from [\"a\",\"b\"]: "
                 + "Unable to deserialize array into Collection: nope"));
     }
 
@@ -1013,7 +1014,7 @@ public class NodeMapperTest {
                 () -> mapper.deserialize(object, BadMapCtor.class));
 
         assertThat(e.getMessage(), equalTo(
-                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest.BadMapCtor "
+                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest$BadMapCtor "
                 + "from {}: Unable to deserialize object into Map: nope"));
     }
 
@@ -1155,7 +1156,7 @@ public class NodeMapperTest {
                 () -> mapper.deserialize(Node.objectNode(), FailingCtor.class));
 
         assertThat(e.getMessage(), equalTo(
-                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest.FailingCtor "
+                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest$FailingCtor "
                 + "from {}: Unable to deserialize a Node when invoking target constructor: nope"));
     }
 
@@ -1328,7 +1329,7 @@ public class NodeMapperTest {
                 () -> mapper.deserialize(Node.from("invalid"), FooEnum.class));
 
         assertThat(e.getMessage(), equalTo(
-                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest.FooEnum "
+                "Deserialization error at (/): unable to create software.amazon.smithy.model.node.NodeMapperTest$FooEnum "
                 + "from \"invalid\": Expected one of the following enum strings: [foo, Baz, BAR]"));
     }
 
@@ -1483,6 +1484,62 @@ public class NodeMapperTest {
 
         public void setIgnoreMe(String ignoreMe) {
             this.ignoreMe = ignoreMe;
+        }
+    }
+
+    @Test
+    public void deserializesMapOfShapeIdToShapeType() {
+        NodeMapper mapper = new NodeMapper();
+        Node input = Node.objectNode()
+                .withMember("shapeTypes", Node.objectNode()
+                        .withMember("smithy.example#A", "union")
+                        .withMember("smithy.example#B", "string"));
+        ShapeIdMap result = mapper.deserialize(input, ShapeIdMap.class);
+
+        assertThat(result.getShapeTypes().keySet().iterator().next(), instanceOf(ShapeId.class));
+        assertThat(result.getShapeTypes().values().iterator().next(), instanceOf(ShapeType.class));
+
+        assertThat(result.getShapeTypes(), hasKey(ShapeId.from("smithy.example#A")));
+        assertThat(result.getShapeTypes(), hasKey(ShapeId.from("smithy.example#B")));
+        assertThat(result.getShapeTypes().get(ShapeId.from("smithy.example#A")), equalTo(ShapeType.UNION));
+        assertThat(result.getShapeTypes().get(ShapeId.from("smithy.example#B")), equalTo(ShapeType.STRING));
+    }
+
+    public static final class ShapeIdMap {
+        private Map<ShapeId, ShapeType> shapeTypes;
+
+        public void setShapeTypes(Map<ShapeId, ShapeType> shapeTypes) {
+            this.shapeTypes = shapeTypes;
+        }
+
+        public Map<ShapeId, ShapeType> getShapeTypes() {
+            return shapeTypes;
+        }
+    }
+
+    @Test
+    public void deserializesNestedGenericTypes() {
+        NodeMapper mapper = new NodeMapper();
+        Node input = Node.objectNode()
+                .withMember("shapeTypes", Node.objectNode()
+                        .withMember("smithy.example#A", Node.arrayNode(Node.objectNode()
+                                .withMember("smithy.example#B", "string"))));
+        ComplicatedShapeIdMap result = mapper.deserialize(input, ComplicatedShapeIdMap.class);
+
+        assertThat(result.getShapeTypes(), hasKey(ShapeId.from("smithy.example#A")));
+        assertThat(result.getShapeTypes(), hasValue(ListUtils.of(
+                MapUtils.of(ShapeId.from("smithy.example#B"), ShapeType.STRING))));
+    }
+
+    public static final class ComplicatedShapeIdMap {
+        private Map<ShapeId, List<Map<ShapeId, ShapeType>>> shapeTypes;
+
+        public void setShapeTypes(Map<ShapeId, List<Map<ShapeId, ShapeType>>> shapeTypes) {
+            this.shapeTypes = shapeTypes;
+        }
+
+        public Map<ShapeId, List<Map<ShapeId, ShapeType>>> getShapeTypes() {
+            return shapeTypes;
         }
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTypeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTypeTest.java
@@ -1,0 +1,23 @@
+package software.amazon.smithy.model.shapes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class ShapeTypeTest {
+    @Test
+    public void createsBuilders() {
+        Shape result = ShapeType.STRING.createBuilderForType().id("example#Foo").build();
+
+        assertThat(result.getType(), Matchers.is(ShapeType.STRING));
+        assertThat(result, Matchers.instanceOf(StringShape.class));
+    }
+
+    @Test
+    public void hasCategory() {
+        assertThat(ShapeType.STRING.getCategory(), Matchers.is(ShapeType.Category.SIMPLE));
+        assertThat(ShapeType.LIST.getCategory(), Matchers.is(ShapeType.Category.AGGREGATE));
+        assertThat(ShapeType.SERVICE.getCategory(), Matchers.is(ShapeType.Category.SERVICE));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.utils.MapUtils;
+
+public class ChangeShapeTypeTest {
+    @ParameterizedTest
+    @MethodSource("simpleTypeTransforms")
+    public void changesSimpleShapeTypes(ShapeType start, ShapeType dest, boolean success) {
+        DocumentationTrait docTrait = new DocumentationTrait("Hi");
+        ShapeId id = ShapeId.from("smithy.example#Test");
+        SourceLocation source = new SourceLocation("/foo", 1, 1);
+        Shape startShape = start.createBuilderForType()
+                .addTrait(docTrait)
+                .id(id)
+                .source(source)
+                .build();
+        Model model = Model.builder().addShape(startShape).build();
+
+        try {
+            Model result = ModelTransformer.create().changeShapeType(model, MapUtils.of(id, dest));
+            if (!success) {
+                Assertions.fail("Expected test to fail");
+            }
+            assertThat(result.expectShape(id).getType(), Matchers.is(dest));
+            assertThat(result.expectShape(id).expectTrait(DocumentationTrait.class), Matchers.equalTo(docTrait));
+            assertThat(result.expectShape(id).getSourceLocation(), Matchers.equalTo(source));
+        } catch (Exception e) {
+            if (success) {
+                throw e;
+            }
+        }
+    }
+
+    private static List<Arguments> simpleTypeTransforms() {
+        Set<ShapeType> simpleTypes = new TreeSet<>();
+        for (ShapeType type : ShapeType.values()) {
+            if (type.getCategory() == ShapeType.Category.SIMPLE) {
+                simpleTypes.add(type);
+            }
+        }
+
+        List<Arguments> result = new ArrayList<>();
+        for (ShapeType start : simpleTypes) {
+            for (ShapeType dest : ShapeType.values()) {
+                if (start != dest) {
+                    result.add(Arguments.of(start, dest, dest.getCategory() == ShapeType.Category.SIMPLE));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    @Test
+    public void changesListToSet() {
+        DocumentationTrait docTrait = new DocumentationTrait("Hi");
+        ShapeId id = ShapeId.from("smithy.example#Test");
+        SourceLocation source = new SourceLocation("/foo", 1, 1);
+        Shape startShape = ListShape.builder()
+                .addTrait(docTrait)
+                .id(id)
+                .source(source)
+                .member(ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+        Model result = ModelTransformer.create().changeShapeType(model, MapUtils.of(id, ShapeType.SET));
+
+        assertThat(result.expectShape(id).getType(), Matchers.is(ShapeType.SET));
+        assertThat(result.expectShape(id).expectTrait(DocumentationTrait.class), Matchers.equalTo(docTrait));
+        assertThat(result.expectShape(id).getSourceLocation(), Matchers.equalTo(source));
+    }
+
+    @Test
+    public void cannotConvertListToAnythingButSet() {
+        Shape startShape = ListShape.builder()
+                .id(ShapeId.from("smithy.example#Test"))
+                .member(ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ModelTransformer.create().changeShapeType(model, MapUtils.of(startShape.getId(), ShapeType.STRING));
+        });
+    }
+
+    @Test
+    public void changesSetToList() {
+        DocumentationTrait docTrait = new DocumentationTrait("Hi");
+        ShapeId id = ShapeId.from("smithy.example#Test");
+        SourceLocation source = new SourceLocation("/foo", 1, 1);
+        Shape startShape = SetShape.builder()
+                .addTrait(docTrait)
+                .id(id)
+                .source(source)
+                .member(ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+        Model result = ModelTransformer.create().changeShapeType(model, MapUtils.of(id, ShapeType.LIST));
+
+        assertThat(result.expectShape(id).getType(), Matchers.is(ShapeType.LIST));
+        assertThat(result.expectShape(id).expectTrait(DocumentationTrait.class), Matchers.equalTo(docTrait));
+        assertThat(result.expectShape(id).getSourceLocation(), Matchers.equalTo(source));
+    }
+
+    @Test
+    public void cannotConvertSetToAnythingButList() {
+        Shape startShape = SetShape.builder()
+                .id(ShapeId.from("smithy.example#Test"))
+                .member(ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ModelTransformer.create().changeShapeType(model, MapUtils.of(startShape.getId(), ShapeType.STRING));
+        });
+    }
+
+    @Test
+    public void changesStructureToUnion() {
+        DocumentationTrait docTrait = new DocumentationTrait("Hi");
+        ShapeId id = ShapeId.from("smithy.example#Test");
+        SourceLocation source = new SourceLocation("/foo", 1, 1);
+        Shape startShape = StructureShape.builder()
+                .addTrait(docTrait)
+                .id(id)
+                .source(source)
+                .addMember("foo", ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+        Model result = ModelTransformer.create().changeShapeType(model, MapUtils.of(id, ShapeType.UNION));
+
+        assertThat(result.expectShape(id).getType(), Matchers.is(ShapeType.UNION));
+        assertThat(result.expectShape(id).expectTrait(DocumentationTrait.class), Matchers.equalTo(docTrait));
+        assertThat(result.expectShape(id).getSourceLocation(), Matchers.equalTo(source));
+        assertThat(result.expectShape(id).members(), Matchers.hasSize(1));
+        assertThat(result.expectShape(id).members().iterator().next(),
+                   Matchers.equalTo(startShape.members().iterator().next()));
+    }
+
+    @Test
+    public void changesUnionToStructure() {
+        DocumentationTrait docTrait = new DocumentationTrait("Hi");
+        ShapeId id = ShapeId.from("smithy.example#Test");
+        SourceLocation source = new SourceLocation("/foo", 1, 1);
+        Shape startShape = UnionShape.builder()
+                .addTrait(docTrait)
+                .id(id)
+                .source(source)
+                .addMember("foo", ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+        Model result = ModelTransformer.create().changeShapeType(model, MapUtils.of(id, ShapeType.STRUCTURE));
+
+        assertThat(result.expectShape(id).getType(), Matchers.is(ShapeType.STRUCTURE));
+        assertThat(result.expectShape(id).expectTrait(DocumentationTrait.class), Matchers.equalTo(docTrait));
+        assertThat(result.expectShape(id).getSourceLocation(), Matchers.equalTo(source));
+        assertThat(result.expectShape(id).members(), Matchers.hasSize(1));
+        assertThat(result.expectShape(id).members().iterator().next(),
+                   Matchers.equalTo(startShape.members().iterator().next()));
+    }
+
+    @Test
+    public void cannotConvertStructureToAnythingButUnion() {
+        Shape startShape = StructureShape.builder().id(ShapeId.from("smithy.example#Test")).build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ModelTransformer.create().changeShapeType(model, MapUtils.of(startShape.getId(), ShapeType.STRING));
+        });
+    }
+
+    @Test
+    public void cannotConvertUnionToAnythingButStructure() {
+        Shape startShape = UnionShape.builder().id(ShapeId.from("smithy.example#Test")).build();
+        Model model = Model.assembler().addShape(startShape).assemble().unwrap();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ModelTransformer.create().changeShapeType(model, MapUtils.of(startShape.getId(), ShapeType.STRING));
+        });
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -45,7 +45,7 @@ public class ReplaceShapesTest {
 
     @Test
     public void cannotChangeComplexShapeTypes() {
-        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+        ModelTransformException ex = assertThrows(ModelTransformException.class, () -> {
             ShapeId shapeId = ShapeId.from("ns.foo#id1");
             StringShape shape = StringShape.builder().id(shapeId).build();
             Model model = Model.builder()
@@ -67,6 +67,7 @@ public class ReplaceShapesTest {
                 return s;
             });
         });
+
         assertEquals("Cannot change the type of ns.foo#id1 from string to structure", ex.getMessage());
     }
 
@@ -94,35 +95,6 @@ public class ReplaceShapesTest {
             }
             return s;
         });
-    }
-
-    @Test
-    public void canNotExchangeListCollectionTypesWithNonReplaceableMembers() {
-        ShapeId shapeId = ShapeId.from("ns.foo#id1");
-        ShapeId structId = ShapeId.from("ns.foo#id2");
-        ListShape shape = ListShape.builder().id(shapeId).member(ShapeId.from("smithy.api#Long")).build();
-        Model model = Model.builder()
-                .addShape(shape)
-                .addShape(LongShape.builder().id(ShapeId.from("smithy.api#Long")).build())
-                .addShape(StructureShape.builder()
-                        .id(structId)
-                        .addMember(
-                                MemberShape.builder()
-                                        .id(structId.withMember("member1"))
-                                        .target("smithy.api#Long")
-                                        .build()
-                        ).build())
-                .build();
-        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
-            ModelTransformer transformer = ModelTransformer.create();
-            transformer.mapShapes(model, s -> {
-                if (s.getId().equals(shapeId)) {
-                    return SetShape.builder().id(shapeId).member(structId).build();
-                }
-                return s;
-            });
-        });
-        assertEquals("Cannot change the type of ns.foo#id1$member from long to structure", ex.getMessage());
     }
 
     @Test


### PR DESCRIPTION
This commit updates the NodeMapper to properly handle generic type
parameters, even for types that have more than one generic type. The
concrete use case this now allows for is that you can deserialize into a
Map where the key is something other than a String.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
