### PR TITLE
Change OpenAPI security schema names to lowercase

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasicConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBasicConverter.java
@@ -36,7 +36,7 @@ public final class HttpBasicConverter implements SecuritySchemeConverter<HttpBas
     public SecurityScheme createSecurityScheme(Context<? extends Trait> context, HttpBasicAuthTrait trait) {
         return SecurityScheme.builder()
                 .type("http")
-                .scheme("Basic")
+                .scheme("basic")
                 .description("HTTP Basic authentication")
                 .build();
     }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearerConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpBearerConverter.java
@@ -36,7 +36,7 @@ public final class HttpBearerConverter implements SecuritySchemeConverter<HttpBe
     public SecurityScheme createSecurityScheme(Context<? extends Trait> context, HttpBearerAuthTrait trait) {
         return SecurityScheme.builder()
                 .type("http")
-                .scheme("Bearer")
+                .scheme("bearer")
                 .description("HTTP Bearer authentication")
                 .build();
     }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigestConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/security/HttpDigestConverter.java
@@ -36,7 +36,7 @@ public final class HttpDigestConverter implements SecuritySchemeConverter<HttpDi
     public SecurityScheme createSecurityScheme(Context<? extends Trait> context, HttpDigestAuthTrait trait) {
         return SecurityScheme.builder()
                 .type("http")
-                .scheme("Digest")
+                .scheme("digest")
                 .description("HTTP Digest authentication")
                 .build();
     }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mixed-security-service.openapi.json
@@ -65,7 +65,7 @@
       "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
-        "scheme": "Basic"
+        "scheme": "basic"
       },
       "aws.auth.sigv4": {
         "type": "apiKey",

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-basic-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-basic-security.openapi.json
@@ -21,7 +21,7 @@
       "smithy.api.httpBasicAuth": {
         "type": "http",
         "description": "HTTP Basic authentication",
-        "scheme": "Basic"
+        "scheme": "basic"
       }
     }
   },

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-digest-security.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/security/http-digest-security.openapi.json
@@ -20,7 +20,7 @@
     "securitySchemes": {
       "smithy.api.httpDigestAuth": {
         "type": "http",
-        "scheme": "Digest",
+        "scheme": "digest",
         "description": "HTTP Digest authentication"
       }
     }


### PR DESCRIPTION
According to the [OpenAPI specification](https://spec.openapis.org/oas/latest.html), security schema names should
be used in lowercase. This causes issues e.g. in the [OpenAPI generator](https://github.com/OpenAPITools/openapi-generator/blob/06faa289bd93c5fe1f2caa376e32ec6cc07627a2/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L4778)
which checks for case sensitive values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
