### PR TITLE
Add transform to add dedicated input and output

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedOperationInput.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedOperationInput.java
@@ -31,10 +31,10 @@ public final class ChangedOperationInput extends AbstractDiffEvaluator {
         return differences.changedShapes(OperationShape.class)
                 .filter(change -> !change.getOldShape().getInputShape().equals(change.getNewShape().getInputShape()))
                 .map(change -> error(change.getNewShape(), String.format(
-                        "Input shape of `%s` changed from `%s` to `%s`",
+                        "Changed operation input of `%s` from `%s` to `%s`",
                         change.getShapeId(),
                         change.getOldShape().getInputShape(),
-                        change.getNewShape().getOutputShape())))
+                        change.getNewShape().getInputShape())))
                 .collect(Collectors.toList());
     }
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedOperationOutput.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedOperationOutput.java
@@ -31,7 +31,7 @@ public final class ChangedOperationOutput extends AbstractDiffEvaluator {
         return differences.changedShapes(OperationShape.class)
                 .filter(change -> !change.getOldShape().getOutputShape().equals(change.getNewShape().getOutputShape()))
                 .map(change -> error(change.getNewShape(), String.format(
-                        "Output shape of `%s` changed from `%s` to `%s`",
+                        "Changed operation output of `%s` from `%s` to `%s`",
                         change.getShapeId(),
                         change.getOldShape().getOutputShape(),
                         change.getNewShape().getOutputShape())))

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
@@ -209,13 +209,10 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                 String message;
                 String pretty = Node.prettyPrintJson(right.toNode());
                 if (path.isEmpty()) {
-                    String template = severity == Severity.DANGER || severity == Severity.ERROR
-                                      ? "It is a breaking change to add the `%s` trait. The added trait value is: %s"
-                                      : "The `%s` trait was added with the value: %s";
-                    message = String.format(template, trait, pretty);
+                    message = String.format("Added trait `%s` with value %s", trait, pretty);
                 } else {
-                    message = String.format("`%s` was added to the `%s` trait with a value of %s",
-                                            path, trait, pretty);
+                    message = String.format("Added trait contents to `%s` at path `%s` with value %s",
+                                            trait, path, pretty);
                 }
 
                 return Collections.singletonList(ValidationEvent.builder()
@@ -246,13 +243,10 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                 String pretty = Node.prettyPrintJson(left.toNode());
                 String message;
                 if (path.isEmpty()) {
-                    String template = severity == Severity.DANGER || severity == Severity.ERROR
-                            ? "It is a breaking change to remove the `%s` trait. The removed trait value was: %s"
-                            : "The `%s` trait was removed. The removed trait value was: %s";
-                    message = String.format(template, trait, pretty);
+                    message = String.format("Removed trait `%s`. Removed value: %s", trait, pretty);
                 } else {
-                    message = String.format("`%s` was removed from the `%s` trait. The removed value was: %s",
-                                            path, trait, pretty);
+                    message = String.format("Removed trait contents from `%s` at path `%s`. Removed value: %s",
+                                            trait, path, pretty);
                 }
 
                 return Collections.singletonList(ValidationEvent.builder()
@@ -283,14 +277,10 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                 String rightPretty = Node.prettyPrintJson(right.toNode());
                 String message;
                 if (path.isEmpty()) {
-                    String template = severity == Severity.DANGER || severity == Severity.ERROR
-                                      ? "It is a breaking change to change the value of the `%s` trait. The value "
-                                        + "changed from %s to %s"
-                                      : "The `%s` trait value changed from %s to %s";
-                    message = String.format(template, trait, leftPretty, rightPretty);
+                    message = String.format("Changed trait `%s` from %s to %s", trait, leftPretty, rightPretty);
                 } else {
-                    message = String.format("`%s` was changed on the `%s` trait from %s to %s",
-                                            path, trait, leftPretty, rightPretty);
+                    message = String.format("Changed trait contents of `%s` at path `%s` from %s to %s",
+                                            trait, path, leftPretty, rightPretty);
                 }
 
                 return Collections.singletonList(ValidationEvent.builder()

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedPaginatedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedPaginatedTraitTest.java
@@ -74,7 +74,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/items` was removed from the `smithy.api#paginated` trait. The removed value was: \"things\""));
+                   containsString("Removed trait contents from `smithy.api#paginated` at path `/items`. Removed value: \"things\""));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/items` was added to the `smithy.api#paginated` trait with a value of \"things\""));
+                   containsString("Added trait contents to `smithy.api#paginated` at path `/items` with value \"things\""));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/items` was changed on the `smithy.api#paginated` trait from \"things\" to \"otherThings\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/items` from \"things\" to \"otherThings\""));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/pageSize` was removed from the `smithy.api#paginated` trait. The removed value was: \"maxResults\""));
+                   containsString("Removed trait contents from `smithy.api#paginated` at path `/pageSize`. Removed value: \"maxResults\""));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/pageSize` was changed on the `smithy.api#paginated` trait from \"maxResults\" to \"otherMaxResults\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/pageSize` from \"maxResults\" to \"otherMaxResults\""));
     }
 
     @Test
@@ -173,7 +173,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/inputToken` was changed on the `smithy.api#paginated` trait from \"token\" to \"otherToken\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/inputToken` from \"token\" to \"otherToken\""));
     }
 
     @Test
