### PR TITLE
Add doc for missing segment when greedy label in middle

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -404,6 +404,10 @@ pattern of ``/prefix/{label+}/suffix`` and an endpoint of ``https://yourhost``:
       - Yes
       - Matches literal "/prefix", captures "foo/suffix/bar" in greedy
         ``label``, and matches literal "/suffix".
+    * - ``http://yourhost/prefix/suffix``
+      - No
+      - Matches literal "/prefix", matches literal "/suffix", but does not
+        contain a segment to match ``label``.
 
 
 Pattern Validation and Conflict Avoidance


### PR DESCRIPTION
Adding another case for clarity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
