### PR TITLE
Refactor queued projections

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionTransformer.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionTransformer.java
@@ -16,11 +16,13 @@
 package software.amazon.smithy.build;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Creates a model transformer by name.
@@ -41,6 +43,18 @@ public interface ProjectionTransformer {
      * @throws IllegalArgumentException if the arguments are invalid.
      */
     Model transform(TransformContext context);
+
+    /**
+     * Allows the composition of projections by returning additional
+     * projections to run after the current one.
+     *
+     * @param context Transformation context.
+     * @return a collection of named projections to run.
+     * @throws IllegalArgumentException if the arguments are invalid.
+     */
+    default List<String> getAdditionalProjections(TransformContext context) {
+        return ListUtils.of();
+    }
 
     /**
      * Creates a {@code ProjectionTransformer} factory function using SPI

--- a/smithy-build/src/main/java/software/amazon/smithy/build/TransformContext.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/TransformContext.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.build;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -46,7 +45,6 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
     private final Set<Path> sources;
     private final String projectionName;
     private final ModelTransformer transformer;
-    private final List<String> queuedProjections = new ArrayList<>();
     private final List<ValidationEvent> originalModelValidationEvents;
 
     private TransformContext(Builder builder) {
@@ -75,7 +73,6 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
                 .sources(sources)
                 .projectionName(projectionName)
                 .transformer(transformer)
-                .queuedProjections(queuedProjections)
                 .originalModelValidationEvents(originalModelValidationEvents);
     }
 
@@ -143,33 +140,6 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
     }
 
     /**
-     * Gets the queue of projections that need to be applied.
-     *
-     * <p>This queue can be added to from transformers to invoke
-     * other projections. It's used by the apply transform, but is
-     * generic enough to be used by other transforms.
-     *
-     * @return Returns the queue of projections to apply.
-     */
-    public Collection<String> getQueuedProjections() {
-        return queuedProjections;
-    }
-
-    /**
-     * Adds a projection to the queue of projections to apply to the
-     * model.
-     *
-     * @param projection Projection to enqueue.
-     */
-    public void enqueueProjection(String projection) {
-        if (projection.equals(getProjectionName())) {
-            throw new SmithyBuildException("Cannot recursively apply the same projection: " + projection);
-        }
-
-        queuedProjections.add(projection);
-    }
-
-    /**
      * Gets an immutable list of {@link ValidationEvent}s that were
      * encountered when loading the source model.
      *
@@ -191,7 +161,6 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
         private String projectionName = "source";
         private ModelTransformer transformer;
         private final List<ValidationEvent> originalModelValidationEvents = new ArrayList<>();
-        private final List<String> queuedProjections = new ArrayList<>();
 
         private Builder() {}
 
@@ -233,12 +202,6 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
         public Builder originalModelValidationEvents(List<ValidationEvent> originalModelValidationEvents) {
             this.originalModelValidationEvents.clear();
             this.originalModelValidationEvents.addAll(originalModelValidationEvents);
-            return this;
-        }
-
-        public Builder queuedProjections(Collection<String> queuedProjections) {
-            this.queuedProjections.clear();
-            this.queuedProjections.addAll(queuedProjections);
             return this;
         }
     }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/Apply.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/Apply.java
@@ -16,8 +16,11 @@
 package software.amazon.smithy.build.transforms;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
 import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Applies transforms of other projections.
@@ -64,12 +67,21 @@ public final class Apply extends BackwardCompatHelper<Apply.Config> {
         return "projections";
     }
 
+    // Override this directly as apply will never transform the model,
+    // so there's no reason to even deserialize the configuration for this
     @Override
-    protected Model transformWithConfig(TransformContext context, Config config) {
-        for (String projection : config.getProjections()) {
-            context.enqueueProjection(projection);
-        }
-
+    public Model transform(TransformContext context) {
         return context.getModel();
     }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        throw new UnsupportedOperationException("transform(TransformContext) should be called directly.");
+    }
+
+    @Override
+    protected Optional<BiFunction<TransformContext, Config, List<String>>> getAdditionalProjectionsFunction() {
+        return Optional.of((context, config) -> ListUtils.copyOf(config.getProjections()));
+    }
+
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ConfigurableProjectionTransformer.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ConfigurableProjectionTransformer.java
@@ -15,10 +15,14 @@
 
 package software.amazon.smithy.build.transforms;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
 import software.amazon.smithy.build.ProjectionTransformer;
 import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * An abstract class used to more easily implement a Smithy build projection
@@ -30,6 +34,10 @@ import software.amazon.smithy.model.node.NodeMapper;
  *
  * <p><strong>If your build transformer requires configuration, then you typically
  * should just extend this class.</strong></p>
+ *
+ * Note: if you override {@link #getAdditionalProjectionsFunction()} and
+ * do not override {@link #transform(TransformContext)}, the configuration for
+ * your transformer will be deserialized twice during execution.
  *
  * @param <T> The configuration setting type (e.g., a POJO).
  */
@@ -59,6 +67,15 @@ public abstract class ConfigurableProjectionTransformer<T> implements Projection
         return transformWithConfig(context, config);
     }
 
+    @Override
+    public List<String> getAdditionalProjections(TransformContext context) {
+        return getAdditionalProjectionsFunction().map(fn -> {
+            NodeMapper mapper = new NodeMapper();
+            T config = mapper.deserialize(context.getSettings(), getConfigType());
+            return fn.apply(context, config);
+        }).orElseGet(ListUtils::of);
+    }
+
     /**
      * Executes the transform using the deserialized configuration object.
      *
@@ -67,4 +84,13 @@ public abstract class ConfigurableProjectionTransformer<T> implements Projection
      * @return Returns the transformed model.
      */
     protected abstract Model transformWithConfig(TransformContext context, T config);
+
+    /**
+     * @return an Optional of either a BiFunction that returns the additional
+     *         projections to run after this one, or empty to indicate this
+     *         projection will never compose other ones.
+     */
+    protected Optional<BiFunction<TransformContext, T, List<String>>> getAdditionalProjectionsFunction() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
*Description of changes:*
TransformContext's queued projections were a side effect of transformer
execution, and TransformContext instances were not maintained throughout
projection execution. In particular, BackwardCompatHelper would create a new
instance of TransformContext for its subclasses, but relying on a side effect
of transformation was dangerous in any case.

This adds a new method to ProjectionTransformer that explicitly models
composition of transforms by returning the names of projections to be run
subsequently. It is defaulted to an empty list.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
