### PR TITLE
Correct documentation for @length and @auth traits

### DIFF
--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -327,7 +327,7 @@ to services and operations:
 * ``ServiceWithAuthTrait`` is annotated with the ``auth`` trait and binds two
   operations:
 
-  * ``OperationC`` is not annoated with the ``auth`` trait and inherits all
+  * ``OperationC`` is not annotated with the ``auth`` trait and inherits all
     of the authentication schemes applied via the ``auth`` trait on the
     service.
 

--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -331,7 +331,7 @@ to services and operations:
     of the authentication schemes applied via the ``auth`` trait on the
     service.
 
-  * ``OperationD`` is annoated with the ``auth`` defines an explicit list of
+  * ``OperationD`` is annotated with the ``auth`` defines an explicit list of
     authentication schemes.
 
 .. tabs::
@@ -377,7 +377,7 @@ to services and operations:
         // supports are: httpBasicAuth, httpDigestAuth
         operation OperationC {}
 
-        // This operation not have the @auth trait and is bound to a service
+        // This operation has the @auth trait and is bound to a service
         // with the @auth trait. The effective set of authentication schemes it
         // supports are: httpBearerAuth
         @auth([httpBearerAuth])

--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -305,19 +305,34 @@ Value type
     shape.
 
 Operations that are not annotated with the ``auth`` trait inherit the ``auth``
-trait of the service they are bound to, and if the operation is not annotated
-with the ``auth`` trait, then the operation is expected to support each of
-the :ref:`authentication scheme traits <authDefinition-trait>` applied to the
+trait of the service they are bound to. If the operation is not annotated with
+the ``auth`` trait, and the service it is bound to is also not annotated with
+the ``auth`` trait, then the operation is expected to support each of the
+:ref:`authentication scheme traits <authDefinition-trait>` applied to the
 service. Each entry in the ``auth`` trait is a shape ID that MUST refer to an
 authentication scheme trait applied to the service in which it is bound.
 
-The following example defines two operations:
+The following example defines all combinations in which ``auth`` can be applied
+to services and operations:
 
-* OperationA defines an explicit list of the authentication schemes it
-  supports using the ``auth`` trait.
-* OperationB is not annotated with the ``auth`` trait, so the schemes
-  supported by this operation inherit all of the authentication schemes
-  applied to the service.
+* ``ServiceWithNoAuthTrait`` does not use the ``auth`` trait and binds two
+  operations:
+
+  * ``OperationA`` is not annoated with the ``auth`` trait and inherits all
+    of the authentication scheme applied to the service.
+
+  * ``OperationB`` is annoated with the ``auth`` defines an explicit list of
+    authentication schemes.
+
+* ``ServiceWithAuthTrait`` is annotated with the ``auth`` trait and binds two
+  operations:
+
+  * ``OperationC`` is not annoated with the ``auth`` trait and inherits all
+    of the authentication schemes applied via the ``auth`` trait on the
+    service.
+
+  * ``OperationD`` is annoated with the ``auth`` defines an explicit list of
+    authentication schemes.
 
 .. tabs::
 
@@ -325,47 +340,58 @@ The following example defines two operations:
 
         @httpBasicAuth
         @httpDigestAuth
