### PR TITLE
Add input and output traits

### DIFF
--- a/docs/source/1.0/spec/aws/aws-cloudformation.rst
+++ b/docs/source/1.0/spec/aws/aws-cloudformation.rst
@@ -193,12 +193,14 @@ The following example defines a CloudFormation resource that excludes the
             output: GetFooResponse,
         }
 
+        @input
         structure GetFooRequest {
             @httpLabel
             @required
             fooId: String,
         }
 
+        @output
         structure GetFooResponse {
             fooId: String,
 
@@ -254,6 +256,7 @@ Given the following model without mutability traits applied,
             output: CreateFooResponse,
         }
 
+        @input
         structure CreateFooRequest {
             createProperty: ComplexProperty,
             mutableProperty: ComplexProperty,
@@ -261,6 +264,7 @@ Given the following model without mutability traits applied,
             createWriteProperty: ComplexProperty,
         }
 
+        @output
         structure CreateFooResponse {
             fooId: String,
         }
@@ -271,11 +275,13 @@ Given the following model without mutability traits applied,
             output: GetFooResponse,
         }
 
+        @input
         structure GetFooRequest {
             @required
             fooId: String,
         }
 
+        @output
         structure GetFooResponse {
             fooId: String,
             createProperty: ComplexProperty,
@@ -288,6 +294,7 @@ Given the following model without mutability traits applied,
             input: UpdateFooRequest,
         }
 
+        @input
         structure UpdateFooRequest {
             @required
             fooId: String,
@@ -412,11 +419,13 @@ and ``barProperty`` properties as fully mutable:
             output: CreateFooResponse,
         }
 
+        @input
         structure CreateFooRequest {
             @cfnMutability("full")
             tags: TagList,
         }
 
+        @output
         structure CreateFooResponse {
             fooId: String,
         }
@@ -478,11 +487,13 @@ The following example defines a CloudFormation resource that marks the
             output: GetFooResponse,
         }
 
+        @input
         structure GetFooRequest {
             @required
             fooId: String
         }
 
+        @output
         structure GetFooResponse {
             @cfnMutability("read")
             updatedAt: Timestamp,
@@ -519,11 +530,13 @@ derivable ``secret`` and ``password`` properties as write only:
             output: CreateFooResponse,
         }
 
+        @input
         structure CreateFooRequest {
             @cfnMutability("write")
             secret: String,
         }
 
+        @output
         structure CreateFooResponse {
             fooId: String,
         }
@@ -634,6 +647,7 @@ The following example defines a CloudFormation resource that has the
             input: GetFooRequest,
         }
 
+        @input
         structure GetFooRequest {
             @required
             fooId: String,
@@ -681,6 +695,7 @@ Given the following model,
             output: CreateFooResponse,
         }
 
+        @input
         structure CreateFooRequest {
             @cfnMutability("full")
             tags: TagList,
@@ -696,6 +711,7 @@ Given the following model,
             createWriteProperty: ComplexProperty,
         }
 
+        @output
         structure CreateFooResponse {
             fooId: String,
         }
@@ -707,6 +723,7 @@ Given the following model,
             output: GetFooResponse,
         }
 
+        @input
         structure GetFooRequest {
             @httpLabel
             @required
@@ -717,6 +734,7 @@ Given the following model,
             fooAlias: String,
         }
 
+        @output
         structure GetFooResponse {
             fooId: String,
 
@@ -739,6 +757,7 @@ Given the following model,
             input: UpdateFooRequest,
         }
 
+        @input
         structure UpdateFooRequest {
             @httpLabel
             @required

--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -996,6 +996,7 @@ using an ``clientEndpointDiscoveryId``.
         @httpError(421)
         structure InvalidEndpointError {}
 
+        @input
         structure DescribeEndpointsInput {
           Operation: String,
           Identifiers: Identifiers,
@@ -1006,6 +1007,7 @@ using an ``clientEndpointDiscoveryId``.
           value: String
         }
 
+        @output
         structure DescribeEndpointsOutput {
           Endpoints: Endpoints,
         }
@@ -1025,140 +1027,16 @@ using an ``clientEndpointDiscoveryId``.
             output: GetObjectOutput
         }
 
+        @input
         structure GetObjectInput {
           @clientEndpointDiscoveryId
           @required
           Id: String,
         }
 
+        @output
         structure GetObjectOutput {
           Object: Blob,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "ns.foo#FooService": {
-                    "type": "service",
-                    "version": "2019-09-10",
-                    "operations": [
-                        {
-                            "target": "ns.foo#DescribeEndpoints"
-                        },
-                        {
-                            "target": "ns.foo#GetObject"
-                        }
-                    ],
-                    "traits": {
-                        "aws.api#clientEndpointDiscovery": {
-                            "operation": "ns.foo#DescribeEndpoints",
-                            "error": "InvalidEndpointError"
-                        }
-                    }
-                },
-                "ns.foo#DescribeEndpoints": {
-                    "type": "operation",
-                    "input": {
-                        "target": "ns.foo#DescribeEndpointsInput"
-                    },
-                    "output": {
-                        "target": "ns.foo#DescribeEndpointsOutput"
-                    }
-                },
-                "ns.foo#DescribeEndpointsInput": {
-                    "type": "structure",
-                    "members": {
-                        "Operation": {
-                            "target": "smithy.api#String"
-                        },
-                        "Identifiers": {
-                            "target": "ns.foo#Identifiers"
-                        }
-                    }
-                },
-                "ns.foo#Identifiers": {
-                    "type": "map",
-                    "key": {
-                        "target": "smithy.api#String"
-                    },
-                    "value": {
-                        "target": "smithy.api#String"
-                    }
-                },
-                "ns.foo#DescribeEndpointsOutput": {
-                    "type": "structure",
-                    "members": {
-                        "Endpoints": {
-                            "target": "ns.foo#Endpoints"
-                        }
-                    }
-                },
-                "ns.foo#Endpoints": {
-                    "type": "list",
-                    "member": {
-                        "target": "ns.foo#Endpoint"
-                    }
-                },
-                "ns.foo#Endpoint": {
-                    "type": "structure",
-                    "members": {
-                        "Address": {
-                            "target": "smithy.api#String"
-                        },
-                        "CachePeriodInMinutes": {
-                            "target": "smithy.api#Long"
-                        }
-                    }
-                },
-                "ns.foo#GetObject": {
-                    "type": "operation",
-                    "input": {
-                        "target": "ns.foo#GetObjectInput"
-                    },
-                    "output": {
-                        "target": "ns.foo#GetObjectOutput"
-                    },
-                    "errors": [
-                        {
-                            "target": "ns.foo#InvalidEndpointError"
-                        }
-                    ],
-                    "traits": {
-                        "aws.api#clientDiscoveredEndpoint": {
-                            "required": true
-                        }
-                    }
-                },
-                "ns.foo#GetObjectInput": {
-                    "type": "structure",
-                    "members": {
-                        "Id": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "aws.api#clientEndpointDiscoveryId": {},
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                },
-                "ns.foo#GetObjectOutput": {
-                    "type": "structure",
-                    "members": {
-                        "Object": {
-                            "target": "smithy.api#Blob"
-                        }
-                    }
-                },
-                "ns.foo#InvalidEndpointError": {
-                    "type": "structure",
-                    "traits": {
-                        "smithy.api#error": "client",
-                        "smithy.api#httpError": 421
-                    }
-                }
-            }
         }
 
 

--- a/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -244,6 +244,7 @@ For example, given the following:
 
 .. code-block:: smithy
 
