### PR TITLE
Fix filterSuppressions handling of members

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/FilterSuppressionsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/FilterSuppressionsTest.java
@@ -64,7 +64,9 @@ public class FilterSuppressionsTest {
         "namespaces,namespaceDenyList",
         "namespaces,filterWithTopLevelImports",
         "namespaces,filterWithProjectionImports",
-        "namespaces,detectsValidatorRemoval"
+        "namespaces,detectsValidatorRemoval",
+        "namespaces,unchanged",
+        "noSuppressions,removeUnused"
     })
     public void runTransformTests(String modelFile, String testName) throws Exception {
         Model model = Model.assembler()

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.unchanged.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.unchanged.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "namespaceDenyList": ["smithy.nonexistent"]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.unchanged.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/namespaces.unchanged.smithy
@@ -1,0 +1,39 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "Test",
+        severity: "WARNING",
+        configuration: {
+            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+        }
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "Test",
+        reason: "reason...",
+        namespace: "smithy.example"
+    },
+    {
+        id: "Lorem",
+        namespace: "smithy.foo"
+    },
+    {
+        id: "Test",
+        namespace: "smithy.example.nested",
+        reason: "reason..."
+    },
+    {
+        id: "Ipsum",
+        namespace: "*"
+    }
+]
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Baz {}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/noSuppressions.removeUnused.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/noSuppressions.removeUnused.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/noSuppressions.removeUnused.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/noSuppressions.removeUnused.smithy
@@ -11,19 +11,14 @@ metadata validators = [
     }
 ]
 
+metadata suppressions = []
+
 namespace smithy.example
 
-@suppress(["NeverUsed"])
-string NoMatches
-
-@suppress(["NeverUsed"])
 structure Foo {
-    @suppress(["NeverUsed"])
     foo: String
 }
 
-@suppress(["NeverUsed"])
 structure Baz {
-    @suppress(["NeverUsed"])
-    baz:String
+    baz: String
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/noSuppressions.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/noSuppressions.smithy
@@ -11,19 +11,14 @@ metadata validators = [
     }
 ]
 
+metadata suppressions = []
+
 namespace smithy.example
 
-@suppress(["NeverUsed"])
-string NoMatches
-
-@suppress(["NeverUsed"])
 structure Foo {
-    @suppress(["NeverUsed"])
     foo: String
 }
 
-@suppress(["NeverUsed"])
 structure Baz {
-    @suppress(["NeverUsed"])
-    baz:String
+    baz: String
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdAllowList.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.eventIdAllowList.smithy
@@ -6,7 +6,7 @@ metadata validators = [
         id: "Test",
         severity: "WARNING",
         configuration: {
-            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+            selector: ":not([id='smithy.example#NoMatches'])"
         }
     }
 ]
@@ -17,6 +17,11 @@ namespace smithy.example
 string NoMatches
 
 @suppress(["Test"])
-structure Foo {}
+structure Foo {
+    @suppress(["Test"])
+    foo: String
+}
 
-structure Baz {}
+structure Baz {
+    baz:String
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.removeUnused.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.removeUnused.smithy
@@ -6,7 +6,7 @@ metadata validators = [
         id: "Test",
         severity: "WARNING",
         configuration: {
-            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+            selector: ":not([id='smithy.example#NoMatches'])"
         }
     }
 ]
@@ -16,6 +16,11 @@ namespace smithy.example
 string NoMatches
 
 @suppress(["Test"])
-structure Foo {}
+structure Foo {
+    @suppress(["Test"])
+    foo: String
+}
 
-structure Baz {}
+structure Baz {
+    baz: String
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/traits.smithy
@@ -6,7 +6,7 @@ metadata validators = [
         id: "Test",
         severity: "WARNING",
         configuration: {
-            selector: ":is([id=smithy.example#Foo], [id=smithy.example#Baz])"
+            selector: ":not([id='smithy.example#NoMatches'])"
         }
     }
 ]
@@ -17,7 +17,13 @@ namespace smithy.example
 string NoMatches
 
 @suppress(["NeverUsed", "Test"])
-structure Foo {}
+structure Foo {
+    @suppress(["NeverUsed", "Test"])
+    foo: String
+}
 
 @suppress(["NeverUsed"])
-structure Baz {}
+structure Baz {
+    @suppress(["NeverUsed"])
+    baz: String
+}


### PR DESCRIPTION
*Issue:*

FilterSuppressions uses builder.addShape [here](https://github.com/awslabs/smithy/blob/6ace7180592717eced4c01b5c317d68b9602c968/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FilterSuppressions.java#L296) ) to update the traits on all shapes, including member shapes. However,  [`builder.addShape`](https://github.com/awslabs/smithy/blob/6ace7180592717eced4c01b5c317d68b9602c968/smithy-model/src/main/java/software/amazon/smithy/model/Model.java#L888-L889) does not support updating member shapes
directly.

*Description of changes:*
Instead use ReplaceShapes which handles replacing member shapes too.

*Testing:*
Updated the traits.smithy test cases to cover the member case. They failed before this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