-        @auth([httpBasicAuth])
-        service AuthenticatedService {
-            version: "2017-02-11",
-            operations: [OperationA, OperationB]
+        @httpBearerAuth
+        service ServiceWithNoAuthTrait {
+            version: "2020-01-29",
+            operations: [
+                OperationA,
+                OperationB
+            ]
         }
 
-        // This operation is configured to only support httpDigestAuth.
-        // It is not expected to support httpBasicAuth.
-        @auth([httpDigestAuth])
+        // This operation does not have the @auth trait and is bound to a service
+        // without the @auth trait. The effective set of authentication schemes it
+        // supports are: httpBasicAuth, httpDigestAuth and httpBearerAuth
         operation OperationA {}
 
-        // This operation defines no auth trait, so it is expected to
-        // support the effective authentication schemes of the service:
-        // httpBasicAuth and httpDigestAuth.
+        // This operation does have the @auth trait and is bound to a service
+        // without the @auth trait. The effective set of authentication schemes it
+        // supports are: httpDigestAuth.
+        @auth([httpDigestAuth])
         operation OperationB {}
+
+        @httpBasicAuth
+        @httpDigestAuth
+        @httpBearerAuth
+        @auth([httpBasicAuth, httpDigestAuth])
+        service ServiceWithAuthTrait {
+            version: "2020-01-29",
+            operations: [
+                OperationC,
+                OperationD
+            ]
+        }
+
+        // This operation does not have the @auth trait and is bound to a service
+        // with the @auth trait. The effective set of authentication schemes it
+        // supports are: httpBasicAuth, httpDigestAuth
+        operation OperationC {}
+
+        // This operation not have the @auth trait and is bound to a service
+        // with the @auth trait. The effective set of authentication schemes it
+        // supports are: httpBearerAuth
+        @auth([httpBearerAuth])
+        operation OperationD {}
 
     .. code-tab:: json
 
         {
             "smithy": "1.0",
             "shapes": {
-                "smithy.example#AuthenticatedService": {
-                    "type": "service",
-                    "version": "2017-02-11",
-                    "operations": [
-                        {
-                            "target": "smithy.example#OperationA"
-                        },
-                        {
-                            "target": "smithy.example#OperationB"
-                        }
-                    ],
-                    "traits": {
-                        "smithy.api#httpBasicAuth": {},
-                        "smithy.api#httpDigestAuth": {},
-                        "smithy.api#auth": [
-                            "smithy.api#httpBasicAuth"
-                        ]
-                    }
-                },
                 "smithy.example#OperationA": {
+                    "type": "operation"
+                },
+                "smithy.example#OperationB": {
                     "type": "operation",
                     "traits": {
                         "smithy.api#auth": [
@@ -373,8 +399,54 @@ The following example defines two operations:
                         ]
                     }
                 },
-                "smithy.example#OperationB": {
+                "smithy.example#OperationC": {
                     "type": "operation"
+                },
+                "smithy.example#OperationD": {
+                    "type": "operation",
+                    "traits": {
+                        "smithy.api#auth": [
+                            "smithy.api#httpBearerAuth"
+                        ]
+                    }
+                },
+                "smithy.example#ServiceWithAuthTrait": {
+                    "type": "service",
+                    "traits": {
+                        "smithy.api#auth": [
+                            "smithy.api#httpBasicAuth",
+                            "smithy.api#httpDigestAuth"
+                        ],
+                        "smithy.api#httpBasicAuth": {},
+                        "smithy.api#httpBearerAuth": {},
+                        "smithy.api#httpDigestAuth": {}
+                    },
+                    "version": "2020-01-29",
+                    "operations": [
+                        {
+                            "target": "smithy.example#OperationC"
+                        },
+                        {
+                            "target": "smithy.example#OperationD"
+                        }
+                    ]
+                },
+                "smithy.example#ServiceWithNoAuthTrait": {
+                    "type": "service",
+                    "traits": {
+                        "smithy.api#httpBasicAuth": {},
+                        "smithy.api#httpBearerAuth": {},
+                        "smithy.api#httpDigestAuth": {}
+                    },
+                    "version": "2020-01-29",
+                    "operations": [
+                        {
+                            "target": "smithy.example#OperationA"
+                        },
+                        {
+                            "target": "smithy.example#OperationB"
+                        }
+                    ]
                 }
             }
         }

--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -321,8 +321,8 @@ to services and operations:
   * ``OperationA`` is not annotated with the ``auth`` trait and inherits all
     of the authentication scheme applied to the service.
 
-  * ``OperationB`` is annoated with the ``auth`` defines an explicit list of
-    authentication schemes.
+  * ``OperationB`` is annotated with the ``auth`` trait and defines an explicit 
+    list of authentication schemes.
 
 * ``ServiceWithAuthTrait`` is annotated with the ``auth`` trait and binds two
   operations:
@@ -331,8 +331,8 @@ to services and operations:
     of the authentication schemes applied via the ``auth`` trait on the
     service.
 
-  * ``OperationD`` is annotated with the ``auth`` defines an explicit list of
-    authentication schemes.
+  * ``OperationD`` is annotated with the ``auth`` trait and defines an explicit 
+    list of authentication schemes.
 
 .. tabs::
 

--- a/docs/source/1.0/spec/core/auth-traits.rst
+++ b/docs/source/1.0/spec/core/auth-traits.rst
@@ -318,7 +318,7 @@ to services and operations:
 * ``ServiceWithNoAuthTrait`` does not use the ``auth`` trait and binds two
   operations:
 
-  * ``OperationA`` is not annoated with the ``auth`` trait and inherits all
+  * ``OperationA`` is not annotated with the ``auth`` trait and inherits all
     of the authentication scheme applied to the service.
 
   * ``OperationB`` is annoated with the ``auth`` defines an explicit list of

--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -327,7 +327,7 @@ Given the following model,
 Summary
     Constrains a shape to minimum and maximum number of elements or size.
 Trait selector
-    ``:test(list, map, string, blob, member > :is(list, map, string, blob))``
+    ``:test(collection, map, string, blob, member > :is(collection, map, string, blob))``
 
     *Any list, map, string, or blob; or a member that targets one of these shapes*
 Value type


### PR DESCRIPTION
Issue:
A couple of instances of incorrect documentation.

*Description of changes:*
1. Fixes the trait selector for `@length` documentation to match what is currently defined in the prelude.smithy.
2. Fixes the incorrect example for `@auth` traits and how effective authentication schemes are determined. This documentation has also been expanded to make it clearer.  These examples can be verified correct by applying the following patch:

```
diff --git a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/ServiceIndexTest.java b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/ServiceIndexTest.java
index c36e335eb..a7a50748f 100644
--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/ServiceIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/ServiceIndexTest.java
@@ -102,7 +102,7 @@ public class ServiceIndexTest {
         ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithNoAuthTrait"),
-                ShapeId.from("smithy.example#OperationWithNoAuthTrait"));
+                ShapeId.from("smithy.example#OperationA"));
 
         assertThat(auth.keySet(), hasSize(3));
         assertThat(auth, hasKey(HttpBasicAuthTrait.ID));
@@ -115,7 +115,7 @@ public class ServiceIndexTest {
         ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithAuthTrait"),
-                ShapeId.from("smithy.example#OperationWithNoAuthTrait"));
+                ShapeId.from("smithy.example#OperationC"));
 
         assertThat(auth.keySet(), hasSize(2));
         assertThat(auth, hasKey(HttpBasicAuthTrait.ID));
@@ -123,11 +123,22 @@ public class ServiceIndexTest {
     }
 
     @Test
-    public void getsAuthSchemesOfOperationWithAuthTrait() {
+    public void getsAuthSchemesOfOperationWithAuthTraitAndServiceWithAuthTrait() {
         ServiceIndex serviceIndex = ServiceIndex.of(model);
         Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
                 ShapeId.from("smithy.example#ServiceWithAuthTrait"),
-                ShapeId.from("smithy.example#OperationWithAuthTrait"));
+                ShapeId.from("smithy.example#OperationD"));
+
+        assertThat(auth.keySet(), hasSize(1));
+        assertThat(auth, hasKey(HttpBearerAuthTrait.ID));
+    }
+
+    @Test
+    public void getsAuthSchemesOfOperationWithAuthTraitAndServiceWithNoAuthTrait() {
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
+        Map<ShapeId, Trait> auth = serviceIndex.getEffectiveAuthSchemes(
+                ShapeId.from("smithy.example#ServiceWithNoAuthTrait"),
+                ShapeId.from("smithy.example#OperationB"));
 
         assertThat(auth.keySet(), hasSize(1));
         assertThat(auth, hasKey(HttpDigestAuthTrait.ID));
diff --git a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/service-index-finds-auth-schemes.smithy b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/service-index-finds-auth-schemes.smithy
index e95bc72d3..f5e5e236a 100644
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/service-index-finds-auth-schemes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/service-index-finds-auth-schemes.smithy
@@ -6,11 +6,22 @@ namespace smithy.example
 service ServiceWithNoAuthTrait {
     version: "2020-01-29",
     operations: [
-        OperationWithNoAuthTrait,
-        OperationWithAuthTrait
+        OperationA,
+        OperationB
     ]
 }
 
+// This operation does not have the @auth trait and is bound to a service
+// without the @auth trait. The effective set of authentication schemes it
+// supports are: httpBasicAuth, httpDigestAuth and httpBearerAuth
+operation OperationA {}
+
+// This operation does have the @auth trait and is bound to a service
+// without the @auth trait. The effective set of authentication schemes it
+// supports are: httpDigestAuth.
+@auth([httpDigestAuth])
+operation OperationB {}
+
 @httpBasicAuth
 @httpDigestAuth
 @httpBearerAuth
@@ -18,12 +29,18 @@ service ServiceWithNoAuthTrait {
 service ServiceWithAuthTrait {
     version: "2020-01-29",
     operations: [
-        OperationWithNoAuthTrait,
-        OperationWithAuthTrait
+        OperationC,
+        OperationD
     ]
 }
 
-operation OperationWithNoAuthTrait {}
+// This operation does not have the @auth trait and is bound to a service
+// with the @auth trait. The effective set of authentication schemes it
+// supports are: httpBasicAuth, httpDigestAuth
+operation OperationC {}
 
-@auth([httpDigestAuth])
-operation OperationWithAuthTrait {}
+// This operation not have the @auth trait and is bound to a service
+// with the @auth trait. The effective set of authentication schemes it
+// supports are: httpBearerAuth
+@auth([httpBearerAuth])
+operation OperationD {}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
