### PR TITLE
Move getType of shape to subclass method

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigDecimalShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigDecimalShape.java
@@ -46,6 +46,11 @@ public final class BigDecimalShape extends NumberShape implements ToSmithyBuilde
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.BIG_DECIMAL;
+    }
+
     /**
      * Builder used to create a {@link BigDecimalShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigIntegerShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BigIntegerShape.java
@@ -46,6 +46,11 @@ public final class BigIntegerShape extends NumberShape implements ToSmithyBuilde
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.BIG_INTEGER;
+    }
+
     /**
      * Builder used to create a {@link BigIntegerShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BlobShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BlobShape.java
@@ -46,6 +46,11 @@ public final class BlobShape extends SimpleShape implements ToSmithyBuilder<Blob
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.BLOB;
+    }
+
     /**
      * Builder used to create a {@link BlobShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BooleanShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/BooleanShape.java
@@ -46,6 +46,11 @@ public final class BooleanShape extends SimpleShape implements ToSmithyBuilder<B
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.BOOLEAN;
+    }
+
     /**
      * Builder used to create a {@link BooleanShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ByteShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ByteShape.java
@@ -46,6 +46,11 @@ public final class ByteShape extends NumberShape implements ToSmithyBuilder<Byte
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.BYTE;
+    }
+
     /**
      * Builder used to create a {@link ByteShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DocumentShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DocumentShape.java
@@ -46,6 +46,11 @@ public final class DocumentShape extends SimpleShape implements ToSmithyBuilder<
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.DOCUMENT;
+    }
+
     /**
      * Builder used to create a {@link DocumentShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DoubleShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/DoubleShape.java
@@ -46,6 +46,11 @@ public final class DoubleShape extends NumberShape implements ToSmithyBuilder<Do
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.DOUBLE;
+    }
+
     /**
      * Builder used to create a {@link DoubleShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/FloatShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/FloatShape.java
@@ -46,6 +46,11 @@ public final class FloatShape extends NumberShape implements ToSmithyBuilder<Flo
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.FLOAT;
+    }
+
     /**
      * Builder used to create a {@link FloatShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntegerShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntegerShape.java
@@ -46,6 +46,11 @@ public final class IntegerShape extends NumberShape implements ToSmithyBuilder<I
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.INTEGER;
+    }
+
     /**
      * Builder used to create a {@link IntegerShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ListShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ListShape.java
@@ -46,6 +46,11 @@ public final class ListShape extends CollectionShape implements ToSmithyBuilder<
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.LIST;
+    }
+
     /**
      * Builder used to create a {@link ListShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/LongShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/LongShape.java
@@ -46,6 +46,11 @@ public final class LongShape extends NumberShape implements ToSmithyBuilder<Long
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.LONG;
+    }
+
     /**
      * Builder used to create a {@link LongShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
@@ -70,6 +70,11 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.MAP;
+    }
+
     /**
      * Get the value member shape of the map.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
@@ -64,6 +64,11 @@ public final class MemberShape extends Shape implements ToSmithyBuilder<MemberSh
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.MEMBER;
+    }
+
     /**
      * Get the targeted member shape ID.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -64,6 +64,11 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.OPERATION;
+    }
+
     /**
      * <p>Gets the optional shape ID of the input of the operation.</p>
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -96,6 +96,11 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
         return Collections.unmodifiableSet(allOperations);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.RESOURCE;
+    }
+
     /**
      * Gets the operations bound through the "collectionOperations" property.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -76,6 +76,11 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
                && errors.equals(o.errors);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.SERVICE;
+    }
+
     /**
      * Get the version of the service. An empty string is returned
      * if the version is undefined.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SetShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SetShape.java
@@ -46,6 +46,11 @@ public final class SetShape extends CollectionShape implements ToSmithyBuilder<S
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.SET;
+    }
+
     /**
      * Builder used to create a {@link SetShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -46,7 +46,6 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
     private final ShapeId id;
     private final Map<ShapeId, Trait> traits;
     private final transient SourceLocation source;
-    private final transient ShapeType type;
 
     /**
      * This class is package-private, which means that all subclasses of this
@@ -58,7 +57,6 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
      */
     @SuppressWarnings("unchecked")
     Shape(AbstractShapeBuilder builder, boolean expectMemberSegments) {
-        type = builder.getShapeType();
         source = builder.getSourceLocation();
         id = SmithyBuilder.requiredState("id", builder.getId());
         traits = builder.copyTraits();
@@ -103,9 +101,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
      *
      * @return Returns the type;
      */
-    public final ShapeType getType() {
-        return type;
-    }
+    public abstract ShapeType getType();
 
     /**
      * Dispatches the shape to the appropriate {@link ShapeVisitor} method.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShortShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShortShape.java
@@ -46,6 +46,11 @@ public final class ShortShape extends NumberShape implements ToSmithyBuilder<Sho
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.SHORT;
+    }
+
     /**
      * Builder used to create a {@link ShortShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StringShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StringShape.java
@@ -46,6 +46,11 @@ public final class StringShape extends SimpleShape implements ToSmithyBuilder<St
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.STRING;
+    }
+
     /**
      * Builder used to create a {@link StringShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/StructureShape.java
@@ -49,6 +49,11 @@ public final class StructureShape extends NamedMembersShape implements ToSmithyB
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.STRUCTURE;
+    }
+
     /**
      * Builder used to create a {@link StructureShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/TimestampShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/TimestampShape.java
@@ -45,6 +45,11 @@ public final class TimestampShape extends SimpleShape implements ToSmithyBuilder
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.TIMESTAMP;
+    }
+
     /**
      * Builder used to create a {@link TimestampShape}.
      */

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/UnionShape.java
@@ -46,6 +46,11 @@ public final class UnionShape extends NamedMembersShape implements ToSmithyBuild
         return Optional.of(this);
     }
 
+    @Override
+    public ShapeType getType() {
+        return ShapeType.UNION;
+    }
+
     /**
      * Builder used to create a {@link UnionShape}.
      */


### PR DESCRIPTION
This was previously stored in an instance variable, but the shape type
is constant per/shape, so that's unnecessary, and it can be returned by
implementing getShapeType in each subclass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
