### PR TITLE
Fix escaping sets in http traits

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -673,7 +673,7 @@ structure with the ``httpLabel`` trait MUST have a corresponding
   ``1985-04-12T23%3A20%3A50.52Z``). The :ref:`timestampFormat-trait`
   MAY be used to use a custom serialization format.
 - Reserved characters defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>`
-  and the `%` itself MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
+  and the `%` itself MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%><"`? ``). Note the inclusion of a literal space, ` `.
 - However, if the label is greedy, then "/" MUST NOT be percent-encoded
   because greedy labels are meant to span multiple path segments.
 
@@ -909,7 +909,7 @@ request:
 * "&" is used to separate query string parameter key-value pairs.
 * "=" is used to separate query string parameter names from values.
 * Reserved characters in keys and values as defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>` and `%`
-  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
+  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%<>"``).
 * ``boolean`` values are serialized as ``true`` or ``false``.
 * ``timestamp`` values are serialized as an :rfc:`3339`
   ``date-time`` string by default (for example, ``1985-04-12T23:20:50.52Z``,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/smithy-rs/pull/953/files, https://github.com/awslabs/aws-sdk-rust/issues/331

*Description of changes:* Update the set of characters that need to be escaped to include characters that are never valid in URIs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
