### PR TITLE
Use gradle plugin version 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then, apply the Smithy Gradle Plugin in your `build.gradle.kts` file and run
 
 ```kotlin
 plugins {
-   id("software.amazon.smithy").version("0.5.3")
+   id("software.amazon.smithy").version("0.6.0")
 }
 ```
 

--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -21,7 +21,7 @@ The following example configures a project to use the Smithy Gradle plugin:
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.3")
+            id("software.amazon.smithy").version("0.6.0")
         }
 
 
@@ -138,7 +138,7 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.3")
+            id("software.amazon.smithy").version("0.6.0")
         }
 
         // The SmithyExtension is used to customize the build. This example
@@ -184,7 +184,7 @@ build that uses the "external" projection.
     .. code-tab:: kotlin
 
         plugins {
-            id("software.amazon.smithy").version("0.5.3")
+            id("software.amazon.smithy").version("0.6.0")
         }
 
         buildscript {

--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -117,7 +117,7 @@ specification from a Smithy model using a buildscript dependency:
 
     plugins {
         java
-        id("software.amazon.smithy").version("0.5.3")
+        id("software.amazon.smithy").version("0.6.0")
     }
 
     buildscript {

--- a/docs/source/1.0/guides/generating-cloudformation-resources.rst
+++ b/docs/source/1.0/guides/generating-cloudformation-resources.rst
@@ -62,7 +62,7 @@ Resource Schemas from a Smithy model :ref:`using a buildscript dependency
 
     plugins {
         java
-        id("software.amazon.smithy").version("0.5.3")
+        id("software.amazon.smithy").version("0.6.0")
     }
 
     buildscript {

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -764,7 +764,7 @@ Then create a new ``build.gradle.kts`` file:
 .. code-block:: kotlin
 
     plugins {
-        id("software.amazon.smithy").version("0.5.3")
+        id("software.amazon.smithy").version("0.6.0")
     }
 
     repositories {
@@ -831,7 +831,7 @@ The ``build.gradle.kts`` should have the following contents:
 .. code-block:: kotlin
 
     plugins {
-        id("software.amazon.smithy").version("0.5.3")
+        id("software.amazon.smithy").version("0.6.0")
     }
 
     repositories {

--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-    id "software.amazon.smithy" version "0.5.3"
+    id "software.amazon.smithy" version "0.6.0"
 }
 
 description = "Defines protocol tests for AWS HTTP protocols."

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-    id "software.amazon.smithy" version "0.5.3"
+    id "software.amazon.smithy" version "0.6.0"
 }
 
 description = "This module provides support for validation in Smithy server SDKs"


### PR DESCRIPTION
Update the packages and docs to use the 0.6.0 version of smithy-gradle-plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
