### PR TITLE
Reduce HttpBindingsMissing severity for non-REST services

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/AbstractValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/AbstractValidator.java
@@ -60,9 +60,13 @@ public abstract class AbstractValidator implements Validator {
         return createEvent(Severity.NOTE, shape, location, message);
     }
 
-    private ValidationEvent createEvent(Severity severity, Shape shape, FromSourceLocation location, String message) {
-        return createEvent(ValidationEvent.builder().severity(severity).message(message)
-                                   .shapeId(shape.getId()).sourceLocation(location.getSourceLocation()));
+    protected final ValidationEvent createEvent(Severity severity, Shape shape, String message) {
+        return createEvent(severity, shape, shape.getSourceLocation(), message);
+    }
+
+    protected final ValidationEvent createEvent(Severity severity, Shape shape, FromSourceLocation loc, String msg) {
+        return createEvent(ValidationEvent.builder().severity(severity).message(msg)
+                                   .shapeId(shape.getId()).sourceLocation(loc.getSourceLocation()));
     }
 
     private ValidationEvent createEvent(ValidationEvent.Builder builder) {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-bindings-missing-validator-warning.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-bindings-missing-validator-warning.errors
@@ -1,0 +1,2 @@
+[WARNING] ns.foo#MissingBindings1: One or more operations in the `ns.foo#MyService` service define the `http` trait, but this operation is missing the `http` trait. | HttpBindingsMissing
+[WARNING] ns.foo#MissingBindings2: One or more operations in the `ns.foo#MyService` service define the `http` trait, but this operation is missing the `http` trait. | HttpBindingsMissing

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-bindings-missing-validator-warning.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-bindings-missing-validator-warning.json
@@ -1,34 +1,6 @@
 {
     "smithy": "1.0",
     "shapes": {
-        "ns.foo#restProtocol": {
-            "type": "structure",
-            "members": {},
-            "traits": {
-                "smithy.api#trait": {
-                    "selector": "service"
-                },
-                "smithy.api#protocolDefinition": {
-                    "traits": [
-                        "smithy.api#cors",
-                        "smithy.api#endpoint",
-                        "smithy.api#hostLabel",
-                        "smithy.api#http",
-                        "smithy.api#httpError",
-                        "smithy.api#httpHeader",
-                        "smithy.api#httpLabel",
-                        "smithy.api#httpPayload",
-                        "smithy.api#httpPrefixHeaders",
-                        "smithy.api#httpQuery",
-                        "smithy.api#httpQueryParams",
-                        "smithy.api#httpResponseCode",
-                        "smithy.api#jsonName",
-                        "smithy.api#timestampFormat"
-                    ]
-                },
-                "smithy.api#documentation": "A simple clone of AWS restJson1."
-            }
-        },
         "ns.foo#MyService": {
             "type": "service",
             "version": "2017-01-17",
@@ -42,10 +14,7 @@
                 {
                     "target": "ns.foo#MissingBindings2"
                 }
-            ],
-            "traits": {
-                "ns.foo#restProtocol": {}
-            }
+            ]
         },
         "ns.foo#HasBindings": {
             "type": "operation",


### PR DESCRIPTION
*Description of changes:*
HttpBindingsMissing emits an ERROR event for all services that have
inconsistently @http traited operations, but not all protocols support @http.
This change inspects the list of supported traits for every protocol trait
applied to the service, and if none of them support the http trait, then
HttpBindingsMissing is emitted at WARNING, instead of ERROR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
