### PR TITLE
Allow to define maven dependencies in smithy-build

### DIFF
--- a/smithy-build/build.gradle
+++ b/smithy-build/build.gradle
@@ -24,4 +24,5 @@ ext {
 dependencies {
     api project(":smithy-utils")
     api project(":smithy-model")
+    implementation 'io.get-coursier:interface:1.0.4'
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.build;
 
+import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -255,6 +256,14 @@ final class SmithyBuildImpl {
         }
     }
 
+    private java.net.URL asUrl(String s) {
+      try {
+        return new java.net.URL(s);
+      } catch (MalformedURLException e) {
+        throw new SmithyBuildException(e);
+      }
+    }
+
     private Model createBaseModel() {
         Model resolvedModel = model;
 
@@ -262,6 +271,7 @@ final class SmithyBuildImpl {
             LOGGER.fine(() -> "Merging the following imports into the loaded model: " + config.getImports());
             ModelAssembler assembler = modelAssemblerSupplier.get().addModel(model);
             config.getImports().forEach(assembler::addImport);
+            config.getMavenImports().stream().map(this::asUrl).forEach(assembler::addImport);
             resolvedModel = assembler.assemble().unwrap();
         }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.build;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -259,14 +258,6 @@ final class SmithyBuildImpl {
         }
     }
 
-    private static java.net.URL asUrl(String s) {
-      try {
-        return new java.net.URL(s);
-      } catch (MalformedURLException e) {
-        throw new SmithyBuildException(e);
-      }
-    }
-
     private static ClassLoader classLoader(List<URL> classpath) {
       return new URLClassLoader(classpath.toArray(new URL[0]), ModelAssembler.class.getClassLoader());
     }
@@ -274,9 +265,8 @@ final class SmithyBuildImpl {
     private static Function<String, Optional<SmithyBuildPlugin>> makePluginFactory(
             SmithyBuildConfig smithyBuildConfig,
             Function<String, Optional<SmithyBuildPlugin>> userDefinedFactory) {
-          List<URL> classpath = smithyBuildConfig.getMavenDependencies()
+          List<URL> classpath = smithyBuildConfig.resolveMavenDependencies()
             .stream()
-            .map(SmithyBuildImpl::asUrl)
             .collect(Collectors.toList());
           if (classpath.size() > 0) {
             ClassLoader classLoader = classLoader(classpath);
@@ -295,9 +285,8 @@ final class SmithyBuildImpl {
             LOGGER.fine(() -> "Merging the following imports into the loaded model: " + config.getImports());
             ModelAssembler assembler = modelAssemblerSupplier.get().addModel(model);
             config.getImports().forEach(assembler::addImport);
-            List<URL> classpath = config.getMavenDependencies()
+            List<URL> classpath = config.resolveMavenDependencies()
               .stream()
-              .map(SmithyBuildImpl::asUrl)
               .collect(Collectors.toList());
             if (classpath.size() > 0) {
               ClassLoader classLoader = classLoader(classpath);

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -42,6 +42,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
 
     private final String version;
     private final List<String> imports;
+    private final List<String> mavenRepositories;
+    private final List<String> mavenImports;
     private final String outputDirectory;
     private final Map<String, ProjectionConfig> projections;
     private final Map<String, ObjectNode> plugins;
@@ -52,6 +54,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         version = builder.version;
         outputDirectory = builder.outputDirectory;
         imports = ListUtils.copyOf(builder.imports);
+        mavenRepositories = ListUtils.copyOf(builder.mavenRepositories);
+        mavenImports = ListUtils.copyOf(builder.mavenImports);
         projections = MapUtils.copyOf(builder.projections);
         plugins = new HashMap<>(builder.plugins);
         ignoreMissingPlugins = builder.ignoreMissingPlugins;
@@ -140,6 +144,30 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         return imports;
     }
 
+      /**
+   * Gets the maven repositories to all of the models to import.
+   *
+   * @return Gets the list of maven repositories to fetch maven imports from.
+   */
+  public List<String> getMavenRepositories() {
+    return mavenRepositories;
+  }
+
+  /**
+   * Gets the maven imports to all of the models to import.
+   *
+   * <p>
+   * Maven imports should follow the following syntax :
+   * `organization:artifact:version`
+   *
+   * @return The list of maven imports which should be fetched and imported into
+   *         the model.
+   */
+  public List<String> getMavenImports() {
+    return mavenImports;
+  }
+
+
     /**
      * @return Gets the optional output directory to store artifacts.
      */
@@ -182,6 +210,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
      */
     public static final class Builder implements SmithyBuilder<SmithyBuildConfig> {
         private final List<String> imports = new ArrayList<>();
+        private final List<String> mavenRepositories = new ArrayList<>();
+        private final List<String> mavenImports = new ArrayList<>();
         private final Map<String, ProjectionConfig> projections = new LinkedHashMap<>();
         private final Map<String, ObjectNode> plugins = new LinkedHashMap<>();
         private String version;
@@ -226,6 +256,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
             config.getOutputDirectory().ifPresent(this::outputDirectory);
             version(config.getVersion());
             imports.addAll(config.getImports());
+            mavenRepositories.addAll(config.getMavenRepositories());
+            mavenImports.addAll(config.getMavenImports());
             projections.putAll(config.getProjections());
             plugins.putAll(config.getPlugins());
 
@@ -258,6 +290,30 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
             this.imports.clear();
             this.imports.addAll(imports);
             return this;
+        }
+
+        /**
+         * Sets maven repositories on the config.
+         *
+         * @param mavenRepositories Maven repositories to set.
+         * @return Returns the builder.
+         */
+        public Builder mavenRepositories(Collection<String> mavenRepositories) {
+          this.mavenRepositories.clear();
+          this.mavenRepositories.addAll(mavenRepositories);
+          return this;
+        }
+
+        /**
+         * Sets maven repositories on the config.
+         *
+         * @param mavenImports Maven imports to set.
+         * @return Returns the builder.
+         */
+        public Builder mavenImports(Collection<String> mavenImports) {
+          this.mavenRepositories.clear();
+          this.mavenRepositories.addAll(mavenImports);
+          return this;
         }
 
         /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.build.model;
 
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -118,6 +119,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
                 .version(version)
                 .outputDirectory(outputDirectory)
                 .imports(imports)
+                .mavenRepositories(mavenRepositories)
+                .mavenDependencies(mavenDependencies)
                 .projections(projections)
                 .plugins(plugins)
                 .ignoreMissingPlugins(ignoreMissingPlugins);
@@ -144,29 +147,41 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         return imports;
     }
 
-      /**
-   * Gets the maven repositories to all of the models to import.
-   *
-   * @return Gets the list of maven repositories to fetch maven imports from.
-   */
-  public List<String> getMavenRepositories() {
-    return mavenRepositories;
-  }
+    /**
+     * Gets the maven repositories to all of the models to import.
+     *
+     * @return Gets the list of maven repositories to fetch maven imports from.
+     */
+    public List<String> getMavenRepositories() {
+      return mavenRepositories;
+    }
 
-  /**
-   * Gets the maven imports to all of the models to import.
-   *
-   * <p>
-   * Maven imports should follow the following syntax :
-   * `organization:artifact:version`
-   *
-   * @return The list of maven imports which should be fetched and imported into
-   *         the model.
-   */
-  public List<String> getMavenDependencies() {
-    return mavenDependencies;
-  }
+    /**
+     * Gets the maven imports to all of the models to import.
+     *
+     * <p>
+     * Maven imports should follow the following syntax :
+     * `organization:artifact:version`
+     *
+     * @return The list of maven imports which should be fetched and imported into
+     *         the model.
+     */
+    public List<String> getMavenDependencies() {
+      return mavenDependencies;
+    }
 
+    /**
+     * Fetches the defined maven dependencies and their transitives.
+     *
+     * If the artifacts are locally in cached, returns them. Otherwise the artifacts
+     * are downloaded from maven repositories and stored in the local cache before
+     * being returned.
+     *
+     * @return The list of URLs pointing to jars, cached in the local machine.
+     */
+    public List<URL> resolveMavenDependencies() {
+      return ConfigLoader.resolveMavenDeps(this);
+    }
 
     /**
      * @return Gets the optional output directory to store artifacts.
@@ -311,8 +326,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
          * @return Returns the builder.
          */
         public Builder mavenDependencies(Collection<String> mavenDependencies) {
-          this.mavenRepositories.clear();
-          this.mavenRepositories.addAll(mavenDependencies);
+          this.mavenDependencies.clear();
+          this.mavenDependencies.addAll(mavenDependencies);
           return this;
         }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -43,7 +43,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     private final String version;
     private final List<String> imports;
     private final List<String> mavenRepositories;
-    private final List<String> mavenImports;
+    private final List<String> mavenDependencies;
     private final String outputDirectory;
     private final Map<String, ProjectionConfig> projections;
     private final Map<String, ObjectNode> plugins;
@@ -55,7 +55,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         outputDirectory = builder.outputDirectory;
         imports = ListUtils.copyOf(builder.imports);
         mavenRepositories = ListUtils.copyOf(builder.mavenRepositories);
-        mavenImports = ListUtils.copyOf(builder.mavenImports);
+        mavenDependencies = ListUtils.copyOf(builder.mavenDependencies);
         projections = MapUtils.copyOf(builder.projections);
         plugins = new HashMap<>(builder.plugins);
         ignoreMissingPlugins = builder.ignoreMissingPlugins;
@@ -163,8 +163,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
    * @return The list of maven imports which should be fetched and imported into
    *         the model.
    */
-  public List<String> getMavenImports() {
-    return mavenImports;
+  public List<String> getMavenDependencies() {
+    return mavenDependencies;
   }
 
 
@@ -211,7 +211,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     public static final class Builder implements SmithyBuilder<SmithyBuildConfig> {
         private final List<String> imports = new ArrayList<>();
         private final List<String> mavenRepositories = new ArrayList<>();
-        private final List<String> mavenImports = new ArrayList<>();
+        private final List<String> mavenDependencies = new ArrayList<>();
         private final Map<String, ProjectionConfig> projections = new LinkedHashMap<>();
         private final Map<String, ObjectNode> plugins = new LinkedHashMap<>();
         private String version;
@@ -257,7 +257,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
             version(config.getVersion());
             imports.addAll(config.getImports());
             mavenRepositories.addAll(config.getMavenRepositories());
-            mavenImports.addAll(config.getMavenImports());
+            mavenDependencies.addAll(config.getMavenDependencies());
             projections.putAll(config.getProjections());
             plugins.putAll(config.getPlugins());
 
@@ -307,12 +307,12 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         /**
          * Sets maven repositories on the config.
          *
-         * @param mavenImports Maven imports to set.
+         * @param mavenDependencies Maven imports to set.
          * @return Returns the builder.
          */
-        public Builder mavenImports(Collection<String> mavenImports) {
+        public Builder mavenDependencies(Collection<String> mavenDependencies) {
           this.mavenRepositories.clear();
-          this.mavenRepositories.addAll(mavenImports);
+          this.mavenRepositories.addAll(mavenDependencies);
           return this;
         }
 

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/mavendeps/smithy-build.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/mavendeps/smithy-build.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "imports": ["foo.json"],
+  "mavenDependencies": ["com.google.code.findbugs:jsr305:3.0.2"]
+}


### PR DESCRIPTION
Draft because no unit-tests yet. I'd ideally like for the smithy-maintainers to validate the approach before committing the time it'll take to add unit-tests. 

#### Changes 

Allows smithy-build to refer to (and fetch) maven dependencies. Custom repositories can be added, but by default fetches from maven-central. 

What might be controversial in this pull-request is the reliance on [coursier-interface](https://github.com/coursier/interface) to do so. [Coursier](https://get-coursier.io/) is a very efficient dependency resolver that the entirety of the scala ecosystem depends on. Coursier-interface is a pure-java interface for coursier, that shades coursier. 

The coursier-interface jar weighs about 4MB 

#### Rationale for this change

My interest mostly has to do with editor experience. Right now, the LSP client needs to instantiate the LSP server. If the opened smithy file depends on some library smithy model, it the LSP client takes the responsibility of pulling the dependencies itself, and calls `java` with the relevant classpath. The smithy model-assembler then [discover models](https://github.com/awslabs/smithy-language-server/blob/5804392edd8fc274201ee21887bdb9e6cde33223/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java) from the classpath. 

Though this works, it's not great, because the dependencies referenced by the LSP client (say, vscode) need also to be referenced by whatever build tool is used to load the models and do something with them. Therefore there is a repetition of configuration between editor and build tool is not desirable, and create a discrepancy in terms of "what is the source of truth ?". 

From what I gather from [this PR](https://github.com/awslabs/smithy-language-server/pull/21), the longer-term vision would be for the LSP server to rely on smithy-build to allow for some granularity in how models rely to each other within a workspace. I think it makes sense, however my organisation's usecases are heavily reliant on sharing smithy models via jars stored in some artifact repository. 

So I think smithy-build configuration should be considered source of truth when it comes to declaring dependencies. The declarative configuration makes it easy for users to define dependencies and edit their files without having to interact with a higher-level build-tool, and those build-tools could leverage smithy-build directly without having to fiddle about passing jars dependencies to it. 

It'd open the door to making the editing and building experience very smooth. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
