### PR TITLE
Remove documentation from Unit shape

### DIFF
--- a/designs/operation-input-output-and-unit-types.md
+++ b/designs/operation-input-output-and-unit-types.md
@@ -217,8 +217,6 @@ The `Unit` shape and `unitType` trait are modeled in the prelude as:
 ```
 namespace smithy.api
 
-/// The single unit type shape, similar to Void and None in other
-/// languages, used to represent no meaningful value.
 @unitType
 structure Unit {}
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -51,8 +51,6 @@ double Double
 
 double PrimitiveDouble
 
-/// The single unit type shape, similar to Void and None in other
-/// languages, used to represent no meaningful value.
 @unitType
 structure Unit {}
 


### PR DESCRIPTION
This commit removes documentation from the Unit shape in the prelude.
This is done to encourage tagged union members that target the Unit
shape to add their own member-specific documentation rather than to rely
on inheriting documentation from the Unit shape.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
