### PR TITLE
Allow serializing prelude in the node serializer

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -54,7 +54,11 @@ public final class ModelSerializer {
 
     private ModelSerializer(Builder builder) {
         metadataFilter = builder.metadataFilter;
-        shapeFilter = builder.shapeFilter.and(FunctionalUtils.not(Prelude::isPreludeShape));
+        if (!builder.includePrelude) {
+            shapeFilter = builder.shapeFilter.and(FunctionalUtils.not(Prelude::isPreludeShape));
+        } else {
+            shapeFilter = builder.shapeFilter;
+        }
         traitFilter = builder.traitFilter;
     }
 
@@ -97,6 +101,7 @@ public final class ModelSerializer {
     public static final class Builder implements SmithyBuilder<ModelSerializer> {
         private Predicate<String> metadataFilter = FunctionalUtils.alwaysTrue();
         private Predicate<Shape> shapeFilter = FunctionalUtils.alwaysTrue();
+        private boolean includePrelude = false;
         private Predicate<Trait> traitFilter = FunctionalUtils.alwaysTrue();
 
         private Builder() {}
@@ -118,6 +123,25 @@ public final class ModelSerializer {
          */
         public Builder shapeFilter(Predicate<Shape> shapeFilter) {
             this.shapeFilter = Objects.requireNonNull(shapeFilter);
+            return this;
+        }
+
+        /**
+         * Enables or disables including the prelude in the serialized model.
+         *
+         * <p>By default, the prelude is not included.
+         *
+         * <p>This should nearly always be left at default, as per the spec the prelude is
+         * inherently part of every model, and so any Smithy implementation must build in
+         * an understanding of the prelude. Disabling this filter can be useful for those
+         * implementations to allow them to build their understanding of it from a JSON
+         * version of the prelude.
+         *
+         * @param includePrelude boolean indicating whether the prelude should be included or not.
+         * @return Returns the builder.
+         */
+        public Builder includePrelude(boolean includePrelude) {
+            this.includePrelude = includePrelude;
             return this;
         }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -21,7 +21,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -141,7 +142,23 @@ public class ModelSerializerTest {
         ModelSerializer serializer = ModelSerializer.builder().build();
         ObjectNode serialized = serializer.serialize(model);
 
-        assertFalse(serialized.getMember("smithy.api").isPresent());
+        ObjectNode shapes = serialized.expectObjectMember("shapes");
+        shapes.getMembers().forEach((key, value) -> {
+            assertThat(key.getValue(), not(startsWith("smithy.api#")));
+        });
+    }
+
+    @Test
+    public void allowsDisablingPreludeFilter() {
+        Model model = Model.assembler().assemble().unwrap();
+        ModelSerializer serializer = ModelSerializer.builder().includePrelude(true).build();
+        ObjectNode serialized = serializer.serialize(model);
+
+        ObjectNode shapes = serialized.expectObjectMember("shapes");
+        assertTrue(shapes.getMembers().size() > 1);
+        shapes.getMembers().forEach((key, value) -> {
+            assertThat(key.getValue(), startsWith("smithy.api#"));
+        });
     }
 
     @Test


### PR DESCRIPTION
This adds a configuration option to the node model serializer that disables filtering the prelude from the output. This is mostly to enable alternate implementation to base their prelude understanding off of a JSON AST version of the prelud model (see #947).

I also noticed that the test to make sure the prelude wasn't included by default was wrong - it was still assuming the pre-1.0 ast format. So I fixed that while I was there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
