### PR TITLE
Add exact match configuration to repeated shape name validator

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -32,7 +32,7 @@
     <!-- Files must contain a copyright header. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright 20(19|20|21) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright 20\d\d Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/docs/source/1.0/guides/model-linters.rst
+++ b/docs/source/1.0/guides/model-linters.rst
@@ -354,12 +354,13 @@ Example:
 
 
 .. _StutteredShapeName:
+.. _RepeatedShapeName:
 
-StutteredShapeName
+RepeatedShapeName
 ==================
 
-Validators that :ref:`structure` member names and :ref:`union` member
-names do not stutter their shape names.
+Validates that :ref:`structure` member names and :ref:`union` member
+names do not repeat their container shape names.
 
 As an example, if a structure named "Table" contained a member named
 "TableName", then this validator would emit a WARNING event.

--- a/docs/source/1.0/guides/model-linters.rst
+++ b/docs/source/1.0/guides/model-linters.rst
@@ -357,10 +357,10 @@ Example:
 .. _RepeatedShapeName:
 
 RepeatedShapeName
-==================
+=================
 
 Validates that :ref:`structure` member names and :ref:`union` member
-names do not repeat their container shape names.
+names do not case-insensitively repeat their container shape names.
 
 As an example, if a structure named "Table" contained a member named
 "TableName", then this validator would emit a WARNING event.
@@ -371,6 +371,19 @@ Rationale
 
 Default severity
     ``WARNING``
+
+Configuration
+    .. list-table::
+       :header-rows: 1
+       :widths: 20 20 60
+
+       * - Property
+         - Type
+         - Description
+       * - exactMatch
+         - ``boolean``
+         - If set to true, the validator will only warn if the member name
+           is case-insensitively identical to the containing shape's name.
 
 
 .. _InputOutputStructureReuse:

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/RepeatedShapeNameValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/RepeatedShapeNameValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -28,12 +28,15 @@ import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidatorService;
 
-@Deprecated
-public final class StutteredShapeNameValidator extends AbstractValidator {
+/**
+ * Validates that structure members and union member names do not
+ * repeat their shape name as prefixes of their member or tag names.
+ */
+public final class RepeatedShapeNameValidator extends AbstractValidator {
 
     public static final class Provider extends ValidatorService.Provider {
         public Provider() {
-            super(StutteredShapeNameValidator.class, StutteredShapeNameValidator::new);
+            super(RepeatedShapeNameValidator.class, RepeatedShapeNameValidator::new);
         }
     }
 
@@ -52,15 +55,14 @@ public final class StutteredShapeNameValidator extends AbstractValidator {
         String lowerCaseShapeName = shapeName.toLowerCase(Locale.US);
         return memberNames.stream()
                 .filter(memberName -> memberName.toLowerCase(Locale.US).startsWith(lowerCaseShapeName))
-                .map(memberName -> stutteredMemberName(model, shape, shapeName, memberName))
+                .map(memberName -> repeatedMemberName(model, shape, shapeName, memberName))
                 .collect(Collectors.toList());
     }
 
-    private ValidationEvent stutteredMemberName(Model model, Shape shape, String shapeName, String memberName) {
-        Shape member = model.getShape(shape.getId().withMember(memberName)).orElseThrow(
-                () -> new RuntimeException("Invalid member name for shape: " + shape + ", " + memberName));
+    private ValidationEvent repeatedMemberName(Model model, Shape shape, String shapeName, String memberName) {
+        Shape member = model.expectShape(shape.getId().withMember(memberName));
         return warning(member, String.format(
-                "The `%s` %s shape stutters its name in the member `%s`; %2$s member names should not be "
-                + "prefixed with the %2$s name.", shapeName, shape.getType(), memberName));
+                "The `%s` %s shape repeats its name in the member `%s`; %2$s member names should not be "
+                        + "prefixed with the %2$s name.", shapeName, shape.getType(), memberName));
     }
 }

--- a/smithy-linters/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.ValidatorService
+++ b/smithy-linters/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.ValidatorService
@@ -2,6 +2,7 @@ software.amazon.smithy.linters.AbbreviationNameValidator$Provider
 software.amazon.smithy.linters.CamelCaseValidator$Provider
 software.amazon.smithy.linters.InputOutputStructureReuseValidator$Provider
 software.amazon.smithy.linters.MissingPaginatedTraitValidator$Provider
