### PR TITLE
Update @length trait documentation regarding collection shapes

### DIFF
--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -329,7 +329,7 @@ Summary
 Trait selector
     ``:test(collection, map, string, blob, member > :is(collection, map, string, blob))``
 
-    *Any list, map, string, or blob; or a member that targets one of these shapes*
+    *Any list, set, map, string, or blob; or a member that targets one of these shapes*
 Value type
     ``structure``
 
@@ -358,6 +358,7 @@ the corresponding shape:
 Shape        Length constrains
 ===========  =====================================
 list         The number of members
+set          The number of members
 map          The number of key-value pairs
 string       The number of Unicode code points
 blob         The size of the blob in bytes


### PR DESCRIPTION
This is an update to [doc changes](https://github.com/awslabs/smithy/pull/988/files#diff-7b0b60de09d6316cd65e2b1ec7e75869eb84627fad7e6549f5834de4515bfa1d) made in https://github.com/awslabs/smithy/pull/988

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