+    @input
     structure Ec2QueryStructuresInput {
         foo: String,
 
@@ -286,6 +287,7 @@ For example, given the following:
 
 .. code-block:: smithy
 
+    @input
     structure Ec2QueryListsInput {
         ListArg: StringList,
         ComplexListArg: GreetingList,

--- a/docs/source/1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-query-protocol.rst
@@ -168,6 +168,7 @@ For example, given the following:
 
 .. code-block:: smithy
 
+    @input
     structure QueryStructuresInput {
         foo: String,
 
@@ -206,6 +207,7 @@ For example, given the following:
 
 .. code-block:: smithy
 
+    @input
     structure QueryListsInput {
         ListArg: StringList,
         ComplexListArg: GreetingList,
@@ -270,6 +272,7 @@ For example, given the following:
 
 .. code-block:: smithy
 
+    @input
     structure QueryMapsInput {
         MapArg: StringMap,
 

--- a/docs/source/1.0/spec/aws/customizations/s3-customizations.rst
+++ b/docs/source/1.0/spec/aws/customizations/s3-customizations.rst
@@ -148,70 +148,27 @@ Value type
 
 Consider the following *abridged* model of S3's ``GetBucketLocation`` operation:
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    use aws.customizations#s3UnwrappedXmlOutput
 
-        use aws.customizations#s3UnwrappedXmlOutput
+    @http(uri: "/GetBucketLocation", method: "GET")
+    @s3UnwrappedXmlOutput
+    operation GetBucketLocation {
+        input: GetBucketLocationInput,
+        output: GetBucketLocationOutput
+    }
 
-        @enum([
-            { value: "us-west-2", name: "us_west_2" }
-        ])
-        string BucketLocationConstraint
+    @output
+    @xmlName("LocationConstraint")
+    structure GetBucketLocationOutput {
+        LocationConstraint: BucketLocationConstraint
+    }
 
-        @xmlName("LocationConstraint")
-        structure GetBucketLocationOutput {
-            LocationConstraint: BucketLocationConstraint,
-        }
-
-        @http(uri: "/GetBucketLocation", method: "GET")
-        @s3UnwrappedXmlOutput
-        operation GetBucketLocation {
-            output: GetBucketLocationOutput,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#BucketLocationConstraint": {
-                    "type": "string",
-                    "traits": {
-                        "smithy.api#enum": [
-                            {
-                                "value": "us-west-2",
-                                "name": "us_west_2"
-                            }
-                        ]
-                    }
-                },
-                "smithy.example#GetBucketLocationOutput": {
-                    "type": "structure",
-                    "members": {
-                        "LocationConstraint": {
-                            "target": "smithy.example#BucketLocationConstraint"
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#xmlName": "LocationConstraint"
-                    }
-                },
-                "smithy.example#GetBucketLocation": {
-                    "type": "operation",
-                    "output": {
-                        "target": "smithy.example#GetBucketLocationOutput"
-                    },
-                    "traits": {
-                        "smithy.api#http": {
-                            "uri": "/GetBucketLocation",
-                            "method": "GET"
-                        },
-                        "aws.customizations#s3UnwrappedXmlOutput": {}
-                    }
-                }
-            }
-        }
+    @enum([
+        { value: "us-west-2", name: "us_west_2" }
+    ])
+    string BucketLocationConstraint
 
 Since this operation is modeled with ``@s3UnwrappedXmlOutput``,
 an Amazon S3 client should expect the response from S3 to be unwrapped as shown below:

--- a/docs/source/1.0/spec/core/behavior-traits.rst
+++ b/docs/source/1.0/spec/core/behavior-traits.rst
@@ -50,6 +50,7 @@ member if and only if the member is not explicitly provided.
             input: AllocateWidgetInput
         }
 
+        @input
         structure AllocateWidgetInput {
             @idempotencyToken
             clientToken: String,
@@ -253,11 +254,13 @@ explicitly on the operation.
             output: GetFoosOutput
         }
 
+        @input
         structure GetFoosInput {
             maxResults: Integer,
             nextToken: String
         }
 
+        @output
         structure GetFoosOutput {
             nextToken: String,
 
@@ -267,63 +270,6 @@ explicitly on the operation.
 
         list StringList {
             member: String
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#GetFoos": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#GetFoosInput"
-                    },
-                    "output": {
-                        "target": "smithy.example#GetFoosOutput"
-                    },
-                    "traits": {
-                        "smithy.api#readonly": {},
-                        "smithy.api#paginated": {
-                            "inputToken": "nextToken",
-                            "outputToken": "nextToken",
-                            "pageSize": "maxResults",
-                            "items": "foos"
-                        }
-                    }
-                },
-                "smithy.example#GetFoosInput": {
-                    "type": "structure",
-                    "members": {
-                        "maxResults": {
-                            "target": "smithy.api#Integer"
-                        },
-                        "nextToken": {
-                            "target": "smithy.api#String"
-                        }
-                    }
-                },
-                "smithy.example#GetFoosOutput": {
-                    "type": "structure",
-                    "members": {
-                        "nextToken": {
-                            "target": "smithy.api#String"
-                        },
-                        "foos": {
-                            "target": "smithy.example#StringList",
-                            "traits": {
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#StringList": {
-                    "type": "list",
-                    "member": {
-                        "target": "smithy.api#String"
-                    }
-                }
-            }
         }
 
 Attaching the ``paginated`` trait to a service provides default pagination
@@ -414,11 +360,13 @@ wrapper where the output token and items are referenced by paths.
             output: GetFoosOutput
         }
 
+        @input
         structure GetFoosInput {
             maxResults: Integer,
             nextToken: String
         }
 
+        @output
         structure GetFoosOutput {
             @required
             result: ResultWrapper
@@ -435,73 +383,6 @@ wrapper where the output token and items are referenced by paths.
             member: String
         }
 
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#GetFoos": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#GetFoosInput"
-                    },
-                    "output": {
-                        "target": "smithy.example#GetFoosOutput"
-                    },
-                    "traits": {
-                        "smithy.api#readonly": {},
-                        "smithy.api#paginated": {
-                            "inputToken": "nextToken",
-                            "outputToken": "result.nextToken",
-                            "pageSize": "maxResults",
-                            "items": "result.foos"
-                        }
-                    }
-                },
-                "smithy.example#GetFoosInput": {
-                    "type": "structure",
-                    "members": {
-                        "maxResults": {
-                            "target": "smithy.api#Integer"
-                        },
-                        "nextToken": {
-                            "target": "smithy.api#String"
-                        }
-                    }
-                },
-                "smithy.example#GetFoosOutput": {
-                    "type": "structure",
-                    "members": {
-                        "result": {
-                            "target": "smithy.example#ResultWrapper",
-                            "traits": {
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#ResultWrapper": {
-                    "type": "structure",
-                    "members": {
-                        "nextToken": {
-                            "target": "smithy.api#String"
-                        },
-                        "foos": {
-                            "target": "smithy.example#StringList",
-                            "traits": {
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#StringList": {
-                    "type": "list",
-                    "member": {
-                        "target": "smithy.api#String"
-                    }
-                }
-            }
-        }
 
 Pagination Behavior
 ===================

--- a/docs/source/1.0/spec/core/documentation-traits.rst
+++ b/docs/source/1.0/spec/core/documentation-traits.rst
@@ -379,6 +379,7 @@ Conflicts with
 
     .. code-tab:: smithy
 
+        @input
         structure PutContentsInput {
             @required
             contents: String,

--- a/docs/source/1.0/spec/core/endpoint-traits.rst
+++ b/docs/source/1.0/spec/core/endpoint-traits.rst
@@ -66,6 +66,7 @@ The following example defines an operation that uses a custom endpoint:
             output: GetStatusOutput
         }
 
+        @input
         structure GetStatusInput {
             @required
             @hostLabel
@@ -102,6 +103,9 @@ The following example defines an operation that uses a custom endpoint:
                                 "smithy.api#hostLabel": {}
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 }
             }
@@ -132,6 +136,7 @@ Given the following operation,
             output: GetStatusOutput
         }
 
+        @input
         structure GetStatusInput {
             @required
             @hostLabel
@@ -168,6 +173,9 @@ Given the following operation,
                                 "smithy.api#hostLabel": {}
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 }
             }

--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -66,6 +66,7 @@ The following example defines an operation that uses HTTP bindings:
             input: PutObjectInput
         }
 
+        @input
         structure PutObjectInput {
             // Sent in the URI label named "key".
             @required
@@ -643,6 +644,7 @@ The following example defines an operation that send an HTTP label named
             output: GetStatusOutput
         }
 
+        @input
         structure GetStatusInput {
             @required
             @httpLabel
@@ -726,9 +728,14 @@ data in a response:
         @readonly
         @http(method: "GET", uri: "/random-binary-data")
         operation GetRandomBinaryData {
-            output: GetRandomBinaryDataOutput,
+            input: GetRandomBinaryDataInput,
+            output: GetRandomBinaryDataOutput
         }
 
+        @input
+        structure GetRandomBinaryDataInput {}
+
+        @output
         structure GetRandomBinaryDataOutput {
             @required
             @httpHeader("Content-Type")
@@ -813,6 +820,7 @@ Given the following Smithy model:
             input: MyOperationInput
         }
 
+        @input
         structure MyOperationInput {
             @httpPrefixHeaders("X-Foo-")
             headers: StringMap
@@ -894,6 +902,7 @@ request:
             output: ListThingsOutput, // omitted for brevity
         }
 
+        @input
         structure ListThingsInput {
             @httpQuery("color")
             color: String,
@@ -991,6 +1000,7 @@ target input map as query string parameters in an HTTP request:
             output: ListThingsOutput, // omitted for brevity
         }
 
+        @input
         structure ListThingsInput {
             @httpQueryParams()
             myParams: MapOfStrings,
@@ -1030,6 +1040,7 @@ disregard the value set by ``httpQueryParams``. For example, given the following
             input: PutThingInput
         }
 
+        @input
         structure PutThingInput {
             @httpQuery
             @required
@@ -1234,6 +1245,7 @@ and HTTP bindings:
             input: PublishMessagesInput
         }
 
+        @input
         structure PublishMessagesInput {
             @httpPayload
             messages: MessageStream,
@@ -1246,53 +1258,6 @@ and HTTP bindings:
 
         structure Message {
             message: String,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#PublishMessages": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#PublishMessagesInput"
-                    },
-                    "traits": {
-                        "smithy.api#http": {
-                            "uri": "/messages",
-                            "method": "POST"
-                        }
-                    }
-                },
-                "smithy.example#PublishMessagesInput": {
-                    "type": "structure",
-                    "members": {
-                        "messages": {
-                            "target": "smithy.example#MessageStream",
-                            "traits": {
-                                "smithy.api#httpPayload": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#MessageStream": {
-                    "type": "union",
-                    "members": {
-                        "message": {
-                            "target": "smithy.example#Message"
-                        }
-                    }
-                },
-                "smithy.example#Message": {
-                    "type": "structure",
-                    "members": {
-                        "message": {
-                            "target": "smithy.api#String"
-                        }
-                    }
-                }
-            }
         }
 
 The following is **invalid** because the operation has the ``http`` trait
@@ -1308,6 +1273,7 @@ marked with the ``httpPayload`` trait:
         input: InvalidOperationInput
     }
 
+    @input
     structure InvalidOperationInput {
         invalid: MessageStream, // <-- Missing the @httpPayload trait
     }

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -1271,6 +1271,7 @@ the conflicting shapes.
             output: GetSomethingOutput,
         }
 
+        @output
         structure GetSomethingOutput {
             widget1: Widget,
             fooWidget: foo.example#Widget,
@@ -1310,6 +1311,9 @@ the conflicting shapes.
                         "fooWidget": {
                             "target": "foo.example#Widget"
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output" true
                     }
                 },
                 "smithy.example#Widget": {
@@ -1349,14 +1353,16 @@ An operation supports the following members:
       - ``string``
       - The optional input ``structure`` of the operation. The value MUST be
         a valid :ref:`shape ID <shape-id>` that targets a
-        :ref:`structure <structure>` shape. The targeted shape MUST NOT be
-        marked with the :ref:`error-trait`.
+        :ref:`structure <structure>` shape. The targeted shape SHOULD be
+        marked with the :ref:`input-trait` and MUST NOT be marked with the
+        :ref:`error-trait`.
     * - output
       - ``string``
       - The optional output ``structure`` of the operation. The value MUST
         be a valid :ref:`shape ID <shape-id>` that targets a
-        :ref:`structure <structure>` shape. The targeted shape MUST NOT
-        be marked with the :ref:`error-trait`.
+        :ref:`structure <structure>` shape. The targeted shape SHOULD be
+        marked with the :ref:`output-trait` and MUST NOT be marked with the
+        :ref:`error-trait`.
     * - errors
       - [``string``]
       - Defines the error ``structure``\s that an operation can return using

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -1268,8 +1268,12 @@ the conflicting shapes.
         }
 
         operation GetSomething {
-            output: GetSomethingOutput,
+            input: GetSomethingInput,
+            output: GetSomethingOutput
         }
+
+        @input
+        structure GetSomethingInput {}
 
         @output
         structure GetSomethingOutput {
@@ -1278,49 +1282,6 @@ the conflicting shapes.
         }
 
         structure Widget {}
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#MyService": {
-                    "type": "service",
-                    "version": "2017-02-11",
-                    "operations": [
-                        {
-                            "target": "smithy.example#GetSomething"
-                        }
-                    ],
-                    "rename": {
-                        "foo.example#Widget": "FooWidget"
-                    }
-                },
-                "smithy.example#GetSomething": {
-                    "type": "operation",
-                    "output": {
-                        "target": "smithy.example#GetSomethingOutput"
-                    }
-                },
-                "smithy.example#GetSomethingOutput": {
-                    "type": "structure",
-                    "members": {
-                        "widget1": {
-                            "target": "smithy.example#Widget"
-                        },
-                        "fooWidget": {
-                            "target": "foo.example#Widget"
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#output" true
-                    }
-                },
-                "smithy.example#Widget": {
-                    "type": "structure"
-                }
-            }
-        }
 
 .. rubric:: Resources and operations can be bound once
 
