### PR TITLE
ci: use setup-java v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
 
       - name: Clean and build
         run: ./gradlew clean build -Plog-tests


### PR DESCRIPTION

*Description of changes:*

setup-java v2 is the latest version
https://github.com/actions/setup-java/blob/main/README.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
