### PR TITLE
Make service version optional when loading models

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -282,7 +282,7 @@ enum AstModelLoader {
         LoaderUtils.checkForAdditionalProperties(node, id, SERVICE_PROPERTIES, modelFile.events());
         applyShapeTraits(id, node, modelFile);
         ServiceShape.Builder builder = new ServiceShape.Builder().id(id).source(node.getSourceLocation());
-        builder.version(node.expectStringMember("version").getValue());
+        node.getStringMember("version").map(StringNode::getValue).ifPresent(builder::version);
         builder.operations(loadOptionalTargetList(modelFile, id, node, "operations"));
         builder.resources(loadOptionalTargetList(modelFile, id, node, "resources"));
         loadServiceRenameIntoBuilder(builder, node);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -559,7 +559,7 @@ final class IdlModelParser extends SimpleParser {
         ServiceShape.Builder builder = new ServiceShape.Builder().id(id).source(location);
         ObjectNode shapeNode = IdlNodeParser.parseObjectNode(this, id.toString());
         LoaderUtils.checkForAdditionalProperties(shapeNode, id, SERVICE_PROPERTY_NAMES, modelFile.events());
-        builder.version(shapeNode.expectStringMember(VERSION_KEY).getValue());
+        shapeNode.getStringMember(VERSION_KEY).map(StringNode::getValue).ifPresent(builder::version);
         modelFile.onShape(builder);
         optionalIdList(shapeNode, OPERATIONS_KEY, builder::addOperation);
         optionalIdList(shapeNode, RESOURCES_KEY, builder::addResource);

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-version-not-required.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-version-not-required.json
@@ -1,0 +1,8 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#MyService": {
+            "type": "service"
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-version-not-required.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-version-not-required.smithy
@@ -1,0 +1,3 @@
+namespace smithy.example
+
+service MyService {}


### PR DESCRIPTION
A previous change was made to make the version of a service optional,
but IDL and AST model loading didn't account for this change so version
still wasn't optional in practice. This fixes that issue and adds an
integration test to ensure it is actually optional when loading both the
AST and IDL.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
