### PR TITLE
Fix quoted string headers restJson1 protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -53,8 +53,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-StringList": """
-            "b,c","\"def\"",a"""
+            "X-StringList": "\"b,c\", \"\\\"def\\\"\", a"
         },
         body: "",
         params: {


### PR DESCRIPTION
Discovered this issue while upgrading smithy-rs to Smithy 1.15. It seems Smithy is parsing `""""b,c","\"def\"",a"""` as `"b,c",""def"",a` instead of the `"b,c","\"def\"",a` that the test intends. Whether or not this is a parsing bug in the Smithy IDL, I'm not sure.

Tested this fix against smithy-rs after making the code changes necessary to support quotes in the header lists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
