### PR TITLE
Fix javadoc search links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,13 @@ project.afterEvaluate {
 allprojects {
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:-html', '-quiet')
+        // Fixed in JDK 12: https://bugs.openjdk.java.net/browse/JDK-8215291
+        // --no-module-directories does not exist in JDK 8 and is removed in 13
+        if (JavaVersion.current().isJava9()
+                || JavaVersion.current().isJava10()
+                || JavaVersion.current().isJava11()) {
+            options.addBooleanOption('-no-module-directories', true)
+        }
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/smithy/issues/1006

*Description of changes:*
Our javadocs are broken due to JDK bug
https://bugs.openjdk.java.net/browse/JDK-8215291 which is fixed in JDK 12.
We can work around it by specifying --no-module-directories when generating
javadocs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
