### PR TITLE
Add filterSuppressions model transform

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -675,6 +675,211 @@ orphaned shapes.
     This transformer does not remove shapes from the prelude.
 
 
+.. _filterSuppressions-transform:
+
+filterSuppressions
+------------------
+
+Removes and modifies suppressions found in :ref:`metadata <suppression-definition>`
+and the :ref:`suppress-trait`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - removeUnused
+      - ``boolean``
+      - Set to true to remove suppressions that have no effect.
+
+        Shapes and validators are often removed when creating a filtered
+        version of model. After removing shapes and validators, suppressions
+        could be left in the model that no longer have any effect. These
+        suppressions could inadvertently disclose information about private
+        or unreleased features.
+
+        If a validation event ID is never emitted, then ``@suppress`` traits
+        will be updated to no longer refer to the ID and removed if they no
+        longer refer to any event. Metadata suppressions are also removed if
+        they have no effect.
+    * - removeReasons
+      - ``boolean``
+      - Set to true to remove the ``reason`` property from metadata suppressions.
+        The reason for a suppression could reveal internal or sensitive
+        information. Removing the "reason" from metadata suppressions is an
+        extra step teams can take to ensure they do not leak internal
+        information when publishing models outside of their organization.
+    * - eventIdAllowList
+      - ``[string]``
+      - Sets a list of event IDs that can be referred to in suppressions.
+        Suppressions that refer to any other event ID will be updated to
+        no longer refer to them, or removed if they no longer refer to any
+        events.
+
+        This setting cannot be used in tandem with ``eventIdDenyList``.
+    * - eventIdDenyList
+      - ``[string]``
+      - Sets a list of event IDs that cannot be referred to in suppressions.
+        Suppressions that refer to any of these event IDs will be updated to
+        no longer refer to them, or removed if they no longer refer to any
+        events.
+
+        This setting cannot be used in tandem with ``eventIdAllowList``.
+    * - namespaceAllowList
+      - ``[string]``
+      - Sets a list of namespaces that can be referred to in metadata
+        suppressions. Metadata suppressions that refer to namespaces
+        outside of this list, including "*", will be removed.
+
+        This setting cannot be used in tandem with ``namespaceDenyList``.
+    * - namespaceDenyList
+      - ``[string]``
+      - Sets a list of namespaces that cannot be referred to in metadata
+        suppressions. Metadata suppressions that refer to namespaces
+        in this list, including "*", will be removed.
+
+        This setting cannot be used in tandem with ``namespaceAllowList``.
+
+The following example removes suppressions that have no effect in the
+``exampleProjection``:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "filterSuppressions",
+                            "args": {
+                                "removeUnused": true
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+The following example removes suppressions from metadata that refer to
+deny-listed namespaces:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "filterSuppressions",
+                            "args": {
+                                "namespaceDenyList": ["com.internal"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+The following example removes suppressions from metadata that refer to
+namespaces outside of the allow-listed namespaces:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "filterSuppressions",
+                            "args": {
+                                "namespaceAllowList": ["com.external"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+The following example removes suppressions that refer to deny-listed event IDs:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "filterSuppressions",
+                            "args": {
+                                "eventIdDenyList": ["MyInternalValidator"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+The following example removes suppressions that refer to event IDs outside
+of the event ID allow list:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "filterSuppressions",
+                            "args": {
+                                "eventIdAllowList": ["A", "B", "C"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+The following example removes the ``reason`` property from metadata
+suppressions:
+
+.. tabs::
+
+    .. code-tab:: json
+
+        {
+            "version": "1.0",
+            "projections": {
+                "exampleProjection": {
+                    "transforms": [
+                        {
+                            "name": "filterSuppressions",
+                            "args": {
+                                "removeReasons": true
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+
 .. _includeTags-transform:
 
 includeTags

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FilterSuppressions.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FilterSuppressions.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.SuppressTrait;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.suppressions.Suppression;
+
+/**
+ * Filters suppressions found in metadata and {@link SuppressTrait} traits.
+ */
+public final class FilterSuppressions extends ConfigurableProjectionTransformer<FilterSuppressions.Config> {
+
+    private static final Logger LOGGER = Logger.getLogger(FilterSuppressions.class.getName());
+
+    /**
+     * {@code filterSuppressions} configuration settings.
+     */
+    public static final class Config {
+
+        private boolean removeUnused = false;
+        private boolean removeReasons = false;
+        private Set<String> eventIdAllowList = Collections.emptySet();
+        private Set<String> eventIdDenyList = Collections.emptySet();
+        private Set<String> namespaceAllowList = Collections.emptySet();
+        private Set<String> namespaceDenyList = Collections.emptySet();
+
+        /**
+         * Gets whether unused suppressions are removed.
+         *
+         * @return Returns true if unused suppressions are removed.
+         */
+        public boolean getRemoveUnused() {
+            return removeUnused;
+        }
+
+        /**
+         * Set to true to remove suppressions that have no effect.
+         *
+         * <p>If a validation event ID is never emitted, then {@code suppress} traits
+         * will be updated to no longer refer to the ID and removed if they no longer
+         * refer to any event. Metadata suppressions are also removed if they have no
+         * effect.
+         *
+         * @param removeUnused Set to true to remove unused suppressions.
+         */
+        public void setRemoveUnused(boolean removeUnused) {
+            this.removeUnused = removeUnused;
+        }
+
+        /**
+         * Gets whether suppression reasons are removed.
+         *
+         * @return Returns true if suppression reasons are removed.
+         */
+        public boolean getRemoveReasons() {
+            return removeReasons;
+        }
+
+        /**
+         * Set to true to remove the {@code reason} property from metadata suppressions.
+         *
+         * <p>The reason for a suppression could reveal internal or sensitive information.
+         * Removing the "reason" from metadata suppressions is an extra step teams can
+         * take to ensure they do not leak internal information when publishing models
+         * outside of their organization.
+         *
+         * @param removeReasons Set to true to remove reasons.
+         */
+        public void setRemoveReasons(boolean removeReasons) {
+            this.removeReasons = removeReasons;
+        }
+
+        /**
+         * Gets a list of allowed event IDs.
+         *
+         * @return Returns the allow list of event IDs.
+         */
+        public Set<String> getEventIdAllowList() {
+            return eventIdAllowList;
+        }
+
+        /**
+         * Sets a list of event IDs that can be referred to in suppressions.
+         *
+         * <p>Suppressions that refer to any other event ID will be updated to
+         * no longer refer to them, or removed if they no longer refer to any events.
+         *
+         * <p>This setting cannot be used in tandem with {@code eventIdDenyList}.
+         *
+         * @param eventIdAllowList IDs to allow.
+         */
+        public void setEventIdAllowList(Set<String> eventIdAllowList) {
+            this.eventIdAllowList = eventIdAllowList;
+        }
+
+        /**
+         * Gets a list of denied event IDs.
+         *
+         * @return Gets the event ID deny list.
+         */
+        public Set<String> getEventIdDenyList() {
+            return eventIdDenyList;
+        }
+
+        /**
+         * Sets a list of event IDs that cannot be referred to in suppressions.
+         *
+         * <p>Suppressions that refer to any of these event IDs will be updated to
+         * no longer refer to them, or removed if they no longer refer to any events.
+         *
+         * <p>This setting cannot be used in tandem with {@code eventIdAllowList}.
+         *
+         * @param eventIdDenyList IDs to deny.
+         */
+        public void setEventIdDenyList(Set<String> eventIdDenyList) {
+            this.eventIdDenyList = eventIdDenyList;
+        }
+
+        /**
+         * Gets the metadata suppression namespace allow list.
+         *
+         * @return The metadata suppression namespace allow list.
+         */
+        public Set<String> getNamespaceAllowList() {
+            return namespaceAllowList;
+        }
+
+        /**
+         * Sets a list of namespaces that can be referred to in metadata suppressions.
+         *
+         * <p>Metadata suppressions that refer to namespaces outside of this list,
+         * including "*", will be removed.
+         *
+         * <p>This setting cannot be used in tandem with {@code namespaceDenyList}.
+         *
+         * @param namespaceAllowList Namespaces to allow.
+         */
+        public void setNamespaceAllowList(Set<String> namespaceAllowList) {
+            this.namespaceAllowList = namespaceAllowList;
+        }
+
+        /**
+         * Gets the metadata suppression namespace deny list.
+         *
+         * @return The metadata suppression namespace deny list.
+         */
+        public Set<String> getNamespaceDenyList() {
+            return namespaceDenyList;
+        }
+
+        /**
+         * Sets a list of namespaces that cannot be referred to in metadata suppressions.
+         *
+         * <p>Metadata suppressions that refer to namespaces in this list,
+         * including "*", will be removed.
+         *
+         * <p>This setting cannot be used in tandem with {@code namespaceAllowList}.
+         *
+         * @param namespaceDenyList Namespaces to deny.
+         */
+        public void setNamespaceDenyList(Set<String> namespaceDenyList) {
+            this.namespaceDenyList = namespaceDenyList;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    public String getName() {
+        return "filterSuppressions";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        if (!config.getEventIdAllowList().isEmpty() && !config.getEventIdDenyList().isEmpty()) {
+            throw new SmithyBuildException(getName() + ": cannot set both eventIdAllowList values and "
+                                           + "eventIdDenyList values at the same time");
+        }
+
+        if (!config.getNamespaceAllowList().isEmpty() && !config.getNamespaceDenyList().isEmpty()) {
+            throw new SmithyBuildException(getName() + ": cannot set both namespaceAllowList values and "
+                                           + "namespaceDenyList values at the same time");
+        }
+
+        Model model = context.getModel();
+        Model.Builder builder = model.toBuilder();
+        Set<String> removedValidators = getRemovedValidators(context, config);
+        List<ValidationEvent> suppressedEvents = context.getOriginalModelValidationEvents().stream()
+                .filter(event -> event.getSeverity() == Severity.SUPPRESSED)
+                .filter(event -> !removedValidators.contains(event.getId()))
+                .collect(Collectors.toList());
+        filterSuppressionTraits(model, builder, config, suppressedEvents);
+        filterMetadata(model, builder, config, suppressedEvents, removedValidators);
+        return builder.build();
+    }
+
+    private Set<String> getRemovedValidators(TransformContext context, Config config) {
+        // Validators could have been removed by other transforms in this projection,
+        // and if they were removed, then validation events referring to them are
+        // no longer relevant. We don't want to keep suppressions around for validators
+        // that were removed.
+        if (!context.getOriginalModel().isPresent()) {
+            return Collections.emptySet();
+        }
+
+        Set<String> originalValidators = getValidatorNames(context.getOriginalModel().get());
+        Set<String> updatedValidators = getValidatorNames(context.getModel());
+
+        if (originalValidators.equals(updatedValidators)) {
+            return Collections.emptySet();
+        }
+
+        originalValidators.removeAll(updatedValidators);
+
+        if (config.getRemoveUnused()) {
+            LOGGER.info(() -> "Detected the removal of the following validators: "
+                              + originalValidators
+                              + ". Suppressions that refer to these validators will be removed.");
+        }
+
+        return originalValidators;
+    }
+
+    private Set<String> getValidatorNames(Model model) {
+        ArrayNode validators = model.getMetadata()
+                .getOrDefault("validators", Node.arrayNode())
+                .expectArrayNode();
+        Set<String> metadataSuppressions = new HashSet<>();
+        for (Node validator : validators) {
+            ObjectNode validatorObject = validator.expectObjectNode();
+            String id = validatorObject
+                    .getStringMember("id")
+                    .orElseGet(() -> validatorObject.expectStringMember("name"))
+                    .getValue();
+            metadataSuppressions.add(id);
+        }
+        return metadataSuppressions;
+    }
+
+    private void filterSuppressionTraits(
+            Model model,
+            Model.Builder builder,
+            Config config,
+            List<ValidationEvent> suppressedEvents
+    ) {
+        // First filter and '@suppress' traits that didn't suppress anything.
+        for (Shape shape : model.getShapesWithTrait(SuppressTrait.class)) {
+            SuppressTrait trait = shape.expectTrait(SuppressTrait.class);
+            List<String> allowed = new ArrayList<>(trait.getValues());
+            allowed.removeIf(value -> !isAllowed(value, config.getEventIdAllowList(), config.getEventIdDenyList()));
+
+            // Only keep IDs that actually acted to suppress an event.
+            if (config.getRemoveUnused()) {
+                Set<String> matched = suppressedEvents.stream()
+                        .filter(event -> Objects.equals(shape.getId(), event.getShapeId().orElse(null)))
+                        .map(ValidationEvent::getId)
+                        .collect(Collectors.toSet());
+                allowed.removeIf(value -> !matched.contains(value));
+            }
+
+            if (allowed.isEmpty()) {
+                builder.addShape(Shape.shapeToBuilder(shape).removeTrait(SuppressTrait.ID).build());
+            } else if (!allowed.equals(trait.getValues())) {
+                trait = trait.toBuilder().values(allowed).build();
+                builder.addShape(Shape.shapeToBuilder(shape).addTrait(trait).build());
+            }
+        }
+    }
+
+    private void filterMetadata(
+            Model model,
+            Model.Builder builder,
+            Config config,
+            List<ValidationEvent> suppressedEvents,
+            Set<String> removedValidators
+    ) {
+        // Next remove metadata suppressions that didn't suppress anything.
+        ArrayNode suppressionsNode = model.getMetadata()
+                .getOrDefault("suppressions", Node.arrayNode()).expectArrayNode();
+        builder.removeMetadataProperty("suppressions");
+        List<ObjectNode> updatedMetadataSuppressions = new ArrayList<>();
+
+        for (Node suppressionNode : suppressionsNode) {
+            ObjectNode object = suppressionNode.expectObjectNode();
+            String id = object.getStringMemberOrDefault("id", "");
+            String namespace = object.getStringMemberOrDefault("namespace", "");
+            if (config.getRemoveReasons()) {
+                object = object.withoutMember("reason");
+            }
+
+            // Only keep the suppression if it passes each filter.
+            if (isAllowed(id, config.getEventIdAllowList(), config.getEventIdDenyList())
+                    && isAllowed(namespace, config.getNamespaceAllowList(), config.getNamespaceDenyList())) {
+                if (!config.getRemoveUnused()) {
+                    updatedMetadataSuppressions.add(object);
+                } else {
+                    Suppression suppression = Suppression.fromMetadata(object);
+                    for (ValidationEvent event : suppressedEvents) {
+                        if (!removedValidators.contains(event.getId()) && suppression.test(event)) {
+                            updatedMetadataSuppressions.add(object);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!updatedMetadataSuppressions.isEmpty()) {
+            builder.putMetadataProperty("suppressions", Node.fromNodes(updatedMetadataSuppressions));
+        }
+    }
+
+    private boolean isAllowed(String value, Collection<String> allowList, Collection<String> denyList) {
+        return (allowList.isEmpty() || allowList.contains(value))
+                && (denyList.isEmpty() || !denyList.contains(value));
+    }
+}

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -1,3 +1,4 @@
+software.amazon.smithy.build.transforms.Apply
 software.amazon.smithy.build.transforms.ExcludeMetadata
 software.amazon.smithy.build.transforms.ExcludeShapesByTag
 software.amazon.smithy.build.transforms.ExcludeShapesByTrait
@@ -5,6 +6,7 @@ software.amazon.smithy.build.transforms.ExcludeTags
 software.amazon.smithy.build.transforms.ExcludeTraits
 software.amazon.smithy.build.transforms.ExcludeTraitsByTag
 software.amazon.smithy.build.transforms.FlattenNamespaces
+software.amazon.smithy.build.transforms.FilterSuppressions
 software.amazon.smithy.build.transforms.IncludeMetadata
 software.amazon.smithy.build.transforms.IncludeNamespaces
 software.amazon.smithy.build.transforms.IncludeServices

--- a/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/SmithyBuildTest.java
@@ -451,7 +451,8 @@ public class SmithyBuildTest {
             new SmithyBuild().config(config).build();
         });
 
-        assertThat(thrown.getMessage(), containsString("Unable to find projection named `bar` referenced by `foo`"));
+        assertThat(thrown.getMessage(),
+                   containsString("Unable to find projection named `bar` referenced by the `foo` projection"));
     }
 
     @Test
@@ -463,7 +464,7 @@ public class SmithyBuildTest {
             new SmithyBuild().config(config).build();
         });
 
-        assertThat(thrown.getMessage(), containsString("Cannot recursively apply the same projection:"));
+        assertThat(thrown.getMessage(), containsString("Cannot recursively apply the same projection: foo"));
     }
 
     @Test

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/FilterSuppressionsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/FilterSuppressionsTest.java
@@ -1,0 +1,102 @@
+package software.amazon.smithy.build.transforms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.ProjectionResult;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.build.SmithyBuildResult;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ModelSerializer;
+
+public class FilterSuppressionsTest {
+    @Test
+    public void cannotSetBothEventIdAllowAndDenyList() {
+        SmithyBuildException thrown = Assertions.assertThrows(SmithyBuildException.class, () -> {
+            Model model = Model.builder().build();
+            TransformContext context = TransformContext.builder()
+                    .model(model)
+                    .settings(Node.objectNode()
+                            .withMember("eventIdAllowList", Node.fromStrings("a"))
+                            .withMember("eventIdDenyList", Node.fromStrings("b")))
+                    .build();
+            new FilterSuppressions().transform(context);
+        });
+
+        assertThat(thrown.getMessage(), containsString("cannot set both eventIdAllowList values"));
+    }
+
+    @Test
+    public void cannotSetBothNamespaceAllowAndDenyList() {
+        SmithyBuildException thrown = Assertions.assertThrows(SmithyBuildException.class, () -> {
+            Model model = Model.builder().build();
+            TransformContext context = TransformContext.builder()
+                    .model(model)
+                    .settings(Node.objectNode()
+                            .withMember("namespaceAllowList", Node.fromStrings("a"))
+                            .withMember("namespaceDenyList", Node.fromStrings("b")))
+                    .build();
+            new FilterSuppressions().transform(context);
+        });
+
+        assertThat(thrown.getMessage(), containsString("cannot set both namespaceAllowList values"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "traits,removeUnused",
+        "traits,eventIdAllowList",
+        "traits,eventIdDenyList",
+        "namespaces,filterByNamespaceAllowList",
+        "namespaces,removeReasons",
+        "namespaces,removeUnused",
+        "namespaces,namespaceDenyList",
+        "namespaces,filterWithTopLevelImports",
+        "namespaces,filterWithProjectionImports",
+        "namespaces,detectsValidatorRemoval"
+    })
+    public void runTransformTests(String modelFile, String testName) throws Exception {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("filtersuppressions/" + modelFile + ".smithy"))
+                .assemble()
+                .unwrap();
+
+        SmithyBuild builder = new SmithyBuild()
+                .model(model)
+                .fileManifestFactory(MockManifest::new);
+
+        SmithyBuildConfig.Builder configBuilder = SmithyBuildConfig.builder();
+        configBuilder.load(Paths.get(
+                        getClass().getResource("filtersuppressions/" + modelFile + "." + testName + ".json").toURI()));
+        configBuilder.outputDirectory("/mocked/is/not/used");
+        builder.config(configBuilder.build());
+
+        SmithyBuildResult results = builder.build();
+        assertTrue(results.getProjectionResult("foo").isPresent());
+
+        ProjectionResult projectionResult = results.getProjectionResult("foo").get();
+        MockManifest manifest = (MockManifest) projectionResult.getPluginManifest("model").get();
+        String modelText = manifest.getFileString("model.json").get();
+        Model resultModel = Model.assembler().addUnparsedModel("/model.json", modelText).assemble().unwrap();
+        Model expectedModel = Model.assembler()
+                .addImport(getClass().getResource("filtersuppressions/" + modelFile + "." + testName + ".smithy"))
+                .assemble()
+                .unwrap();
+
+        Node resultNode = ModelSerializer.builder().build().serialize(resultModel);
+        Node expectedNode = ModelSerializer.builder().build().serialize(expectedModel);
+
+        Node.assertEquals(resultNode, expectedNode);
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.detectsValidatorRemoval.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.detectsValidatorRemoval.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "excludeMetadata",
+                    "args": {
+                        "keys": ["validators"]
+                    }
+                },
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.detectsValidatorRemoval.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.detectsValidatorRemoval.smithy
@@ -1,0 +1,7 @@
+$version: "1.0"
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterByNamespaceAllowList.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterByNamespaceAllowList.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "namespaceAllowList": ["smithy.example", "*"]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterByNamespaceAllowList.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterByNamespaceAllowList.smithy
@@ -1,0 +1,30 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        "id": "Test",
+        "namespace": "smithy.example",
+        "reason": "reason..."
+    },
+    {
+        "id": "Ipsum",
+        "namespace": "*"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithProjectionImports.2.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithProjectionImports.2.smithy
@@ -1,0 +1,17 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test2",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id|name^=Foo])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["Test"]) // unused
+structure Foo2 {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithProjectionImports.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithProjectionImports.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "imports": ["namespaces.filterWithTopLevelImports.2.smithy"],
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithProjectionImports.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithProjectionImports.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "Test2",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id|name^=Foo])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        reason: "reason...",
+        namespace: "smithy.example"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}
+
+structure Foo2 {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithTopLevelImports.2.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithTopLevelImports.2.smithy
@@ -1,0 +1,17 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test2",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id|name^=Foo])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["Test"]) // unused
+structure Foo2 {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithTopLevelImports.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithTopLevelImports.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "imports": ["namespaces.filterWithProjectionImports.2.smithy"],
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithTopLevelImports.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.filterWithTopLevelImports.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "Test2",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id|name^=Foo])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        reason: "reason...",
+        namespace: "smithy.example"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}
+
+structure Foo2 {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.namespaceDenyList.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.namespaceDenyList.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "namespaceDenyList": ["smithy.foo", "*"]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.namespaceDenyList.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.namespaceDenyList.smithy
@@ -1,0 +1,31 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        reason: "reason...",
+        namespace: "smithy.example"
+    },
+    {
+        id: "Test",
+        namespace: "smithy.example.nested",
+        reason: "reason..."
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeReasons.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeReasons.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeReasons": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeReasons.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeReasons.smithy
@@ -1,0 +1,37 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        namespace: "smithy.example"
+    },
+    {
+        id: "Lorem",
+        namespace: "smithy.foo"
+    },
+    {
+        id: "Test",
+        namespace: "smithy.example.nested"
+    },
+    {
+        id: "Ipsum",
+        namespace: "*"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeUnused.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeUnused.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeUnused.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.removeUnused.smithy
@@ -1,0 +1,26 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        reason: "reason...",
+        namespace: "smithy.example"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.smithy
@@ -1,0 +1,39 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        reason: "reason...",
+        namespace: "smithy.example"
+    },
+    {
+        id: "Lorem",
+        namespace: "smithy.foo"
+    },
+    {
+        id: "Test",
+        namespace: "smithy.example.nested",
+        reason: "reason..."
+    },
+    {
+        id: "Ipsum",
+        namespace: "*"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdAllowList.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdAllowList.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "eventIdAllowList": ["Test"]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdAllowList.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdAllowList.smithy
@@ -1,0 +1,22 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["Test"])
+string NoMatches
+
+@suppress(["Test"])
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdDenyList.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdDenyList.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "eventIdDenyList": ["Test"]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdDenyList.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdDenyList.smithy
@@ -1,0 +1,23 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["NeverUsed"])
+string NoMatches
+
+@suppress(["NeverUsed"])
+structure Foo {}
+
+@suppress(["NeverUsed"])
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.removeUnused.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.removeUnused.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.removeUnused.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.removeUnused.smithy
@@ -1,0 +1,21 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+namespace smithy.example
+
+string NoMatches
+
+@suppress(["Test"])
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.smithy
@@ -1,0 +1,23 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["NeverUsed", "Test"])
+string NoMatches
+
+@suppress(["NeverUsed", "Test"])
+structure Foo {}
+
+@suppress(["NeverUsed"])
+structure Baz {}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -862,6 +862,11 @@ public final class Model implements ToSmithyBuilder<Model> {
             return this;
         }
 
+        public Builder removeMetadataProperty(String key) {
+            metadata.remove(key);
+            return this;
+        }
+
         public Builder clearMetadata() {
             metadata.clear();
             return this;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,9 +18,8 @@ package software.amazon.smithy.model.loader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -28,24 +27,20 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.SuppressTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.Validator;
 import software.amazon.smithy.model.validation.ValidatorFactory;
+import software.amazon.smithy.model.validation.suppressions.Suppression;
 import software.amazon.smithy.model.validation.validators.ResourceCycleValidator;
 import software.amazon.smithy.model.validation.validators.TargetValidator;
-import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Validates a model, including validators and suppressions loaded from
- * traits.
- *
- * <p>ModelValidator is used to apply validation to a loaded Model. This
- * class is used in tandem with {@link ModelAssembler}.
+ * traits and metadata.
  *
  * <p>Validators found in metadata and suppressions found in traits are
  * automatically created and applied to the model. Explicitly provided
@@ -55,12 +50,12 @@ import software.amazon.smithy.utils.SetUtils;
 final class ModelValidator {
 
     private static final String SUPPRESSIONS = "suppressions";
-    private static final String ID = "id";
-    private static final String NAMESPACE = "namespace";
-    private static final String REASON = "reason";
-    private static final String STAR = "*";
-    private static final String EMPTY_REASON = "";
-    private static final Collection<String> SUPPRESSION_KEYS = ListUtils.of(ID, NAMESPACE, REASON);
+
+    // Lazy initialization holder class idiom to hold a default validator factory.
+    private static final class LazyValidatorFactoryHolder {
+        static final ValidatorFactory INSTANCE = ValidatorFactory.createServiceFactory(
+                ModelAssembler.class.getClassLoader());
+    }
 
     /** If these validators fail, then many others will too. Validate these first. */
     private static final Set<Class<? extends Validator>> CORE_VALIDATORS = SetUtils.of(
@@ -68,75 +63,141 @@ final class ModelValidator {
             ResourceCycleValidator.class
     );
 
-    private final List<Validator> validators;
-    private final ArrayList<ValidationEvent> events = new ArrayList<>();
-    private final ValidatorFactory validatorFactory;
-    private final Model model;
-    private final Map<String, Map<String, String>> namespaceSuppressions = new HashMap<>();
-    private final Consumer<ValidationEvent> eventListener;
+    private final List<Validator> validators = new ArrayList<>();
+    private final List<Suppression> suppressions = new ArrayList<>();
+    private ValidatorFactory validatorFactory;
+    private Consumer<ValidationEvent> eventListener;
 
-    private ModelValidator(
-            Model model,
-            ValidatorFactory validatorFactory,
-            List<Validator> validators,
-            Consumer<ValidationEvent> eventListener
-    ) {
-        this.model = model;
-        this.validatorFactory = validatorFactory;
-        this.validators = new ArrayList<>(validators);
-        this.validators.removeIf(v -> CORE_VALIDATORS.contains(v.getClass()));
-        this.eventListener = eventListener;
+    /**
+     * Sets the custom {@link Validator}s to use when running the ModelValidator.
+     *
+     * @param validators Validators to set.
+     * @return Returns the ModelValidator.
+     */
+    public ModelValidator validators(Collection<? extends Validator> validators) {
+        this.validators.clear();
+        validators.forEach(this::addValidator);
+        return this;
     }
 
     /**
-     * Validates the given Model using validators configured explicitly and
-     * detected through metadata.
+     * Adds a custom {@link Validator} to the ModelValidator.
      *
-     * @param model Model to validate.
-     * @param validatorFactory Factory used to find ValidatorService providers.
-     * @param validators Additional validators to use.
-     * @param eventListener Consumer invoked each time a validation event is encountered.
-     * @return Returns the encountered validation events.
+     * @param validator Validator to add.
+     * @return Returns the ModelValidator.
      */
-    static List<ValidationEvent> validate(
-            Model model,
-            ValidatorFactory validatorFactory,
-            List<Validator> validators,
-            Consumer<ValidationEvent> eventListener
-    ) {
-        return new ModelValidator(model, validatorFactory, validators, eventListener).doValidate();
+    public ModelValidator addValidator(Validator validator) {
+        validators.add(Objects.requireNonNull(validator));
+        return this;
     }
 
-    private List<ValidationEvent> doValidate() {
-        assembleNamespaceSuppressions();
-        List<ValidatorDefinition> assembledValidatorDefinitions = assembleValidatorDefinitions();
-        assembleValidators(assembledValidatorDefinitions);
+    /**
+     * Sets the {@link Suppression}s to use with the validator.
+     *
+     * @param suppressions Suppressions to set.
+     * @return Returns the ModelValidator.
+     */
+    public ModelValidator suppressions(Collection<? extends Suppression> suppressions) {
+        this.suppressions.clear();
+        suppressions.forEach(this::addSuppression);
+        return this;
+    }
 
-        // Perform critical validation before other more granular semantic validators.
-        // If these validators fail, then many other validators will fail as well,
-        // which will only obscure the root cause.
-        events.addAll(new TargetValidator().validate(model));
-        events.addAll(new ResourceCycleValidator().validate(model));
-        // Emit any events that have already occurred.
-        events.forEach(eventListener);
+    /**
+     * Adds a custom {@link Suppression} to the validator.
+     *
+     * @param suppression Suppression to add.
+     * @return Returns the ModelValidator.
+     */
+    public ModelValidator addSuppression(Suppression suppression) {
+        suppressions.add(Objects.requireNonNull(suppression));
+        return this;
+    }
 
-        if (LoaderUtils.containsErrorEvents(events)) {
-            return events;
+    /**
+     * Sets the factory used to find built-in {@link Validator}s and to load
+     * validators found in model metadata.
+     *
+     * @param validatorFactory Factory to use to load {@code Validator}s.
+     *
+     * @return Returns the ModelValidator.
+     */
+    public ModelValidator validatorFactory(ValidatorFactory validatorFactory) {
+        this.validatorFactory = validatorFactory;
+        return this;
+    }
+
+    /**
+     * Sets a custom event listener that receives each {@link ValidationEvent}
+     * as it is emitted.
+     *
+     * @param eventListener Event listener that consumes each event.
+     * @return Returns the ModelValidator.
+     */
+    public ModelValidator eventListener(Consumer<ValidationEvent> eventListener) {
+        this.eventListener = eventListener;
+        return this;
+    }
+
+    /**
+     * Creates a reusable Model Validator that uses every registered validator,
+     * suppression, and extracts validators and suppressions from each
+     * provided model.
+     *
+     * @return Returns the created {@link Validator}.
+     */
+    public Validator createValidator() {
+        if (validatorFactory == null) {
+            validatorFactory = LazyValidatorFactoryHolder.INSTANCE;
         }
 
-        List<ValidationEvent> result = validators
-                .parallelStream()
-                .flatMap(validator -> validator.validate(model).stream())
-                .map(this::suppressEvent)
-                .filter(ModelValidator::filterPrelude)
-                // Emit events as they occur during validation.
-                .peek(eventListener)
-                .collect(Collectors.toList());
+        List<Validator> staticValidators = resolveStaticValidators();
 
-        // Add in events encountered while building up validators and suppressions.
-        result.addAll(events);
+        return model -> {
+            List<ValidationEvent> coreEvents = new ArrayList<>();
 
-        return result;
+            // Add suppressions found in the model via metadata.
+            List<Suppression> modelSuppressions = new ArrayList<>(suppressions);
+            loadModelSuppressions(modelSuppressions, model);
+
+            // Add validators defined in the model through metadata.
+            List<Validator> modelValidators = new ArrayList<>(staticValidators);
+            loadModelValidators(validatorFactory, modelValidators, model, coreEvents, modelSuppressions);
+
+            // Perform critical validation before other more granular semantic validators.
+            // If these validators fail, then many other validators will fail as well,
+            // which will only obscure the root cause.
+            coreEvents.addAll(new TargetValidator().validate(model));
+            coreEvents.addAll(new ResourceCycleValidator().validate(model));
+            // Emit any events that have already occurred.
+            coreEvents.forEach(eventListener);
+
+            if (LoaderUtils.containsErrorEvents(coreEvents)) {
+                return coreEvents;
+            }
+
+            List<ValidationEvent> result = modelValidators
+                    .parallelStream()
+                    .flatMap(validator -> validator.validate(model).stream())
+                    .filter(ModelValidator::filterPrelude)
+                    .map(event -> suppressEvent(model, event, modelSuppressions))
+                    // Emit events as they occur during validation.
+                    .peek(eventListener)
+                    .collect(Collectors.toList());
+
+            // Add in events encountered while building up validators and suppressions.
+            result.addAll(coreEvents);
+
+            return result;
+        };
+    }
+
+    private List<Validator> resolveStaticValidators() {
+        List<Validator> resolvedValidators = new ArrayList<>(validatorFactory.loadBuiltinValidators());
+        resolvedValidators.addAll(validators);
+        // These core validators are applied first, so don't run them again.
+        resolvedValidators.removeIf(v -> CORE_VALIDATORS.contains(v.getClass()));
+        return resolvedValidators;
     }
 
     private static boolean filterPrelude(ValidationEvent event) {
@@ -149,25 +210,17 @@ final class ModelValidator {
                 .isPresent();
     }
 
-    /**
-     * Load validator definitions, aggregating any errors along the way.
-     *
-     * @return Returns the loaded validator definitions.
-     */
-    private List<ValidatorDefinition> assembleValidatorDefinitions() {
-        ValidatedResult<List<ValidatorDefinition>> result = ValidationLoader.loadValidators(model.getMetadata());
-        events.addAll(result.getValidationEvents());
-        return result.getResult().orElseGet(Collections::emptyList);
-    }
-
-    /**
-     * Loads validators from model metadata, combines with explicit
-     * validators, and aggregates errors.
-     *
-     * @param definitions List of validator definitions to resolve
-     *  using the validator factory.
-     */
-    private void assembleValidators(List<ValidatorDefinition> definitions) {
+    private static void loadModelValidators(
+            ValidatorFactory validatorFactory,
+            List<Validator> validators,
+            Model model,
+            List<ValidationEvent> events,
+            List<Suppression> suppressions
+    ) {
+        // Load validators defined in metadata.
+        ValidatedResult<List<ValidatorDefinition>> loaded = ValidationLoader.loadValidators(model.getMetadata());
+        events.addAll(loaded.getValidationEvents());
+        List<ValidatorDefinition> definitions = loaded.getResult().orElseGet(Collections::emptyList);
         ValidatorFromDefinitionFactory factory = new ValidatorFromDefinitionFactory(validatorFactory);
 
         // Attempt to create the Validator instances and collect errors along the way.
@@ -176,13 +229,14 @@ final class ModelValidator {
             result.getResult().ifPresent(validators::add);
             events.addAll(result.getValidationEvents());
             if (result.getValidationEvents().isEmpty() && !result.getResult().isPresent()) {
-                events.add(suppressEvent(unknownValidatorError(val.name, val.sourceLocation)));
+                ValidationEvent event = unknownValidatorError(val.name, val.sourceLocation);
+                events.add(suppressEvent(model, event, suppressions));
             }
         }
     }
 
     // Unknown validators don't fail the build!
-    private ValidationEvent unknownValidatorError(String name, SourceLocation location) {
+    private static ValidationEvent unknownValidatorError(String name, SourceLocation location) {
         return ValidationEvent.builder()
                 // Per the spec, the eventID is "UnknownValidator_<validatorName>".
                 .id("UnknownValidator_" + name)
@@ -192,81 +246,56 @@ final class ModelValidator {
                 .build();
     }
 
-    // Find all namespace suppressions.
-    private void assembleNamespaceSuppressions() {
+    private static void loadModelSuppressions(List<Suppression> suppressions, Model model) {
         model.getMetadataProperty(SUPPRESSIONS).ifPresent(value -> {
             List<ObjectNode> values = value.expectArrayNode().getElementsAs(ObjectNode.class);
             for (ObjectNode rule : values) {
-                rule.warnIfAdditionalProperties(SUPPRESSION_KEYS);
-                String id = rule.expectStringMember(ID).getValue();
-                String namespace = rule.expectStringMember(NAMESPACE).getValue();
-                String reason = rule.getStringMemberOrDefault(REASON, EMPTY_REASON);
-                namespaceSuppressions.computeIfAbsent(id, i -> new HashMap<>()).put(namespace, reason);
+                suppressions.add(Suppression.fromMetadata(rule));
             }
         });
     }
 
-    private ValidationEvent suppressEvent(ValidationEvent event) {
+    private static ValidationEvent suppressEvent(Model model, ValidationEvent event, List<Suppression> suppressions) {
         // ERROR and SUPPRESSED events cannot be suppressed.
         if (!event.getSeverity().canSuppress()) {
             return event;
         }
 
-        String reason = resolveReason(event);
+        Suppression matchedSuppression = findMatchingSuppression(model, event, suppressions);
 
-        // The event is not suppressed, return as-is.
-        if (reason == null) {
+        if (matchedSuppression == null) {
             return event;
         }
 
         // The event was suppressed so change the severity and reason.
         ValidationEvent.Builder builder = event.toBuilder();
         builder.severity(Severity.SUPPRESSED);
-        if (!reason.equals(EMPTY_REASON)) {
-            builder.suppressionReason(reason);
-        }
+        matchedSuppression.getReason().ifPresent(builder::suppressionReason);
 
         return builder.build();
     }
 
-    // Get the reason as a String if it is suppressed, or null otherwise.
-    private String resolveReason(ValidationEvent event) {
+    private static Suppression findMatchingSuppression(
+            Model model,
+            ValidationEvent event,
+            List<Suppression> suppressions
+    ) {
         return event.getShapeId()
                 .flatMap(model::getShape)
-                .flatMap(shape -> matchSuppression(shape, event.getId()))
-                // This is always evaluated if a reason hasn't been found.
-                .orElseGet(() -> matchWildcardNamespaceSuppressions(event.getId()));
-    }
-
-    private Optional<String> matchSuppression(Shape shape, String eventId) {
-        // Traits take precedent over service suppressions.
-        if (shape.getTrait(SuppressTrait.class).isPresent()) {
-            if (shape.expectTrait(SuppressTrait.class).getValues().contains(eventId)) {
-                // The "" is filtered out before being passed to the
-                // updated ValidationEvent.
-                return Optional.of(EMPTY_REASON);
-            }
-        }
-
-        // Check namespace-wide suppressions.
-        if (namespaceSuppressions.containsKey(eventId)) {
-            Map<String, String> namespaces = namespaceSuppressions.get(eventId);
-            if (namespaces.containsKey(shape.getId().getNamespace())) {
-                return Optional.of(namespaces.get(shape.getId().getNamespace()));
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    private String matchWildcardNamespaceSuppressions(String eventId) {
-        if (namespaceSuppressions.containsKey(eventId)) {
-            Map<String, String> namespaces = namespaceSuppressions.get(eventId);
-            if (namespaces.containsKey(STAR)) {
-                return namespaces.get(STAR);
-            }
-        }
-
-        return null;
+                // First check for trait based suppressions.
+                .flatMap(shape -> shape.hasTrait(SuppressTrait.class)
+                                  ? Optional.of(Suppression.fromSuppressTrait(shape))
+                                  : Optional.empty())
+                // Try to suppress it.
+                .flatMap(suppression -> suppression.test(event) ? Optional.of(suppression) : Optional.empty())
+                // If it wasn't suppressed, then try the rules loaded from metadata.
+                .orElseGet(() -> {
+                    for (Suppression suppression : suppressions) {
+                        if (suppression.test(event)) {
+                            return suppression;
+                        }
+                    }
+                    return null;
+                });
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -201,8 +201,9 @@ public abstract class Node implements FromSourceLocation, ToNode {
      * @param values String values to add to the ArrayNode.
      * @return Returns the created ArrayNode.
      */
-    public static ArrayNode fromNodes(List<Node> values) {
-        return new ArrayNode(values, SourceLocation.none());
+    @SuppressWarnings("unchecked")
+    public static ArrayNode fromNodes(List<? extends Node> values) {
+        return new ArrayNode((List<Node>) values, SourceLocation.none());
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/MetadataSuppression.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/MetadataSuppression.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.suppressions;
+
+import java.util.Collection;
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * A suppression created from metadata.
+ *
+ * <p>"*" is used as a wildcard to suppress events in any namespace.
+ */
+final class MetadataSuppression implements Suppression {
+
+    private static final String ID = "id";
+    private static final String NAMESPACE = "namespace";
+    private static final String REASON = "reason";
+    private static final Collection<String> SUPPRESSION_KEYS = ListUtils.of(ID, NAMESPACE, REASON);
+
+    private final String id;
+    private final String namespace;
+    private final String reason;
+
+    MetadataSuppression(String id, String namespace, String reason) {
+        this.id = id;
+        this.namespace = namespace;
+        this.reason = reason;
+    }
+
+    static MetadataSuppression fromNode(Node node) {
+        ObjectNode rule = node.expectObjectNode();
+        rule.warnIfAdditionalProperties(SUPPRESSION_KEYS);
+        String id = rule.expectStringMember(ID).getValue();
+        String namespace = rule.expectStringMember(NAMESPACE).getValue();
+        String reason = rule.getStringMemberOrDefault(REASON, null);
+        return new MetadataSuppression(id, namespace, reason);
+    }
+
+    @Override
+    public boolean test(ValidationEvent event) {
+        return event.getId().equals(id) && matchesNamespace(event);
+    }
+
+    @Override
+    public Optional<String> getReason() {
+        return Optional.ofNullable(reason);
+    }
+
+    private boolean matchesNamespace(ValidationEvent event) {
+        return namespace.equals("*")
+               || event.getShapeId().filter(id -> id.getNamespace().equals(namespace)).isPresent();
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/Suppression.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/Suppression.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.suppressions;
+
+import java.util.Optional;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.SuppressTrait;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.Validator;
+
+/**
+ * Suppresses {@link ValidationEvent}s emitted from {@link Validator}s.
+ */
+@FunctionalInterface
+public interface Suppression {
+
+    /**
+     * Determines if the suppression applies to the given event.
+     *
+     * @param event Event to test.
+     * @return Returns true if the suppression applies.
+     */
+    boolean test(ValidationEvent event);
+
+    /**
+     * Gets the optional reason for the suppression.
+     *
+     * @return Returns the optional suppression reason.
+     */
+    default Optional<String> getReason() {
+        return Optional.empty();
+    }
+
+    /**
+     * Creates a suppression using the {@link SuppressTrait} of
+     * the given shape.
+     *
+     * @param shape Shape to get the {@link SuppressTrait} from.
+     * @return Returns the created suppression.
+     * @throws ExpectationNotMetException if the shape has no {@link SuppressTrait}.
+     */
+    static Suppression fromSuppressTrait(Shape shape) {
+        return new TraitSuppression(shape.getId(), shape.expectTrait(SuppressTrait.class));
+    }
+
+    /**
+     * Creates a suppression from a {@link Node} found in the
+     * "suppressions" metadata of a Smithy model.
+     *
+     * @param node Node to parse.
+     * @return Returns the loaded suppression.
+     * @throws ExpectationNotMetException if the suppression node is malformed.
+     */
+    static Suppression fromMetadata(Node node) {
+        return MetadataSuppression.fromNode(node);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/TraitSuppression.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/TraitSuppression.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.suppressions;
+
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.SuppressTrait;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * A suppression based on the {@link SuppressTrait}.
+ */
+final class TraitSuppression implements Suppression {
+
+    private final ShapeId shape;
+    private final SuppressTrait trait;
+
+    TraitSuppression(ShapeId shape, SuppressTrait trait) {
+        this.shape = shape;
+        this.trait = trait;
+    }
+
+    @Override
+    public boolean test(ValidationEvent event) {
+        return event.getShapeId().filter(shape::equals).isPresent() && trait.getValues().contains(event.getId());
+    }
+}


### PR DESCRIPTION
This commit adds support for filtering suppressions by removing
unused suppressions, removing the reason from suppressions,
removing suppressions based on an event ID allow/deny list,
and removing suppressions based on a namespace allow/deny list.

This model transform is useful for projecting models with
internal information for external customers so that suppressions
can be retained in the model without exposing internal information.

To support this change, a Suppression abstraction had to be exposed
in smithy-model that was previously never exposed. However, for now,
the abstraction is as bare-bones as possible, and the concrete
suppression types are package-private. ModelValidator was also
significantly refactored to adapt to these Suppression changes, but
remains package-private until we have a compelling reason to expose
it outside of just using ModelAssembler for validation.

smithy-build required a significant refactor to support passing in
the encountered validation events of a projection to ModelTransformers
via the TransformContext object. This gave the FilterSuppressions
transform that ability to access ValidationEvents without needing to
do another expensive round of validation. Only the validation events
encountered for the model at the start of each projection, including
loaded imports, are passed to transforms (that is, intermediate
transforms of the model are not re-validated). However,
FilterSuppressions performs a diff of the validators defined in the
original model and validators defined in the projected model up to
that point to determine if suppressions for any removed validators
should also be removed.

The implementation of the apply transform in smithy-build was also
technically changed in a backward-incompatible way, though this
change will likely not impact any code other than that in the
smithy-build package itself. The transform still works in the same
way, it was just refactored to be implemented just like any other
transform.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