+software.amazon.smithy.linters.RepeatedShapeNameValidator$Provider
 software.amazon.smithy.linters.ReservedWordsValidator$Provider
 software.amazon.smithy.linters.ShouldHaveUsedTimestampValidator$Provider
 software.amazon.smithy.linters.StandardOperationVerbValidator$Provider

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name-exact.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name-exact.errors
@@ -1,0 +1,2 @@
+[WARNING] smithy.example#RepeatingStructure$repeatingStructure: The `RepeatingStructure` structure shape repeats its name in the member `repeatingStructure`; structure member names should not be equal to the structure name. | RepeatedShapeName
+[WARNING] smithy.example#RepeatingUnion$repeatingUnion: The `RepeatingUnion` union shape repeats its name in the member `repeatingUnion`; union member names should not be equal to the union name. | RepeatedShapeName

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name-exact.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name-exact.smithy
@@ -1,0 +1,22 @@
+metadata validators = [{
+    name: "RepeatedShapeName",
+    configuration: {
+        exactMatch: true
+    }
+}]
+
+namespace smithy.example
+
+structure RepeatingStructure {
+    repeatingStructure: String,
+
+    // This is fine because it's not an exact match
+    repeatingStructureMember: String,
+}
+
+union RepeatingUnion {
+    repeatingUnion: String,
+
+    // This is fine because it's not an exact match
+    repeatingUnionMember: String,
+}

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name.errors
@@ -1,0 +1,6 @@
+[WARNING] ns.foo#Invalid$InvalidBaz: The `Invalid` structure shape repeats its name in the member `InvalidBaz`; structure member names should not be prefixed with the structure name. | RepeatedShapeName
+[WARNING] ns.foo#Invalid$invalidBar: The `Invalid` structure shape repeats its name in the member `invalidBar`; structure member names should not be prefixed with the structure name. | RepeatedShapeName
+[WARNING] ns.foo#Invalid$invalidFoo: The `Invalid` structure shape repeats its name in the member `invalidFoo`; structure member names should not be prefixed with the structure name. | RepeatedShapeName
+[WARNING] ns.foo#Invalid2$Invalid2Baz: The `Invalid2` union shape repeats its name in the member `Invalid2Baz`; union member names should not be prefixed with the union name. | RepeatedShapeName
+[WARNING] ns.foo#Invalid2$invalid2Bar: The `Invalid2` union shape repeats its name in the member `invalid2Bar`; union member names should not be prefixed with the union name. | RepeatedShapeName
+[WARNING] ns.foo#Invalid2$invalid2Foo: The `Invalid2` union shape repeats its name in the member `invalid2Foo`; union member names should not be prefixed with the union name. | RepeatedShapeName

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/repeated-shape-name.json
@@ -47,7 +47,7 @@
     "metadata": {
         "validators": [
             {
-                "name": "StutteredShapeName"
+                "name": "RepeatedShapeName"
             }
         ]
     }

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/stuttered-shape-name.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/stuttered-shape-name.errors
@@ -1,6 +1,0 @@
-[WARNING] ns.foo#Invalid$InvalidBaz: The `Invalid` structure shape stutters its name in the member `InvalidBaz`; structure member names should not be prefixed with the structure name. | StutteredShapeName
-[WARNING] ns.foo#Invalid$invalidBar: The `Invalid` structure shape stutters its name in the member `invalidBar`; structure member names should not be prefixed with the structure name. | StutteredShapeName
-[WARNING] ns.foo#Invalid$invalidFoo: The `Invalid` structure shape stutters its name in the member `invalidFoo`; structure member names should not be prefixed with the structure name. | StutteredShapeName
-[WARNING] ns.foo#Invalid2$Invalid2Baz: The `Invalid2` union shape stutters its name in the member `Invalid2Baz`; union member names should not be prefixed with the union name. | StutteredShapeName
-[WARNING] ns.foo#Invalid2$invalid2Bar: The `Invalid2` union shape stutters its name in the member `invalid2Bar`; union member names should not be prefixed with the union name. | StutteredShapeName
-[WARNING] ns.foo#Invalid2$invalid2Foo: The `Invalid2` union shape stutters its name in the member `invalid2Foo`; union member names should not be prefixed with the union name. | StutteredShapeName


### PR DESCRIPTION
This adds a configuration option to the repeating shape name validator to specify that it should be an exact match rather than a prefix check.

This also deprecates the old validator in favor of the new one due to its less than ideal name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
