### PR TITLE
fix: update Glacier test method expectation

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -112,7 +112,7 @@ operation UploadArchive {
         id: "GlacierMultipartChecksums",
         documentation: "Glacier requires checksum headers that are cumbersome to provide.",
         protocol: restJson1,
-        method: "POST",
+        method: "PUT",
         uri: "/foo/vaults/bar/multipart-uploads/baz",
         headers: {
             "X-Amz-Glacier-Version": "2012-06-01",


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:*

Fixes the expected HTTP method of the `GlacierMultipartChecksums` test to PUT as defined in the model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
