### PR TITLE
Fix http-content-type protocol tests with mismatched params/headers

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -128,7 +128,6 @@ apply TestPayloadStructure @httpRequestTests([
             "Content-Length"
         ],
         params: {
-            testId: "t-12345",
             payloadConfig: {
                 data: 25,
             }
@@ -146,7 +145,8 @@ apply TestPayloadStructure @httpRequestTests([
         body: "{}",
         bodyMediaType: "application/json",
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "X-Amz-Test-Id": "t-12345"
         },
         requireHeaders: [
             "Content-Length"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/3058

*Description of changes:*
RestJsonTestPayloadStructure and RestJsonHttpWithHeadersButNoPayload had a `testId` param but no assertion for X-Amz-Test-Id header. Made the params/headers match.

*Testing:*
Regenerated test in aws-sdk-js-v3 and confirmed it fixes https://github.com/aws/aws-sdk-js-v3/issues/3058.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
