### PR TITLE
Fix RestJsonInputUnionWithUnitMember

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/unions.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/unions.smithy
@@ -446,7 +446,7 @@ apply JsonUnions @httpResponseTests([
 
 
 /// This operation defines a union with a Unit member.
-@http(uri: "/PostPlayerInput", method: "POST")
+@http(uri: "/PostPlayerAction", method: "POST")
 operation PostPlayerAction {
     input: PostPlayerActionInput,
     output: PostPlayerActionOutput
@@ -474,8 +474,8 @@ apply PostPlayerAction @httpRequestTests([
         id: "RestJsonInputUnionWithUnitMember",
         documentation: "Unit types in unions are serialized like normal structures in requests.",
         protocol: restJson1,
-        method: "PUT",
-        "uri": "/MovePlayer",
+        method: "POST",
+        uri: "/PostPlayerAction",
         body: """
             {
                 "action": {


### PR DESCRIPTION
The method and URI were wrong, likely due to copy/paste errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