@@ -1351,18 +1312,18 @@ An operation supports the following members:
       - Description
     * - input
       - ``string``
-      - The optional input ``structure`` of the operation. The value MUST be
-        a valid :ref:`shape ID <shape-id>` that targets a
-        :ref:`structure <structure>` shape. The targeted shape SHOULD be
-        marked with the :ref:`input-trait` and MUST NOT be marked with the
-        :ref:`error-trait`.
+      - The optional input ``structure`` of the operation. Every operation
+        SHOULD define a dedicated input structure shape marked with the
+        :ref:`input-trait`. The targeted shape MUST be a valid
+        :ref:`shape ID <shape-id>` that targets a :ref:`structure <structure>`
+        shape.
     * - output
       - ``string``
-      - The optional output ``structure`` of the operation. The value MUST
-        be a valid :ref:`shape ID <shape-id>` that targets a
-        :ref:`structure <structure>` shape. The targeted shape SHOULD be
-        marked with the :ref:`output-trait` and MUST NOT be marked with the
-        :ref:`error-trait`.
+      - The optional output ``structure`` of the operation. Every operation
+        SHOULD define a dedicated output structure shape marked with the
+        :ref:`output-trait`. The targeted shape MUST be a valid
+        :ref:`shape ID <shape-id>` that targets a :ref:`structure <structure>`
+        shape.
     * - errors
       - [``string``]
       - Defines the error ``structure``\s that an operation can return using
@@ -1374,42 +1335,21 @@ structure named ``Input``, returns an output structure named ``Output``, and
 can potentially return the ``NotFound`` or ``BadRequest``
 :ref:`error structures <error-trait>`.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    namespace smithy.example
 
-        namespace smithy.example
+    operation MyOperation {
+        input: MyOperationInput,
+        output: MyOperationOutput,
+        errors: [NotFound, BadRequest]
+    }
 
-        operation MyOperation {
-            input: Input,
-            output: Output,
-            errors: [NotFound, BadRequest]
-        }
+    @input
+    structure MyOperationInput {}
 
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#MyOperation": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#Input"
-                    },
-                    "output": {
-                        "target": "smithy.example#Output"
-                    },
-                    "errors": [
-                        {
-                            "target": "smithy.example#NotFound"
-                        },
-                        {
-                            "target": "smithy.example#BadRequest"
-                        }
-                    ]
-                }
-            }
-        }
+    @output
+    structure MyOperationOutput {}
 
 
 ..  _resource:
@@ -1765,67 +1705,16 @@ For example, given the following model,
             output: GetForecastOutput
         }
 
+        @input
         structure GetForecastInput {
             @required
             forecastId: ForecastId,
         }
 
