### PR TITLE
Add aws.iam#iamResource trait

### DIFF
--- a/docs/source/1.0/spec/aws/aws-iam.rst
+++ b/docs/source/1.0/spec/aws/aws-iam.rst
@@ -534,6 +534,53 @@ The following example defines two operations:
         operation OperationB {}
 
 
+.. smithy-trait:: aws.iam#iamResource
+.. _aws.iam#iamResource-trait:
+
+-----------------------------
+``aws.iam#iamResource`` trait
+-----------------------------
+
+Summary
+    Indicates properties of a Smithy resource in AWS IAM.
+Trait selector
+    ``resource``
+Value type
+    ``structure``
+
+The ``aws.iam#iamResource`` trait is a structure that supports the following
+members:
+
+.. list-table::
+    :header-rows: 1
+    :widths:  10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - name
+      - ``string``
+      - The name of the resource in AWS IAM.
+
+The following example defines a simple resource with a name in AWS IAM that
+deviates from the :ref:`shape name of the shape ID <shape-id>` of the resource.
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        namespace smithy.example
+
+        use aws.iam#iamResource
+
+        @iamResource(name: "super")
+        resource SuperResource {
+            identifiers: {
+                superId: String,
+            },
+        }
+
+
 .. _deriving-condition-keys:
 
 -----------------------

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.iam.traits;
+
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+import software.amazon.smithy.model.traits.AbstractTraitBuilder;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Indicates properties of a Smithy resource in AWS IAM.
+ */
+public final class IamResourceTrait extends AbstractTrait
+        implements ToSmithyBuilder<IamResourceTrait> {
+    public static final ShapeId ID = ShapeId.from("aws.iam#iamResource");
+
+    public final String name;
+
+    private IamResourceTrait(Builder builder) {
+        super(ID, builder.getSourceLocation());
+        name = builder.name;
+    }
+
+    /**
+     * Get the AWS IAM resource name.
+     *
+     * @return Returns the name.
+     */
+    public Optional<String> getName() {
+        return Optional.of(name);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected Node createNode() {
+        NodeMapper mapper = new NodeMapper();
+        mapper.disableToNodeForClass(IamResourceTrait.class);
+        mapper.setOmitEmptyValues(true);
+        return mapper.serialize(this).expectObjectNode();
+    }
+
+    @Override
+    public SmithyBuilder<IamResourceTrait> toBuilder() {
+        return builder().sourceLocation(getSourceLocation()).name(name);
+    }
+
+    public static final class Provider extends AbstractTrait.Provider {
+        public Provider() {
+            super(ID);
+        }
+
+        @Override
+        public Trait createTrait(ShapeId target, Node value) {
+            return new NodeMapper().deserialize(value, IamResourceTrait.class);
+        }
+    }
+
+    public static final class Builder extends AbstractTraitBuilder<IamResourceTrait, Builder> {
+        private String name;
+
+        private Builder() {}
+
+        @Override
+        public IamResourceTrait build() {
+            return new IamResourceTrait(this);
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+    }
+}

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -4,3 +4,4 @@ software.amazon.smithy.aws.iam.traits.DefineConditionKeysTrait$Provider
 software.amazon.smithy.aws.iam.traits.DisableConditionKeyInferenceTrait$Provider
 software.amazon.smithy.aws.iam.traits.RequiredActionsTrait$Provider
 software.amazon.smithy.aws.iam.traits.SupportedPrincipalTypesTrait$Provider
+software.amazon.smithy.aws.iam.traits.IamResourceTrait$Provider

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
@@ -70,6 +70,23 @@
                 "smithy.api#documentation": "The principal types that can use the service or operation."
             }
         },
+        "aws.iam#iamResource": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "The name of the resource in AWS IAM."
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "resource"
+                },
+                "smithy.api#documentation": "Indicates properties of a Smithy resource in AWS IAM."
+            }
+        },
         "aws.iam#IamIdentifier": {
             "type": "string",
             "traits": {

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/IamResourceTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/IamResourceTraitTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.iam.traits;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class IamResourceTraitTest {
+    @Test
+    public void loadsFromModel() {
+        Model result = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("iam-resource.smithy"))
+                .assemble()
+                .unwrap();
+
+        Shape superResource = result.expectShape(ShapeId.from("smithy.example#SuperResource"));
+
+        assertTrue(superResource.hasTrait(IamResourceTrait.class));
+        assertEquals(superResource.expectTrait(IamResourceTrait.class).getName().get(), "super");
+    }
+}

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/iam-resource.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/iam-resource.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@aws.api#service(sdkId: "My")
+service MyService {
+    version: "2020-07-02",
+    resources: [SuperResource]
+}
+
+@aws.iam#iamResource(name: "super")
+resource SuperResource {
+    identifiers: {
+        id1: String,
+    },
+    read: GetResource
+}
+
+@readonly
+operation GetResource {
+    input: GetResourceInput,
+    output: GetResourceOutput,
+}
+
+structure GetResourceInput {
+    @required
+    id1: String
+}
+
+structure GetResourceOutput {
+    super: Super,
+}
+
+structure Super {
+    id1: String,
+}

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/supported-principal-types.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/supported-principal-types.smithy
@@ -3,7 +3,7 @@ $version: "1.0"
 namespace smithy.example
 
 @aws.iam#supportedPrincipalTypes(["IAMUser", "IAMRole"])
-operation MyService {}
+service MyService {}
 
 @aws.iam#supportedPrincipalTypes(["Root", "FederatedUser"])
 operation MyOperation {}


### PR DESCRIPTION
This commit adds the `@iamResource` trait that indicates properties of a
Smithy resource in AWS IAM. This trait currently supports only one
property, name, indicates when the name of a resource in AWS IAM is
different than that of the resource shape name in a Smithy model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
