### PR TITLE
Fix some RestJson query string protocol request tests for servers

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -139,6 +139,10 @@ apply AllQueryStringTypes @httpRequestTests([
         params: {
             queryFloat: "NaN",
             queryDouble: "NaN",
+            queryParamsMapOfStringList: {
+                "Float": ["NaN"],
+                "Double": ["NaN"],
+            }
         }
     },
     {
@@ -155,6 +159,10 @@ apply AllQueryStringTypes @httpRequestTests([
         params: {
             queryFloat: "Infinity",
             queryDouble: "Infinity",
+            queryParamsMapOfStringList: {
+                "Float": ["Infinity"],
+                "Double": ["Infinity"],
+            }
         }
     },
     {
@@ -171,6 +179,10 @@ apply AllQueryStringTypes @httpRequestTests([
         params: {
             queryFloat: "-Infinity",
             queryDouble: "-Infinity",
+            queryParamsMapOfStringList: {
+                "Float": ["-Infinity"],
+                "Double": ["-Infinity"],
+            }
         }
     },
 ])


### PR DESCRIPTION
From a server perspective, `params` is the expected output after request
deserialization. Since `queryParamsMapOfStringList` is bound with
`@httpQueryParams` to the query string, its value must be present and
derived from the input `queryParams` field of the request test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