+        @output
         structure GetForecastOutput {
             @required
             weather: WeatherData,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#Forecast": {
-                    "type": "resource",
-                    "identifiers": {
-                        "forecastId": {
-                            "target": "smithy.example#ForecastId"
-                        }
-                    },
-                    "read": {
-                        "target": "smithy.example#GetForecast"
-                    }
-                },
-                "smithy.example#GetForecast": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#GetForecastInput"
-                    },
-                    "output": {
-                        "target": "smithy.example#GetForecastOutput"
-                    },
-                    "traits": {
-                        "smithy.api#readonly": {}
-                    }
-                },
-                "smithy.example#GetForecastInput": {
-                    "type": "structure",
-                    "members": {
-                        "forecastId": {
-                            "target": "smithy.example#ForecastId",
-                            "traits": {
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#GetForecastOutput": {
-                    "type": "structure",
-                    "members": {
-                        "weather": {
-                            "target": "smithy.example#WeatherData",
-                            "traits": {
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                }
-            }
         }
 
 ``GetForecast`` forms a valid instance operation because the operation is
@@ -1855,50 +1744,10 @@ Given the following model,
             output: BatchPutForecastsOutput
         }
 
+        @input
         structure BatchPutForecastsInput {
             @required
             forecasts: BatchPutForecastList,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#Forecast": {
-                    "type": "resource",
-                    "identifiers": {
-                        "forecastId": {
-                            "target": "smithy.example#ForecastId"
-                        }
-                    },
-                    "collectionOperations": [
-                        {
-                            "target": "smithy.example#BatchPutForecasts"
-                        }
-                    ]
-                },
-                "smithy.example#BatchPutForecasts": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#BatchPutForecastsInput"
-                    },
-                    "output": {
-                        "target": "smithy.example#BatchPutForecastsOutput"
-                    }
-                },
-                "smithy.example#BatchPutForecastsInput": {
-                    "type": "structure",
-                    "members": {
-                        "forecasts": {
-                            "target": "smithy.example#BatchPutForecastList",
-                            "traits": {
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                }
-            }
         }
 
 ``BatchPutForecasts`` forms a valid collection operation with implicit
@@ -1939,6 +1788,7 @@ For example, given the following,
         output: GetHistoricalForecastOutput
     }
 
+    @input
     structure GetHistoricalForecastInput {
         @required
         @resourceIdentifier("forecastId")
@@ -2009,6 +1859,7 @@ The following example defines the ``PutForecast`` operation.
         output: PutForecastOutput
     }
 
+    @input
     structure PutForecastInput {
         // The client provides the resource identifier.
         @required
@@ -2056,6 +1907,7 @@ The following example defines the ``CreateForecast`` operation.
         output: CreateForecastOutput
     }
 
+    @input
     structure CreateForecastInput {
         // No identifier is provided by the client, so the service is
         // responsible for providing the identifier of the resource.
@@ -2085,6 +1937,7 @@ For example:
         errors: [ResourceNotFound]
     }
 
+    @input
     structure GetForecastInput {
         @required
         forecastId: ForecastId,
@@ -2112,6 +1965,7 @@ For example:
         errors: [ResourceNotFound]
     }
 
+    @input
     structure UpdateForecastInput {
         @required
         forecastId: ForecastId,
@@ -2142,6 +1996,7 @@ For example:
         errors: [ResourceNotFound]
     }
 
+    @input
     structure DeleteForecastInput {
         @required
         forecastId: ForecastId,
@@ -2172,11 +2027,13 @@ For example:
         output: ListForecastsOutput
     }
 
+    @input
     structure ListForecastsInput {
         maxResults: Integer,
         nextToken: String
     }
 
+    @output
     structure ListForecastsOutput {
         nextToken: String,
         @required

--- a/docs/source/1.0/spec/core/resource-traits.rst
+++ b/docs/source/1.0/spec/core/resource-traits.rst
@@ -308,6 +308,7 @@ match for the name of the resource identifier.
             errors: [NoSuchResource]
         }
 
+        @input
         structure GetFileInput {
             @required
             directory: String,

--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -753,6 +753,7 @@ in the closure of a service.
     @tags(["invalid"])
     operation OperationD {}
 
+    @input
     structure OperationAInput {
         badValue: BadEnum,
         goodValue: GoodEnum,

--- a/docs/source/1.0/spec/core/stream-traits.rst
+++ b/docs/source/1.0/spec/core/stream-traits.rst
@@ -47,9 +47,14 @@ Validation
     .. code-tab:: smithy
 
         operation StreamingOperation {
+            input: StreamingOperationInput,
             output: StreamingOperationOutput,
         }
 
+        @input
+        structure StreamingOperationInput {}
+
+        @output
         structure StreamingOperationOutput {
             @required
             streamId: String
@@ -125,6 +130,7 @@ stream in its input by referencing a member that targets a union:
             input: PublishMessagesInput
         }
 
+        @input
         structure PublishMessagesInput {
             room: String,
             messages: PublishEvents,
@@ -201,9 +207,14 @@ stream in its output:
         namespace smithy.example
 
         operation SubscribeToMovements {
+            input: SubscribeToMovementsInput,
             output: SubscribeToMovementsOutput
         }
 
+        @input
+        structure SubscribeToMovementsInput {}
+
+        @output
         structure SubscribeToMovementsOutput {
             movements: MovementEvents,
         }
@@ -226,71 +237,6 @@ stream in its output:
         @error("client")
         @retryable(throttling: true)
         structure ThrottlingError {}
-
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#SubscribeToMovements": {
-                    "type": "operation",
-                    "output": {
-                        "target": "smithy.example#SubscribeToMovementsOutput"
-                    }
-                },
-                "smithy.example#SubscribeToMovementsOutput": {
-                    "type": "structure",
-                    "members": {
-                        "movements": {
-                            "target": "smithy.example#MovementEvents"
-                        }
-                    }
-                },
-                "smithy.example#MovementEvents": {
-                    "type": "union",
-                    "members": {
-                        "up": {
-                            "target": "smithy.example#Movement"
-                        },
-                        "down": {
-                            "target": "smithy.example#Movement"
-                        },
-                        "left": {
-                            "target": "smithy.example#Movement"
-                        },
-                        "right": {
-                            "target": "smithy.example#Movement"
-                        },
-                        "throttlingError": {
-                            "target": "smithy.example#ThrottlingError"
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#streaming": {}
-                    }
-                },
-                "smithy.example#Movement": {
-                    "type": "structure",
-                    "members": {
-                        "velocity": {
-                            "target": "smithy.api#Float"
-                        }
-                    }
-                },
-                "smithy.example#ThrottlingError": {
-                    "type": "structure",
-                    "traits": {
-                        "smithy.api#documentation": "An example error emitted when the client is throttled and should terminate the event stream.",
-                        "smithy.api#error": "client",
-                        "smithy.api#retryable": {
-                            "throttling": true
-                        }
-                    }
-                }
-            }
-        }
-
 
 Modeled errors in event streams
 ===============================
@@ -342,6 +288,7 @@ service, followed by the events sent in the payload of the HTTP message.
             input: PublishMessagesInput
         }
 
+        @input
         structure PublishMessagesInput {
             @httpLabel
             @required
@@ -360,62 +307,6 @@ service, followed by the events sent in the payload of the HTTP message.
             message: String,
         }
 
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#PublishMessages": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#PublishMessagesInput"
-                    },
-                    "traits": {
-                        "smithy.api#http": {
-                            "uri": "/messages/{room}",
-                            "method": "POST"
-                        }
-                    }
-                },
-                "smithy.example#PublishMessagesInput": {
-                    "type": "structure",
-                    "members": {
-                        "room": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#httpLabel:": {},
-                                "smithy.api#required": {}
-                            }
-                        },
-                        "messages": {
-                            "target": "smithy.example#MessageStream",
-                            "traits": {
-                                "smithy.api#httpPayload": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#MessageStream": {
-                    "type": "union",
-                    "members": {
-                        "message": {
-                            "target": "smithy.example#Message"
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#streaming": {}
-                    }
-                },
-                "smithy.example#Message": {
-                    "type": "structure",
-                    "members": {
-                        "message": {
-                            "target": "smithy.api#String"
-                        }
-                    }
-                }
-            }
-        }
 
 .. _initial-response:
 
@@ -449,67 +340,20 @@ message.
             output: SubscribeToMessagesOutput
         }
 
+        @input
         structure SubscribeToMessagesInput {
             @httpLabel
             @required
             room: String
         }
 
+        @output
         structure SubscribeToMessagesOutput {
             @httpHeader("X-Connection-Lifetime")
             connectionLifetime: Integer,
 
             @httpPayload
             messages: MessageStream,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#PublishMessages": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#PublishMessagesInput"
-                    },
-                    "traits": {
-                        "smithy.api#http": {
-                            "uri": "/messages/{room}",
-                            "method": "POST"
-                        }
-                    }
-                },
-                "smithy.example#SubscribeToMessagesInput": {
-                    "type": "structure",
-                    "members": {
-                        "room": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#httpLabel:": {},
-                                "smithy.api#required": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#SubscribeToMessagesOutput": {
-                    "type": "structure",
-                    "members": {
-                        "connectionLifetime": {
-                            "target": "smithy.api#Integer",
-                            "traits": {
-                                "smithy.api#httpHeader:": "X-Connection-Lifetime"
-                            }
-                        },
-                        "messages": {
-                            "target": "smithy.example#MessageStream",
-                            "traits": {
-                                "smithy.api#httpPayload": {}
-                            }
-                        }
-                    }
-                }
-            }
         }
 
 Initial message client and server behavior
@@ -546,9 +390,14 @@ on the name of an event. For example, given the following event stream:
     namespace smithy.example
 
     operation SubscribeToEvents {
+        input: SubscribeToEventsInput,
         output: SubscribeToEventsOutput
     }
 
+    @input
+    structure SubscribeToEventsInput {}
+
+    @output
     structure SubscribeToEventsOutput {
         events: Events,
     }

--- a/docs/source/1.0/spec/core/type-refinement-traits.rst
+++ b/docs/source/1.0/spec/core/type-refinement-traits.rst
@@ -138,6 +138,62 @@ in Java).
         }
 
 
+.. smithy-trait:: smithy.api#input
+.. _input-trait::
+
+---------------
+``input`` trait
+---------------
+
+Summary
+    Specializes a structure for use only as the input of a single operation.
+Trait selector
+    ``structure``
+Value type
+    Annotation trait.
+Conflicts with
+    :ref:`input-trait`, :ref:`error-trait`
+
+Structure shapes marked with the ``@input`` trait MUST adhere to the
+following constraints:
+
+1. They can only be referenced in the model as an operation's input.
+2. They cannot be used as the input of more than one operation.
+3. They MUST have a shape name that starts with the name of any operation
+   they are associated with.
+
+These constraints allow tooling to specialize operation input shapes in
+ways that would otherwise require complex model transformations.
+
+
+.. smithy-trait:: smithy.api#output
+.. _output-trait::
+
+----------------
+``output`` trait
+----------------
+
+Summary
+    Specializes a structure for use only as the output of a single operation.
+Trait selector
+    ``structure``
+Value type
+    Annotation trait.
+Conflicts with
+    :ref:`output-trait`, :ref:`error-trait`
+
+Structure shapes marked with the ``@output`` trait MUST adhere to the
+following constraints:
+
+1. They can only be referenced in the model as an operation's output.
+2. They cannot be used as the output of more than one operation.
+3. They MUST have a shape name that starts with the name of any operation
+   they are associated with.
+
+These constraints allow tooling to specialize operation output shapes in
+ways that would otherwise require complex model transformations.
+
+
 .. smithy-trait:: smithy.api#sparse
 .. _sparse-trait:
 

--- a/docs/source/1.0/spec/core/type-refinement-traits.rst
+++ b/docs/source/1.0/spec/core/type-refinement-traits.rst
@@ -139,7 +139,7 @@ in Java).
 
 
 .. smithy-trait:: smithy.api#input
-.. _input-trait::
+.. _input-trait:
 
 ---------------
 ``input`` trait
@@ -159,15 +159,17 @@ following constraints:
 
 1. They can only be referenced in the model as an operation's input.
 2. They cannot be used as the input of more than one operation.
-3. They MUST have a shape name that starts with the name of any operation
-   they are associated with.
+3. They SHOULD have a shape name that starts with the name of the
+   operation that targets it (if any). For example, if a shape is the input
+   of the ``GetSprocket`` operation, then the shape SHOULD be named
+   ``GetSprocketInput``.
 
 These constraints allow tooling to specialize operation input shapes in
 ways that would otherwise require complex model transformations.
 
 
 .. smithy-trait:: smithy.api#output
