### PR TITLE
Fix some query string literals documentation examples

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -323,14 +323,14 @@ Given a pattern of ``/path?requiredKey=requiredValue`` and an endpoint of
         or bound to another input member.
     * - ``http://yourhost/path``
       - No
-      - Does not contain a query string parameter named "requiredValue".
+      - Does not contain a query string parameter named "requiredKey".
     * - ``http://yourhost/path?``
       - No
-      - Does not contain a query string parameter named "requiredValue".
+      - Does not contain a query string parameter named "requiredKey".
     * - ``http://yourhost/path?requiredKey=otherValue``
       - No
-      - Contains a query string parameter named "requiredValue" but its value
-        is not "requiredValue" .
+      - Contains a query string parameter named "requiredKey" but its value
+        is not "requiredValue".
 
 
 .. _greedy-labels:


### PR DESCRIPTION
https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#query-string-literals


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
