### PR TITLE
Add tests for quoted strings in headers

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -47,6 +47,21 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         }
     },
     {
+        id: "RestJsonInputAndOutputWithQuotedStringHeaders",
+        documentation: "Tests requests with string list header bindings that require quoting",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-StringList": """
+            "b,c","\"def\"",a"""
+        },
+        body: "",
+        params: {
+            headerStringList: ["b,c", "\"def\"", "a"]
+        }
+    },
+    {
         id: "RestJsonInputAndOutputWithNumericHeaders",
         documentation: "Tests requests with numeric header bindings",
         protocol: restJson1,
@@ -97,7 +112,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         body: "",
         params: {
@@ -188,6 +203,19 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         }
     },
     {
+        id: "RestJsonInputAndOutputWithQuotedStringHeaders",
+        documentation: "Tests responses with string list header bindings that require quoting",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "X-StringList": """
+            "b,c","\"def\"",a"""
+        },
+        params: {
+            headerStringList: ["a", "b,c", "\"def\""]
+        }
+    },
+    {
         id: "RestJsonInputAndOutputWithNumericHeaders",
         documentation: "Tests responses with numeric header bindings",
         protocol: restJson1,
@@ -233,7 +261,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         params: {
             headerTimestampList: [1576540098, 1576540098]


### PR DESCRIPTION
*Description of changes:*
RFC 7230 sec 3.2.6 defines header values as potentially quoted strings, which
makes commas in header values unambiguous. It's also the only way to escape a
reserved character. This adds a test for list values with a comma and for list
values with escaped double quotes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
