### PR TITLE
Add support for validating different IDL versions

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -87,8 +87,9 @@ enum AstModelLoader {
     private static final Set<String> SERVICE_PROPERTIES = SetUtils.of(
             TYPE, "version", "operations", "resources", "rename", TRAITS);
 
-    ModelFile load(TraitFactory traitFactory, ObjectNode model) {
+    ModelFile load(Version modelVersion, TraitFactory traitFactory, ObjectNode model) {
         FullyResolvedModelFile modelFile = new FullyResolvedModelFile(traitFactory);
+        modelFile.setVersion(modelVersion);
         LoaderUtils.checkForAdditionalProperties(model, null, TOP_LEVEL_PROPERTIES, modelFile.events());
         loadMetadata(model, modelFile);
         loadShapes(model, modelFile);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderUtils.java
@@ -55,18 +55,6 @@ final class LoaderUtils {
     }
 
     /**
-     * Checks if the given version string is supported.
-     *
-     * @param versionString Version string to check (e.g., 1, 1.0).
-     * @return Returns true if this is a supported model version.
-     */
-    static boolean isVersionSupported(String versionString) {
-        return versionString.equals("1")
-               || versionString.equals("1.0")
-               || versionString.equals("1.1");
-    }
-
-    /**
      * Create a {@link ValidationEvent} for a shape conflict.
      *
      * @param id Shape ID in conflict.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
@@ -87,13 +87,14 @@ final class ModelLoader {
     // This loader supports version 1.0 and 1.1. Support for 0.5 and 0.4 was removed in 0.10.
     static ModelFile loadParsedNode(TraitFactory traitFactory, Node node) {
         ObjectNode model = node.expectObjectNode("Smithy documents must be an object. Found {type}.");
-        StringNode version = model.expectStringMember(SMITHY);
+        StringNode versionNode = model.expectStringMember(SMITHY);
+        Version version = Version.fromString(versionNode.getValue());
 
-        if (LoaderUtils.isVersionSupported(version.getValue())) {
-            return AstModelLoader.INSTANCE.load(traitFactory, model);
-        } else {
-            throw new ModelSyntaxException("Unsupported Smithy version number: " + version.getValue(), version);
+        if (version != null) {
+            return AstModelLoader.INSTANCE.load(version, traitFactory, model);
         }
+
+        throw new ModelSyntaxException("Unsupported Smithy version number: " + versionNode.getValue(), versionNode);
     }
 
     // Allows importing JAR files by discovering models inside of a JAR file.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelSyntaxException.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelSyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,20 +18,76 @@ package software.amazon.smithy.model.loader;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
  * Thrown when the syntax of the IDL is invalid.
  */
-public class ModelSyntaxException extends SourceException {
+public class ModelSyntaxException extends SourceException implements ToShapeId {
+    private final ShapeId shapeId;
+
     public ModelSyntaxException(String message, int line, int column) {
-        this(message, SourceLocation.NONE.getFilename(), line, column);
+        this(builder().message(message).sourceLocation(line, column));
     }
 
     public ModelSyntaxException(String message, String filename, int line, int column) {
-        this(message, new SourceLocation(filename, line, column));
+        this(builder().message(message).sourceLocation(filename, line, column));
     }
 
     public ModelSyntaxException(String message, FromSourceLocation sourceLocation) {
-        super(message, sourceLocation);
+        this(builder().message(message).sourceLocation(sourceLocation.getSourceLocation()));
+    }
+
+    private ModelSyntaxException(Builder builder) {
+        super(builder.message, builder.sourceLocation);
+        this.shapeId = builder.shapeId;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public ShapeId toShapeId() {
+        return shapeId;
+    }
+
+    static final class Builder implements SmithyBuilder<ModelSyntaxException> {
+        private SourceLocation sourceLocation = SourceLocation.NONE;
+        private ShapeId shapeId = null;
+        private String message;
+
+        private Builder() {}
+
+        @Override
+        public ModelSyntaxException build() {
+            SmithyBuilder.requiredState("message", message);
+            return new ModelSyntaxException(this);
+        }
+
+        Builder shapeId(ShapeId shapeId) {
+            this.shapeId = shapeId;
+            return this;
+        }
+
+        Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        Builder sourceLocation(FromSourceLocation sourceLocation) {
+            this.sourceLocation = sourceLocation.getSourceLocation();
+            return this;
+        }
+
+        Builder sourceLocation(String filename, int line, int column) {
+            return sourceLocation(new SourceLocation(filename, line, column));
+        }
+
+        Builder sourceLocation(int line, int column) {
+            return sourceLocation(SourceLocation.NONE.getFilename(), line, column);
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Version.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Version.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.MixinTrait;
+
+/**
+ * Tracks version-specific features and validation.
+ */
+enum Version {
+
+    UNKNOWN(""),
+    VERSION_1_0("1.0"),
+    VERSION_1_1("1.1"),
+    VERSION_2_0("2.0");
+
+    private final String version;
+
+    Version(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Creates a Version from a string, or returns null if the version
+     * cannot be found.
+     *
+     * @param value Value to convert to a Version enum.
+     * @return Returns the resolved enum value or null if not found.
+     */
+    static Version fromString(String value) {
+        switch (value) {
+            case "1.0":
+            case "1":
+                return VERSION_1_0;
+            // TODO: remove all traces of "1.1" and replace with "2"
+            case "1.1":
+                return VERSION_1_1;
+            case "2":
+            case "2.0":
+                return VERSION_2_0;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return version;
+    }
+
+    /**
+     * Checks if this version of the IDL supports mixins.
+     *
+     * @return Returns true if this version supports mixins.
+     */
+    boolean supportsMixins() {
+        return this == VERSION_1_1 || this == VERSION_2_0;
+    }
+
+    /**
+     * Returns true if this version of the IDL supports using "!" as
+     * syntactic sugar for applying the required trait.
+     *
+     * @return Returns true if this version of the IDL supports "!" sugar.
+     */
+    boolean supportsRequiredSugar() {
+        return this == VERSION_1_1 || this == VERSION_2_0;
+    }
+
+    /**
+     * Perform version-specific trait validation.
+     *
+     * @param target Shape the trait is applied to.
+     * @param traitId The shape ID of the trait.
+     * @param value The Node value of the trait.
+     * @throws ModelSyntaxException if the given trait cannot be used in this version.
+     */
+    void validateVersionedTrait(ShapeId target, ShapeId traitId, Node value) {
+        if (traitId.equals(MixinTrait.ID) && (this != Version.VERSION_2_0 && this != VERSION_1_1)) {
+            throw ModelSyntaxException.builder()
+                    .message(String.format("Mixins can only be used in Smithy 2.0 or later. Attempted to apply "
+                                           + "a @mixin trait to `%s` in a model file using version `%s`.",
+                                           target, version))
+                    .shapeId(target)
+                    .sourceLocation(value)
+                    .build();
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
@@ -85,12 +85,29 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
      * @return Returns a created validation event with an ID of Model.
      */
     public static ValidationEvent fromSourceException(SourceException exception, String prefix) {
+        // Extract shape IDs from exceptions that implement ToShapeId.
+        ShapeId id = (exception instanceof ToShapeId)
+                ? ((ToShapeId) exception).toShapeId()
+                : null;
+        return fromSourceException(exception, prefix, id);
+    }
+
+    /**
+     * Creates a new ValidationEvent from a {@link SourceException}.
+     *
+     * @param exception Exception to use to create the event.
+     * @param prefix Prefix string to add to the message.
+     * @param shapeId ShapeId to associate with the event.
+     * @return Returns a created validation event with an ID of Model.
+     */
+    public static ValidationEvent fromSourceException(SourceException exception, String prefix, ShapeId shapeId) {
         // Get the message without source location since it's in the event.
         return ValidationEvent.builder()
                 .id(MODEL_ERROR)
                 .severity(ERROR)
                 .message(prefix + exception.getMessageWithoutLocation())
                 .sourceLocation(exception.getSourceLocation())
+                .shapeId(shapeId)
                 .build();
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -252,7 +252,7 @@ public class IdlModelLoaderTest {
         MemberShape member = shape.getMember("foo").get();
         RequiredTrait trait = member.expectTrait(RequiredTrait.class);
 
-        assertThat(trait.getSourceLocation().getLine(), equalTo(4));
+        assertThat(trait.getSourceLocation().getLine(), equalTo(5));
         assertThat(trait.getSourceLocation().getColumn(), equalTo(16));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-list-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-list-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Parse error at line 5, column 11 near `: `: Duplicate member of com.foo#List: 'member' | Model
+[ERROR] com.foo#List: Parse error at line 5, column 11 near `: `: Duplicate member of com.foo#List: 'member' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-map-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-map-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Parse error at line 5, column 8 near `: `: Duplicate member of com.foo#Map: 'key' | Model
+[ERROR] com.foo#Map: Parse error at line 5, column 8 near `: `: Duplicate member of com.foo#Map: 'key' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-set-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-set-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Parse error at line 5, column 11 near `: `: Duplicate member of com.foo#Set: 'member' | Model
+[ERROR] com.foo#Set: Parse error at line 5, column 11 near `: `: Duplicate member of com.foo#Set: 'member' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-structure-member-names.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/dupe-structure-member-names.errors
@@ -1,1 +1,1 @@
-[ERROR] -: Parse error at line 5, column 8 near `: `: Duplicate member of com.foo#Struct: 'foo' | Model
+[ERROR] com.foo#Struct: Parse error at line 5, column 8 near `: `: Duplicate member of com.foo#Struct: 'foo' | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/dangling-with.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/dangling-with.smithy
@@ -1,4 +1,5 @@
-// Parse error at line 5, column 1 near ``: Expected a valid identifier character, but found ''
+// Parse error at line 6, column 1 near ``: Expected a valid identifier character, but found ''
+$version: "2"
 namespace com.foo
 
 structure Foo with

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-resource.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-resource.smithy
@@ -1,4 +1,5 @@
-// Parse error at line 4, column 15 near `with`: Expected: '{', but found 'w'
+// Parse error at line 5, column 15 near `with`: Expected: '{', but found 'w'
+$version: "2"
 namespace com.foo
 
 resource Test with X {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-string.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-mixins-on-string.smithy
@@ -1,4 +1,5 @@
-// Parse error at line 4, column 21 near ` X`: Unexpected shape type: with
+// Parse error at line 5, column 21 near ` X`: Unexpected shape type: with
+$version: "2"
 namespace com.foo
 
 string MyString with X

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-statement-after-structure-name.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/invalid-statement-after-structure-name.smithy
@@ -1,4 +1,5 @@
-// Parse error at line 4, column 15 near `Baz`: Expected: '{', but found 'B'
+// Parse error at line 5, column 15 near `Baz`: Expected: '{', but found 'B'
+$version: "2"
 namespace com.foo
 
 structure Foo Baz {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/missing-rest-of-with-word.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/missing-rest-of-with-word.smithy
@@ -1,4 +1,5 @@
-// Parse error at line 4, column 18 near ` Baz`: Expected: 'h', but found ' '
+// Parse error at line 5, column 18 near ` Baz`: Expected: 'h', but found ' '
+$version: "2"
 namespace com.foo
 
 structure Foo wit Baz {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-trait-in-explicit-1-0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-trait-in-explicit-1-0.smithy
@@ -1,0 +1,6 @@
+// Mixins can only be used in Smithy 2.0 or later. Attempted to apply a @mixin trait to `com.foo#Foo` in a model file using version `1.0`.
+$version: "1.0"
+namespace com.foo
+
+@mixin
+structure Foo {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-trait-in-implicit-1-0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-trait-in-implicit-1-0.smithy
@@ -1,0 +1,5 @@
+// Mixins can only be used in Smithy 2.0 or later. Attempted to apply a @mixin trait to `com.foo#Foo` in a model file using version ``.
+namespace com.foo
+
+@mixin
+structure Foo {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-usage-in-explicit-1-0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-usage-in-explicit-1-0.smithy
@@ -1,0 +1,5 @@
+// Parse error at line 5, column 19 near ` Bar`: Mixins can only be used with Smithy version 2 or later. Attempted to use mixins with version `1.0`.
+$version: "1.0"
+namespace smithy.example
+
+structure Foo with Bar {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-usage-in-implicit-1-0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/mixins-usage-in-implicit-1-0.smithy
@@ -1,0 +1,4 @@
+// Parse error at line 4, column 19 near ` Bar`: Mixins can only be used with Smithy version 2 or later. Attempted to use mixins with version ``.
+namespace smithy.example
+
+structure Foo with Bar {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/with-but-no-ids.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/mixins/with-but-no-ids.smithy
@@ -1,4 +1,5 @@
-// Parse error at line 4, column 20 near `{}`: Expected a valid identifier character, but found '{'
+// Parse error at line 5, column 20 near `{}`: Expected a valid identifier character, but found '{'
+$version: "2"
 namespace com.foo
 
 structure Foo with {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/multiple-required-exclamations.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/multiple-required-exclamations.smithy
@@ -1,6 +1,0 @@
-// Parse error at line 5, column 17 near `!\n`: Expected a valid identifier character, but found '!'
-namespace smithy.example
-
-structure Foo {
-    bar: String!!
-}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/required/multiple-required-exclamations.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/required/multiple-required-exclamations.smithy
@@ -1,0 +1,7 @@
+// Parse error at line 6, column 17 near `!\n`: Expected a valid identifier character, but found '!'
+$version: "2"
+namespace smithy.example
+
+structure Foo {
+    bar: String!!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/required/required-bang-with-explicit-1-0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/required/required-bang-with-explicit-1-0.smithy
@@ -1,0 +1,7 @@
+// Parse error at line 6, column 16 near `!\n`: The '!' suffix can only be used on structure members when using Smithy 2.0 or later, but you're using version `1.0`. Make `$version: "2"` the first line of this file.
+$version: "1"
+namespace smithy.example
+
+structure Foo {
+    bar: String!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/required/required-bang-with-implicit-1-0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid/required/required-bang-with-implicit-1-0.smithy
@@ -1,0 +1,6 @@
+// Parse error at line 5, column 16 near `!\n`: The '!' suffix can only be used on structure members when using Smithy 2.0 or later, but you're using version ``. Make `$version: "2"` the first line of this file.
+namespace smithy.example
+
+structure Foo {
+    bar: String!
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixins-can-override-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixins-can-override-traits.smithy
@@ -1,3 +1,4 @@
+$version: "2"
 namespace smithy.example
 
 /// A

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/required-sugar-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/required-sugar-test.smithy
@@ -1,3 +1,4 @@
+$version: "2"
 namespace smithy.example
 
 structure MyStruct {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/required-sugar.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/required-sugar.smithy
@@ -1,3 +1,4 @@
+$version: "2"
 namespace example.weather
 
 structure Foo {


### PR DESCRIPTION
Various IDL features are only supported in versions > 1.0, including
mixins, the "!" suffix for structure members, and other features soon to
come. This commit adds version-specific validation to the IDL loading
process to ensure that these features are only used in the appropriate
versions.

Given we're moving to Smithy IDL 2.0 instead of 1.1, I started using 2.0
in test cases. I'll send a followup commit that updates everything from
1.0 or 1.1 to 2.0. I kept that out of this commit to make it easier to
review.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