-.. _output-trait::
+.. _output-trait:
 
 ----------------
 ``output`` trait
@@ -187,8 +189,10 @@ following constraints:
 
 1. They can only be referenced in the model as an operation's output.
 2. They cannot be used as the output of more than one operation.
-3. They MUST have a shape name that starts with the name of any operation
-   they are associated with.
+3. They SHOULD have a shape name that starts with the name of the
+   operation that targets it (if any). For example, if a shape is the output
+   of the ``GetSprocket`` operation, then the shape SHOULD be named
+   ``GetSprocketOutput``.
 
 These constraints allow tooling to specialize operation output shapes in
 ways that would otherwise require complex model transformations.

--- a/docs/source/1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source/1.0/spec/http-protocol-compliance-tests.rst
@@ -533,60 +533,18 @@ that uses :ref:`HTTP binding traits <http-traits>`.
             }
         ])
         operation SayGoodbye {
+            input: SayGoodbyeInput,
             output: SayGoodbyeOutput
         }
 
+        @input
+        structure SayGoodbyeInput {}
+
+        @output
         structure SayGoodbyeOutput {
             @httpHeader("X-Farewell")
             farewell: String,
         }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#SayGoodbye": {
-                    "type": "operation",
-                    "output": {
-                        "target": "smithy.example#SayGoodbyeOutput"
-                    },
-                    "traits": {
-                        "smithy.api#http": {
-                            "method": "POST",
-                            "uri": "/",
-                            "code": 200
-                        },
-                        "smithy.test#httpResponseTests": [
-                            {
-                                "id": "say_goodbye",
-                                "protocol": "smithy.example#exampleProtocol",
-                                "headers": {
-                                    "Content-Length": "0",
-                                    "X-Farewell": "Bye"
-                                },
-                                "params": {
-                                    "farewell": "Bye"
-                                },
-                                "code": 200
-                            }
-                        ]
-                    }
-                },
-                "smithy.example#SayGoodbyeOutput": {
-                    "type": "structure",
-                    "members": {
-                        "farewell": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#httpHeader": "X-Farewell"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
 
 HTTP error response example
 ===========================

--- a/docs/source/1.0/spec/mqtt.rst
+++ b/docs/source/1.0/spec/mqtt.rst
@@ -332,12 +332,14 @@ topic using an :ref:`event stream <event-streams>`:
             output: SubscribeForEventsOutput
         }
 
+        @input
         structure SubscribeForEventsInput {
             @required
             @topicLabel
             id: String,
         }
 
+        @output
         structure SubscribeForEventsOutput {
             events: EventStream,
         }
@@ -349,62 +351,6 @@ topic using an :ref:`event stream <event-streams>`:
 
         structure Event {
             message: String,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "smithy.example#SubscribeForEvents": {
-                    "type": "operation",
-                    "input": {
-                        "target": "smithy.example#SubscribeForEventsInput"
-                    },
-                    "traits": {
-                        "smithy.mqtt#subscribe": "events/{id}"
-                    }
-                },
-                "smithy.example#SubscribeForEventsInput": {
-                    "type": "structure",
-                    "members": {
-                        "id": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#required": {},
-                                "smithy.mqtt#topicLabel": {}
-                            }
-                        }
-                    }
-                },
-                "smithy.example#SubscribeForEventsOutput": {
-                    "type": "structure",
-                    "members": {
-                        "events": {
-                            "target": "smithy.example#EventStream"
-                        }
-                    }
-                },
-                "smithy.example#EventStream": {
-                    "type": "union",
-                    "members": {
-                        "message": {
-                            "target": "smithy.example#Event"
-                        }
-                    },
-                    "traits" {
-                        "smithy.api#streaming": {}
-                    }
-                },
-                "smithy.example#Event": {
-                    "type": "structure",
-                    "members": {
-                        "message": {
-                            "target": "smithy.api#String"
-                        }
-                    }
-                }
-            }
         }
 
 Subscribe validation

--- a/docs/source/1.0/spec/waiters.rst
+++ b/docs/source/1.0/spec/waiters.rst
@@ -635,11 +635,13 @@ triggered if the ``status`` property equals ``failed``.
         output: GetThingOutput,
     }
 
+    @input
     structure GetThingInput {
         @required
         name: String,
     }
 
+    @output
     structure GetThingOutput {
         status: String
     }

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -315,6 +315,7 @@ Let's define the operation used to "read" a ``City``.
             errors: [NoSuchResource]
         }
 
+        @input
         structure GetCityInput {
             // "cityId" provides the identifier for the resource and
             // has to be marked as required.
@@ -322,6 +323,7 @@ Let's define the operation used to "read" a ``City``.
             cityId: CityId
         }
 
+        @output
         structure GetCityOutput {
             // "required" is used on output to indicate if the service
             // will always provide a value for the member.
@@ -376,6 +378,9 @@ Let's define the operation used to "read" a ``City``.
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#GetCityOutput": {
@@ -393,6 +398,9 @@ Let's define the operation used to "read" a ``City``.
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 },
                 "example.weather#CityCoordinates": {
@@ -443,11 +451,13 @@ And define the operation used to "read" a ``Forecast``.
 
         // "cityId" provides the only identifier for the resource since
         // a Forecast doesn't have its own.
+        @input
         structure GetForecastInput {
             @required
             cityId: CityId,
         }
 
+        @output
         structure GetForecastOutput {
             chanceOfRain: Float
         }
@@ -478,14 +488,20 @@ And define the operation used to "read" a ``Forecast``.
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#GetForecastOutput": {
                     "type": "structure",
                     "members": {
                         "chanceOfRain": {
-                            "target": "smithy.api#Float"
+                            "target": "smithy.api#Float",
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 }
             }
@@ -533,11 +549,13 @@ cities, so there's no way we could provide a ``City`` identifier.
             output: ListCitiesOutput
         }
 
+        @input
         structure ListCitiesInput {
             nextToken: String,
             pageSize: Integer
         }
 
+        @output
         structure ListCitiesOutput {
             nextToken: String,
 
@@ -605,6 +623,9 @@ cities, so there's no way we could provide a ``City`` identifier.
                         "pageSize": {
                             "target": "smithy.api#Integer"
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#ListCitiesOutput": {
@@ -619,6 +640,9 @@ cities, so there's no way we could provide a ``City`` identifier.
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 },
                 "example.weather#CitySummaries": {
@@ -694,9 +718,14 @@ service.
 
         @readonly
         operation GetCurrentTime {
+            input: GetCurrentTimeInput,
             output: GetCurrentTimeOutput
         }
 
+        @input
+        structure GetCurrentTimeInput {}
+
+        @output
         structure GetCurrentTimeOutput {
             @required
             time: Timestamp
@@ -723,6 +752,9 @@ service.
                 },
                 "example.weather#GetCurrentTime": {
                     "type": "operation",
+                    "input": {
+                        "target": "example.weather#GetCurrentTimeInput"
+                    },
                     "output": {
                         "target": "example.weather#GetCurrentTimeOutput"
                     },
@@ -730,6 +762,12 @@ service.
                         "smithy.api#readonly": true
                     }
                 },
+                "example.weather#GetCurrentTimeInput": {
+                    "type": "structure",
+                    "traits": {
+                        "smithy.api#input": true
+                    }
+                }
                 "example.weather#GetCurrentTimeOutput": {
                     "type": "structure",
                     "members": {
@@ -739,6 +777,9 @@ service.
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 }
             }
@@ -891,6 +932,7 @@ Finally, the complete ``weather.smithy`` model should look like:
             errors: [NoSuchResource]
         }
 
+        @input
         structure GetCityInput {
             // "cityId" provides the identifier for the resource and
             // has to be marked as required.
@@ -898,6 +940,7 @@ Finally, the complete ``weather.smithy`` model should look like:
             cityId: CityId
         }
 
+        @output
         structure GetCityOutput {
             // "required" is used on output to indicate if the service
             // will always provide a value for the member.
@@ -934,11 +977,13 @@ Finally, the complete ``weather.smithy`` model should look like:
             output: ListCitiesOutput
         }
 
+        @input
         structure ListCitiesInput {
             nextToken: String,
             pageSize: Integer
         }
 
