### PR TITLE
Add input and output traits with inlined IO

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/doc-comments.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/doc-comments.json
@@ -51,12 +51,16 @@
             }
         },
         "smithy.example#MyOperationInput": {
-            "type": "structure"
+            "type": "structure",
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "smithy.example#MyOperationOutput": {
             "type": "structure",
             "traits": {
-                "smithy.api#documentation": "These are not ignored because they come AFTER the walrus\noperator."
+                "smithy.api#documentation": "These are not ignored because they come AFTER the walrus\noperator.",
+                "smithy.api#output": {}
             }
         }
     }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/custom-suffix.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/custom-suffix.json
@@ -11,10 +11,16 @@
             }
         },
         "com.example#OperationRequest": {
-            "type": "structure"
+            "type": "structure",
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.example#OperationResponse": {
-            "type": "structure"
+            "type": "structure",
+            "traits": {
+                "smithy.api#output": {}
+            }
         }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.json
@@ -203,6 +203,29 @@
                 "smithy.api#documentation": "Here too",
                 "smithy.api#output": {}
             }
+        },
+        "com.example#DuplicateTrait": {
+            "type": "operation",
+            "input": {
+                "target": "com.example#DuplicateTraitInput"
+            },
+            "output": {
+                "target": "com.example#DuplicateTraitOutput"
+            }
+        },
+        "com.example#DuplicateTraitInput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.example#DuplicateTraitOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.json
@@ -16,6 +16,9 @@
                 "id": {
                     "target": "smithy.api#String"
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.example#DerivedNamesOutput": {
@@ -24,6 +27,9 @@
                 "id": {
                     "target": "smithy.api#String"
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.example#UsesTraits": {
@@ -43,7 +49,8 @@
                 }
             },
             "traits": {
-                "smithy.api#sensitive": {}
+                "smithy.api#sensitive": {},
+                "smithy.api#input": {}
             }
         },
         "com.example#UsesTraitsOutput": {
@@ -54,7 +61,8 @@
                 }
             },
             "traits": {
-                "smithy.api#sensitive": {}
+                "smithy.api#sensitive": {},
+                "smithy.api#output": {}
             }
         },
         "com.example#NameBearer": {
@@ -88,7 +96,10 @@
                 {
                     "target": "com.example#NameBearer"
                 }
-            ]
+            ],
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.example#UsesMixinsOutput": {
             "type": "structure",
@@ -101,7 +112,10 @@
                 {
                     "target": "com.example#NameBearer"
                 }
-            ]
+            ],
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.example#UsesTraitsAndMixins": {
             "type": "operation",
@@ -120,7 +134,8 @@
                 }
             },
             "traits": {
-                "smithy.api#sensitive": {}
+                "smithy.api#sensitive": {},
+                "smithy.api#input": {}
             },
             "mixins": [
                 {
@@ -136,7 +151,8 @@
                 }
             },
             "traits": {
-                "smithy.api#sensitive": {}
+                "smithy.api#sensitive": {},
+                "smithy.api#output": {}
             },
             "mixins": [
                 {
@@ -154,10 +170,16 @@
             }
         },
         "com.example#EmptyShapesInput": {
-            "type": "structure"
+            "type": "structure",
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.example#EmptyShapesOutput": {
-            "type": "structure"
+            "type": "structure",
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.example#HasDocComments": {
             "type": "operation",
@@ -171,13 +193,15 @@
         "com.example#HasDocCommentsInput": {
             "type": "structure",
             "traits": {
-                "smithy.api#documentation": "The trait parser automagically handles these"
+                "smithy.api#documentation": "The trait parser automagically handles these",
+                "smithy.api#input": {}
             }
         },
         "com.example#HasDocCommentsOutput": {
             "type": "structure",
             "traits": {
-                "smithy.api#documentation": "Here too"
+                "smithy.api#documentation": "Here too",
+                "smithy.api#output": {}
             }
         }
     }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.smithy
@@ -67,3 +67,8 @@ operation HasDocComments {
         /// Here too
         {}
 }
+
+operation DuplicateTrait {
+    input := @input {}
+    output := @output {}
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/inline-io.smithy
@@ -11,6 +11,11 @@ operation DerivedNames {
     }
 }
 
+operation DoesNotInlineWithoutIOTrait {
+    input: DoesNotInlineWithoutIOTraitInput
+    output: DoesNotInlineWithoutIOTraitOutput
+}
+
 operation EmptyShapes {
     input := {}
     output := {}
@@ -59,6 +64,10 @@ operation UsesTraitsAndMixins {
             id: String
         }
 }
+
+structure DoesNotInlineWithoutIOTraitInput {}
+
+structure DoesNotInlineWithoutIOTraitOutput {}
 
 @mixin
 structure NameBearer {


### PR DESCRIPTION
This updates inlined IO shapes to automatically include the input and output traits.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
