### PR TITLE
Allow common errors to be bound to a service

### DIFF
--- a/docs/source/1.0/spec/core/json-ast.rst
+++ b/docs/source/1.0/spec/core/json-ast.rst
@@ -399,6 +399,12 @@ shapes defined in JSON support the same properties as the Smithy IDL.
       - [:ref:`AST shape reference <ast-shape-reference>`]
       - Binds a list of resources to the service. Each reference MUST target
         a resource.
+    * - errors
+      - [:ref:`AST shape reference <ast-shape-reference>`]
+      - Defines a list of common errors that every operation bound within the
+        closure of the service can return. Each provided shape ID MUST target
+        a :ref:`structure <structure>` shape that is marked with the
+        :ref:`error-trait`.
     * - traits
       - map of :ref:`shape ID <shape-id>` to trait values
       - Traits to apply to the service
@@ -423,6 +429,11 @@ shapes defined in JSON support the same properties as the Smithy IDL.
                 "resources": [
                     {
                         "target": "smithy.example#SomeResource"
+                    }
+                ],
+                "errors": [
+                    {
+                        "target": "smithy.example#SomeError"
                     }
                 ],
                 "traits": {

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -1014,6 +1014,12 @@ The service shape supports the following properties:
       - Binds a set of ``resource`` shapes to the service. Each element in
         the given list MUST be a valid :ref:`shape ID <shape-id>` that targets
         a :ref:`resource <resource>` shape.
+    * - errors
+      - [``string``]
+      - Defines a list of common errors that every operation bound within the
+        closure of the service can return. Each provided shape ID MUST target
+        a :ref:`structure <structure>` shape that is marked with the
+        :ref:`error-trait`.
     * - rename
       - map of :ref:`shape ID <shape-id>` to ``string``
       - Disambiguates shape name conflicts in the
@@ -1059,6 +1065,47 @@ The following example defines a service with no operations or resources.
                 }
             }
         }
+
+The following example defines a service shape that defines a set of errors
+that are common to every operation in the service:
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        namespace smithy.example
+
+        service MyService {
+            version: "2017-02-11",
+            errors: [SomeError]
+        }
+
+        @error("client")
+        structure SomeError {}
+
+    .. code-tab:: json
+
+        {
+            "smithy": "1.0",
+            "shapes": {
+                "smithy.example#MyService": {
+                    "type": "service",
+                    "version": "2017-02-11",
+                    "errors": [
+                        {
+                            "target": "smithy.example#SomeError"
+                        }
+                    ]
+                },
+                "smithy.example#SomeError": {
+                    "type": "structure",
+                    "traits": {
+                        "smithy.api#error": "client"
+                    }
+                }
+            }
+        }
+
 
 
 .. _service-operations:

--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -1145,6 +1145,9 @@ The table below lists the labeled directed relationships from each shape.
     * - service
       - resource
       - Each resource that is bound to a service.
