### PR TITLE
docs: delete unnecessary condition on URI path labels

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -199,7 +199,6 @@ capture path segments.
 Labels MUST adhere to the following constraints:
 
 #. Labels MUST NOT appear in the query string.
-#. Labels MUST NOT appear in the fragment (e.g. "/foo#{bar}" is invalid).
 #. Each label MUST span an entire path segment (e.g., "/{foo}/bar" is valid,
    and "/{foo}bar" is invalid).
 


### PR DESCRIPTION
The spec says that URI patterns 'MUST NOT contain a fragment (i.e.
"#")'. Therefore, saying later that 'Labels MUST NOT appear in the
fragment' is confusing and redundant.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
