### PR TITLE
Make setting a service version optional

### DIFF
--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -1002,8 +1002,8 @@ The service shape supports the following properties:
       - Description
     * - version
       - ``string``
-      - **Required**. Defines the version of the service. The version can be
-        provided in any format (e.g., ``2017-02-11``, ``2.0``, etc).
+      - Defines the optional version of the service. The version can be provided in
+        any format (e.g., ``2017-02-11``, ``2.0``, etc).
     * - :ref:`operations <service-operations>`
       - [``string``]
       - Binds a set of ``operation`` shapes to the service. Each

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 import software.amazon.smithy.utils.MapUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -33,7 +32,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
 
     private ServiceShape(Builder builder) {
         super(builder);
-        version = SmithyBuilder.requiredState("version", builder.version);
+        version = builder.version;
         rename = MapUtils.orderedCopyOf(builder.rename);
     }
 
@@ -71,6 +70,9 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
     }
 
     /**
+     * Get the version of the service. An empty string is returned
+     * if the version is undefined.
+     *
      * @return The version of the service.
      */
     public String getVersion() {
@@ -107,7 +109,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
      * Builder used to create a {@link ServiceShape}.
      */
     public static final class Builder extends EntityShape.Builder<Builder, ServiceShape> {
-        private String version;
+        private String version = "";
         private final Map<ShapeId, String> rename = new TreeMap<>();
 
         @Override
@@ -121,7 +123,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
         }
 
         public Builder version(String version) {
-            this.version = version;
+            this.version = version == null ? "" : version;
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -424,8 +424,12 @@ public final class SmithyIdlModelSerializer {
         @Override
         public Void serviceShape(ServiceShape shape) {
             serializeTraits(shape);
-            codeWriter.openBlock("service $L {", shape.getId().getName())
-                    .write("version: $S,", shape.getVersion());
+            codeWriter.openBlock("service $L {", shape.getId().getName());
+
+            if (!StringUtils.isBlank(shape.getVersion())) {
+                codeWriter.write("version: $S,", shape.getVersion());
+            }
+
             codeWriter.writeOptionalIdList("operations", shape.getOperations());
             codeWriter.writeOptionalIdList("resources", shape.getResources());
             if (!shape.getRename().isEmpty()) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.shapes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodePointer;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
@@ -140,5 +142,21 @@ public class ModelSerializerTest {
         ObjectNode serialized = serializer.serialize(model);
 
         assertFalse(serialized.getMember("smithy.api").isPresent());
+    }
+
+    @Test
+    public void doesNotSerializeEmptyServiceVersions() {
+        ServiceShape service = ServiceShape.builder()
+                .id("com.foo#Example")
+                .build();
+        Model model = Model.builder().addShape(service).build();
+        ModelSerializer serializer = ModelSerializer.builder().build();
+        ObjectNode result = serializer.serialize(model);
+
+        assertThat(NodePointer.parse("/shapes/com.foo#Example")
+                           .getValue(result)
+                           .expectObjectNode()
+                           .getStringMap(),
+                   not(hasKey("version")));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
@@ -58,4 +58,13 @@ public class ServiceShapeTest {
 
         assertThat(serviceShape.getContextualName(id), equalTo("FooName"));
     }
+
+    @Test
+    public void versionDefaultsToEmptyString() {
+        ServiceShape shape = ServiceShape.builder()
+                .id("com.foo#Example")
+                .build();
+
+        assertThat(shape.getVersion(), equalTo(""));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.model.shapes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.provider.EnumSource;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.traits.DocumentationTrait;
@@ -135,5 +137,17 @@ public class SmithyIdlModelSerializerTest {
                 .build();
         Map<Path, String> serialized = serializer.serialize(model);
         assertThat(serialized.keySet(), contains(basePath.resolve("metadata.smithy")));
+    }
+
+    @Test
+    public void emptyServiceVersionNotSerialized() {
+        ServiceShape service = ServiceShape.builder()
+                .id("com.foo#Example")
+                .build();
+        Model model = Model.builder().addShape(service).build();
+        SmithyIdlModelSerializer serializer = SmithyIdlModelSerializer.builder().build();
+        Map<Path, String> serialized = serializer.serialize(model);
+
+        assertThat(serialized.get(Paths.get("com.foo.smithy")), not(containsString("version: \"\"")));
     }
 }


### PR DESCRIPTION
Not all use cases for Smithy modelt s can provide a service version. For
example, when using Smithy to generate libraries, not client/server
interactions, there's not really a version negotiation, so no version is
necessary in the model definition.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
