### PR TITLE
Make adoption of Unit easier for existing models

### DIFF
--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -1366,6 +1366,16 @@ closure of a service. This constraint allows services to discern between
 operations and resources using only their shape name rather than a
 fully-qualified path from the service to the shape.
 
+.. rubric:: Undeclared operation inputs and outputs are not a
+            part of the service closure
+
+:ref:`smithy.api#Unit <unit-type>` is the shape that is implicitly targeted by
+operation inputs and outputs when they are not explicitly declared. This does
+not, however, add ``smithy.api#Unit`` to the service's closure, and does not
+require renaming to avoid conflicts with other shapes named ``Unit``. Unions in
+the service closure with members targeting ``smithy.api#Unit``, however, will
+cause ``smithy.api#Unit`` to be a part of the service closure.
+
 
 ..  _operation:
 

--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -1209,9 +1209,21 @@ The table below lists the labeled directed relationships from each shape.
     * - operation
       - input
       - The input structure of the operation (if present).
+
+        .. note::
+
+            :ref:`smithy.api#Unit <unit-type>` is considered "not present"
+            for this relationship, and will not be yielded.
+
     * - operation
       - output
       - The output structure of the operation (if present).
+
+        .. note::
+
+            :ref:`smithy.api#Unit <unit-type>` is considered "not present"
+            for this relationship, and will not be yielded.
+
     * - operation
       - error
       - Each error structure referenced by the operation (if present).

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/TopologicalIndexTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/TopologicalIndexTest.java
@@ -19,7 +19,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.UnitTypeTrait;
+import software.amazon.smithy.utils.FunctionalUtils;
 
 public class TopologicalIndexTest {
 
@@ -101,9 +101,9 @@ public class TopologicalIndexTest {
         TopologicalIndex index = TopologicalIndex.of(model);
 
         assertThat(index.getRecursiveClosure(model.expectShape(ShapeId.from("smithy.example#MyString"))),
-                   empty());
+                empty());
         assertThat(index.getRecursiveClosure(model.expectShape(ShapeId.from("smithy.example#Recursive$b"))),
-                   not(empty()));
+                not(empty()));
     }
 
     @Test
