### PR TITLE
Reduce builder copies using a managed reference

### DIFF
--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.aws.traits;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -26,6 +25,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -56,7 +56,7 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
         this.requestChecksumRequired = builder.requestChecksumRequired;
         this.requestAlgorithmMember = builder.requestAlgorithmMember;
         this.requestValidationModeMember = builder.requestValidationModeMember;
-        this.responseAlgorithms = ListUtils.copyOf(builder.responseAlgorithms);
+        this.responseAlgorithms = builder.responseAlgorithms.copy();
     }
 
     public static Builder builder() {
@@ -172,7 +172,7 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
         private boolean requestChecksumRequired;
 
         private String requestValidationModeMember;
-        private final List<String> responseAlgorithms = new ArrayList<>();
+        private final BuilderRef<List<String>> responseAlgorithms = BuilderRef.forList();
 
         private Builder() {}
 
@@ -198,12 +198,12 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
 
         public Builder responseAlgorithms(List<String> algorithms) {
             this.responseAlgorithms.clear();
-            this.responseAlgorithms.addAll(algorithms);
+            this.responseAlgorithms.get().addAll(algorithms);
             return this;
         }
 
         public Builder addResponseAlgorithm(String algorithm) {
-            this.responseAlgorithms.add(algorithm);
+            this.responseAlgorithms.get().add(algorithm);
             return this;
         }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.aws.traits.auth;
 
-import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
@@ -25,8 +24,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -41,7 +39,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
     private CognitoUserPoolsTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
-        this.providerArns = ListUtils.copyOf(SmithyBuilder.requiredState("providerArns", builder.providerArns));
+        this.providerArns = builder.providerArns.copy();
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -90,7 +88,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
     /** Builder for {@link CognitoUserPoolsTrait}. */
     public static final class Builder extends AbstractTraitBuilder<CognitoUserPoolsTrait, Builder> {
-        private final List<String> providerArns = new ArrayList<>();
+        private final BuilderRef<List<String>> providerArns = BuilderRef.forList();
 
         private Builder() {}
 
@@ -107,7 +105,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
          */
         public Builder providerArns(List<String> providerArns) {
             clearProviderArns();
-            this.providerArns.addAll(providerArns);
+            this.providerArns.get().addAll(providerArns);
             return this;
         }
 
@@ -118,7 +116,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
          * @return Returns the builder.
          */
         public Builder addProviderArn(String arn) {
-            providerArns.add(arn);
+            providerArns.get().add(arn);
             return this;
         }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsProtocolTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsProtocolTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.aws.traits.protocols;
 
-import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -23,7 +22,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 
 /**
  * Represents a configurable AWS protocol trait.
@@ -42,8 +41,8 @@ public abstract class AwsProtocolTrait extends AbstractTrait {
     // package-private constructor (at least for now)
     AwsProtocolTrait(ShapeId id, Builder<?, ?> builder) {
         super(id, builder.getSourceLocation());
-        http = ListUtils.copyOf(builder.http);
-        eventStreamHttp = ListUtils.copyOf(builder.eventStreamHttp);
+        http = builder.http.copy();
+        eventStreamHttp = builder.eventStreamHttp.copy();
     }
 
     /**
@@ -89,8 +88,8 @@ public abstract class AwsProtocolTrait extends AbstractTrait {
      */
     public abstract static class Builder<T extends Trait, B extends Builder> extends AbstractTraitBuilder<T, B> {
 
-        private final List<String> http = new ArrayList<>();
-        private final List<String> eventStreamHttp = new ArrayList<>();
+        private final BuilderRef<List<String>> http = BuilderRef.forList();
+        private final BuilderRef<List<String>> eventStreamHttp = BuilderRef.forList();
 
         /**
          * Sets the list of supported HTTP protocols.
@@ -101,7 +100,7 @@ public abstract class AwsProtocolTrait extends AbstractTrait {
         @SuppressWarnings("unchecked")
         public B http(List<String> http) {
             this.http.clear();
-            this.http.addAll(http);
+            this.http.get().addAll(http);
             return (B) this;
         }
 
@@ -114,7 +113,7 @@ public abstract class AwsProtocolTrait extends AbstractTrait {
         @SuppressWarnings("unchecked")
         public B eventStreamHttp(List<String> eventStreamHttp) {
             this.eventStreamHttp.clear();
-            this.eventStreamHttp.addAll(eventStreamHttp);
+            this.eventStreamHttp.get().addAll(eventStreamHttp);
             return (B) this;
         }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionResult.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionResult.java
@@ -15,9 +15,6 @@
 
 package software.amazon.smithy.build;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,8 +22,7 @@ import java.util.Optional;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -41,8 +37,8 @@ public final class ProjectionResult {
     private ProjectionResult(Builder builder) {
         this.projectionName = SmithyBuilder.requiredState("projectionName", builder.projectionName);
         this.model = SmithyBuilder.requiredState("model", builder.model);
-        this.events = ListUtils.copyOf(builder.events);
-        this.pluginManifests = MapUtils.copyOf(builder.pluginManifests);
+        this.events = builder.events.copy();
+        this.pluginManifests = builder.pluginManifests.copy();
     }
 
     /**
@@ -115,8 +111,8 @@ public final class ProjectionResult {
     public static final class Builder implements SmithyBuilder<ProjectionResult> {
         private String projectionName;
         private Model model;
-        private final Map<String, FileManifest> pluginManifests = new HashMap<>();
-        private final Collection<ValidationEvent> events = new ArrayList<>();
+        private final BuilderRef<Map<String, FileManifest>> pluginManifests = BuilderRef.forUnorderedMap();
+        private final BuilderRef<List<ValidationEvent>> events = BuilderRef.forList();
 
         @Override
         public ProjectionResult build() {
@@ -153,7 +149,7 @@ public final class ProjectionResult {
          * @return Returns the builder.
          */
         public Builder addPluginManifest(String pluginName, FileManifest manifest) {
-            pluginManifests.put(pluginName, manifest);
+            pluginManifests.get().put(pluginName, manifest);
             return this;
         }
 
@@ -164,7 +160,7 @@ public final class ProjectionResult {
          * @return Returns the builder.
          */
         public Builder addEvent(ValidationEvent event) {
-            events.add(Objects.requireNonNull(event));
+            events.get().add(Objects.requireNonNull(event));
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -242,7 +242,7 @@ public abstract class Node implements FromSourceLocation, ToNode {
      * @return Returns the ObjectNode builder.
      */
     public static ObjectNode.Builder objectNodeBuilder() {
-        return new ObjectNode.Builder();
+        return ObjectNode.builder();
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
@@ -18,10 +18,6 @@ package software.amazon.smithy.model.node.internal;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.BooleanNode;
@@ -33,7 +29,7 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
-public final class NodeHandler extends JsonHandler<List<Node>, Map<StringNode, Node>> {
+public final class NodeHandler extends JsonHandler<ArrayNode.Builder, ObjectNode.Builder> {
 
     private Node value;
 
@@ -94,33 +90,33 @@ public final class NodeHandler extends JsonHandler<List<Node>, Map<StringNode, N
     }
 
     @Override
-    List<Node> startArray() {
-        return new ArrayList<>();
+    ArrayNode.Builder startArray() {
+        return ArrayNode.builder();
     }
 
     @Override
-    void endArrayValue(List<Node> array) {
-        array.add(value);
+    void endArrayValue(ArrayNode.Builder builder) {
+        builder.withValue(value);
     }
 
     @Override
-    void endArray(List<Node> array, SourceLocation location) {
-        value = new ArrayNode(array, location);
+    void endArray(ArrayNode.Builder builder, SourceLocation location) {
+        value = builder.sourceLocation(location).build();
     }
 
     @Override
-    Map<StringNode, Node> startObject() {
-        return new LinkedHashMap<>();
+    ObjectNode.Builder startObject() {
+        return ObjectNode.builder();
     }
 
     @Override
-    void endObjectValue(Map<StringNode, Node> object, String name, SourceLocation keyLocation) {
+    void endObjectValue(ObjectNode.Builder object, String name, SourceLocation keyLocation) {
         StringNode key = new StringNode(name, keyLocation);
-        object.put(key, value);
+        object.withMember(key, value);
     }
 
     @Override
-    void endObject(Map<StringNode, Node> object, SourceLocation location) {
-        value = new ObjectNode(object, location);
+    void endObject(ObjectNode.Builder object, SourceLocation location) {
+        value = object.sourceLocation(location).build();
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
@@ -16,13 +16,11 @@
 package software.amazon.smithy.model.shapes;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -35,7 +33,7 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<?, ?>,
         implements SmithyBuilder<S>, FromSourceLocation {
 
     private ShapeId id;
-    private Map<ShapeId, Trait> traits;
+    private final BuilderRef<Map<ShapeId, Trait>> traits = BuilderRef.forUnorderedMap();
     private SourceLocation source = SourceLocation.none();
 
     AbstractShapeBuilder() {}
@@ -151,11 +149,7 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<?, ?>,
             throw new IllegalArgumentException("trait must not be null");
         }
 
-        if (traits == null) {
-            traits = new HashMap<>();
-        }
-
-        traits.put(trait.toShapeId(), trait);
+        traits.get().put(trait.toShapeId(), trait);
         return (B) this;
     }
 
@@ -180,8 +174,8 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<?, ?>,
      */
     @SuppressWarnings("unchecked")
     public final B removeTrait(ShapeId traitId) {
-        if (traits != null) {
-            traits.remove(traitId);
+        if (traits.hasValue()) {
+            traits.get().remove(traitId);
         }
         return (B) this;
     }
@@ -193,9 +187,7 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<?, ?>,
      */
     @SuppressWarnings("unchecked")
     public final B clearTraits() {
-        if (traits != null) {
-            traits.clear();
-        }
+        traits.clear();
         return (B) this;
     }
 
@@ -228,6 +220,6 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<?, ?>,
     }
 
     Map<ShapeId, Trait> copyTraits() {
-        return traits == null ? Collections.emptyMap() : MapUtils.copyOf(traits);
+        return traits.copy();
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EntityShape.java
@@ -16,9 +16,8 @@
 package software.amazon.smithy.model.shapes;
 
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
-import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.BuilderRef;
 
 /**
  * Abstract class representing service and resource shapes.
@@ -30,8 +29,8 @@ public abstract class EntityShape extends Shape {
 
     EntityShape(Builder<?, ?> builder) {
         super(builder, false);
-        resources = SetUtils.orderedCopyOf(builder.resources);
-        operations = SetUtils.orderedCopyOf(builder.operations);
+        resources = builder.resources.copy();
+        operations = builder.operations.copy();
     }
 
     /**
@@ -88,19 +87,19 @@ public abstract class EntityShape extends Shape {
     public abstract static class Builder<B extends Builder<?, ?>, S extends EntityShape>
             extends AbstractShapeBuilder<B, S> {
 
-        private final Set<ShapeId> resources = new LinkedHashSet<>();
-        private final Set<ShapeId> operations = new LinkedHashSet<>();
+        private final BuilderRef<Set<ShapeId>> resources = BuilderRef.forOrderedSet();
+        private final BuilderRef<Set<ShapeId>> operations = BuilderRef.forOrderedSet();
 
         @SuppressWarnings("unchecked")
         public B operations(Collection<ShapeId> ids) {
             clearOperations();
-            operations.addAll(ids);
+            operations.get().addAll(ids);
             return (B) this;
         }
 
         @SuppressWarnings("unchecked")
         public B addOperation(ToShapeId id) {
-            operations.add(id.toShapeId());
+            operations.get().add(id.toShapeId());
             return (B) this;
         }
 
@@ -110,7 +109,7 @@ public abstract class EntityShape extends Shape {
 
         @SuppressWarnings("unchecked")
         public B removeOperation(ToShapeId id) {
-            operations.remove(id.toShapeId());
+            operations.get().remove(id.toShapeId());
             return (B) this;
         }
 
@@ -123,13 +122,13 @@ public abstract class EntityShape extends Shape {
         @SuppressWarnings("unchecked")
         public B resources(Collection<ShapeId> ids) {
             clearResources();
-            resources.addAll(ids);
+            resources.get().addAll(ids);
             return (B) this;
         }
 
         @SuppressWarnings("unchecked")
         public B addResource(ToShapeId id) {
-            resources.add(id.toShapeId());
+            resources.get().add(id.toShapeId());
             return (B) this;
         }
 
@@ -139,7 +138,7 @@ public abstract class EntityShape extends Shape {
 
         @SuppressWarnings("unchecked")
         public B removeResource(ToShapeId id) {
-            resources.remove(id.toShapeId());
+            resources.get().remove(id.toShapeId());
             return (B) this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import software.amazon.smithy.model.knowledge.OperationIndex;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -36,7 +36,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
 
     private OperationShape(Builder builder) {
         super(builder, false);
-        errors = ListUtils.copyOf(builder.errors);
+        errors = builder.errors.copy();
         input = builder.input;
         output = builder.output;
     }
@@ -137,7 +137,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
     public static final class Builder extends AbstractShapeBuilder<Builder, OperationShape> {
         private ShapeId input;
         private ShapeId output;
-        private final List<ShapeId> errors = new ArrayList<>();
+        private final BuilderRef<List<ShapeId>> errors = BuilderRef.forList();
 
         @Override
         public ShapeType getShapeType() {
@@ -187,7 +187,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
          * @return Returns the builder.
          */
         public Builder addError(ToShapeId errorShapeId) {
-            errors.add(errorShapeId.toShapeId());
+            errors.get().add(errorShapeId.toShapeId());
             return this;
         }
 
@@ -209,7 +209,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
          * @return Returns the builder.
          */
         public Builder addErrors(Collection<ShapeId> errorShapeIds) {
-            errors.addAll(Objects.requireNonNull(errorShapeIds));
+            errors.get().addAll(Objects.requireNonNull(errorShapeIds));
             return this;
         }
 
@@ -220,7 +220,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
          * @return Returns the builder.
          */
         public Builder removeError(ToShapeId errorShapeId) {
-            errors.remove(errorShapeId.toShapeId());
+            errors.get().remove(errorShapeId.toShapeId());
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -18,14 +18,11 @@ package software.amazon.smithy.model.shapes;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import software.amazon.smithy.utils.MapUtils;
-import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -44,14 +41,14 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
 
     private ResourceShape(Builder builder) {
         super(builder);
-        identifiers = MapUtils.orderedCopyOf(builder.identifiers);
+        identifiers = builder.identifiers.copy();
         put = builder.put;
         create = builder.create;
         read = builder.read;
         update = builder.update;
         delete = builder.delete;
         list = builder.list;
-        collectionOperations = SetUtils.orderedCopyOf(builder.collectionOperations);
+        collectionOperations = builder.collectionOperations.copy();
 
         // Compute all operations bound to the resource.
         allOperations.addAll(getOperations());
@@ -202,8 +199,8 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
      * Builder used to create a {@link ResourceShape}.
      */
     public static final class Builder extends EntityShape.Builder<Builder, ResourceShape> {
-        private final Map<String, ShapeId> identifiers = new LinkedHashMap<>();
-        private final Set<ShapeId> collectionOperations = new LinkedHashSet<>();
+        private final BuilderRef<Map<String, ShapeId>> identifiers = BuilderRef.forOrderedMap();
+        private final BuilderRef<Set<ShapeId>> collectionOperations = BuilderRef.forOrderedSet();
         private ShapeId put;
         private ShapeId create;
         private ShapeId read;
@@ -229,7 +226,7 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
          */
         public Builder identifiers(Map<String, ShapeId> identifiers) {
             this.identifiers.clear();
-            this.identifiers.putAll(identifiers);
+            this.identifiers.get().putAll(identifiers);
             return this;
         }
 
@@ -241,7 +238,7 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
          * @return Returns the builder.
          */
         public Builder addIdentifier(String name, ToShapeId identifier) {
-            identifiers.put(Objects.requireNonNull(name), identifier.toShapeId());
+            identifiers.get().put(Objects.requireNonNull(name), identifier.toShapeId());
             return this;
         }
 
@@ -281,12 +278,12 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
 
         public Builder collectionOperations(Collection<ShapeId> ids) {
             clearCollectionOperations();
-            collectionOperations.addAll(ids);
+            collectionOperations.get().addAll(ids);
             return this;
         }
 
         public Builder addCollectionOperation(ToShapeId id) {
-            collectionOperations.add(id.toShapeId());
+            collectionOperations.get().add(id.toShapeId());
             return this;
         }
 
@@ -295,7 +292,7 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
         }
 
         public Builder removeCollectionOperation(ToShapeId id) {
-            collectionOperations.remove(id.toShapeId());
+            collectionOperations.get().remove(id.toShapeId());
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -15,15 +15,12 @@
 
 package software.amazon.smithy.model.shapes;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -38,8 +35,8 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
     private ServiceShape(Builder builder) {
         super(builder);
         version = builder.version;
-        rename = MapUtils.orderedCopyOf(builder.rename);
-        errors = ListUtils.copyOf(builder.errors);
+        rename = builder.rename.copy();
+        errors = builder.errors.copy();
     }
 
     public static Builder builder() {
@@ -134,8 +131,8 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
      */
     public static final class Builder extends EntityShape.Builder<Builder, ServiceShape> {
         private String version = "";
-        private final Map<ShapeId, String> rename = new TreeMap<>();
-        private final List<ShapeId> errors = new ArrayList<>();
+        private final BuilderRef<Map<ShapeId, String>> rename = BuilderRef.forOrderedMap();
+        private final BuilderRef<List<ShapeId>> errors = BuilderRef.forList();
 
         @Override
         public ServiceShape build() {
@@ -164,12 +161,12 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
         }
 
         public Builder putRename(ShapeId from, String to) {
-            this.rename.put(Objects.requireNonNull(from), Objects.requireNonNull(to));
+            this.rename.get().put(Objects.requireNonNull(from), Objects.requireNonNull(to));
             return this;
         }
 
         public Builder removeRename(ToShapeId from) {
-            rename.remove(from.toShapeId());
+            rename.get().remove(from.toShapeId());
             return this;
         }
 
@@ -194,7 +191,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
          * @return Returns the builder.
          */
         public Builder addError(ToShapeId errorShapeId) {
-            errors.add(errorShapeId.toShapeId());
+            errors.get().add(errorShapeId.toShapeId());
             return this;
         }
 
@@ -218,7 +215,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
          * @return Returns the builder.
          */
         public Builder addErrors(List<ShapeId> errorShapeIds) {
-            errors.addAll(Objects.requireNonNull(errorShapeIds));
+            errors.get().addAll(Objects.requireNonNull(errorShapeIds));
             return this;
         }
 
@@ -229,7 +226,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
          * @return Returns the builder.
          */
         public Builder removeError(ToShapeId errorShapeId) {
-            errors.remove(errorShapeId.toShapeId());
+            errors.get().remove(errorShapeId.toShapeId());
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
@@ -15,13 +15,12 @@
 
 package software.amazon.smithy.model.traits;
 
-import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -34,7 +33,7 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
 
     public AuthDefinitionTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
-        traits = ListUtils.copyOf(builder.traits);
+        traits = builder.traits.copy();
     }
 
     /**
@@ -89,7 +88,7 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
     }
 
     public static final class Builder extends AbstractTraitBuilder<AuthDefinitionTrait, Builder> {
-        private final List<ShapeId> traits = new ArrayList<>();
+        private final BuilderRef<List<ShapeId>> traits = BuilderRef.forList();
 
         @Override
         public AuthDefinitionTrait build() {
@@ -98,12 +97,12 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
 
         public Builder traits(List<ShapeId> traits) {
             this.traits.clear();
-            this.traits.addAll(traits);
+            this.traits.get().addAll(traits);
             return this;
         }
 
         public Builder addTrait(ShapeId trait) {
-            traits.add(trait);
+            traits.get().add(trait);
             return this;
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.model.traits;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.SourceException;
@@ -23,7 +22,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -36,7 +35,7 @@ public final class EnumTrait extends AbstractTrait implements ToSmithyBuilder<En
 
     private EnumTrait(Builder builder) {
         super(ID, builder.sourceLocation);
-        this.definitions = ListUtils.copyOf(builder.definitions);
+        this.definitions = builder.definitions.copy();
         if (definitions.isEmpty()) {
             throw new SourceException("enum must have at least one entry", getSourceLocation());
         }
@@ -95,20 +94,20 @@ public final class EnumTrait extends AbstractTrait implements ToSmithyBuilder<En
      * Builder used to create the enum trait.
      */
     public static final class Builder extends AbstractTraitBuilder<EnumTrait, Builder> {
-        private final List<EnumDefinition> definitions = new ArrayList<>();
+        private final BuilderRef<List<EnumDefinition>> definitions = BuilderRef.forList();
 
         public Builder addEnum(EnumDefinition value) {
-            definitions.add(value);
+            definitions.get().add(value);
             return this;
         }
 
         public Builder removeEnum(String value) {
-            definitions.removeIf(def -> def.getValue().equals(value));
+            definitions.get().removeIf(def -> def.getValue().equals(value));
             return this;
         }
 
         public Builder removeEnumByName(String name) {
-            definitions.removeIf(def -> def.getName().filter(n -> n.equals(name)).isPresent());
+            definitions.get().removeIf(def -> def.getName().filter(n -> n.equals(name)).isPresent());
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
@@ -15,13 +15,12 @@
 
 package software.amazon.smithy.model.traits;
 
-import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -38,7 +37,7 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
 
     public ProtocolDefinitionTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
-        traits = ListUtils.copyOf(builder.traits);
+        traits = builder.traits.copy();
         noInlineDocumentSupport = builder.noInlineDocumentSupport;
     }
 
@@ -111,7 +110,7 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
     }
 
     public static final class Builder extends AbstractTraitBuilder<ProtocolDefinitionTrait, Builder> {
-        private final List<ShapeId> traits = new ArrayList<>();
+        private final BuilderRef<List<ShapeId>> traits = BuilderRef.forList();
         private boolean noInlineDocumentSupport;
 
         @Override
@@ -121,12 +120,12 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
 
         public Builder traits(List<ShapeId> traits) {
             this.traits.clear();
-            this.traits.addAll(traits);
+            this.traits.get().addAll(traits);
             return this;
         }
 
         public Builder addTrait(ShapeId trait) {
-            traits.add(trait);
+            traits.get().add(trait);
             return this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/StringListTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/StringListTrait.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.traits;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -26,6 +25,7 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.BuilderRef;
 
 /**
  * Contains abstract functionality to build traits that contain a list
@@ -83,7 +83,7 @@ public abstract class StringListTrait extends AbstractTrait {
     public abstract static class Builder<TRAIT extends StringListTrait, BUILDER extends Builder>
             extends AbstractTraitBuilder<TRAIT, BUILDER> {
 
-        private final List<String> values = new ArrayList<>();
+        private final BuilderRef<List<String>> values = BuilderRef.forList();
 
         /**
          * Gets the values set in the builder.
@@ -91,7 +91,7 @@ public abstract class StringListTrait extends AbstractTrait {
          * @return Returns the set values.
          */
         public List<String> getValues() {
-            return Collections.unmodifiableList(values);
+            return values.copy();
         }
 
         /**
@@ -102,7 +102,7 @@ public abstract class StringListTrait extends AbstractTrait {
          */
         @SuppressWarnings("unchecked")
         public BUILDER addValue(String value) {
-            values.add(Objects.requireNonNull(value));
+            values.get().add(Objects.requireNonNull(value));
             return (BUILDER) this;
         }
 
@@ -115,7 +115,7 @@ public abstract class StringListTrait extends AbstractTrait {
         @SuppressWarnings("unchecked")
         public BUILDER values(Collection<String> values) {
             clearValues();
-            this.values.addAll(values);
+            this.values.get().addAll(values);
             return (BUILDER) this;
         }
 
@@ -127,7 +127,7 @@ public abstract class StringListTrait extends AbstractTrait {
          */
         @SuppressWarnings("unchecked")
         public BUILDER removeValue(String value) {
-            this.values.remove(value);
+            this.values.get().remove(value);
             return (BUILDER) this;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.traits;
 
 import static software.amazon.smithy.model.node.Node.loadArrayOfString;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -28,7 +27,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -62,7 +61,7 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
     public TraitDefinition(TraitDefinition.Builder builder) {
         super(ID, builder.sourceLocation);
         selector = builder.selector;
-        conflicts = ListUtils.copyOf(builder.conflicts);
+        conflicts = builder.conflicts.copy();
         structurallyExclusive = builder.structurallyExclusive;
     }
 
@@ -148,7 +147,7 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
      */
     public static final class Builder extends AbstractTraitBuilder<TraitDefinition, Builder> {
         private Selector selector = Selector.IDENTITY;
-        private final List<ShapeId> conflicts = new ArrayList<>();
+        private final BuilderRef<List<ShapeId>> conflicts = BuilderRef.forList();
         private StructurallyExclusive structurallyExclusive;
 
         private Builder() {}
@@ -165,12 +164,12 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
 
         public Builder addConflict(ShapeId id) {
             Objects.requireNonNull(id);
-            conflicts.add(id);
+            conflicts.get().add(id);
             return this;
         }
 
         public Builder removeConflict(ToShapeId id) {
-            conflicts.remove(id.toShapeId());
+            conflicts.get().remove(id.toShapeId());
             return this;
         }
 

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/BuilderRef.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/BuilderRef.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Manages the creation, copying, and reuse of values created by builders.
+ *
+ * <p>BuilderRef manages the state of a mutable value contained in a builder.
+ * It ensures that things like arrays built up in a builder can be used
+ * directly in objects being built without copies, and it allows the builder
+ * to be reused without mutating previously built objects.
+ *
+ * <p>Smithy uses lots of builders to build up immutable objects. To make an
+ * immutable object in Java, you need to make defensive copies of things like
+ * lists, sets, and maps, but doing that for every single one of these types
+ * in builders results in lots of copies. One option is to just use the lists
+ * et al contained in builders directly in the built objects, but that runs the
+ * risk of the builder being further mutated and thus mutating the object.
+ * Another option is to clear out the state of the builder and give "ownership"
+ * of lists et al to built objects, but that means builders can't easily be
+ * used to build up multiple objects (and while that rare, it's a use case that
+ * probably *should* work, and always has worked in Smithy).
+ *
+ * <p>BuilderRef creates the value if needed when the builder needs to mutate
+ * the wrapped value (see {@link #get}. It creates an immutable copy of the value
+ * when {@link #copy} is called, and an immutable "borrowed" reference to the
+ * copied value is maintained in the reference. This borrowed copy can be queried
+ * using {@link #peek}, but it can't be mutated. If the reference only has a
+ * borrowed value but attempts to call {@link #get}, then a copy of the borrowed
+ * value is created and returned from {@code get()}.
+ *
+ * @param <T> Type of value being created.
+ */
+public interface BuilderRef<T> {
+    /**
+     * Gets a mutable {@code T} from the reference, creating one if needed.
+     *
+     * <p>Subsequent calls to {@link #hasValue()} will return true after
+     * this method is called.
+     *
+     * @return Returns a mutable {@code T} value.
+     */
+    T get();
+
+    /**
+     * Gets an immutable {@code T} from the reference, reusing borrowed
+     * values if possible, and creating owned values if needed.
+     *
+     * <p>Attempting to mutate the provided value <em>should</em> fail
+     * at runtime, but even if it doesn't, doing so could inadvertently
+     * mutate previously built objects.
+     *
+     * <p>Subsequent calls to {@link #hasValue()} may or may not return true
+     * after this method is called.
+     *
+     * @return Returns an immutable peeked {@code T} value.
+     */
+    T peek();
+
+    /**
+     * Creates an immutable copy of {@code T}.
+     *
+     * <p>Subsequent calls to {@link #hasValue()} may or may not return true
+     * after this method is called.
+     *
+     * @return Returns the copied immutable value.
+     */
+    T copy();
+
+    /**
+     * Checks if the reference currently has a borrowed or owned value.
+     *
+     * <p>This method does not check if the contained value is considered
+     * empty. This method only returns true if the reference contains any
+     * kind of previously built value. This might be useful for builder
+     * methods that attempt to remove values from the contained object.
+     * If there is no contained object, then there's no need to create
+     * one just to remove a value from an empty container.
+     *
+     * @return Returns true if the reference contains a value of any kind.
+     */
+    boolean hasValue();
+
+    /**
+     * Removes any borrowed or owned values from the reference.
+     *
+     * <p>Subsequent calls to {@link #hasValue()} will return false after
+     * this method is called.
+     */
+    void clear();
+
+    /**
+     * Creates a builder reference to an unordered map.
+     *
+     * @param <K> Type of key of the map.
+     * @param <V> Type of value of the map.
+     * @return Returns the created map.
+     */
+    static <K, V> BuilderRef<Map<K, V>> forUnorderedMap() {
+        return new DefaultBuilderRef<>(HashMap::new, HashMap::new,
+                                       Collections::unmodifiableMap, Collections::emptyMap);
+    }
+
+    /**
+     * Creates a builder reference to a ordered map.
+     *
+     * @param <K> Type of key of the map.
+     * @param <V> Type of value of the map.
+     * @return Returns the created map.
+     */
+    static <K, V> BuilderRef<Map<K, V>> forOrderedMap() {
+        return new DefaultBuilderRef<>(LinkedHashMap::new, LinkedHashMap::new,
+                                       Collections::unmodifiableMap, Collections::emptyMap);
+    }
+
+    /**
+     * Creates a builder reference to a list.
+     *
+     * @param <T> Type of value in the list.
+     * @return Returns the created list.
+     */
+    static <T> BuilderRef<List<T>> forList() {
+        return new DefaultBuilderRef<>(ArrayList::new, ArrayList::new,
+                                       Collections::unmodifiableList, Collections::emptyList);
+    }
+
+    /**
+     * Creates a builder reference to an unordered set.
+     *
+     * @param <T> Type of value in the set.
+     * @return Returns the created set.
+     */
+    static <T> BuilderRef<Set<T>> forUnorderedSet() {
+        return new DefaultBuilderRef<>(HashSet::new, HashSet::new,
+                                       Collections::unmodifiableSet, Collections::emptySet);
+    }
+
+    /**
+     * Creates a builder reference to an ordered set.
+     *
+     * @param <T> Type of value in the set.
+     * @return Returns the created set.
+     */
+    static <T> BuilderRef<Set<T>> forOrderedSet() {
+        return new DefaultBuilderRef<>(LinkedHashSet::new, LinkedHashSet::new,
+                                       Collections::unmodifiableSet, Collections::emptySet);
+    }
+}

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/DefaultBuilderRef.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/DefaultBuilderRef.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.utils;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Default implementation of {@link BuilderRef}.
+ *
+ * <p>This class is not threadsafe; it should only be used to build up
+ * other objects using {@link #copy()}.
+ *
+ * @param <T> The type of value being built, borrowed, and copied.
+ */
+final class DefaultBuilderRef<T> implements BuilderRef<T> {
+
+    private final Supplier<T> ctor;
+    private final Function<T, T> copyCtor;
+    private final Function<T, T> immutableWrapper;
+    private final Supplier<T> emptyCtorOptimization;
+    private T immutableOwned;
+    private T owned;
+    private T borrowed;
+
+    DefaultBuilderRef(
+            Supplier<T> ctor,
+            Function<T, T> copyCtor,
+            Function<T, T> immutableWrapper,
+            Supplier<T> emptyCtorOptimization
+    ) {
+        this.ctor = ctor;
+        this.copyCtor = copyCtor;
+        this.immutableWrapper = immutableWrapper;
+        this.emptyCtorOptimization = emptyCtorOptimization;
+    }
+
+    @Override
+    public T get() {
+        if (owned != null) {
+            return owned;
+        } else if (borrowed != null) {
+            // The reference has a borrowed value, so it can't be mutated. Copy it and make it owned.
+            return setOwned(applyCopyCtor(borrowed));
+        } else {
+            // The reference has no owned or borrowed value, so create a new owned value.
+            return setOwned(applyCtor());
+        }
+    }
+
+    @Override
+    public T peek() {
+        if (immutableOwned != null) {
+            return immutableOwned;
+        } else if (owned != null) {
+            // The reference has not yet created an immutable wrapper of the owned value.
+            immutableOwned = applyImmutableWrapper(owned);
+            return immutableOwned;
+        } else if (borrowed != null) {
+            // The reference already contains an immutable borrowed value.
+            return borrowed;
+        } else if (emptyCtorOptimization != null) {
+            return applyEmptyCtorOptimization();
+        } else {
+            // Create and store an owned value, then create an immutable borrowed reference recursively.
+            setOwned(applyCtor());
+            return peek();
+        }
+    }
+
+    @Override
+    public T copy() {
+        if (owned != null) {
+            // The currently owned value will be the copied result. The reference will keep a "borrowed"
+            // pointer to this value. Use peek() to get or create an immutably wrapped owned value.
+            T result = peek();
+            setOwned(null);
+            borrowed = result;
+            return result;
+        } else if (borrowed != null) {
+            // Copy the borrowed value and make it immutable.
+            return applyImmutableWrapper(applyCopyCtor(borrowed));
+        } else if (emptyCtorOptimization != null) {
+            // The value is empty and was never created, so call the empty ctor supplier if available.
+            return applyEmptyCtorOptimization();
+        } else {
+            // Cache the value so subsequent calls to peek reuse the computed value.
+            borrowed = applyImmutableWrapper(applyCtor());
+            return borrowed;
+        }
+    }
+
+    @Override
+    public boolean hasValue() {
+        return owned != null || borrowed != null;
+    }
+
+    @Override
+    public void clear() {
+        setOwned(null);
+    }
+
+    private T setOwned(T value) {
+        owned = value;
+        immutableOwned = null;
+        borrowed = null;
+        return value;
+    }
+
+    private T applyCtor() {
+        return Objects.requireNonNull(ctor.get(), "BuilderRef 'ctor' must not return null");
+    }
+
+    private T applyCopyCtor(T value) {
+        return Objects.requireNonNull(copyCtor.apply(value), "BuilderRef 'copyCtor' must not return null");
+    }
+
+    private T applyImmutableWrapper(T value) {
+        return Objects.requireNonNull(immutableWrapper.apply(value),
+                                      "BuilderRef 'immutableWrapper' must not return null");
+    }
+
+    private T applyEmptyCtorOptimization() {
+        return Objects.requireNonNull(emptyCtorOptimization.get(),
+                                      "BuilderRef 'emptyCtorOptimization' must not return null");
+    }
+}

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/FunctionalUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/FunctionalUtils.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.utils;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -24,6 +25,8 @@ public final class FunctionalUtils {
 
     @SuppressWarnings("rawtypes")
     private static final Predicate ALWAYS_TRUE = x -> true;
+
+    private static final Function<Object, Object> IDENTITY = value -> value;
 
     private FunctionalUtils() {}
 
@@ -47,5 +50,16 @@ public final class FunctionalUtils {
     @SuppressWarnings("unchecked")
     public static <T> Predicate<T> alwaysTrue() {
         return (Predicate<T>) ALWAYS_TRUE;
+    }
+
+    /**
+     * Returns an identity function that always returns the given value.
+     *
+     * @param <T> Type of value to return.
+     * @return Returns the identity function.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> Function<T, T> identity() {
+        return (Function<T, T>) IDENTITY;
     }
 }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/BuilderRefTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/BuilderRefTest.java
@@ -1,0 +1,84 @@
+package software.amazon.smithy.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class BuilderRefTest {
+    @Test
+    public void createsValues() {
+        BuilderRef<List<String>> strings = BuilderRef.forList();
+        strings.get().add("a");
+        strings.get().add("b");
+
+        assertThat(strings.copy(), contains("a", "b"));
+    }
+
+    @Test
+    public void createsValuesAndCanBuildMore() {
+        BuilderRef<List<String>> strings = BuilderRef.forList();
+        strings.get().add("a");
+        strings.get().add("b");
+
+        List<String> first = strings.copy();
+        assertThat(strings.peek(), equalTo(first));
+
+        strings.get().add("c");
+        assertThat(strings.peek(), not(equalTo(first)));
+
+        List<String> second = strings.copy();
+
+        assertThat(first, not(equalTo(second)));
+        assertThat(second, contains("a", "b", "c"));
+    }
+
+    @Test
+    public void copiesOfBorrowedValuesCopiesBorrowedValue() {
+        BuilderRef<List<String>> strings = BuilderRef.forList();
+        strings.get().add("a");
+
+        List<String> first = strings.copy();
+        List<String> second = strings.copy();
+
+        assertThat(first, equalTo(second));
+    }
+
+    @Test
+    public void copyingEmptyListsMightBeOptimized() {
+        BuilderRef<List<String>> strings = BuilderRef.forList();
+
+        List<String> first = strings.copy();
+        List<String> second = strings.copy();
+
+        assertThat(first, equalTo(second));
+    }
+
+    @Test
+    public void peekingEmptyListsMightBeOptimized() {
+        BuilderRef<List<String>> strings = BuilderRef.forList();
+
+        List<String> first = strings.peek();
+        List<String> second = strings.peek();
+
+        assertThat(first, equalTo(second));
+    }
+
+    @Test
+    public void tracksIfHasValue() {
+        BuilderRef<List<String>> strings = BuilderRef.forList();
+
+        assertThat(strings.hasValue(), equalTo(false));
+
+        strings.get().add("a");
+
+        assertThat(strings.hasValue(), equalTo(true));
+
+        strings.clear();
+
+        assertThat(strings.hasValue(), equalTo(false));
+    }
+}

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.waiters;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -24,7 +23,7 @@ import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitService;
-import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -40,7 +39,7 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
 
     private WaitableTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
-        this.waiters = MapUtils.orderedCopyOf(builder.waiters);
+        this.waiters = builder.waiters.copy();
     }
 
     public static Builder builder() {
@@ -73,7 +72,7 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
 
     public static final class Builder extends AbstractTraitBuilder<WaitableTrait, Builder> {
 
-        private final Map<String, Waiter> waiters = new LinkedHashMap<>();
+        private final BuilderRef<Map<String, Waiter>> waiters = BuilderRef.forOrderedMap();
 
         private Builder() {}
 
@@ -83,7 +82,7 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
         }
 
         public Builder put(String name, Waiter value) {
-            waiters.put(name, value);
+            waiters.get().put(name, value);
             return this;
         }
 
@@ -94,7 +93,7 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
 
         public Builder replace(Map<String, Waiter> waiters) {
             clear();
-            this.waiters.putAll(waiters);
+            this.waiters.get().putAll(waiters);
             return this;
         }
     }

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/Waiter.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/Waiter.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.waiters;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,7 +26,7 @@ import software.amazon.smithy.model.node.NumberNode;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.node.ToNode;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.Tagged;
@@ -58,11 +57,11 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
 
     private Waiter(Builder builder) {
         this.documentation = builder.documentation;
-        this.acceptors = ListUtils.copyOf(builder.acceptors);
+        this.acceptors = builder.acceptors.copy();
         this.minDelay = builder.minDelay;
         this.maxDelay = builder.maxDelay;
         this.deprecated = builder.deprecated;
-        this.tags = ListUtils.copyOf(builder.tags);
+        this.tags = builder.tags.copy();
     }
 
     public static Builder builder() {
@@ -207,11 +206,11 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
     public static final class Builder implements SmithyBuilder<Waiter> {
 
         private String documentation;
-        private final List<Acceptor> acceptors = new ArrayList<>();
+        private final BuilderRef<List<Acceptor>> acceptors = BuilderRef.forList();
         private int minDelay = DEFAULT_MIN_DELAY;
         private int maxDelay = DEFAULT_MAX_DELAY;
         private boolean deprecated = false;
-        private final List<String> tags = new ArrayList<>();
+        private final BuilderRef<List<String>> tags = BuilderRef.forList();
 
         private Builder() {}
 
@@ -237,7 +236,7 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
         }
 
         public Builder addAcceptor(Acceptor acceptor) {
-            this.acceptors.add(Objects.requireNonNull(acceptor));
+            this.acceptors.get().add(Objects.requireNonNull(acceptor));
             return this;
         }
 
@@ -263,7 +262,7 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
         }
 
         public Builder addTag(String tag) {
-            this.tags.add(Objects.requireNonNull(tag));
+            this.tags.get().add(Objects.requireNonNull(tag));
             return this;
         }
 


### PR DESCRIPTION
This commit reduces the number of copies builders need to make when
building up immutable objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
