### PR TITLE
fix: add trailing / for machine learning test

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/services/machinelearning.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/services/machinelearning.smithy
@@ -42,7 +42,7 @@ service AmazonML_20141212 {
         uri: "/",
         host: "example.com",
         resolvedHost: "custom.example.com",
-        body: "{\"MLModelId\": \"foo\", \"Record\": {}, \"PredictEndpoint\": \"https://custom.example.com\"}",
+        body: "{\"MLModelId\": \"foo\", \"Record\": {}, \"PredictEndpoint\": \"https://custom.example.com/\"}",
         bodyMediaType: "application/json",
         headers: {"Content-Type": "application/x-amz-json-1.1"},
         params: {


### PR DESCRIPTION
Based on  `params`'s field `PredictEndpoint`, it seems that we need to add a trailing slash (or remove it from line 51). 

`PredictEndpoint` seems to be of type `String`, so if we don't have this change, our protocol unit tests will fail because we are doing a string comparison between the `params` and deserialized `body` field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
