### PR TITLE
Add a test for regex expressions in path segments

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -245,8 +245,34 @@ structure HttpRequestWithFloatLabelsInput {
     @httpLabel
     @required
     float: Float,
-    
+
     @httpLabel
     @required
     double: Double,
+}
+
+apply HttpRequestWithRegexLiteral @httpRequestTests([
+    {
+        id: "RestJsonToleratesRegexCharsInSegments",
+        documentation: "Path matching is not broken by regex expressions in literal segments",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/ReDosLiteral/abc/(a+)+",
+        body: "",
+        params: {
+            str: "abc"
+        }
+    },
+])
+
+@readonly
+@http(method: "GET", uri: "/ReDosLiteral/{str}/(a+)+")
+operation HttpRequestWithRegexLiteral {
+    input: HttpRequestWithRegexLiteralInput
+}
+
+structure HttpRequestWithRegexLiteralInput {
+    @httpLabel
+    @required
+    str: String
 }

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -35,6 +35,7 @@ service RestJson {
         HttpRequestWithLabelsAndTimestampFormat,
         HttpRequestWithGreedyLabelInPath,
         HttpRequestWithFloatLabels,
+        HttpRequestWithRegexLiteral,
 
         // @httpQuery and @httpQueryParams tests
         AllQueryStringTypes,


### PR DESCRIPTION
*Description of changes:*
Characters like (, ) and + can be present, unescaped, in a path segment but
cause problems for protocol implementations that use regular expressions to
process paths. This adds a simple protocol test to help discover problems
with these implementations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