+    * - service
+      - error
+      - Each error structure referenced by the service (if present).
     * - resource
       - identifier
       - The identifier referenced by the resource (if specified).

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedServiceError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedServiceError.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.smithy.diff.ChangedShape;
+import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Emits a warning when an error is added to a service.
+ */
+public final class AddedServiceError extends AbstractDiffEvaluator {
+    @Override
+    public List<ValidationEvent> evaluate(Differences differences) {
+        return differences.changedShapes(ServiceShape.class)
+                .flatMap(change -> createErrorViolations(change).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<ValidationEvent> createErrorViolations(ChangedShape<ServiceShape> change) {
+        if (change.getOldShape().getErrors().equals(change.getNewShape().getErrors())) {
+            return Collections.emptyList();
+        }
+
+        List<ValidationEvent> events = new ArrayList<>();
+        for (ShapeId id : change.getNewShape().getErrors()) {
+            if (!change.getOldShape().getErrors().contains(id)) {
+                events.add(warning(change.getNewShape(), String.format(
+                        "The `%s` error was added to the `%s` service, making this error common "
+                        + "to all operations within the service. This is backward-compatible if the "
+                        + "error is only encountered as a result of a change in behavior of "
+                        + "the client (for example, the client sends a new "
+                        + "parameter to an operation).",
+                        id, change.getShapeId())));
+            }
+        }
+
+        return events;
+    }
+}

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedServiceError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedServiceError.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.smithy.diff.ChangedShape;
+import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Emits a warning when an error is removed from a service.
+ */
+public final class RemovedServiceError extends AbstractDiffEvaluator {
+    @Override
+    public List<ValidationEvent> evaluate(Differences differences) {
+        return differences.changedShapes(ServiceShape.class)
+                .flatMap(change -> createErrorViolations(change).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<ValidationEvent> createErrorViolations(ChangedShape<ServiceShape> change) {
+        if (change.getOldShape().getErrors().equals(change.getNewShape().getErrors())) {
+            return Collections.emptyList();
+        }
+
+        List<ValidationEvent> events = new ArrayList<>();
+        for (ShapeId id : change.getOldShape().getErrors()) {
+            if (!change.getNewShape().getErrors().contains(id)) {
+                events.add(warning(change.getNewShape(), String.format(
+                        "The `%s` error was removed from the `%s` service. This means that it "
+                        + "is no longer considered an error common to all operations within the "
+                        + "service.",
+                        change.getShapeId(), id)));
+            }
+        }
+
+        return events;
+    }
+}

--- a/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
+++ b/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
@@ -2,6 +2,7 @@ software.amazon.smithy.diff.evaluators.AddedEntityBinding
 software.amazon.smithy.diff.evaluators.AddedMetadata
 software.amazon.smithy.diff.evaluators.AddedOperationError
 software.amazon.smithy.diff.evaluators.AddedOperationInputOutput
+software.amazon.smithy.diff.evaluators.AddedServiceError
 software.amazon.smithy.diff.evaluators.AddedShape
 software.amazon.smithy.diff.evaluators.AddedTraitDefinition
 software.amazon.smithy.diff.evaluators.ChangedEnumTrait
@@ -21,6 +22,7 @@ software.amazon.smithy.diff.evaluators.RemovedMetadata
 software.amazon.smithy.diff.evaluators.RemovedOperationError
 software.amazon.smithy.diff.evaluators.RemovedOperationInput
 software.amazon.smithy.diff.evaluators.RemovedOperationOutput
+software.amazon.smithy.diff.evaluators.RemovedServiceError
 software.amazon.smithy.diff.evaluators.RemovedShape
 software.amazon.smithy.diff.evaluators.RemovedTraitDefinition
 software.amazon.smithy.diff.evaluators.ServiceRename

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedServiceErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedServiceErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,15 +22,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
-public class RemovedOperationErrorTest {
+public class AddedServiceErrorTest {
     @Test
-    public void detectsRemovedErrors() {
+    public void detectsAddedErrors() {
         Shape e1 = StructureShape.builder()
                 .id("foo.baz#E1")
                 .addTrait(new ErrorTrait("client"))
@@ -39,17 +39,12 @@ public class RemovedOperationErrorTest {
                 .id("foo.baz#E2")
                 .addTrait(new ErrorTrait("client"))
                 .build();
-        OperationShape operation1 = OperationShape.builder()
-                .id("foo.baz#Operation")
-                .addError(e1)
-                .addError(e2)
-                .build();
-        Shape operation2 = operation1.toBuilder().clearErrors().build();
-        Model modelA = Model.assembler().addShapes(operation1, e1, e2).assemble().unwrap();
-        Model modelB = Model.assembler().addShapes(operation2, e1, e2).assemble().unwrap();
+        ServiceShape service1 = ServiceShape.builder().id("foo.baz#S").version("X").build();
+        ServiceShape service2 = service1.toBuilder().addError(e1.getId()).addError(e2.getId()).build();
+        Model modelA = Model.assembler().addShapes(service1, e1, e2).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, e1, e2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        // Emits an event for each removal.
-        assertThat(TestHelper.findEvents(events, "RemovedOperationError").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "AddedServiceError").size(), equalTo(2));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedServiceErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedServiceErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
-public class RemovedOperationErrorTest {
+public class RemovedServiceErrorTest {
     @Test
     public void detectsRemovedErrors() {
         Shape e1 = StructureShape.builder()
@@ -39,17 +39,18 @@ public class RemovedOperationErrorTest {
                 .id("foo.baz#E2")
                 .addTrait(new ErrorTrait("client"))
                 .build();
-        OperationShape operation1 = OperationShape.builder()
-                .id("foo.baz#Operation")
+        ServiceShape service1 = ServiceShape.builder()
+                .id("foo.baz#S")
+                .version("X")
                 .addError(e1)
                 .addError(e2)
                 .build();
-        Shape operation2 = operation1.toBuilder().clearErrors().build();
-        Model modelA = Model.assembler().addShapes(operation1, e1, e2).assemble().unwrap();
-        Model modelB = Model.assembler().addShapes(operation2, e1, e2).assemble().unwrap();
+        ServiceShape service2 = service1.toBuilder().clearErrors().build();
+        Model modelA = Model.assembler().addShapes(service1, e1, e2).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, e1, e2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        // Emits an event for each removal.
-        assertThat(TestHelper.findEvents(events, "RemovedOperationError").size(), equalTo(2));
+        // Emits one even for both removals.
+        assertThat(TestHelper.findEvents(events, "RemovedServiceError").size(), equalTo(2));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
@@ -18,11 +18,11 @@ package software.amazon.smithy.model.knowledge;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -189,7 +189,7 @@ public final class OperationIndex implements KnowledgeIndex {
      * @return Returns the list of error structures, or an empty list.
      */
     public List<StructureShape> getErrors(ToShapeId service, ToShapeId operation) {
-        Set<StructureShape> result = new TreeSet<>(getErrors(service));
+        Set<StructureShape> result = new LinkedHashSet<>(getErrors(service));
         result.addAll(getErrors(operation));
         return new ArrayList<>(result);
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -68,6 +68,7 @@ enum AstModelLoader {
     private static final String TRAITS = "traits";
     private static final String TYPE = "type";
     private static final String TARGET = "target";
+    private static final String ERRORS = "errors";
 
     private static final List<String> TOP_LEVEL_PROPERTIES = ListUtils.of("smithy", SHAPES, METADATA);
     private static final List<String> APPLY_PROPERTIES = ListUtils.of(TYPE, TRAITS);
@@ -78,12 +79,12 @@ enum AstModelLoader {
     private static final Set<String> MEMBER_PROPERTIES = SetUtils.of(TARGET, TRAITS);
     private static final Set<String> REFERENCE_PROPERTIES = SetUtils.of(TARGET);
     private static final Set<String> OPERATION_PROPERTY_NAMES = SetUtils.of(
-            TYPE, "input", "output", "errors", TRAITS);
+            TYPE, "input", "output", ERRORS, TRAITS);
     private static final Set<String> RESOURCE_PROPERTIES = SetUtils.of(
             TYPE, "create", "read", "update", "delete", "list", "put",
             "identifiers", "resources", "operations", "collectionOperations", TRAITS);
     private static final Set<String> SERVICE_PROPERTIES = SetUtils.of(
-            TYPE, "version", "operations", "resources", "rename", TRAITS);
+            TYPE, "version", "operations", "resources", "rename", ERRORS, TRAITS);
 
     ModelFile load(TraitFactory traitFactory, ObjectNode model) {
         FullyResolvedModelFile modelFile = new FullyResolvedModelFile(traitFactory);
@@ -244,7 +245,7 @@ enum AstModelLoader {
         OperationShape.Builder builder = OperationShape.builder()
                 .id(id)
                 .source(node.getSourceLocation())
-                .addErrors(loadOptionalTargetList(modelFile, id, node, "errors"));
+                .addErrors(loadOptionalTargetList(modelFile, id, node, ERRORS));
 
         loadOptionalTarget(modelFile, id, node, "input").ifPresent(builder::input);
         loadOptionalTarget(modelFile, id, node, "output").ifPresent(builder::output);
@@ -285,6 +286,7 @@ enum AstModelLoader {
         builder.operations(loadOptionalTargetList(modelFile, id, node, "operations"));
         builder.resources(loadOptionalTargetList(modelFile, id, node, "resources"));
         loadServiceRenameIntoBuilder(builder, node);
+        builder.addErrors(loadOptionalTargetList(modelFile, id, node, ERRORS));
         modelFile.onShape(builder);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -89,6 +89,7 @@ final class IdlModelParser extends SimpleParser {
     private static final String IDENTIFIERS_KEY = "identifiers";
     private static final String VERSION_KEY = "version";
     private static final String TYPE_KEY = "type";
+    private static final String ERRORS_KEYS = "errors";
 
     static final Collection<String> RESOURCE_PROPERTY_NAMES = ListUtils.of(
             TYPE_KEY, CREATE_KEY, READ_KEY, UPDATE_KEY, DELETE_KEY, LIST_KEY,
@@ -550,7 +551,7 @@ final class IdlModelParser extends SimpleParser {
         modelFile.onShape(builder);
         optionalId(node, "input", builder::input);
         optionalId(node, "output", builder::output);
-        optionalIdList(node, "errors", builder::addError);
+        optionalIdList(node, ERRORS_KEYS, builder::addError);
     }
 
     private void parseServiceStatement(ShapeId id, SourceLocation location) {
@@ -562,6 +563,7 @@ final class IdlModelParser extends SimpleParser {
         modelFile.onShape(builder);
         optionalIdList(shapeNode, OPERATIONS_KEY, builder::addOperation);
         optionalIdList(shapeNode, RESOURCES_KEY, builder::addResource);
+        optionalIdList(shapeNode, ERRORS_KEYS, builder::addError);
         AstModelLoader.loadServiceRenameIntoBuilder(builder, shapeNode);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -71,6 +71,10 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
         for (ShapeId resource : shape.getResources()) {
             addBinding(result, shape, resource, RelationshipType.RESOURCE);
         }
+        // Add ERROR relationships from service -> errors.
+        for (ShapeId errorId : shape.getErrors()) {
+            result.add(relationship(shape, RelationshipType.ERROR, errorId));
+        }
         return result;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -232,6 +232,7 @@ public final class ModelSerializer {
 
             serviceBuilder.withOptionalMember("operations", createOptionalIdList(shape.getOperations()));
             serviceBuilder.withOptionalMember("resources", createOptionalIdList(shape.getResources()));
+            serviceBuilder.withOptionalMember("errors", createOptionalIdList(shape.getErrors()));
 
             if (!shape.getRename().isEmpty()) {
                 ObjectNode.Builder renameBuilder = Node.objectNodeBuilder();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -180,7 +180,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
          * @param errorShapeIds Error shape IDs to add.
          * @return Returns the builder.
          */
-        public Builder addErrors(List<ShapeId> errorShapeIds) {
+        public Builder addErrors(Collection<ShapeId> errorShapeIds) {
             errors.addAll(Objects.requireNonNull(errorShapeIds));
             return this;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -432,6 +432,7 @@ public final class SmithyIdlModelSerializer {
 
             codeWriter.writeOptionalIdList("operations", shape.getOperations());
             codeWriter.writeOptionalIdList("resources", shape.getResources());
+            codeWriter.writeOptionalIdList("errors", shape.getErrors());
             if (!shape.getRename().isEmpty()) {
                 codeWriter.openBlock("rename: {", "}", () -> {
                     for (Map.Entry<ShapeId, String> entry : shape.getRename().entrySet()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/CopyServiceErrorsToOperationsTransform.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/CopyServiceErrorsToOperationsTransform.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Copies errors from a service onto each operation bound to the service.
+ */
+final class CopyServiceErrorsToOperationsTransform {
+
+    private final ServiceShape forService;
+
+    CopyServiceErrorsToOperationsTransform(ServiceShape forService) {
+        this.forService = forService;
+    }
+
+    Model transform(ModelTransformer transformer, Model model) {
+        if (forService.getErrors().isEmpty()) {
+            return model;
+        }
+
+        Set<Shape> toReplace = new HashSet<>();
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        for (OperationShape operation : topDownIndex.getContainedOperations(forService)) {
+            Set<ShapeId> errors = new LinkedHashSet<>(operation.getErrors());
+            errors.addAll(forService.getErrors());
+            toReplace.add(operation.toBuilder().errors(errors).build());
+        }
+
+        return transformer.replaceShapes(model, toReplace);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -33,6 +33,7 @@ import software.amazon.smithy.model.neighbor.UnreferencedShapes;
 import software.amazon.smithy.model.neighbor.UnreferencedTraitDefinitions;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -477,5 +478,17 @@ public final class ModelTransformer {
      */
     public Model changeShapeType(Model model, Map<ShapeId, ShapeType> shapeToType) {
         return new ChangeShapeType(shapeToType).transform(this, model);
+    }
+
+    /**
+     * Copies the errors defined on the given service onto each operation bound to the
+     * service, effectively flattening service error inheritance.
+     *
+     * @param model Model to modify.
+     * @param forService Service shape to use as the basis for copying errors to operations.
+     * @return Returns the transformed model.
+     */
+    public Model copyServiceErrorsToOperations(Model model, ServiceShape forService) {
+        return new CopyServiceErrorsToOperationsTransform(forService).transform(this, model);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
@@ -223,7 +223,7 @@ public final class TargetValidator extends AbstractValidator {
 
     private ValidationEvent errorNoTrait(Shape shape, ShapeId target) {
         return error(shape, format(
-                "Operation error targets an invalid structure, `%s`, that is not marked with the `error` trait.",
+                "`%s` cannot be bound as an error because it is not marked with the `error` trait.",
                 target));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/OperationIndexTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -62,12 +63,9 @@ public class OperationIndexTest {
         OperationIndex opIndex = OperationIndex.of(model);
         Shape input = model.getShape(ShapeId.from("ns.foo#Input")).get();
         Shape output = model.getShape(ShapeId.from("ns.foo#Output")).get();
-        Shape error1 = model.getShape(ShapeId.from("ns.foo#Error1")).get();
-        Shape error2 = model.getShape(ShapeId.from("ns.foo#Error2")).get();
 
         assertThat(opIndex.getInput(ShapeId.from("ns.foo#B")), is(Optional.of(input)));
         assertThat(opIndex.getOutput(ShapeId.from("ns.foo#B")), is(Optional.of(output)));
-        assertThat(opIndex.getErrors(ShapeId.from("ns.foo#B")), containsInAnyOrder(error1, error2));
     }
 
     @Test
@@ -106,5 +104,23 @@ public class OperationIndexTest {
 
         assertThat(opIndex.isOutputStructure(output), is(true));
         assertThat(opIndex.isOutputStructure(input), is(false));
+    }
+
+    @Test
+    public void getsOperationErrorsAndInheritedErrors() {
+        OperationIndex opIndex = OperationIndex.of(model);
+        ShapeId a = ShapeId.from("ns.foo#A");
+        ShapeId b = ShapeId.from("ns.foo#B");
+        ServiceShape service = model.expectShape(ShapeId.from("ns.foo#MyService"), ServiceShape.class);
+        StructureShape error1 = model.expectShape(ShapeId.from("ns.foo#Error1"), StructureShape.class);
+        StructureShape error2 = model.expectShape(ShapeId.from("ns.foo#Error2"), StructureShape.class);
+        StructureShape common1 = model.expectShape(ShapeId.from("ns.foo#CommonError1"), StructureShape.class);
+        StructureShape common2 = model.expectShape(ShapeId.from("ns.foo#CommonError2"), StructureShape.class);
+
+        assertThat(opIndex.getErrors(service), containsInAnyOrder(common1, common2));
+        assertThat(opIndex.getErrors(a), empty());
+        assertThat(opIndex.getErrors(service, a), containsInAnyOrder(common1, common2));
+        assertThat(opIndex.getErrors(b), containsInAnyOrder(error1, error2));
+        assertThat(opIndex.getErrors(service, b), containsInAnyOrder(error1, error2, common1, common2));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/OperationShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/OperationShapeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.shapes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class OperationShapeTest {
+    @Test
+    public void combinesErrorsWithServiceErrors() {
+        ServiceShape service = ServiceShape.builder()
+                .id("com.foo#Example")
+                .version("x")
+                .addError("com.foo#Common1")
+                .addError(ShapeId.from("com.foo#Common2"))
+                .build();
+
+        OperationShape operation = OperationShape.builder()
+                .id("com.foo#Operation")
+                .addError("com.foo#OperationError")
+                .build();
+
+        List<ShapeId> allErrors = operation.getErrors(service);
+
+        assertThat(allErrors, contains(
+                ShapeId.from("com.foo#Common1"),
+                ShapeId.from("com.foo#Common2"),
+                ShapeId.from("com.foo#OperationError")));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.SourceException;
@@ -66,5 +67,24 @@ public class ServiceShapeTest {
                 .build();
 
         assertThat(shape.getVersion(), equalTo(""));
+    }
+
+    @Test
+    public void hasErrors() {
+        ServiceShape shape = ServiceShape.builder()
+                .id("com.foo#Example")
+                .version("x")
+                .addError("com.foo#Common1")
+                .addError(ShapeId.from("com.foo#Common2"))
+                .build();
+
+        assertThat(shape, equalTo(shape));
+        assertThat(shape, equalTo(shape.toBuilder().build()));
+
+        ServiceShape shape2 = shape.toBuilder()
+                .errors(Arrays.asList(ShapeId.from("com.foo#Common1"), ShapeId.from("com.foo#Common2")))
+                .build();
+
+        assertThat(shape, equalTo(shape2));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/CopyServiceErrorsToOperationsTransformTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/CopyServiceErrorsToOperationsTransformTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+
+public class CopyServiceErrorsToOperationsTransformTest {
+    @Test
+    public void copiesErrors() {
+        StructureShape errorShape1 = StructureShape.builder()
+                .id("ns.foo#Error1")
+                .addTrait(new ErrorTrait("client"))
+                .build();
+        StructureShape errorShape2 = StructureShape.builder()
+                .id("ns.foo#Error2")
+                .addTrait(new ErrorTrait("client"))
+                .build();
+        OperationShape operation1 = OperationShape.builder()
+                .id("smithy.example#Operation1")
+                .addError(errorShape1)
+                .build();
+        OperationShape operation2 = OperationShape.builder()
+                .id("smithy.example#Operation2")
+                .build();
+        ServiceShape service = ServiceShape.builder()
+                .id("ns.foo#Svc")
+                .version("2017-01-17")
+                .addError(errorShape2)
+                .addOperation(operation1)
+                .build();
+        Model model = Model.builder()
+                .addShapes(service, errorShape1, errorShape2, operation1, operation2)
+                .build();
+        Model result = ModelTransformer.create().copyServiceErrorsToOperations(model, service);
+
+        // operation2 is not in the service closure so leave it alone.
+        assertThat(operation2, Matchers.equalTo(result.expectShape(operation2.getId())));
+
+        // Make sure service errors were copied to the operation bound within it.
+        assertThat(result.expectShape(operation1.getId(), OperationShape.class).getErrors(),
+                Matchers.containsInAnyOrder(errorShape1.getId(), errorShape2.getId()));
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-errors.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-errors.errors
@@ -1,0 +1,3 @@
+[ERROR] ns.foo#InvalidService1: service shape has an `error` relationship to an unresolved shape `ns.foo#NotFound` | Target
+[ERROR] ns.foo#InvalidService2: service shape `error` relationships must target a structure shape, but found (string: `smithy.api#String`) | Target
+[ERROR] ns.foo#InvalidService3: `ns.foo#NotError` cannot be bound as an error because it is not marked with the `error` trait. | Target

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-errors.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-errors.json
@@ -1,0 +1,35 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "ns.foo#InvalidService1": {
+            "type": "service",
+            "version": "x",
+            "errors": [
+                {
+                    "target": "ns.foo#NotFound"
+                }
+            ]
+        },
+        "ns.foo#InvalidService2": {
+            "type": "service",
+            "version": "x",
+            "errors": [
+                {
+                    "target": "smithy.api#String"
+                }
+            ]
+        },
+        "ns.foo#InvalidService3": {
+            "type": "service",
+            "version": "x",
+            "errors": [
+                {
+                    "target": "ns.foo#NotError"
+                }
+            ]
+        },
+        "ns.foo#NotError": {
+            "type": "structure"
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator.errors
@@ -9,7 +9,7 @@
 [ERROR] ns.foo#InvalidListMemberResource$member: Members cannot target resource shapes, but found (resource: `ns.foo#MyResource`) | Target
 [ERROR] ns.foo#InvalidListMemberService$member: Members cannot target service shapes, but found (service: `ns.foo#MyService`) | Target
 [ERROR] ns.foo#InvalidMapType: Map key member targets (structure: `ns.foo#ValidInput`), but is expected to target a string | Target
-[ERROR] ns.foo#InvalidOperationBadErrorTraits: Operation error targets an invalid structure, `ns.foo#ValidInput`, that is not marked with the `error` trait. | Target
+[ERROR] ns.foo#InvalidOperationBadErrorTraits: `ns.foo#ValidInput` cannot be bound as an error because it is not marked with the `error` trait. | Target
 [ERROR] ns.foo#InvalidOperationBadErrorTraits: Operation input targets an invalid structure `ns.foo#ValidError` that is marked with the `error` trait. | Target
 [ERROR] ns.foo#InvalidOperationBadErrorTraits: Operation output targets an invalid structure `ns.foo#ValidError` that is marked with the `error` trait. | Target
 [ERROR] ns.foo#InvalidResourceBindingReference: resource shape has a `resource` relationship to an unresolved shape `ns.foo#NotFound` | Target

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/operation-index-test.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/operation-index-test.json
@@ -11,6 +11,14 @@
                 {
                     "target": "ns.foo#B"
                 }
+            ],
+            "errors": [
+                {
+                    "target": "ns.foo#CommonError1"
+                },
+                {
+                    "target": "ns.foo#CommonError2"
+                }
             ]
         },
         "ns.foo#A": {
@@ -52,6 +60,18 @@
             }
         },
         "ns.foo#Error2": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#error": "server"
+            }
+        },
+        "ns.foo#CommonError1": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#error": "server"
+            }
+        },
+        "ns.foo#CommonError2": {
             "type": "structure",
             "traits": {
                 "smithy.api#error": "server"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-errors.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-errors.json
@@ -1,0 +1,31 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "ns.foo#Common1": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#error": "client"
+            }
+        },
+        "ns.foo#Common2": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#error": "server"
+            }
+        },
+        "ns.foo#EmptyService": {
+            "type": "service",
+            "version": "2020-02-18",
+            "errors": [
+                {
+                    "target": "ns.foo#Common1"
+                },
+                {
+                    "target": "ns.foo#Common2"
+                }
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-errors.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-errors.smithy
@@ -1,0 +1,17 @@
+$version: "1.0"
+
+namespace ns.foo
+
+service EmptyService {
+    version: "2020-02-18",
+    errors: [
+        Common1,
+        Common2,
+    ],
+}
+
+@error("client")
+structure Common1 {}
+
+@error("server")
+structure Common2 {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-errors.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-errors.smithy
@@ -1,0 +1,17 @@
+$version: "1.0"
+
+namespace ns.foo
+
+service EmptyService {
+    version: "2020-02-18",
+    errors: [
+        Common1,
+        Common2,
+    ],
+}
+
+@error("client")
+structure Common1 {}
+
+@error("server")
+structure Common2 {}

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -498,4 +498,20 @@ public class OpenApiConverterTest {
 
         Node.assertEquals(result, expectedNode);
     }
+
+    @Test
+    public void generatesOpenApiForSharedErrors() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("service-with-common-errors.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#MyService"));
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("service-with-common-errors.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-common-errors.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-common-errors.json
@@ -1,0 +1,43 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#MyService": {
+            "type": "service",
+            "version": "2017-02-11",
+            "operations": [
+                {
+                    "target": "smithy.example#GetSomething"
+                }
+            ],
+            "errors": [
+                {
+                    "target": "smithy.example#MyError"
+                }
+            ],
+            "traits": {
+                "aws.protocols#restJson1": {}
+            }
+        },
+        "smithy.example#GetSomething": {
+            "type": "operation",
+            "output": {
+                "target": "smithy.example#GetSomethingOutput"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/"
+                }
+            }
+        },
+        "smithy.example#GetSomethingOutput": {
+            "type": "structure"
+        },
+        "smithy.example#MyError": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#error": "client"
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-common-errors.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-common-errors.openapi.json
@@ -1,0 +1,22 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "MyService",
+        "version": "2017-02-11"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "GetSomething",
+                "responses": {
+                    "200": {
+                        "description": "GetSomething 200 response"
+                    },
+                    "400": {
+                        "description": "MyError 400 response"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit allows a common list of errors to be bound to a service
shape so that every operation within the closure of the service
implicitly can return the common errors. This is a very common pattern,
and this change makes it easier to add common errors without needing
things like validation to enforce them being added to every operation.

Existing code generation tooling will either need to be updated to
perform a model transform that copies common errors onto each operation
bound within a service (see `copyServiceErrorsToOperations`), or they
need to use the introduced `getErrors` method on `OperationIndex` that
also takes in a service shape ID.

Closes #894

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
