### PR TITLE
Clarify doc about sources plugin

### DIFF
--- a/docs/source/1.0/guides/building-models/build-config.rst
+++ b/docs/source/1.0/guides/building-models/build-config.rst
@@ -1446,14 +1446,15 @@ Smithy models contained within the JAR are copied as a source model while the
 JAR itself is not copied. If there are no source models, an empty manifest is
 created.
 
-When applying a projection, a new model file is created that contains only
-the shapes, trait definitions, and metadata that were defined in a source
-model *and* all of the newly added shapes, traits, and metadata.
+When building projections other than ``source``, a new model file is created
+that contains only the shapes, trait definitions, and metadata that were
+defined in a source model *and* all of the newly added shapes, traits, and
+metadata.
 
 The manifest file is a newline (``\n``) separated file that contains the
 relative path from the manifest file to each model file created by the
 sources plugin. Lines that start with a number sign (#) are comments and are
 ignored. A Smithy manifest file is stored in a JAR as ``META-INF/smithy/manifest``.
-All model names referenced by the manifest are relative to ``META-INF/smithy/``.
+All model files referenced by the manifest are relative to ``META-INF/smithy/``.
 
 .. _Java SPI: https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html


### PR DESCRIPTION
* All model _names_ referenced by the manifest, may be confused with shape names. All model _files_ seems clearer.
* _building_ a projection seems clearer than _applying_ a projection. And matches the earlier sentence - _When building the source projection_.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