+        @output
         structure ListCitiesOutput {
             nextToken: String,
 
@@ -963,9 +1008,14 @@ Finally, the complete ``weather.smithy`` model should look like:
 
         @readonly
         operation GetCurrentTime {
+            input: GetCurrentTimeInput,
             output: GetCurrentTimeOutput
         }
 
+        @input
+        structure GetCurrentTimeInput {}
+
+        @output
         structure GetCurrentTimeOutput {
             @required
             time: Timestamp
@@ -979,11 +1029,13 @@ Finally, the complete ``weather.smithy`` model should look like:
 
         // "cityId" provides the only identifier for the resource since
         // a Forecast doesn't have its own.
+        @input
         structure GetForecastInput {
             @required
             cityId: CityId,
         }
 
+        @output
         structure GetForecastOutput {
             chanceOfRain: Float
         }
@@ -1123,6 +1175,9 @@ Finally, the complete ``weather.smithy`` model should look like:
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#GetCityOutput": {
@@ -1140,15 +1195,27 @@ Finally, the complete ``weather.smithy`` model should look like:
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 },
                 "example.weather#GetCurrentTime": {
                     "type": "operation",
+                    "input": {
+                        "target": "example.weather#GetCurrentTimeInput"
+                    },
                     "output": {
                         "target": "example.weather#GetCurrentTimeOutput"
                     },
                     "traits": {
                         "smithy.api#readonly": true
+                    }
+                },
+                "example.weather#GetCurrentTimeInput": {
+                    "type": "structure",
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#GetCurrentTimeOutput": {
@@ -1160,6 +1227,9 @@ Finally, the complete ``weather.smithy`` model should look like:
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 },
                 "example.weather#GetForecast": {
@@ -1183,6 +1253,9 @@ Finally, the complete ``weather.smithy`` model should look like:
                                 "smithy.api#required": true
                             }
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#GetForecastOutput": {
@@ -1191,6 +1264,9 @@ Finally, the complete ``weather.smithy`` model should look like:
                         "chanceOfRain": {
                             "target": "smithy.api#Float"
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 },
                 "example.weather#ListCities": {
@@ -1217,6 +1293,9 @@ Finally, the complete ``weather.smithy`` model should look like:
                         "pageSize": {
                             "target": "smithy.api#Integer"
                         }
+                    },
+                    "traits": {
+                        "smithy.api#input": true
                     }
                 },
                 "example.weather#ListCitiesOutput": {
@@ -1231,6 +1310,9 @@ Finally, the complete ``weather.smithy`` model should look like:
                         "nextToken": {
                             "target": "smithy.api#String"
                         }
+                    },
+                    "traits": {
+                        "smithy.api#output": true
                     }
                 },
                 "example.weather#NoSuchResource": {

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -105,29 +105,15 @@ weather service.
 ``Weather`` is a :ref:`service` shape that is defined inside of a
 :ref:`namespace <namespaces>`.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    namespace example.weather
 
-        namespace example.weather
-
-        /// Provides weather forecasts.
-        /// Triple slash comments attach documentation to shapes.
-        service Weather {
-            version: "2006-03-01"
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#Weather": {
-                    "type": "service",
-                    "version": "2006-03-01"
-                }
-            }
-        }
+    /// Provides weather forecasts.
+    /// Triple slash comments attach documentation to shapes.
+    service Weather {
+        version: "2006-03-01"
+    }
 
 .. admonition:: What's that syntax?
     :class: note
@@ -150,64 +136,25 @@ Defining resources
 A resource is contained within a service or another resource. Resources have
 identifiers, operations, and any number of child resources.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    namespace example.weather
 
-        namespace example.weather
+    /// Provides weather forecasts.
+    service Weather {
+        version: "2006-03-01",
+        resources: [City]
+    }
 
-        /// Provides weather forecasts.
-        service Weather {
-            version: "2006-03-01",
-            resources: [City]
-        }
+    resource City {
+        identifiers: { cityId: CityId },
+        read: GetCity,
+        list: ListCities,
+    }
 
-        resource City {
-            identifiers: { cityId: CityId },
-            read: GetCity,
-            list: ListCities,
-        }
-
-        // "pattern" is a trait.
-        @pattern("^[A-Za-z0-9 ]+$")
-        string CityId
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#Weather": {
-                    "type": "service",
-                    "version": "2006-03-01",
-                    "resources": [
-                        {
-                            "target": "example.weather#City"
-                        }
-                    ]
-                },
-                "example.weather#City": {
-                    "type": "resource",
-                    "identifiers": {
-                        "cityId": {
-                            "target": "example.weather#CityId"
-                        }
-                    },
-                    "read": {
-                        "target": "example.weather#GetCity"
-                    },
-                    "list": {
-                        "target": "example.weather#ListCities"
-                    }
-                },
-                "example.weather#CityId": {
-                    "type": "string",
-                    "traits": {
-                        "smithy.api#pattern": "^[A-Za-z0-9 ]+$"
-                    }
-                }
-            }
-        }
+    // "pattern" is a trait.
+    @pattern("^[A-Za-z0-9 ]+$")
+    string CityId
 
 Because the ``Weather`` service contains many cities, the ``City`` resource
 defines an :ref:`identifier <resource-identifiers>`. *Identifiers* are used
@@ -222,59 +169,19 @@ identity of the resource.
 Each ``City`` has a single ``Forecast``. This can be defined by adding the
 ``Forecast`` to the ``resources`` property of the ``City``.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    resource City {
+        identifiers: { cityId: CityId },
+        read: GetCity,
+        list: ListCities,
+        resources: [Forecast],
+    }
 
-        resource City {
-            identifiers: { cityId: CityId },
-            read: GetCity,
-            list: ListCities,
-            resources: [Forecast],
-        }
-
-        resource Forecast {
-            identifiers: { cityId: CityId },
-            read: GetForecast,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#City": {
-                    "type": "resource",
-                    "identifiers": {
-                        "cityId": {
-                            "target": "example.weather#CityId"
-                        }
-                    },
-                    "read": {
-                        "target": "example.weather#GetCity"
-                    },
-                    "list": {
-                        "target": "example.weather#ListCities"
-                    },
-                    "resources": [
-                        {
-                            "target": "example.weather#Forecast"
-                        }
-                    ]
-                },
-                "example.weather#Forecast": {
-                    "type": "resource",
-                    "identifiers": {
-                        "cityId": {
-                            "target": "example.weather#CityId"
-                        }
-                    },
-                    "read": {
-                        "target": "example.weather#GetForecast"
-                    }
-                }
-            }
-        }
+    resource Forecast {
+        identifiers: { cityId: CityId },
+        read: GetForecast,
+    }
 
 Child resources must define the exact same identifiers property of their
 parent, but they are allowed to add any number of additional identifiers if
@@ -304,208 +211,72 @@ your API.
 
 Let's define the operation used to "read" a ``City``.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    @readonly
+    operation GetCity {
+        input: GetCityInput,
+        output: GetCityOutput,
+        errors: [NoSuchResource]
+    }
 
-        @readonly
-        operation GetCity {
-            input: GetCityInput,
-            output: GetCityOutput,
-            errors: [NoSuchResource]
-        }
+    @input
+    structure GetCityInput {
+        // "cityId" provides the identifier for the resource and
+        // has to be marked as required.
+        @required
+        cityId: CityId
+    }
 
-        @input
-        structure GetCityInput {
-            // "cityId" provides the identifier for the resource and
-            // has to be marked as required.
-            @required
-            cityId: CityId
-        }
+    @output
+    structure GetCityOutput {
+        // "required" is used on output to indicate if the service
+        // will always provide a value for the member.
+        @required
+        name: String,
 
-        @output
-        structure GetCityOutput {
-            // "required" is used on output to indicate if the service
-            // will always provide a value for the member.
-            @required
-            name: String,
+        @required
+        coordinates: CityCoordinates,
+    }
 
-            @required
-            coordinates: CityCoordinates,
-        }
+    structure CityCoordinates {
+        @required
+        latitude: Float,
 
-        structure CityCoordinates {
-            @required
-            latitude: Float,
+        @required
+        longitude: Float,
+    }
 
-            @required
-            longitude: Float,
-        }
-
-        // "error" is a trait that is used to specialize
-        // a structure as an error.
-        @error("client")
-        structure NoSuchResource {
-            @required
-            resourceType: String
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#GetCity": {
-                    "type": "operation",
-                    "input": {
-                        "target": "example.weather#GetCityInput"
-                    },
-                    "output": {
-                        "target": "example.weather#GetCityOutput"
-                    },
-                    "errors": [
-                        {
-                            "target": "example.weather#NoSuchResource"
-                        }
-                    ]
-                },
-                "example.weather#GetCityInput": {
-                    "type": "structure",
-                    "members": {
-                        "cityId": {
-                            "target": "example.weather#CityId",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#input": true
-                    }
-                },
-                "example.weather#GetCityOutput": {
-                    "type": "structure",
-                    "members": {
-                        "name": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        },
-                        "coordinates": {
-                            "target": "example.weather#CityCoordinates",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#output": true
-                    }
-                },
-                "example.weather#CityCoordinates": {
-                    "type": "structure",
-                    "members": {
-                        "latitude": {
-                            "target": "smithy.api#Float",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        },
-                        "longitude": {
-                            "target": "smithy.api#Float",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    }
-                },
-                "example.weather#NoSuchResource": {
-                    "type": "structure",
-                    "members": {
-                        "resourceType": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#error": "client"
-                    }
-                }
-            }
-        }
+    // "error" is a trait that is used to specialize
+    // a structure as an error.
+    @error("client")
+    structure NoSuchResource {
+        @required
+        resourceType: String
+    }
 
 And define the operation used to "read" a ``Forecast``.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    @readonly
+    operation GetForecast {
+        input: GetForecastInput,
+        output: GetForecastOutput
+    }
 
-        @readonly
-        operation GetForecast {
-            input: GetForecastInput,
-            output: GetForecastOutput
-        }
+    // "cityId" provides the only identifier for the resource since
+    // a Forecast doesn't have its own.
+    @input
+    structure GetForecastInput {
+        @required
+        cityId: CityId,
+    }
 