@@ -114,10 +114,9 @@ public class TopologicalIndexTest {
                 .unwrap();
         TopologicalIndex index = TopologicalIndex.of(recursive);
 
-        // The topological index must capture all shapes in the index not in the prelude,
-        // but include the Unit shape.
+        // The topological index must capture all shapes in the index not in the prelude.
         Set<Shape> nonPrelude = recursive.shapes()
-                .filter(shape -> shape.getId().equals(UnitTypeTrait.UNIT) || !Prelude.isPreludeShape(shape))
+                .filter(FunctionalUtils.not(Prelude::isPreludeShape))
                 .collect(Collectors.toSet());
         Set<Shape> topologicalShapes = new HashSet<>(index.getOrderedShapes());
         topologicalShapes.addAll(index.getRecursiveShapes());
@@ -129,7 +128,6 @@ public class TopologicalIndexTest {
                 .map(ShapeId::toString)
                 .collect(Collectors.toList());
         assertThat(orderedIds, contains(
-                "smithy.api#Unit",
                 "smithy.example#MyString",
                 "smithy.example#NonRecursive$foo",
                 "smithy.example#NonRecursive",

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DeconflictingStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DeconflictingStrategy.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.jsonschema;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
@@ -49,12 +50,12 @@ final class DeconflictingStrategy implements RefStrategy {
     private final Map<ShapeId, String> pointers = new HashMap<>();
     private final Map<String, ShapeId> reversePointers = new HashMap<>();
 
-    DeconflictingStrategy(Model model, RefStrategy delegate) {
+    DeconflictingStrategy(Model model, RefStrategy delegate, Predicate<Shape> shapePredicate) {
         this.delegate = delegate;
 
         // Pre-compute a map of all converted shape refs. Sort the shapes
         // to make the result deterministic.
-        model.shapes().filter(FunctionalUtils.not(this::isIgnoredShape)).sorted().forEach(shape -> {
+        model.shapes().filter(shapePredicate.and(FunctionalUtils.not(this::isIgnoredShape))).sorted().forEach(shape -> {
             String pointer = delegate.toPointer(shape.getId());
             if (!reversePointers.containsKey(pointer)) {
                 pointers.put(shape.getId(), pointer);

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/RefStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/RefStrategy.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.jsonschema;
 
+import java.util.function.Predicate;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -70,14 +71,16 @@ interface RefStrategy {
      * @param model Model being converted.
      * @param config Conversion configuration.
      * @param propertyNamingStrategy Property naming strategy.
+     * @param shapePredicate a predicate to use to filter shapes in model when determining conflicts.
      * @return Returns the created strategy.
      */
     static RefStrategy createDefaultStrategy(
             Model model,
             JsonSchemaConfig config,
-            PropertyNamingStrategy propertyNamingStrategy
+            PropertyNamingStrategy propertyNamingStrategy,
+            Predicate<Shape> shapePredicate
     ) {
         RefStrategy delegate = new DefaultRefStrategy(model, config, propertyNamingStrategy);
-        return new DeconflictingStrategy(model, delegate);
+        return new DeconflictingStrategy(model, delegate, shapePredicate);
     }
 }

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/DefaultRefStrategyTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/DefaultRefStrategyTest.java
@@ -2,6 +2,7 @@ package software.amazon.smithy.jsonschema;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static software.amazon.smithy.utils.FunctionalUtils.alwaysTrue;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -19,7 +20,7 @@ public class DefaultRefStrategyTest {
     @Test
     public void usesDefaultPointer() {
         RefStrategy ref = RefStrategy.createDefaultStrategy(
-                Model.builder().build(), new JsonSchemaConfig(), propertyNamingStrategy);
+                Model.builder().build(), new JsonSchemaConfig(), propertyNamingStrategy, alwaysTrue());
         String pointer = ref.toPointer(ShapeId.from("smithy.example#Foo"));
 
         assertThat(pointer, equalTo("#/definitions/Foo"));
@@ -30,7 +31,7 @@ public class DefaultRefStrategyTest {
         JsonSchemaConfig config = new JsonSchemaConfig();
         config.setDefinitionPointer("#/components/schemas");
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(Model.builder().build(), config, propertyNamingStrategy);
+                .createDefaultStrategy(Model.builder().build(), config, propertyNamingStrategy, alwaysTrue());
         String pointer = ref.toPointer(ShapeId.from("smithy.example#Foo"));
 
         assertThat(pointer, equalTo("#/components/schemas/Foo"));
@@ -41,7 +42,7 @@ public class DefaultRefStrategyTest {
         JsonSchemaConfig config = new JsonSchemaConfig();
         config.setDefinitionPointer("#/components/schemas");
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(Model.builder().build(), config, propertyNamingStrategy);
+                .createDefaultStrategy(Model.builder().build(), config, propertyNamingStrategy, alwaysTrue());
         String pointer = ref.toPointer(ShapeId.from("smithy.example#Foo"));
 
         assertThat(pointer, equalTo("#/components/schemas/Foo"));
@@ -52,7 +53,7 @@ public class DefaultRefStrategyTest {
         JsonSchemaConfig config = new JsonSchemaConfig();
         config.setAlphanumericOnlyRefs(true);
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(Model.builder().build(), config, propertyNamingStrategy);
+                .createDefaultStrategy(Model.builder().build(), config, propertyNamingStrategy, alwaysTrue());
         String pointer = ref.toPointer(ShapeId.from("smithy.example#Foo_Bar"));
 
         assertThat(pointer, equalTo("#/definitions/FooBar"));
@@ -71,7 +72,7 @@ public class DefaultRefStrategyTest {
                 .build();
         Model model = Model.builder().addShapes(string, list, member).build();
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy);
+                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy, alwaysTrue());
         String pointer = ref.toPointer(member.getId());
 
         assertThat(pointer, equalTo("#/definitions/Scripts/items"));
@@ -95,7 +96,7 @@ public class DefaultRefStrategyTest {
                 .build();
         Model model = Model.builder().addShapes(string, map, key, value).build();
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy);
+                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy, alwaysTrue());
 
         assertThat(ref.toPointer(key.getId()), equalTo("#/definitions/Scripts/propertyNames"));
         assertThat(ref.toPointer(value.getId()), equalTo("#/definitions/Scripts/additionalProperties"));
@@ -114,7 +115,7 @@ public class DefaultRefStrategyTest {
                 .build();
         Model model = Model.builder().addShapes(string, struct, member).build();
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy);
+                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy, alwaysTrue());
 
         assertThat(ref.toPointer(struct.getId()), equalTo("#/definitions/Scripts"));
         assertThat(ref.toPointer(member.getId()), equalTo("#/definitions/Scripts/properties/pages"));
@@ -131,7 +132,7 @@ public class DefaultRefStrategyTest {
                 .build();
         Model model = Model.builder().addShapes(baz, bam).build();
         RefStrategy ref = RefStrategy
-                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy);
+                .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy, alwaysTrue());
 
         assertThat(ref.toPointer(baz.getMember("bam").get().getId()), equalTo("#/definitions/Bam"));
     }
@@ -144,7 +145,7 @@ public class DefaultRefStrategyTest {
                 .unwrap();
         JsonSchemaConfig config = new JsonSchemaConfig();
         config.setService(ShapeId.from("smithy.example#MyService"));
-        RefStrategy ref = RefStrategy.createDefaultStrategy(model, config, propertyNamingStrategy);
+        RefStrategy ref = RefStrategy.createDefaultStrategy(model, config, propertyNamingStrategy, alwaysTrue());
 
         assertThat(ref.toPointer(ShapeId.from("smithy.example#Widget")), equalTo("#/definitions/Widget"));
         assertThat(ref.toPointer(ShapeId.from("foo.example#Widget")), equalTo("#/definitions/FooWidget"));

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.json
@@ -237,6 +237,9 @@
                 },
                 "b": {
                     "target": "smithy.api#String"
+                },
+                "c": {
+                    "target": "smithy.api#Unit"
                 }
             }
         }

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.jsonschema.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/test-service.jsonschema.json
@@ -114,7 +114,6 @@
       "oneOf": [
         {
           "type": "object",
-          "title": "a",
           "required": [
             "a"
           ],
@@ -122,11 +121,11 @@
             "a": {
               "type": "string"
             }
-          }
+          },
+          "title": "a"
         },
         {
           "type": "object",
-          "title": "b",
           "required": [
             "b"
           ],
@@ -134,9 +133,25 @@
             "b": {
               "type": "string"
             }
-          }
+          },
+          "title": "b"
+        },
+        {
+          "type": "object",
+          "required": [
+            "c"
+          ],
+          "properties": {
+            "c": {
+              "$ref": "#/definitions/Unit"
+            }
+          },
+          "title": "c"
         }
       ]
+    },
+    "Unit": {
+      "type": "object"
     }
   }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
@@ -79,15 +79,9 @@ public final class OperationIndex implements KnowledgeIndex {
      * Gets the optional input structure of an operation, and returns an
      * empty optional if the input targets {@code smithy.api#Unit}.
      *
-     * <p>This method is only here for backward compatibility. Instead,
-     * use {@link #getInputShape(ToShapeId)} and
-     * {@link #expectInputShape(ToShapeId)}.
-     *
      * @param operation Operation to get the input structure of.
      * @return Returns the optional operation input structure.
-     * @deprecated Use {@link #getInputShape(ToShapeId)} instead.
      */
-    @Deprecated
     public Optional<StructureShape> getInput(ToShapeId operation) {
         return getInputShape(operation).filter(shape -> !shape.getId().equals(UnitTypeTrait.UNIT));
     }
@@ -168,15 +162,9 @@ public final class OperationIndex implements KnowledgeIndex {
      * Gets the optional output structure of an operation, and returns an
      * empty optional if the output targets {@code smithy.api#Unit}.
      *
-     * <p>This method is only here for backward compatibility. Instead,
-     * use {@link #getOutputShape(ToShapeId)} and
-     * {@link #expectOutputShape(ToShapeId)}.
-     *
      * @param operation Operation to get the output structure of.
      * @return Returns the optional operation output structure.
-     * @deprecated Use {@link #getOutputShape(ToShapeId)} instead.
      */
-    @Deprecated
     public Optional<StructureShape> getOutput(ToShapeId operation) {
         return getOutputShape(operation).filter(shape -> !shape.getId().equals(UnitTypeTrait.UNIT));
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -153,8 +153,10 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
     @Override
     public List<Relationship> operationShape(OperationShape shape) {
         List<Relationship> result = new ArrayList<>();
-        result.add(relationship(shape, RelationshipType.INPUT, shape.getInputShape()));
-        result.add(relationship(shape, RelationshipType.OUTPUT, shape.getOutputShape()));
+
+        shape.getInput().ifPresent(input -> result.add(relationship(shape, RelationshipType.INPUT, input)));
+        shape.getOutput().ifPresent(output -> result.add(relationship(shape, RelationshipType.OUTPUT, output)));
+
         for (ShapeId errorId : shape.getErrors()) {
             result.add(relationship(shape, RelationshipType.ERROR, errorId));
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -76,9 +76,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
      * then an empty optional is returned.
      *
      * @return Returns the optional shape ID.
-     * @deprecated Use {@link #getInputShape()}
      */
-    @Deprecated
     public Optional<ShapeId> getInput() {
         return input.equals(UnitTypeTrait.UNIT) ? Optional.empty() : Optional.of(input);
     }
@@ -90,9 +88,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
      * then an empty optional is returned.
      *
      * @return Returns the optional shape ID.
-     * @deprecated Use {@link #getOutputShape()}
      */
-    @Deprecated
     public Optional<ShapeId> getOutput() {
         return output.equals(UnitTypeTrait.UNIT) ? Optional.empty() : Optional.of(output);
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.not;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -237,5 +238,17 @@ public class IdlModelLoaderTest {
         // Spot check for a specific "use" shape.
         assertThat(model.expectShape(ShapeId.from("smithy.example#MyService"), ServiceShape.class).getRename(),
                    equalTo(MapUtils.of(ShapeId.from("foo.example#Widget"), "FooWidget")));
+    }
+
+    @Test
+    public void loadsServicesWithNonconflictingUnitTypes() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("valid/__shared.json"))
+                .addImport(getClass().getResource("valid/service-with-nonconflicting-unit.smithy"))
+                .assemble()
+                .unwrap();
+
+        // Make sure we can find our Unit type
+        assertThat(model.expectShape(ShapeId.from("smithy.example#Unit")), Matchers.notNullValue());
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-nonconflicting-unit.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-nonconflicting-unit.json
@@ -1,0 +1,38 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#Example": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "smithy.example#ExampleOutput"
+            }
+        },
+        "smithy.example#ExampleOutput": {
+            "type": "structure",
+            "members": {
+                "unit": {
+                    "target": "smithy.example#Unit"
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "smithy.example#TestService": {
+            "type": "service",
+            "version": "1",
+            "operations": [
+                {
+                    "target": "smithy.example#Example"
+                }
+            ]
+        },
+        "smithy.example#Unit": {
+            "type": "structure",
+            "members": {}
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-nonconflicting-unit.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-nonconflicting-unit.smithy
@@ -1,0 +1,21 @@
+$version: "1.0"
+
+namespace smithy.example
+
+service TestService {
+    version: "1",
+    operations: [Example]
+}
+
+operation Example {
+    // Implicit input: Unit,
+    output: ExampleOutput
+}
+
+@output
+structure ExampleOutput {
+    unit: Unit
+}
+
+// This shape does not conflict with the implicit Unit shape.
+structure Unit {}

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -514,4 +514,20 @@ public class OpenApiConverterTest {
 
         Node.assertEquals(result, expectedNode);
     }
+
+    @Test
+    public void convertsUnitsThatDoNotConflict() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("nonconflicting-unit.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example.rest#RestService"));
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("nonconflicting-unit.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nonconflicting-unit.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nonconflicting-unit.openapi.json
@@ -1,0 +1,68 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "RestService",
+        "version": "1"
+    },
+    "paths": {
+        "/ping": {
+            "post": {
+                "operationId": "Ping",
+                "responses": {
+                    "200": {
+                        "description": "Ping 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PingResponseContent"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ping2": {
+            "post": {
+                "operationId": "Ping2",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Ping2RequestContent"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Ping2 200 response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Ping2RequestContent": {
+                "type": "object",
+                "properties": {
+                    "unit": {
+                        "$ref": "#/components/schemas/Unit"
+                    }
+                }
+            },
+            "PingResponseContent": {
+                "type": "object",
+                "properties": {
+                    "unit": {
+                        "$ref": "#/components/schemas/Unit"
+                    }
+                }
+            },
+            "Unit": {
+                "type": "object"
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nonconflicting-unit.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nonconflicting-unit.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+namespace example.rest
+
+use aws.protocols#restJson1
+
+@restJson1
+service RestService {
+    version: "1",
+    operations: [Ping, Ping2]
+}
+
+@http(method: "POST", uri: "/ping")
+operation Ping {
+    // Implicit input: Unit,
+    output: PingOutput
+}
+
+@http(method: "POST", uri: "/ping2")
+operation Ping2 {
+    input: Ping2Input
+    // Implicit output: Unit
+}
+
+@output
+structure PingOutput {
+    unit: Unit
+}
+
+@input
+structure Ping2Input {
+    unit: Unit
+}
+
+// This shape does not conflict with the implicit Unit shape.
+structure Unit {}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service-integer.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service-integer.openapi.json
@@ -173,6 +173,16 @@
           }
         }
       }
+    },
+    "/ping": {
+      "post": {
+        "operationId": "Ping",
+        "responses": {
+          "200": {
+            "description": "Ping 200 response"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -310,8 +320,23 @@
             "required": [
               "b"
             ]
+          },
+          {
+            "type": "object",
+            "title": "c",
+            "properties": {
+              "c": {
+                "$ref": "#/components/schemas/Unit"
+              }
+            },
+            "required": [
+              "c"
+            ]
           }
         ]
+      },
+      "Unit": {
+        "type": "object"
       }
     }
   }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.json
@@ -13,7 +13,11 @@
                 },
                 {
                     "target": "example.rest#CreateFoo"
+                },
+                {
+                    "target": "example.rest#Ping"
                 }
+
             ],
             "traits": {
                 "aws.protocols#restJson1": {}
@@ -222,6 +226,21 @@
             }
 
         },
+        "example.rest#Ping": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "uri": "/ping",
+                    "method": "POST"
+                }
+            }
+        },
         "example.rest#Blob": {
             "type": "blob"
         },
@@ -327,6 +346,9 @@
                 },
                 "b": {
                     "target": "example.rest#String"
+                },
+                "c": {
+                    "target": "smithy.api#Unit"
                 }
             }
         }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -173,6 +173,16 @@
           }
         }
       }
+    },
+    "/ping": {
+      "post": {
+        "operationId": "Ping",
+        "responses": {
+          "200": {
+            "description": "Ping 200 response"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -310,8 +320,23 @@
             "required": [
               "b"
             ]
+          },
+          {
+            "type": "object",
+            "title": "c",
+            "properties": {
+              "c": {
+                "$ref": "#/components/schemas/Unit"
+              }
+            },
+            "required": [
+              "c"
+            ]
           }
         ]
+      },
+      "Unit": {
+        "type": "object"
       }
     }
   }


### PR DESCRIPTION
*Description of changes:*
Prevents Unit from being added to the service closure if it is only used by operation inputs and/or outputs, and
special-cases Unit for both operations and unions in JSONSchema conversion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
