### PR TITLE
Remove support for http prefix header maps of lists

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -788,11 +788,10 @@ Trait selector
     .. code-block:: none
 
         structure > member
-        :test(> map > member[id|member=value] > :test(string, collection > member > string))
+        :test(> map > member[id|member=value] > string)
 
     The ``httpPrefixHeaders`` trait can be applied to ``structure`` members
-    that target a ``map`` of ``string``, or a ``map`` of ``list``/``set`` of
-    ``string``.
+    that target a ``map`` of ``string``.
 Value type
     ``string`` value that defines the prefix to prepend to each header field
     name stored in the targeted map member. For example, given a prefix value

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -610,7 +610,7 @@ string httpHeader
 /// Binds a map of key-value pairs to prefixed HTTP headers.
 @trait(selector: """
         structure > member
-        :test(> map > member[id|member=value] > :test(string, collection > member > string))""",
+        :test(> map > member[id|member=value] > string)""",
         structurallyExclusive: "member",
         conflicts: [httpLabel, httpQuery, httpHeader, httpPayload, httpResponseCode, httpQueryParams])
 @tags(["diff.error.const"])

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/prefix-headers.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/prefix-headers.smithy
@@ -24,9 +24,5 @@ structure Output {
 
 map Headers {
     key: String,
-    value: StringList,
-}
-
-list StringList {
-    member: String
+    value: String
 }


### PR DESCRIPTION
This commit removes support for binding the httpPrefixHeaders trait
to a map with a value targeting a list of strings.

This behavior isn't actually supported in practice by any client
or server implementations. It is also extremely difficult to support
not only because HTTP headers have no hard requirement on a common
grammar (see Set-Cookie), but also because many HTTP cliens can't
reliably control whether headers are sent in a single header field
or across multiple header fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
