### PR TITLE
Make accept test server only

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -78,9 +78,20 @@ apply NoInputAndOutput @httpRequestTests([
         method: "POST",
         uri: "/NoInputAndOutputOutput",
         body: "",
+    },
+    {
+        id: "RestJsonNoInputAndOutputAllowsAccept",
+        documentation: """
+                Servers should allow the accept header to be set to the
+                default content-type.""",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/NoInputAndOutputOutput",
+        body: "",
         headers: {
             "Accept": "application/json"
         },
+        appliesTo: "server"
     }
 ])
 


### PR DESCRIPTION
Clients don't need to pass accept, but servers need to accept it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
