### PR TITLE
Revert escape changes for timestamp header serialization

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -112,7 +112,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         body: "",
         params: {
@@ -261,7 +261,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
+            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
         },
         params: {
             headerTimestampList: [1576540098, 1576540098]


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/awslabs/smithy/issues/1015

*Description of changes:* 
This reverts the change made for timestamp headers in https://github.com/awslabs/smithy/pull/986

The `http-date` timestampFormat is unambigous in terms of where commas
are located, so do not need escaping according to RFC 7230 sec 3.2.6.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
