### PR TITLE
Reduce allocations and garbage

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/CompositeModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/CompositeModelFile.java
@@ -119,10 +119,18 @@ final class CompositeModelFile implements ModelFile {
 
     @Override
     public List<ValidationEvent> events() {
-        List<ValidationEvent> events = new ArrayList<>(mergeEvents);
+        // Size the array using the known size of all events.
+        int size = mergeEvents.size();
+        for (ModelFile modelFile : modelFiles) {
+            size += modelFile.events().size();
+        }
+
+        List<ValidationEvent> events = new ArrayList<>(size);
+        events.addAll(mergeEvents);
         for (ModelFile modelFile : modelFiles) {
             events.addAll(modelFile.events());
         }
+
         return events;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidatedResult.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidatedResult.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.validation;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,9 +40,14 @@ public final class ValidatedResult<T> {
      * @param result Value to set.
      * @param events Events to set.
      */
-    public ValidatedResult(T result, Collection<ValidationEvent> events) {
+    public ValidatedResult(T result, List<ValidationEvent> events) {
         this.result = result;
-        this.events = ListUtils.copyOf(events);
+        this.events = Collections.unmodifiableList(events);
+    }
+
+    @Deprecated
+    public ValidatedResult(T result, Collection<ValidationEvent> events) {
+        this(result, ListUtils.copyOf(events));
     }
 
     /**
@@ -52,8 +58,13 @@ public final class ValidatedResult<T> {
      * @param <T> The type of value in the result.
      * @return Returns the created ValidatedResult.
      */
-    public static <T> ValidatedResult<T> fromErrors(Collection<ValidationEvent> events) {
+    public static <T> ValidatedResult<T> fromErrors(List<ValidationEvent> events) {
         return new ValidatedResult<>(null, events);
+    }
+
+    @Deprecated
+    public static <T> ValidatedResult<T> fromErrors(Collection<ValidationEvent> events) {
+        return fromErrors(ListUtils.copyOf(events));
     }
 
     /**
@@ -141,6 +152,11 @@ public final class ValidatedResult<T> {
      * @return Returns true if there are errors or unsuppressed dangers.
      */
     public boolean isBroken() {
-        return !getValidationEvents(Severity.ERROR).isEmpty() || !getValidationEvents(Severity.DANGER).isEmpty();
+        for (ValidationEvent event : events) {
+            if (event.getSeverity() == Severity.ERROR || event.getSeverity() == Severity.DANGER) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationUtils.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -60,9 +60,15 @@ public final class ValidationUtils {
      * @return Returns the string.
      */
     public static String orderedTickedList(Collection<?> values) {
-        return values.size() == 0
-               ? ""
-               : "`" + values.stream().map(Objects::toString).collect(Collectors.joining("`, `")) + "`";
+        if (values.size() == 0) {
+            return "";
+        }
+
+        StringJoiner joiner = new StringJoiner("`, `", "`", "`");
+        for (Object value : values) {
+            joiner.add(value.toString());
+        }
+        return joiner.toString();
     }
 
     /**
@@ -80,21 +86,10 @@ public final class ValidationUtils {
     }
 
     public static String tickedList(Stream<?> values) {
-        return tickedList(values.map(Object::toString).sorted().collect(Collectors.toList()));
+        return values.map(Object::toString).sorted().collect(Collectors.joining("`, `", "`", "`"));
     }
 
-    /**
-     * Find shape IDs in a collection that do not have case-insensitively
-     * unique member names.
-     *
-     * <p>The returned map is sorted by the conflicting name, and the list of
-     * conflicting shape values is also sorted to ensure that validation
-     * events can just print the map directly with consistent error messages.
-     *
-     * @param shapes Shapes collection to check.
-     * @param <T> The type of shape being checked.
-     * @return Returns a map that only contains the conflicting shapes.
-     */
+    @Deprecated
     public static <T extends ToShapeId> Map<String, List<ShapeId>> findDuplicateShapeNames(Collection<T> shapes) {
         return shapes.stream()
                 .map(ToShapeId::toShapeId)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -15,17 +15,14 @@
 
 package software.amazon.smithy.model.validation.validators;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
 import software.amazon.smithy.model.neighbor.Relationship;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -38,26 +35,26 @@ public final class PrivateAccessValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        Set<Shape> privateShapes = model.getShapesWithTrait(PrivateTrait.class);
-        NeighborProvider provider = NeighborProviderIndex.of(model).getProvider();
-        return model.shapes()
-                .filter(shape -> !(shape instanceof SimpleShape))
-                .flatMap(shape -> validateNeighbors(shape, provider.getNeighbors(shape), privateShapes))
-                .collect(Collectors.toList());
+        NeighborProvider provider = NeighborProviderIndex.of(model).getReverseProvider();
+
+        List<ValidationEvent> events = new ArrayList<>();
+        for (Shape privateShape : model.getShapesWithTrait(PrivateTrait.class)) {
+            validateNeighbors(privateShape, provider.getNeighbors(privateShape), events);
+        }
+
+        return events;
     }
 
-    private Stream<ValidationEvent> validateNeighbors(
-            Shape shape,
-            List<Relationship> relationships,
-            Set<Shape> privateShapes
-    ) {
-        return relationships.stream()
-                .filter(rel -> privateShapes.contains(rel.getNeighborShape().orElse(null)))
-                .filter(rel -> !rel.getNeighborShapeId().getNamespace().equals(shape.getId().getNamespace()))
-                .map(rel -> error(shape, String.format(
+    private void validateNeighbors(Shape shape, List<Relationship> relationships, List<ValidationEvent> events) {
+        String namespace = shape.getId().getNamespace();
+        for (Relationship rel : relationships) {
+            if (!rel.getShape().getId().getNamespace().equals(namespace)) {
+                events.add(error(rel.getShape(), String.format(
                         "This shape has an invalid %s relationship that targets a private shape, `%s`, in "
                         + "another namespace.",
                         rel.getRelationshipType().toString().toLowerCase(Locale.US),
-                        rel.getNeighborShapeId())));
+                        rel.getNeighborShape().get().getId())));
+            }
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnreferencedShapeValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnreferencedShapeValidator.java
@@ -15,12 +15,12 @@
 
 package software.amazon.smithy.model.validation.validators;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.neighbor.UnreferencedShapes;
-import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -31,16 +31,17 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class UnreferencedShapeValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
-        long serviceShapes = model.shapes(ServiceShape.class).count();
-
         // Do not emit validation warnings if no services are present in the model.
-        if (serviceShapes == 0) {
+        if (model.getServiceShapes().isEmpty()) {
             return Collections.emptyList();
         }
 
-        return new UnreferencedShapes().compute(model).stream()
-                .map(shape -> note(shape, String.format(
-                        "The %s shape is not connected to from any service shape.", shape.getType())))
-                .collect(Collectors.toList());
+        List<ValidationEvent> events = new ArrayList<>();
+        for (Shape shape : new UnreferencedShapes().compute(model)) {
+            events.add(note(shape, String.format(
+                    "The %s shape is not connected to from any service shape.", shape.getType())));
+        }
+
+        return events;
     }
 }


### PR DESCRIPTION
This commit attempts to cut down on the amount of allocations used when
validating Smithy models, including limiting the use of Streams in core
APIs, no longer copying validation events passed to ValidatedResult, and
no longer caching the result of every selector used in trait defintions
when evaluating trait targets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
