### PR TITLE
Fix timestamp list headers restXml protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -97,7 +97,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         body: "",
         params: {


### PR DESCRIPTION
It looks like this test case was missed in https://github.com/awslabs/smithy/pull/986. I think this is the last of them. After applying this fix, all the protocol tests passed against smithy-rs with the code adjustments to support quoted values in the header lists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
