### PR TITLE
fix: update glacier test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -66,6 +66,7 @@ service Glacier {
         params: {
             accountId: "foo",
             vaultName: "bar",
+            body: "hello world"
         },
         appliesTo: "client",
     },
@@ -123,6 +124,7 @@ operation UploadArchive {
             accountId: "foo",
             vaultName: "bar",
             uploadId: "baz",
+            body: "hello world"
         },
         appliesTo: "client",
     }


### PR DESCRIPTION
*Description of changes:*
The body of the request needs to be a param to the test or the input for the test doesn't generate correctly. In other tests where there Is a payload, it's listed as a param: https://github.com/awslabs/smithy/blob/main/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy#L41

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