-        // "cityId" provides the only identifier for the resource since
-        // a Forecast doesn't have its own.
-        @input
-        structure GetForecastInput {
-            @required
-            cityId: CityId,
-        }
-
-        @output
-        structure GetForecastOutput {
-            chanceOfRain: Float
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#GetForecast": {
-                    "type": "operation",
-                    "input": {
-                        "target": "example.weather#GetForecastInput"
-                    },
-                    "output": {
-                        "target": "example.weather#GetForecastOutput"
-                    },
-                    "traits": {
-                        "smithy.api#readonly": true
-                    }
-                },
-                "example.weather#GetForecastInput": {
-                    "type": "structure",
-                    "members": {
-                        "cityId": {
-                            "target": "example.weather#CityId",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#input": true
-                    }
-                },
-                "example.weather#GetForecastOutput": {
-                    "type": "structure",
-                    "members": {
-                        "chanceOfRain": {
-                            "target": "smithy.api#Float",
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#output": true
-                    }
-                }
-            }
-        }
+    @output
+    structure GetForecastOutput {
+        chanceOfRain: Float
+    }
 
 .. admonition:: Review
     :class: tip
@@ -527,149 +298,54 @@ is a :ref:`collection operation <collection-operations>`, and as such, MUST NOT
 bind the identifier of a ``City`` to its input structure; we are listing
 cities, so there's no way we could provide a ``City`` identifier.
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    /// Provides weather forecasts.
+    @paginated(inputToken: "nextToken", outputToken: "nextToken",
+               pageSize: "pageSize")
+    service Weather {
+        version: "2006-03-01",
+        resources: [City]
+    }
 
-        /// Provides weather forecasts.
-        @paginated(inputToken: "nextToken", outputToken: "nextToken",
-                   pageSize: "pageSize")
-        service Weather {
-            version: "2006-03-01",
-            resources: [City]
-        }
+    // The paginated trait indicates that the operation may
+    // return truncated results. Applying this trait to the service
+    // sets default pagination configuration settings on each operation.
+    @paginated(items: "items")
+    @readonly
+    operation ListCities {
+        input: ListCitiesInput,
+        output: ListCitiesOutput
+    }
 
-        // The paginated trait indicates that the operation may
-        // return truncated results. Applying this trait to the service
-        // sets default pagination configuration settings on each operation.
-        @paginated(items: "items")
-        @readonly
-        operation ListCities {
-            input: ListCitiesInput,
-            output: ListCitiesOutput
-        }
+    @input
+    structure ListCitiesInput {
+        nextToken: String,
+        pageSize: Integer
+    }
 
-        @input
-        structure ListCitiesInput {
-            nextToken: String,
-            pageSize: Integer
-        }
+    @output
+    structure ListCitiesOutput {
+        nextToken: String,
 
-        @output
-        structure ListCitiesOutput {
-            nextToken: String,
+        @required
+        items: CitySummaries,
+    }
 
-            @required
-            items: CitySummaries,
-        }
+    // CitySummaries is a list of CitySummary structures.
+    list CitySummaries {
+        member: CitySummary
+    }
 