@@ -189,6 +189,6 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("`/outputToken` was changed on the `smithy.api#paginated` trait from \"token\" to \"otherToken\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/outputToken` from \"token\" to \"otherToken\""));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -90,9 +90,9 @@ public class ModifiedTraitTest {
 
     public static Collection<String[]> data() {
         return Arrays.asList(new String[][] {
-                {null, "hi", "diff.error.add", "to add"},
-                {"hi", null, "diff.error.remove", "to remove"},
-                {"foo", "baz", "diff.error.update", "to change"},
+                {null, "hi", "diff.error.add", "Added"},
+                {"hi", null, "diff.error.remove", "Removed"},
+                {"foo", "baz", "diff.error.update", "Changed"},
         });
     }
 
@@ -122,9 +122,9 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.NOTE).count(), equalTo(2L));
 
         assertThat(messages, containsInAnyOrder(
-                "The `smithy.example#b` trait value changed from \"hello\" to \"hello!\"",
-                "The `smithy.example#a` trait was removed. The removed trait value was: {}",
-                "The `smithy.example#c` trait was added with the value: \"foo\""
+                "Changed trait `smithy.example#b` from \"hello\" to \"hello!\"",
+                "Removed trait `smithy.example#a`. Removed value: {}",
+                "Added trait `smithy.example#c` with value \"foo\""
         ));
     }
 
@@ -146,8 +146,8 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.WARNING).count(), equalTo(1L));
 
         assertThat(messages, containsInAnyOrder(
-                "`/baz/foo` was changed on the `smithy.example#aTrait` trait from \"bye\" to \"adios\"",
-                "`/bar` was added to the `smithy.example#aTrait` trait with a value of \"no\""
+                "Added trait contents to `smithy.example#aTrait` at path `/bar` with value \"no\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from \"bye\" to \"adios\""
         ));
     }
 
@@ -166,14 +166,11 @@ public class ModifiedTraitTest {
 
         assertThat(events, hasSize(4));
         assertThat(messages, containsInAnyOrder(
-                "`/foo/1` was changed on the `smithy.example#aTrait` trait from \"b\" to \"B\"",
-                "`/foo/3` was added to the `smithy.example#aTrait` trait with a value of \"4\"",
-                "`/foo/2` was removed from the `smithy.example#aTrait` trait. The removed value was: \"3\"",
-                "`/foo` was removed from the `smithy.example#aTrait` trait. The removed value was: [\n"
-                + "    \"1\",\n"
-                + "    \"2\",\n"
-                + "    \"3\"\n"
-                + "]"
+                "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from \"b\" to \"B\"",
+                "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value \"4\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: \"3\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: "
+                + "[\n    \"1\",\n    \"2\",\n    \"3\"\n]"
         ));
     }
 
@@ -192,14 +189,10 @@ public class ModifiedTraitTest {
 
         assertThat(events, hasSize(4));
         assertThat(messages, containsInAnyOrder(
-                "`/foo/1` was changed on the `smithy.example#aTrait` trait from \"b\" to \"B\"",
-                "`/foo/3` was added to the `smithy.example#aTrait` trait with a value of \"4\"",
-                "`/foo/2` was removed from the `smithy.example#aTrait` trait. The removed value was: \"3\"",
-                "`/foo` was removed from the `smithy.example#aTrait` trait. The removed value was: [\n"
-                + "    \"1\",\n"
-                + "    \"2\",\n"
-                + "    \"3\"\n"
-                + "]"
+                "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from \"b\" to \"B\"",
+                "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value \"4\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: \"3\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: [\n    \"1\",\n    \"2\",\n    \"3\"\n]"
         ));
     }
 
@@ -218,14 +211,10 @@ public class ModifiedTraitTest {
 
         assertThat(events, hasSize(4));
         assertThat(messages, containsInAnyOrder(
-                "`/foo/bam` was changed on the `smithy.example#aTrait` trait from \"b\" to \"B\"",
-                "`/foo` was removed from the `smithy.example#aTrait` trait. The removed value was: {\n"
-                + "    \"baz\": \"1\",\n"
-                + "    \"bam\": \"2\",\n"
-                + "    \"boo\": \"3\""
-                + "\n}",
-                "`/foo/qux` was added to the `smithy.example#aTrait` trait with a value of \"4\"",
-                "`/foo/boo` was removed from the `smithy.example#aTrait` trait. The removed value was: \"3\""
+                "Changed trait contents of `smithy.example#aTrait` at path `/foo/bam` from \"b\" to \"B\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: {\n    \"baz\": \"1\",\n    \"bam\": \"2\",\n    \"boo\": \"3\"\n}",
+                "Added trait contents to `smithy.example#aTrait` at path `/foo/qux` with value \"4\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo/boo`. Removed value: \"3\""
         ));
     }
 
@@ -244,8 +233,8 @@ public class ModifiedTraitTest {
 
         assertThat(events, hasSize(2));
         assertThat(messages, containsInAnyOrder(
-                "`/baz/foo` was changed on the `smithy.example#aTrait` trait from \"a\" to \"b\"",
-                "`/baz/baz` was changed on the `smithy.example#aTrait` trait from \"a\" to \"b\""
+                "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from \"a\" to \"b\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/baz/baz` from \"a\" to \"b\""
         ));
     }
 
