### PR TITLE
Fix validation tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/validation/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/main.smithy
@@ -14,6 +14,7 @@ service RestJsonValidation {
         MalformedEnum,
         MalformedLength,
         MalformedLengthOverride,
+        MalformedLengthQueryString,
         MalformedPattern,
         MalformedPatternOverride,
         MalformedRange,

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-required.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-required.smithy
@@ -83,40 +83,6 @@ apply MalformedRequired @httpMalformedRequestTests([
         }
     },
     {
-        id: "RestJsonMalformedRequiredQueryNoValue",
-        documentation: """
-        When a required member has no value in the query string,
-        the response should be a 400 ValidationException.""",
-        protocol: restJson1,
-        request: {
-            method: "POST",
-            uri: "/MalformedRequired",
-            body: """
-            { "string": "abc" }""",
-            queryParams: [
-                "stringInQuery"
-            ],
-            headers: {
-                "content-type": "application/json",
-                "string-in-headers": "abc"
-            },
-        },
-        response: {
-            code: 400,
-            headers: {
-                "x-amzn-errortype": "ValidationException"
-            },
-            body: {
-                mediaType: "application/json",
-                assertion: {
-                    contents: """
-                    { "message" : "1 validation error detected. Value null at '/string' failed to satisfy constraint: Member must not be null",
-                      "fieldList" : [{"message": "Value null at '/string' failed to satisfy constraint: Member must not be null", "path": "/string"}]}"""
-                }
-            }
-        }
-    },
-    {
         id: "RestJsonMalformedRequiredHeaderUnset",
         documentation: """
         When a required member is not set in headers,


### PR DESCRIPTION
*Description of changes:*
Fixes malformed request tests for validation:

- An extra trailing = in the blob input made the blob content invalid, not too
long for the constraint.

- Query strings specified without an associated value map to empty string, not
null. This means that they satisfy required constraints, and length constraints
must be used to enforce that a value is specified when they have dynamic
values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