-        // CitySummaries is a list of CitySummary structures.
-        list CitySummaries {
-            member: CitySummary
-        }
+    // CitySummary contains a reference to a City.
+    @references([{resource: City}])
+    structure CitySummary {
+        @required
+        cityId: CityId,
 
-        // CitySummary contains a reference to a City.
-        @references([{resource: City}])
-        structure CitySummary {
-            @required
-            cityId: CityId,
-
-            @required
-            name: String,
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#Weather": {
-                    "type": "service",
-                    "version": "2006-03-01",
-                    "resources": [
-                        {
-                            "target": "example.weather#City"
-                        }
-                    ],
-                    "traits": {
-                        "smithy.api#paginated": {
-                            "inputToken": "nextToken",
-                            "outputToken": "nextToken",
-                            "pageSize": "pageSize"
-                        }
-                    }
-                },
-                "example.weather#ListCities": {
-                    "type": "operation",
-                    "input": {
-                        "target": "example.weather#ListCitiesInput"
-                    },
-                    "output": {
-                        "target": "example.weather#ListCitiesOutput"
-                    },
-                    "traits": {
-                        "smithy.api#readonly": true,
-                        "smithy.api#paginated": {
-                            "items": "items"
-                        }
-                    }
-                },
-                "example.weather#ListCitiesInput": {
-                    "type": "structure",
-                    "members": {
-                        "nextToken": {
-                            "target": "smithy.api#String"
-                        },
-                        "pageSize": {
-                            "target": "smithy.api#Integer"
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#input": true
-                    }
-                },
-                "example.weather#ListCitiesOutput": {
-                    "type": "structure",
-                    "members": {
-                        "nextToken": {
-                            "target": "smithy.api#String"
-                        },
-                        "items": {
-                            "target": "example.weather#CitySummaries",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#output": true
-                    }
-                },
-                "example.weather#CitySummaries": {
-                    "type": "list",
-                    "member": {
-                        "target": "example.weather#CitySummary"
-                    }
-                },
-                "example.weather#CitySummary": {
-                    "type": "structure",
-                    "members": {
-                        "cityId": {
-                            "target": "example.weather#CityId",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        },
-                        "name": {
-                            "target": "smithy.api#String",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        @required
+        name: String,
+    }
 
 The ``ListCities`` operation is :ref:`paginated <paginated-trait>`, meaning
 the results of invoking the operation can be truncated, requiring subsequent
@@ -703,87 +379,32 @@ property. The following operation gets the current time from the ``Weather``
 service.
 
 
-.. tabs::
+.. code-block:: smithy
 
-    .. code-tab:: smithy
+    /// Provides weather forecasts.
+    @paginated(inputToken: "nextToken", outputToken: "nextToken",
+               pageSize: "pageSize")
+    service Weather {
+        version: "2006-03-01",
+        resources: [City],
+        operations: [GetCurrentTime]
+    }
 
-        /// Provides weather forecasts.
-        @paginated(inputToken: "nextToken", outputToken: "nextToken",
-                   pageSize: "pageSize")
-        service Weather {
-            version: "2006-03-01",
-            resources: [City],
-            operations: [GetCurrentTime]
-        }
+    @readonly
+    operation GetCurrentTime {
+        input: GetCurrentTimeInput,
+        output: GetCurrentTimeOutput
+    }
 
-        @readonly
-        operation GetCurrentTime {
-            input: GetCurrentTimeInput,
-            output: GetCurrentTimeOutput
-        }
+    @input
+    structure GetCurrentTimeInput {}
 
-        @input
-        structure GetCurrentTimeInput {}
+    @output
+    structure GetCurrentTimeOutput {
+        @required
+        time: Timestamp
+    }
 
-        @output
-        structure GetCurrentTimeOutput {
-            @required
-            time: Timestamp
-        }
-
-    .. code-tab:: json
-
-        {
-            "smithy": "1.0",
-            "shapes": {
-                "example.weather#Weather": {
-                    "type": "service",
-                    "version": "2006-03-01",
-                    "resources": [
-                        {
-                            "target": "example.weather#City"
-                        }
-                    ],
-                    "operations": [
-                        {
-                            "target": "example.weather#GetCurrentTime"
-                        }
-                    ]
-                },
-                "example.weather#GetCurrentTime": {
-                    "type": "operation",
-                    "input": {
-                        "target": "example.weather#GetCurrentTimeInput"
-                    },
-                    "output": {
-                        "target": "example.weather#GetCurrentTimeOutput"
-                    },
-                    "traits": {
-                        "smithy.api#readonly": true
-                    }
-                },
-                "example.weather#GetCurrentTimeInput": {
-                    "type": "structure",
-                    "traits": {
-                        "smithy.api#input": true
-                    }
-                }
-                "example.weather#GetCurrentTimeOutput": {
-                    "type": "structure",
-                    "members": {
-                        "time": {
-                            "target": "smithy.api#Timestamp",
-                            "traits": {
-                                "smithy.api#required": true
-                            }
-                        }
-                    },
-                    "traits": {
-                        "smithy.api#output": true
-                    }
-                }
-            }
-        }
 
 Building the Model
 ==================

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/InputTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/InputTrait.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class InputTrait extends AnnotationTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.api#input");
+
+    public InputTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public InputTrait() {
+        this(Node.objectNode());
+    }
+
+    public static final class Provider extends AnnotationTrait.Provider<InputTrait> {
+        public Provider() {
+            super(ID, InputTrait::new);
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/OutputTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/OutputTrait.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class OutputTrait extends AnnotationTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.api#output");
+
+    public OutputTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public OutputTrait() {
+        this(Node.objectNode());
+    }
+
+    public static final class Provider extends AnnotationTrait.Provider<OutputTrait> {
+        public Provider() {
+            super(ID, OutputTrait::new);
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/OperationInputOutputValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/OperationInputOutputValidator.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.validators;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Relationship;
+import software.amazon.smithy.model.neighbor.RelationshipType;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.InputTrait;
+import software.amazon.smithy.model.traits.OutputTrait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationUtils;
+
+/**
+ * Detects when a structure marked with the input trait or output
+ * trait is used in other contexts than input or output or reused
+ * by multiple operations.
+ */
+public final class OperationInputOutputValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        NeighborProvider reverseProvider = NeighborProviderIndex.of(model).getReverseProvider();
+        validateInputOutput(model.getShapesWithTrait(InputTrait.class), reverseProvider, events, "input", "output");
+        validateInputOutput(model.getShapesWithTrait(OutputTrait.class), reverseProvider, events, "output", "input");
+        return events;
+    }
+
+    private void validateInputOutput(
+            Set<Shape> shapes,
+            NeighborProvider reverseProvider,
+            List<ValidationEvent> events,
+            String descriptor,
+            String invalid
+    ) {
+        for (Shape shape : shapes) {
+            Set<ShapeId> operations = new HashSet<>();
+            for (Relationship rel : reverseProvider.getNeighbors(shape)) {
+                String relName = rel.getSelectorLabel().orElse("");
+                if (relName.equals(descriptor)) {
+                    // Ensure there's one input/output target.
+                    operations.add(rel.getShape().getId());
+                    // Make sure the operation name is part of the target shape ID.
+                    if (!rel.getNeighborShapeId().getName().startsWith(rel.getShape().getId().getName())) {
+                        events.add(emitBadInputOutputName(rel.getShape(), descriptor, rel.getNeighborShapeId()));
+                    }
+                } else if (relName.equals(invalid)) {
+                    // Input shouldn't reference output, and vice versa.
+                    events.add(emitInvalidOperationBinding(rel.getShape(), descriptor, invalid));
+                } else if (rel.getRelationshipType() == RelationshipType.MEMBER_TARGET) {
+                    // Members can't target shapes marked with @input or @output.
+                    events.add(emitInvalidMemberRef(rel.getShape().asMemberShape().get(), descriptor));
+                }
+            }
+
+            // Only a single shape can target an @input|@output shape.
+            if (operations.size() > 1) {
+                events.add(emitMultipleUses(shape, descriptor, operations));
+            }
+        }
+    }
+
+    private ValidationEvent emitInvalidOperationBinding(Shape operation, String property, String invalid) {
+        return error(operation, "Operation " + property + " cannot target structures marked with the @"
+                                + invalid + " trait");
+    }
+
+    private ValidationEvent emitInvalidMemberRef(MemberShape member, String trait) {
+        return error(member, "This member illegally references a structure marked with the @"
+                             + trait + " trait: " + member.getTarget());
+    }
+
+    private ValidationEvent emitBadInputOutputName(Shape operation, String property, ShapeId target) {
+        return error(operation, String.format(
+                        "The %s of this operation should target a shape that starts with the operation's name, '%s', "
+                        + "but the targeted shape is `%s`", property, operation.getId().getName(), target));
+    }
+
+    private ValidationEvent emitMultipleUses(Shape shape, String descriptor, Set<ShapeId> operations) {
+        return error(shape, "This shape is marked with the @" + descriptor + " trait but is used illegally by "
+                            + "multiple operations: " + ValidationUtils.tickedList(operations));
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -30,12 +30,14 @@ software.amazon.smithy.model.traits.HttpTrait$Provider
 software.amazon.smithy.model.traits.IdempotencyTokenTrait$Provider
 software.amazon.smithy.model.traits.IdempotentTrait$Provider
 software.amazon.smithy.model.traits.IdRefTrait$Provider
+software.amazon.smithy.model.traits.InputTrait$Provider
 software.amazon.smithy.model.traits.InternalTrait$Provider
 software.amazon.smithy.model.traits.JsonNameTrait$Provider
 software.amazon.smithy.model.traits.LengthTrait$Provider
 software.amazon.smithy.model.traits.MediaTypeTrait$Provider
 software.amazon.smithy.model.traits.NoReplaceTrait$Provider
 software.amazon.smithy.model.traits.OptionalAuthTrait$Provider
+software.amazon.smithy.model.traits.OutputTrait$Provider
 software.amazon.smithy.model.traits.PaginatedTrait$Provider
 software.amazon.smithy.model.traits.PatternTrait$Provider
 software.amazon.smithy.model.traits.PrivateTrait$Provider

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -20,6 +20,7 @@ software.amazon.smithy.model.validation.validators.HttpUriConflictValidator
 software.amazon.smithy.model.validation.validators.LengthTraitValidator
 software.amazon.smithy.model.validation.validators.MediaTypeValidator
 software.amazon.smithy.model.validation.validators.NoInlineDocumentSupportValidator
+software.amazon.smithy.model.validation.validators.OperationInputOutputValidator
 software.amazon.smithy.model.validation.validators.PaginatedTraitValidator
 software.amazon.smithy.model.validation.validators.PrivateAccessValidator
 software.amazon.smithy.model.validation.validators.RangeTraitValidator

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -817,3 +817,13 @@ structure httpChecksumProperty {
     },
 ])
 string HttpChecksumLocation
+
+/// Specializes a structure for use only as the input of a single operation.
+@trait(selector: "structure", conflicts: [output, error])
+@tags(["diff.error.const"])
+structure input {}
+
+/// Specializes a structure for use only as the output of a single operation.
+@trait(selector: "structure", conflicts: [input, error])
+@tags(["diff.error.const"])
+structure output {}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/InputTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/InputTraitTest.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.model.traits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class InputTraitTest {
+
+    @Test
+    public void loadsTrait() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#input"), ShapeId.from("ns.qux#foo"), Node.objectNode());
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(InputTrait.class));
+        assertThat(trait.get().toNode(), equalTo(Node.objectNode()));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/OutputTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/OutputTraitTest.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.model.traits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class OutputTraitTest {
+
+    @Test
+    public void loadsTrait() {
+        TraitFactory provider = TraitFactory.createServiceFactory();
+        Optional<Trait> trait = provider.createTrait(
+                ShapeId.from("smithy.api#output"), ShapeId.from("ns.qux#foo"), Node.objectNode());
+
+        assertTrue(trait.isPresent());
+        assertThat(trait.get(), instanceOf(OutputTrait.class));
+        assertThat(trait.get().toNode(), equalTo(Node.objectNode()));
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-input-output-operation-bindings.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-input-output-operation-bindings.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#GetFoo: Operation input cannot target structures marked with the @output trait | OperationInputOutput
+[ERROR] smithy.example#GetFoo: Operation output cannot target structures marked with the @input trait | OperationInputOutput

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-input-output-operation-bindings.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-input-output-operation-bindings.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooOutput,
+    output: GetFooInput // these are flipped!
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-member-target-to-input-output.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-member-target-to-input-output.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#BadStructure$i: This member illegally references a structure marked with the @input trait: smithy.example#GetFooInput | OperationInputOutput
+[ERROR] smithy.example#BadStructure$o: This member illegally references a structure marked with the @output trait: smithy.example#GetFooOutput | OperationInputOutput

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-member-target-to-input-output.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-member-target-to-input-output.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+namespace smithy.example
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}
+
+structure BadStructure {
+    i: GetFooInput,
+    o: GetFooOutput
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-multiple-operations-same-shape.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-multiple-operations-same-shape.errors
@@ -1,0 +1,4 @@
+[ERROR] smithy.example#GetFoo2: The input of this operation should target a shape that starts with the operation's name, 'GetFoo2', but the targeted shape is `smithy.example#GetFooInput` | OperationInputOutput
+[ERROR] smithy.example#GetFoo2: The output of this operation should target a shape that starts with the operation's name, 'GetFoo2', but the targeted shape is `smithy.example#GetFooOutput` | OperationInputOutput
+[ERROR] smithy.example#GetFooInput: This shape is marked with the @input trait but is used illegally by multiple operations: `smithy.example#GetFoo`, `smithy.example#GetFoo2` | OperationInputOutput
+[ERROR] smithy.example#GetFooOutput: This shape is marked with the @output trait but is used illegally by multiple operations: `smithy.example#GetFoo`, `smithy.example#GetFoo2` | OperationInputOutput

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-multiple-operations-same-shape.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-multiple-operations-same-shape.errors
@@ -1,4 +1,4 @@
-[ERROR] smithy.example#GetFoo2: The input of this operation should target a shape that starts with the operation's name, 'GetFoo2', but the targeted shape is `smithy.example#GetFooInput` | OperationInputOutput
-[ERROR] smithy.example#GetFoo2: The output of this operation should target a shape that starts with the operation's name, 'GetFoo2', but the targeted shape is `smithy.example#GetFooOutput` | OperationInputOutput
+[WARNING] smithy.example#GetFoo2: The input of this operation should target a shape that starts with the operation's name, 'GetFoo2', but the targeted shape is `smithy.example#GetFooInput` | OperationInputOutputName
+[WARNING] smithy.example#GetFoo2: The output of this operation should target a shape that starts with the operation's name, 'GetFoo2', but the targeted shape is `smithy.example#GetFooOutput` | OperationInputOutputName
 [ERROR] smithy.example#GetFooInput: This shape is marked with the @input trait but is used illegally by multiple operations: `smithy.example#GetFoo`, `smithy.example#GetFoo2` | OperationInputOutput
 [ERROR] smithy.example#GetFooOutput: This shape is marked with the @output trait but is used illegally by multiple operations: `smithy.example#GetFoo`, `smithy.example#GetFoo2` | OperationInputOutput

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-multiple-operations-same-shape.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/invalid-multiple-operations-same-shape.smithy
@@ -1,0 +1,18 @@
+$version: "1.0"
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+operation GetFoo2 {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/valid-input-output-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/input-output-traits/valid-input-output-traits.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}


### PR DESCRIPTION
These traits allow shapes to be specialized as only acting as input or
output for a single operation. This will make it easier to generate code
from Smithy models, and we will be able to give more relaxed backward
compatibility semantics to structures that are marked as `@input`
structures.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