@@ -264,18 +253,18 @@ public class ModifiedTraitTest {
 
         assertThat(events, hasSize(12));
         assertThat(messages, containsInAnyOrder(
-                "`/a` was added to the `smithy.example#aTrait` trait with a value of \"a\"",
-                "`/b` was removed from the `smithy.example#aTrait` trait. The removed value was: \"a\"",
-                "`/c` was changed on the `smithy.example#aTrait` trait from \"a\" to \"c\"",
-                "`/d` was changed on the `smithy.example#aTrait` trait from \"a\" to \"d\"",
-                "`/e` was added to the `smithy.example#aTrait` trait with a value of \"a\"",
-                "`/f` was removed from the `smithy.example#aTrait` trait. The removed value was: \"a\"",
-                "`/g` was changed on the `smithy.example#aTrait` trait from \"a\" to \"h\"",
-                "`/h` was changed on the `smithy.example#aTrait` trait from \"a\" to \"h\"",
-                "`/i` was added to the `smithy.example#aTrait` trait with a value of \"a\"",
-                "`/j` was removed from the `smithy.example#aTrait` trait. The removed value was: \"a\"",
-                "`/k` was changed on the `smithy.example#aTrait` trait from \"a\" to \"k\"",
-                "`/l` was changed on the `smithy.example#aTrait` trait from \"a\" to \"l\""
+                "Added trait contents to `smithy.example#aTrait` at path `/a` with value \"a\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/b`. Removed value: \"a\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/c` from \"a\" to \"c\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/d` from \"a\" to \"d\"",
+                "Added trait contents to `smithy.example#aTrait` at path `/e` with value \"a\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/f`. Removed value: \"a\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/g` from \"a\" to \"h\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/h` from \"a\" to \"h\"",
+                "Added trait contents to `smithy.example#aTrait` at path `/i` with value \"a\"",
+                "Removed trait contents from `smithy.example#aTrait` at path `/j`. Removed value: \"a\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/k` from \"a\" to \"k\"",
+                "Changed trait contents of `smithy.example#aTrait` at path `/l` from \"a\" to \"l\""
         ));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -649,8 +649,8 @@ public final class ModelAssembler {
         for (Map.Entry<ShapeId, Map<ShapeId, Trait>> entry : resolvedTraits.traits().entrySet()) {
             ShapeId target = entry.getKey();
             for (Trait trait : entry.getValue().values()) {
-                // Find trait values that weren't defined, and ignore ephemeral traits.
-                if (!trait.isEphemeral() && !ids.contains(trait.toShapeId())) {
+                // Find trait values that weren't defined, and ignore synthetic traits.
+                if (!trait.isSynthetic() && !ids.contains(trait.toShapeId())) {
                     events.add(ValidationEvent.builder()
                             .id(Validator.MODEL_ERROR)
                             .severity(severity)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -649,8 +649,8 @@ public final class ModelAssembler {
         for (Map.Entry<ShapeId, Map<ShapeId, Trait>> entry : resolvedTraits.traits().entrySet()) {
             ShapeId target = entry.getKey();
             for (Trait trait : entry.getValue().values()) {
-                // Find trait values that weren't defined.
-                if (!ids.contains(trait.toShapeId())) {
+                // Find trait values that weren't defined, and ignore ephemeral traits.
+                if (!trait.isEphemeral() && !ids.contains(trait.toShapeId())) {
                     events.add(ValidationEvent.builder()
                             .id(Validator.MODEL_ERROR)
                             .severity(severity)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeSerializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeSerializers.java
@@ -382,6 +382,8 @@ final class DefaultNodeSerializers {
                     return false;
                 } else if (value.isArrayNode() && value.expectArrayNode().isEmpty()) {
                     return false;
+                } else if (value.isBooleanNode() && !value.expectBooleanNode().getValue()) {
+                    return false;
                 }
             }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeMapper.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeMapper.java
@@ -289,7 +289,7 @@ public final class NodeMapper {
     }
 
     /**
-     * Gets whether or not empty arrays and empty objects are omitted from
+     * Gets whether or not false, empty arrays, and empty objects are omitted from
      * serialized POJOs.
      *
      * @return Returns true if empty arrays and POJOs returned from POJO getters are omitted.
@@ -299,9 +299,9 @@ public final class NodeMapper {
     }
 
     /**
-     * Gets whether or not empty arrays and objects are omitted from serialized POJOs.
+     * Gets whether or not false, empty arrays, and empty objects are omitted from serialized POJOs.
      *
-     * @param omitEmptyValues Set to true if empty arrays and objects returned from POJO getters are omitted.
+     * @param omitEmptyValues Set to true if false, empty arrays, and objects returned from POJO getters are omitted.
      */
     public void setOmitEmptyValues(boolean omitEmptyValues) {
         this.omitEmptyValues = omitEmptyValues;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -59,7 +59,8 @@ public final class ModelSerializer {
         } else {
             shapeFilter = builder.shapeFilter;
         }
-        traitFilter = builder.traitFilter;
+        // Never serialize ephemeral traits.
+        traitFilter = builder.traitFilter.and(FunctionalUtils.not(Trait::isEphemeral));
     }
 
     public ObjectNode serialize(Model model) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -59,8 +59,8 @@ public final class ModelSerializer {
         } else {
             shapeFilter = builder.shapeFilter;
         }
-        // Never serialize ephemeral traits.
-        traitFilter = builder.traitFilter.and(FunctionalUtils.not(Trait::isEphemeral));
+        // Never serialize synthetic traits.
+        traitFilter = builder.traitFilter.and(FunctionalUtils.not(Trait::isSynthetic));
     }
 
     public ObjectNode serialize(Model model) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -64,8 +64,8 @@ public final class SmithyIdlModelSerializer {
     private SmithyIdlModelSerializer(Builder builder) {
         metadataFilter = builder.metadataFilter;
         shapeFilter = builder.shapeFilter.and(FunctionalUtils.not(Prelude::isPreludeShape));
-        // Never serialize ephemeral traits.
-        traitFilter = builder.traitFilter.and(FunctionalUtils.not(Trait::isEphemeral));
+        // Never serialize synthetic traits.
+        traitFilter = builder.traitFilter.and(FunctionalUtils.not(Trait::isSynthetic));
         basePath = builder.basePath;
         if (basePath != null) {
             Function<Shape, Path> shapePlacer = builder.shapePlacer;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -64,7 +64,8 @@ public final class SmithyIdlModelSerializer {
     private SmithyIdlModelSerializer(Builder builder) {
         metadataFilter = builder.metadataFilter;
         shapeFilter = builder.shapeFilter.and(FunctionalUtils.not(Prelude::isPreludeShape));
-        traitFilter = builder.traitFilter;
+        // Never serialize ephemeral traits.
+        traitFilter = builder.traitFilter.and(FunctionalUtils.not(Trait::isEphemeral));
         basePath = builder.basePath;
         if (basePath != null) {
             Function<Shape, Path> shapePlacer = builder.shapePlacer;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/InputTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/InputTrait.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.model.traits;
 
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Specializes a structure as the input of a single operation.
@@ -31,6 +33,10 @@ public final class InputTrait extends AnnotationTrait {
 
     public InputTrait() {
         this(Node.objectNode());
+    }
+
+    public InputTrait(SourceLocation sourceLocation) {
+        this(new ObjectNode(MapUtils.of(), sourceLocation));
     }
 
     public static final class Provider extends AnnotationTrait.Provider<InputTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/OutputTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/OutputTrait.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.model.traits;
 
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Specializes a structure as the output of a single operation.
@@ -31,6 +33,10 @@ public final class OutputTrait extends AnnotationTrait {
 
     public OutputTrait() {
         this(Node.objectNode());
+    }
+
+    public OutputTrait(SourceLocation sourceLocation) {
+        this(new ObjectNode(MapUtils.of(), sourceLocation));
     }
 
     public static final class Provider extends AnnotationTrait.Provider<OutputTrait> {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
@@ -62,6 +62,21 @@ public interface Trait extends FromSourceLocation, ToNode, ToShapeId {
     ShapeId toShapeId();
 
     /**
+     * Checks if this trait is persisted with the shape, or if it is an
+     * ephemeral, or transient shape, only meant to temporarily aid in
+     * some kind of model transformation.
+     *
+     * <p>Because ephemeral traits are not persisted with shapes, they also
+     * do not need to be defined in Smithy's semantic model before they can
+     * be used in the model.
+     *
+     * @return Returns true if the trait is not persisted on the shape.
+     */
+    default boolean isEphemeral() {
+        return false;
+    }
+
+    /**
      * Used in a stream flatMapStream to return a {@link Stream} with a
      * {@link Pair} of Shape and Trait if the trait is present on the
      * given shape.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/Trait.java
@@ -62,17 +62,17 @@ public interface Trait extends FromSourceLocation, ToNode, ToShapeId {
     ShapeId toShapeId();
 
     /**
-     * Checks if this trait is persisted with the shape, or if it is an
-     * ephemeral, or transient shape, only meant to temporarily aid in
-     * some kind of model transformation.
+     * Checks if this trait is persisted with the shape, or if it is a
+     * synthetic, or transient trait, only meant to temporarily aid in
+     * some kind of in-memory model transformation.
      *
-     * <p>Because ephemeral traits are not persisted with shapes, they also
+     * <p>Because synthetic traits are not persisted with shapes, they also
      * do not need to be defined in Smithy's semantic model before they can
      * be used in the model.
      *
      * @return Returns true if the trait is not persisted on the shape.
      */
-    default boolean isEphemeral() {
+    default boolean isSynthetic() {
         return false;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ephemeral/OriginalShapeIdTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ephemeral/OriginalShapeIdTrait.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits.ephemeral;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+/**
+ * Used to provide the original shape ID of a shape that is renamed
+ * in the semantic model.
+ *
+ * <p>This is an ephemeral trait that is not defined in the semantic model,
+ * nor is it persisted when the model is serialized.
+ */
+public final class OriginalShapeIdTrait extends AbstractTrait {
+
+    public static final ShapeId ID = ShapeId.from("smithy.transient#originalShapeId");
+
+    private final ShapeId originalId;
+
+    public OriginalShapeIdTrait(ShapeId original) {
+        super(ID, SourceLocation.NONE);
+        this.originalId = original;
+    }
+
+    /**
+     * Gets the original shape ID of the shape before it was renamed.
+     *
+     * @return Returns the shape original shape ID.
+     */
+    public ShapeId getOriginalId() {
+        return originalId;
+    }
+
+    @Override
+    public boolean isEphemeral() {
+        return true;
+    }
+
+    @Override
+    protected Node createNode() {
+        return Node.from(getOriginalId().toString());
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/synthetic/OriginalShapeIdTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/synthetic/OriginalShapeIdTrait.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.smithy.model.traits.ephemeral;
+package software.amazon.smithy.model.traits.synthetic;
 
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
@@ -24,12 +24,12 @@ import software.amazon.smithy.model.traits.AbstractTrait;
  * Used to provide the original shape ID of a shape that is renamed
  * in the semantic model.
  *
- * <p>This is an ephemeral trait that is not defined in the semantic model,
+ * <p>This is a synthetic trait that is not defined in the semantic model,
  * nor is it persisted when the model is serialized.
  */
 public final class OriginalShapeIdTrait extends AbstractTrait {
 
-    public static final ShapeId ID = ShapeId.from("smithy.transient#originalShapeId");
+    public static final ShapeId ID = ShapeId.from("smithy.synthetic#originalShapeId");
 
     private final ShapeId originalId;
 
@@ -48,7 +48,7 @@ public final class OriginalShapeIdTrait extends AbstractTrait {
     }
 
     @Override
-    public boolean isEphemeral() {
+    public boolean isSynthetic() {
         return true;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutput.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutput.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Relationship;
+import software.amazon.smithy.model.neighbor.RelationshipDirection;
+import software.amazon.smithy.model.neighbor.RelationshipType;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.InputTrait;
+import software.amazon.smithy.model.traits.OutputTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
+import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+
+/**
+ * @see ModelTransformer#createDedicatedInputAndOutput(Model, String, String)
+ */
+final class CreateDedicatedInputAndOutput {
+    private final String inputSuffix;
+    private final String outputSuffix;
+
+    CreateDedicatedInputAndOutput(String inputSuffix, String outputSuffix) {
+        this.inputSuffix = inputSuffix;
+        this.outputSuffix = outputSuffix;
+    }
+
+    Model transform(ModelTransformer transformer, Model model) {
+        NeighborProvider reverse = NeighborProviderIndex.of(model).getReverseProvider();
+        OperationIndex operationIndex = OperationIndex.of(model);
+
+        List<Shape> updates = new ArrayList<>();
+        List<Shape> toRemove = new ArrayList<>();
+        for (OperationShape operation : model.getOperationShapes()) {
+            StructureShape input = operationIndex.expectInputShape(operation);
+            StructureShape updatedInput = createdUpdatedInput(model, operation, input, reverse);
+            StructureShape output = operationIndex.expectOutputShape(operation);
+            StructureShape updatedOutput = createdUpdatedOutput(model, operation, output, reverse);
+
+            if (!updatedInput.equals(input) || !updatedOutput.equals(output)) {
+                OperationShape.Builder builder = operation.toBuilder();
+                if (!updatedInput.equals(input)) {
+                    updates.add(updatedInput);
+                    builder.input(updatedInput);
+                    // If the ID changed and the original is no longer referenced, then remove it.
+                    if (!input.getId().equals(updatedInput.getId())
+                            && isSingularReference(reverse, input, RelationshipType.INPUT)) {
+                        toRemove.add(input);
+                    }
+                }
+                if (!updatedOutput.equals(output)) {
+                    updates.add(updatedOutput);
+                    builder.output(updatedOutput);
+                    // If the ID changed and the original is no longer referenced, then remove it.
+                    if (!output.getId().equals(updatedOutput.getId())
+                            && isSingularReference(reverse, output, RelationshipType.OUTPUT)) {
+                        toRemove.add(output);
+                    }
+                }
+                updates.add(builder.build());
+            }
+        }
+
+        // Replace the operations and add new shapes.
+        Model result = transformer.replaceShapes(model, updates);
+
+        // Remove no longer referenced shapes.
+        return transformer.removeShapes(result, toRemove);
+    }
+
+    private StructureShape createdUpdatedInput(
+            Model model,
+            OperationShape operation,
+            StructureShape input,
+            NeighborProvider reverse
+    ) {
+        if (input.hasTrait(InputTrait.class)) {
+            return renameShapeIfNeeded(model, input, operation, inputSuffix);
+        } else if (isDedicatedHeuristic(operation, input, reverse, RelationshipType.INPUT)) {
+            InputTrait trait = new InputTrait();
+            return renameShapeIfNeeded(model, input.toBuilder().addTrait(trait).build(), operation, inputSuffix);
+        } else {
+            return createSyntheticShape(model, operation, inputSuffix, input, new InputTrait());
+        }
+    }
+
+    private StructureShape createdUpdatedOutput(
+            Model model,
+            OperationShape operation,
+            StructureShape output,
+            NeighborProvider reverse
+    ) {
+        if (output.hasTrait(OutputTrait.class)) {
+            return renameShapeIfNeeded(model, output, operation, outputSuffix);
+        } else if (isDedicatedHeuristic(operation, output, reverse, RelationshipType.OUTPUT)) {
+            OutputTrait trait = new OutputTrait();
+            return renameShapeIfNeeded(model, output.toBuilder().addTrait(trait).build(), operation, outputSuffix);
+        } else {
+            return createSyntheticShape(model, operation, outputSuffix, output, new OutputTrait());
+        }
+    }
+
+    private StructureShape renameShapeIfNeeded(
+            Model model,
+            StructureShape struct,
+            OperationShape operation,
+            String suffix
+    ) {
+        // Check if the shape already has the desired name.
+        ShapeId expectedName = ShapeId.fromParts(operation.getId().getNamespace(),
+                                                 operation.getId().getName() + suffix);
+        if (struct.getId().equals(expectedName)) {
+            return struct;
+        }
+
+        ShapeId newId = createSyntheticShapeId(model, operation, suffix);
+        return struct.toBuilder()
+                .id(newId)
+                .addTrait(new OriginalShapeIdTrait(struct.getId()))
+                .build();
+    }
+
+    private boolean isDedicatedHeuristic(
+            OperationShape operation,
+            StructureShape struct,
+            NeighborProvider reverse,
+            RelationshipType expected
+    ) {
+        // Only assume that a shape is dedicated to the operation its name starts with the operation name.
+        if (!struct.getId().getName().startsWith(operation.getId().getName())) {
+            return false;
+        }
+
+        // Check if the shape is only referenced as input or output.
+        return isSingularReference(reverse, struct, expected);
+    }
+
+    private boolean isSingularReference(NeighborProvider reverse, Shape shape, RelationshipType expected) {
+        int totalDirectedEdges = 0;
+
+        // We need to exclude inverted edges like MEMBER_CONTAINER, and only look for directed
+        // edges like INPUT and OUTPUT.
+        for (Relationship rel : reverse.getNeighbors(shape)) {
+            if (rel.getRelationshipType().getDirection() == RelationshipDirection.DIRECTED) {
+                totalDirectedEdges++;
+                if (rel.getRelationshipType() != expected) {
+                    return false;
+                }
+            }
+        }
+
+        return totalDirectedEdges == 1;
+    }
+
+    private static StructureShape createSyntheticShape(
+            Model model,
+            OperationShape operation,
+            String suffix,
+            StructureShape source,
+            Trait inputOutputTrait
+    ) {
+        ShapeId newId = createSyntheticShapeId(model, operation, suffix);
+
+        // Special handling for copying unit types (that, you don't copy unit types)
+        StructureShape.Builder builder = source.getId().equals(UnitTypeTrait.UNIT)
+                ? StructureShape.builder()
+                : source.toBuilder();
+
+        builder.id(newId);
+        builder.addTrait(inputOutputTrait);
+
+        if (!newId.equals(source.getId())) {
+            builder.addTrait(new OriginalShapeIdTrait(source.getId()));
+        }
+
+        return builder.build();
+    }
+
+    private static ShapeId createSyntheticShapeId(
+            Model model,
+            OperationShape operation,
+            String suffix
+    ) {
+        // Synthesize an input shape as a dedicated copy of the existing input.
+        ShapeId newId = ShapeId.fromParts(operation.getId().getNamespace(),
+                                          operation.getId().getName() + suffix);
+
+        if (model.getShapeIds().contains(newId)) {
+            ShapeId deconflicted = resolveConflict(newId, suffix);
+            if (model.getShapeIds().contains(deconflicted)) {
+                throw new ModelTransformException(String.format(
+                        "Unable to generate a synthetic %s shape for the %s operation. The %s shape already exists "
+                        + "in the model, and the conflict resolver also returned a shape ID that already exists: %s",
+                        suffix,
+                        operation.getId(),
+                        newId,
+                        deconflicted));
+            }
+            newId = deconflicted;
+        }
+
+        return newId;
+    }
+
+    private static ShapeId resolveConflict(ShapeId id, String suffix) {
+        // Say GetFooRequest exists. This then returns GetFooOperationRequest.
+        String updatedName = id.getName().replace(suffix, "Operation" + suffix);
+        return ShapeId.fromParts(id.getNamespace(), updatedName);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -39,7 +39,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
-import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 import software.amazon.smithy.utils.FunctionalUtils;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -501,9 +501,11 @@ public final class ModelTransformer {
      * context.
      *
      * <p>If an operation's input already targets a shape marked with the {@code input}
-     * trait, then the operation and input shape is left as-is regardless of its name.
-     * If an operation's output already targets a shape marked with the {@code output}
-     * trait, then the operation and output shape is left as-is regardless of its name.
+     * trait, then the existing input shape is used as input, though the shape will
+     * be renamed if it does not use the given {@code inputSuffix}. If an operation's
+     * output already targets a shape marked with the {@code output} trait, then the
+     * existing output shape is used as output, though the shape will be renamed if it
+     * does not use the given {@code outputSuffix}.
      *
      * <p>If the operation's input shape starts with the name of the operation and is
      * only used throughout the model as the input of the operation, then it is updated
@@ -532,7 +534,7 @@ public final class ModelTransformer {
      * shapes in the model, then a {@link ModelTransformException} is thrown.
      *
      * <p>Any time a shape is renamed, the original shape ID of the shape is captured
-     * on the shape using the ephemeral {@link OriginalShapeIdTrait}. This might be
+     * on the shape using the synthetic {@link OriginalShapeIdTrait}. This might be
      * useful for protocols that need to serialize input and output shape names.
      *
      * @param model Model to update.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
@@ -45,6 +45,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.traits.TraitDefinition;
+import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
 
 public class ModelTest {
 
@@ -233,6 +234,20 @@ public class ModelTest {
 
         assertThat(shapes, hasSize(1));
         assertThat(shapes, contains(string));
+    }
+
+    @Test
+    public void transientShapesCanBeQueriedLikeNormalTraits() {
+        ShapeId originalId = ShapeId.from("com.foo.nested#Str");
+        StringShape stringShape = StringShape.builder()
+                .id("com.foo#Str")
+                .addTrait(new OriginalShapeIdTrait(originalId))
+                .build();
+        Model model = Model.builder()
+                .addShape(stringShape)
+                .build();
+
+        assertThat(model.getShapesWithTrait(OriginalShapeIdTrait.class), contains(stringShape));
     }
 
     /**

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
@@ -45,7 +45,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.traits.TraitDefinition;
-import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 
 public class ModelTest {
 
@@ -237,7 +237,7 @@ public class ModelTest {
     }
 
     @Test
-    public void transientShapesCanBeQueriedLikeNormalTraits() {
+    public void syntheticTraitsCanBeQueriedLikeNormalTraits() {
         ShapeId originalId = ShapeId.from("com.foo.nested#Str");
         StringShape stringShape = StringShape.builder()
                 .id("com.foo#Str")

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -65,6 +65,7 @@ import software.amazon.smithy.model.traits.DynamicTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.SuppressTrait;
+import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -658,5 +659,29 @@ public class ModelAssemblerTest {
                 .unwrap();
 
         assertThat(collectedEvents, equalTo(toEmit));
+    }
+
+    // Ephemeral traits are used to add information to shapes that's not persisted on the
+    // shape when serializing, and the trait might not be defined in the metamodel. This
+    // requires that validators ignore ephemeral traits, and that the model assembler doesn't
+    // fail if an unknown ephemeral trait is encountered.
+    //
+    // This validator ensures that ephemeral traits don't trip up the assembler, and that
+    // built-in validators don't care that the trait isn't defined in the semantic model.
+    // They only need to be defined in code.
+    @Test
+    public void transientTraitsAreNotValidated() {
+        ShapeId originalId = ShapeId.from("com.foo.nested#Str");
+        StringShape stringShape = StringShape.builder()
+                .id("com.foo#Str")
+                .addTrait(new OriginalShapeIdTrait(originalId))
+                .build();
+        Model model = Model.assembler()
+                .addShape(stringShape)
+                .assemble()
+                .unwrap();
+
+        assertThat(model.expectShape(stringShape.getId()).expectTrait(OriginalShapeIdTrait.class).getOriginalId(),
+                   equalTo(originalId));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -65,7 +65,7 @@ import software.amazon.smithy.model.traits.DynamicTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.SuppressTrait;
-import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -661,12 +661,12 @@ public class ModelAssemblerTest {
         assertThat(collectedEvents, equalTo(toEmit));
     }
 
-    // Ephemeral traits are used to add information to shapes that's not persisted on the
+    // Synthetic traits are used to add information to shapes that's not persisted on the
     // shape when serializing, and the trait might not be defined in the metamodel. This
-    // requires that validators ignore ephemeral traits, and that the model assembler doesn't
-    // fail if an unknown ephemeral trait is encountered.
+    // requires that validators ignore synthetic traits, and that the model assembler doesn't
+    // fail if an unknown synthetic trait is encountered.
     //
-    // This validator ensures that ephemeral traits don't trip up the assembler, and that
+    // This validator ensures that synthetic traits don't trip up the assembler, and that
     // built-in validators don't care that the trait isn't defined in the semantic model.
     // They only need to be defined in code.
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
@@ -380,7 +380,7 @@ public class NodeMapperTest {
         mapper.setOmitEmptyValues(true);
         Node result = mapper.serialize(pojo);
 
-        assertThat(result, equalTo(Node.objectNode()));
+        assertThat(result, equalTo(Node.objectNode().withMember("true", true)));
     }
 
     public static final class PojoWithEmptyValues {
@@ -390,6 +390,14 @@ public class NodeMapperTest {
 
         public EmptyPojo getBaz() {
             return new EmptyPojo();
+        }
+
+        public boolean isFalse() {
+            return false;
+        }
+
+        public boolean isTrue() {
+            return true;
         }
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -33,7 +33,7 @@ import software.amazon.smithy.model.node.NodePointer;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
-import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 
 public class ModelSerializerTest {
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -20,14 +20,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.params.provider.EnumSource;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.node.NodePointer;
-import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
-import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 import software.amazon.smithy.utils.IoUtils;
 
 public class SmithyIdlModelSerializerTest {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutputTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutputTest.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.InputTrait;
 import software.amazon.smithy.model.traits.OutputTrait;
-import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 
 public class CreateDedicatedInputAndOutputTest {
     private Model compareTransform(String prefix, Function<Model, Model> transform) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutputTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutputTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ModelSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.InputTrait;
+import software.amazon.smithy.model.traits.OutputTrait;
+import software.amazon.smithy.model.traits.ephemeral.OriginalShapeIdTrait;
+
+public class CreateDedicatedInputAndOutputTest {
+    private Model compareTransform(String prefix, Function<Model, Model> transform) {
+        Model before = Model.assembler()
+                .addImport(getClass().getResource("dedicated-input-output/" + prefix + "-before.smithy"))
+                .assemble()
+                .unwrap();
+        Model actualResult = transform.apply(before);
+        Model expectedResult = Model.assembler()
+                .addImport(getClass().getResource("dedicated-input-output/" + prefix + "-after.smithy"))
+                .assemble()
+                .unwrap();
+
+        Node actualNode = ModelSerializer.builder().build().serialize(actualResult);
+        Node expectedNode = ModelSerializer.builder().build().serialize(expectedResult);
+
+        Node.assertEquals(actualNode, expectedNode);
+
+        return actualResult;
+    }
+
+    @Test
+    public void createsDedicatedInputHeuristic() {
+        Model result = compareTransform("creates-dedicated-input-heuristic", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Input", "Output");
+        });
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooInput")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).expectTrait(OutputTrait.class);
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooInput")).getTrait(OriginalShapeIdTrait.class),
+                   Matchers.equalTo(Optional.empty()));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).getTrait(OriginalShapeIdTrait.class),
+                   Matchers.equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void createsDedicatedOutputHeuristic() {
+        Model result = compareTransform("creates-dedicated-output-heuristic", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Input", "Output");
+        });
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooInput")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).expectTrait(OutputTrait.class);
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooInput")).getTrait(OriginalShapeIdTrait.class),
+                   Matchers.equalTo(Optional.empty()));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).getTrait(OriginalShapeIdTrait.class),
+                   Matchers.equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void createsDedicatedInputAndOutputHeuristic() {
+        Model result = compareTransform("creates-dedicated-input-output-heuristic", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Request", "Response");
+        });
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooRequest")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooResponse")).expectTrait(OutputTrait.class);
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooRequest")).getTrait(OriginalShapeIdTrait.class),
+                   Matchers.equalTo(Optional.empty()));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooResponse")).getTrait(OriginalShapeIdTrait.class),
+                   Matchers.equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void createsDedicatedCopies() {
+        Model result = compareTransform("creates-dedicated-copies", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Input", "Output");
+        });
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooInput")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).expectTrait(OutputTrait.class);
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooInput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.example#GetFooData")));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOutput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.example#Foo")));
+    }
+
+    @Test
+    public void createsDedicatedCopiesAndDeconflicts() {
+        Model result = compareTransform("creates-dedicated-copies-and-deconflicts", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Input", "Output");
+        });
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooOperationInput")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooOperationOutput")).expectTrait(OutputTrait.class);
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOperationInput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.example#GetFooData")));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOperationOutput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.example#Foo")));
+    }
+
+    @Test
+    public void removesDisconnectedShapes() {
+        Model result = compareTransform("removes-disconnected-shapes", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Input", "Output");
+        });
+
+        assertThat(result.getShapeIds(), Matchers.not(Matchers.hasItem(ShapeId.from("smithy.example#GetFooData"))));
+        assertThat(result.getShapeIds(), Matchers.not(Matchers.hasItem(ShapeId.from("smithy.example#Foo"))));
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooInput")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).expectTrait(OutputTrait.class);
+
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooInput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.example#GetFooData")));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOutput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.example#Foo")));
+    }
+
+    @Test
+    public void handlesUnitTypes() {
+        Model result = compareTransform("handles-unit-types", model -> {
+            return ModelTransformer.create().createDedicatedInputAndOutput(model, "Input", "Output");
+        });
+
+        result.expectShape(ShapeId.from("smithy.example#GetFooInput")).expectTrait(InputTrait.class);
+        result.expectShape(ShapeId.from("smithy.example#GetFooOutput")).expectTrait(OutputTrait.class);
+
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooInput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.api#Unit")));
+        assertThat(result.expectShape(ShapeId.from("smithy.example#GetFooOutput"))
+                           .expectTrait(OriginalShapeIdTrait.class)
+                           .getOriginalId(),
+                   Matchers.equalTo(ShapeId.from("smithy.api#Unit")));
+    }
+
+    @Test
+    public void detectsConflictResolverLoop() {
+        Assertions.assertThrows(ModelTransformException.class, () -> {
+            Model before = Model.assembler()
+                    .addImport(getClass().getResource("dedicated-input-output/unable-to-deconflict.smithy"))
+                    .assemble()
+                    .unwrap();
+            ModelTransformer.create().createDedicatedInputAndOutput(before, "Input", "Output");
+        });
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-after.smithy
@@ -1,0 +1,41 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {
+    @required
+    id: String
+}
+
+@output
+structure GetFooOutput {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure GetFooData {
+    @required
+    id: String
+}
+
+structure Foo {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure Reused {
+    foo: Foo,
+    data: GetFooData
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-and-deconflicts-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-and-deconflicts-after.smithy
@@ -1,0 +1,45 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooOperationInput,
+    output: GetFooOperationOutput
+}
+
+@input
+structure GetFooOperationInput {
+    @required
+    id: String
+}
+
+@output
+structure GetFooOperationOutput {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure GetFooData {
+    @required
+    id: String
+}
+
+structure Foo {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure Reused {
+    foo: Foo,
+    data: GetFooData
+}
+
+structure GetFooInput {}
+
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-and-deconflicts-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-and-deconflicts-before.smithy
@@ -1,0 +1,34 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooData,
+    output: Foo
+}
+
+structure GetFooData {
+    @required
+    id: String
+}
+
+structure Foo {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure Reused {
+    foo: Foo,
+    data: GetFooData
+}
+
+// Say a service has a super unfortunate existing conflicting shape that
+// looks like the input of GetFoo:
+structure GetFooInput {}
+
+// Say a service has a super unfortunate existing conflicting shape that
+// looks like the output of GetFoo:
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-copies-before.smithy
@@ -1,0 +1,26 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooData,
+    output: Foo
+}
+
+structure GetFooData {
+    @required
+    id: String
+}
+
+structure Foo {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure Reused {
+    foo: Foo,
+    data: GetFooData
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-heuristic-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-heuristic-after.smithy
@@ -1,0 +1,14 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-heuristic-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-heuristic-before.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-output-heuristic-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-output-heuristic-after.smithy
@@ -1,0 +1,14 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooRequest,
+    output: GetFooResponse
+}
+
+@input
+structure GetFooRequest {}
+
+@output
+structure GetFooResponse {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-output-heuristic-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-input-output-heuristic-before.smithy
@@ -1,0 +1,12 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooRequest,
+    output: GetFooResponse
+}
+
+structure GetFooRequest {}
+
+structure GetFooResponse {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-output-heuristic-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-output-heuristic-after.smithy
@@ -1,0 +1,14 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-output-heuristic-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-output-heuristic-before.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/handles-unit-types-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/handles-unit-types-after.smithy
@@ -1,0 +1,14 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/handles-unit-types-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/handles-unit-types-before.smithy
@@ -1,0 +1,5 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shapes-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shapes-after.smithy
@@ -1,0 +1,23 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {
+    @required
+    id: String
+}
+
+@output
+structure GetFooOutput {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shapes-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shapes-before.smithy
@@ -1,0 +1,21 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooData,
+    output: Foo
+}
+
+structure GetFooData {
+    @required
+    id: String
+}
+
+structure Foo {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/unable-to-deconflict.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/unable-to-deconflict.smithy
@@ -1,0 +1,33 @@
+$version: "1.0"
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooData,
+    output: Foo
+}
+
+structure GetFooData {
+    @required
+    id: String
+}
+
+structure Foo {
+    @required
+    id: String,
+
+    @required
+    createdAt: Timestamp
+}
+
+structure Reused {
+    foo: Foo,
+    data: GetFooData
+}
+
+// This should never happen in practice, but this test will catch when
+// the deconflicting function returns a still conflicting name.
+structure GetFooInput {}
+structure GetFooOutput {}
+structure GetFooOperationInput {}
+structure GetFooOperationOutput {}


### PR DESCRIPTION
Adds a ModelTransformer transform that ensures every shape defines a
dedicated input and output shape marked with the @input and @output
traits and uses a consistent naming strategy.

The goal of this transform is to consolidate much of the logic that has
been repeated in various AWS SDK code generators to generate synthetic
input and output shapes for operations. It provides a consisten name for
these shapes so that generators know that they can use the name as-is if
they'd like.

Because shapes are sometimes renamed with this transform, it's important
to know what the original shape ID was. This might matter for protocols
that need to know the name of the input shape when serializing a request
or response (like AWS rest-xml). To accomplish this, I added the concept
of ephemeral traits to the model that allow traits to be added to shapes
that are only defined in code rather than through a trait definition.
Ephemeral traits are not persisted when a model is serialized, but
otherwise can be used just like any other trait. When a shape is
renamed, an ephemeral trait named OriginalShapeIdTrait is added to the
shape to provide the original shape ID of the shape so that things like
code generators can query it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
