### PR TITLE
Add links to Kotlin and Swift generators

### DIFF
--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -148,6 +148,14 @@ of polish or that they work for all use cases.
       - Kotlin
       - 0.x
       - Rust client code generation for Smithy.
+    * - `Kotlin client codegen <https://github.com/awslabs/smithy-kotlin>`_
+      - Kotlin
+      - 0.x
+      - Kotlin client code generation for Smithy.
+    * - `Swift client codegen <https://github.com/awslabs/smithy-swift>`_
+      - Kotlin
+      - 0.x
+      - Swift client code generation for Smithy.
 
 
 ----------------


### PR DESCRIPTION
Add Kotlin and Swift to https://awslabs.github.io/smithy/implementations.html#code-generators

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
