### PR TITLE
Scope conflict detection more narrowly in JSONSchema conversion

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
@@ -189,6 +189,12 @@
                         "smithy.api#httpQuery": "version",
                         "smithy.api#required": {}
                     }
+                },
+                "connectionType": {
+                    "target": "smithy.example#ConnectionType",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-connection-type"
+                    }
                 }
             }
         },
@@ -201,6 +207,21 @@
                         "smithy.api#httpHeader": "requestId"
                     }
                 }
+            }
+        },
+        "smithy.example#ConnectionType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "a",
+                        "name": "A"
+                    },
+                    {
+                        "value": "c",
+                        "name": "C"
+                    }
+                ]
             }
         }
     }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
@@ -28,6 +28,13 @@
               "nullable": true
             },
             "required": true
+          },
+          {
+            "name": "x-amz-connection-type",
+            "in": "header",
+            "schema": {
+              "$ref": "#/components/schemas/ConnectionType"
+            }
           }
         ],
         "responses": {
@@ -128,6 +135,13 @@
               "nullable": true
             },
             "required": true
+          },
+          {
+            "name": "x-amz-connection-type",
+            "in": "header",
+            "schema": {
+              "$ref": "#/components/schemas/ConnectionType"
+            }
           }
         ],
         "responses": {
@@ -201,5 +215,15 @@
       }
     }
   },
-  "components": { }
+  "components": {
+    "schemas": {
+      "ConnectionType": {
+        "type": "string",
+        "enum": [
+          "a",
+          "c"
+        ]
+      }
+    }
+  }
 }

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/CfnConfig.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/CfnConfig.java
@@ -76,6 +76,10 @@ public final class CfnConfig extends JsonSchemaConfig {
         // https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L210
         // https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L166
         super.setUnionStrategy(UnionStrategy.ONE_OF);
+
+        // @cfnResource's additionalSchemas property references shapes that aren't in the service closure
+        // so conversions must be able to reference those shapes
+        super.setEnableOutOfServiceReferences(true);
     }
 
     @Override

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -109,6 +109,7 @@ public class JsonSchemaConfig {
     private final NodeMapper nodeMapper = new NodeMapper();
     private ShapeId service;
     private boolean supportNonNumericFloats = false;
+    private boolean enableOutOfServiceReferences = false;
 
     public JsonSchemaConfig() {
         nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
@@ -365,5 +366,22 @@ public class JsonSchemaConfig {
      */
     public void setSupportNonNumericFloats(boolean supportNonNumericFloats) {
         this.supportNonNumericFloats = supportNonNumericFloats;
+    }
+
+    public boolean isEnableOutOfServiceReferences() {
+        return enableOutOfServiceReferences;
+    }
+
+    /**
+     * Set to true to enable references to shapes outside the service closure.
+     *
+     * Setting this to true means that all the shapes in the model must not conflict, whereas
+     * leaving it at the default, false, means that only the shapes connected to the configured
+     * service via {@link #setService(ShapeId)} must not conflict.
+     *
+     * @param enableOutOfServiceReferences true if out-of-service references should be allowed. default: false
+     */
+    public void setEnableOutOfServiceReferences(boolean enableOutOfServiceReferences) {
+        this.enableOutOfServiceReferences = enableOutOfServiceReferences;
     }
 }

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/multiple-closures-with-conflicting-shapes.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/multiple-closures-with-conflicting-shapes.json
@@ -1,0 +1,81 @@
+{
+  "smithy": "1.0",
+  "shapes": {
+    "com.foo#ServiceA": {
+      "type": "service",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "com.foo#OperationA"
+        }
+      ]
+    },
+    "com.foo#OperationA": {
+      "type": "operation",
+      "input": {
+        "target": "com.foo#StructureA"
+      }
+    },
+    "com.bar#ServiceB": {
+      "type": "service",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "com.bar#OperationB"
+        }
+      ]
+    },
+    "com.bar#OperationB": {
+      "type": "operation",
+      "input": {
+        "target": "com.bar#StructureB"
+      }
+    },
+    "com.foo#StructureA": {
+      "type": "structure",
+      "members": {
+        "a": {
+          "target": "com.foo#ConflictString"
+        }
+      }
+    },
+    "com.foo#ConflictString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": [
+          {
+            "value": "y",
+            "name": "Y"
+          },
+          {
+            "value": "z",
+            "name": "Z"
+          }
+        ]
+      }
+    },
+    "com.bar#StructureB": {
+      "type": "structure",
+      "members": {
+        "a": {
+          "target": "com.bar#ConflictString"
+        }
+      }
+    },
+    "com.bar#ConflictString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": [
+          {
+            "value": "a",
+            "name": "A"
+          },
+          {
+            "value": "b",
+            "name": "B"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*
When creating JSONSchema from a Smithy model, any two conflicting shapes with
the same unqualified name would cause the process to fail, when in most cases
the conflict is only important if it occurs between two shapes connected to
the service in question.

CloudFormation resource schema generation must consider additional shapes
via @cfnResource's additionalSchemas property. This property is read by
the CFN index and subsequently discarded, so I simply disabled the more
narrowly-scoped conflict detection for CFN specifically. This can be removed
once shapes can be connected directly to a service.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
