### PR TITLE
Use the original Node when creating traits

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.json
@@ -30,7 +30,6 @@
                         "integration.request.querystring.provider": "method.request.querystring.vendor"
                     },
                     "cacheNamespace": "cache namespace",
-                    "cacheKeyParameters": [],
                     "responses": {
                         "2\\d{2}": {
                             "statusCode": "200",

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.json
@@ -31,7 +31,6 @@
                         "integration.request.querystring.provider": "method.request.querystring.vendor"
                     },
                     "cacheNamespace": "cache namespace",
-                    "cacheKeyParameters": [],
                     "passThroughBehavior": "never",
                     "payloadFormatVersion": "1.0",
                     "responses": {

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
@@ -67,7 +67,9 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
                 AuthorizerDefinition authorizer = mapper.deserialize(node, AuthorizerDefinition.class);
                 builder.putAuthorizer(key.getValue(), authorizer);
             });
-            return builder.build();
+            AuthorizersTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -88,7 +88,9 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            return new NodeMapper().deserialize(value, IntegrationTrait.class);
+            IntegrationTrait result = new NodeMapper().deserialize(value, IntegrationTrait.class);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
@@ -56,7 +56,9 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            return new NodeMapper().deserialize(value, MockIntegrationTrait.class);
+            MockIntegrationTrait result = new NodeMapper().deserialize(value, MockIntegrationTrait.class);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-apigateway-traits/src/test/resources/software/amazon/smithy/aws/apigateway/traits/errorfiles/valid-integration.json
+++ b/smithy-aws-apigateway-traits/src/test/resources/software/amazon/smithy/aws/apigateway/traits/errorfiles/valid-integration.json
@@ -73,7 +73,6 @@
             "type": "operation",
             "traits": {
                 "aws.apigateway#mockIntegration": {
-                    "type": "aws",
                     "requestTemplates": {
                         "application/json": "#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }",
                         "application/xml": "#set ($root=$input.path('$')) <stage>$root.name</stage> "

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
@@ -86,7 +86,9 @@ public final class CfnResourceTrait extends AbstractTrait
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            return new NodeMapper().deserialize(value, CfnResourceTrait.class);
+            CfnResourceTrait result = new NodeMapper().deserialize(value, CfnResourceTrait.class);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
@@ -59,7 +59,9 @@ public final class DefineConditionKeysTrait extends AbstractTrait implements ToS
                         entry.getValue().expectObjectNode());
                 builder.putConditionKey(entry.getKey().getValue(), definition);
             }
-            return builder.build();
+            DefineConditionKeysTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
@@ -72,7 +72,9 @@ public final class IamResourceTrait extends AbstractTrait
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            return new NodeMapper().deserialize(value, IamResourceTrait.class);
+            IamResourceTrait result = new NodeMapper().deserialize(value, IamResourceTrait.class);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnReferenceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnReferenceTrait.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.aws.traits;
 
+import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -64,7 +65,9 @@ public final class ArnReferenceTrait extends AbstractTrait implements ToSmithyBu
             objectNode.getStringMember(RESOURCE)
                     .map(stringNode -> stringNode.expectShapeId(target.getNamespace()))
                     .ifPresent(builder::resource);
-            return builder.build();
+            ArnReferenceTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 
@@ -116,6 +119,27 @@ public final class ArnReferenceTrait extends AbstractTrait implements ToSmithyBu
                 .withOptionalMember(SERVICE, getService().map(ShapeId::toString).map(Node::from))
                 .withOptionalMember(RESOURCE, getResource().map(ShapeId::toString).map(Node::from))
                 .build();
+    }
+
+    // Due to the defaulting of this trait, equals has to be overridden
+    // so that inconsequential differences in toNode do not effect equality.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ArnReferenceTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            ArnReferenceTrait ot = (ArnReferenceTrait) other;
+            return Objects.equals(type, ot.type)
+                    && Objects.equals(service, ot.service)
+                    && Objects.equals(resource, ot.resource);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), type, service, resource);
     }
 
     /** Builder for {@link ArnReferenceTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.aws.traits;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.SourceException;
@@ -76,7 +77,9 @@ public final class ArnTrait extends AbstractTrait implements ToSmithyBuilder<Arn
             builder.absolute(objectNode.getBooleanMemberOrDefault(ABSOLUTE));
             builder.noRegion(objectNode.getBooleanMemberOrDefault(NO_REGION));
             builder.noAccount(objectNode.getBooleanMemberOrDefault(NO_ACCOUNT));
-            return builder.build();
+            ArnTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 
@@ -149,6 +152,28 @@ public final class ArnTrait extends AbstractTrait implements ToSmithyBuilder<Arn
                 .noRegion(isNoRegion())
                 .noAccount(isNoAccount())
                 .template(getTemplate());
+    }
+
+    // Due to the defaulting of this trait, equals has to be overridden
+    // so that inconsequential differences in toNode do not effect equality.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ArnTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            ArnTrait oa = (ArnTrait) other;
+            return template.equals(oa.template)
+                    && absolute == oa.absolute
+                    && noAccount == oa.noAccount
+                    && noRegion == oa.noRegion;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), template, absolute, noAccount, noRegion);
     }
 
     /** Builder for {@link ArnTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
@@ -163,7 +163,9 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
                     .map(StringNode::getValue)
                     .ifPresent(builder::requestValidationModeMember);
 
-            return builder.build();
+            HttpChecksumTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.traits;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
 import software.amazon.smithy.model.SourceException;
@@ -79,7 +80,9 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
             objectNode.getStringMember("endpointPrefix")
                     .map(StringNode::getValue)
                     .ifPresent(builder::endpointPrefix);
-            return builder.build(target);
+            ServiceTrait result = builder.build(target);
+            result.setNodeCache(value);
+            return result;
         }
     }
 
@@ -177,6 +180,30 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .withMember("cloudTrailEventSource", Node.from(getCloudTrailEventSource()))
                 .withMember("endpointPrefix", Node.from(getEndpointPrefix()))
                 .build();
+    }
+
+    // Due to the defaulting of this trait, equals has to be overridden
+    // so that inconsequential differences in toNode do not effect equality.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ServiceTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            ServiceTrait os = (ServiceTrait) other;
+            return sdkId.equals(os.sdkId)
+                    && arnNamespace.equals(os.arnNamespace)
+                    && cloudFormationName.equals(os.cloudFormationName)
+                    && cloudTrailEventSource.equals(os.cloudTrailEventSource)
+                    && endpointPrefix.equals(os.endpointPrefix);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), sdkId, arnNamespace, cloudFormationName,
+                            cloudTrailEventSource, endpointPrefix);
     }
 
     /** Builder for {@link ServiceTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
@@ -50,10 +50,12 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
         @Override
         public Trait createTrait(ShapeId target, Node value) {
             ObjectNode objectNode = value.expectObjectNode();
-            return builder()
+            CognitoUserPoolsTrait result = builder()
                     .sourceLocation(value)
                     .providerArns(objectNode.expectArrayMember(PROVIDER_ARNS).getElementsAs(StringNode::getValue))
                     .build();
+            result.setNodeCache(objectNode);
+            return result;
         }
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/SigV4Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/SigV4Trait.java
@@ -88,7 +88,9 @@ public final class SigV4Trait extends AbstractTrait implements ToSmithyBuilder<S
             Builder builder = builder().sourceLocation(value);
             ObjectNode objectNode = value.expectObjectNode();
             builder.name(objectNode.expectStringMember(NAME).getValue());
-            return builder.build();
+            SigV4Trait result = builder.build();
+            result.setNodeCache(objectNode);
+            return result;
         }
     }
 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
@@ -92,10 +92,12 @@ public final class ClientDiscoveredEndpointTrait extends AbstractTrait
         @Override
         public ClientDiscoveredEndpointTrait createTrait(ShapeId target, Node value) {
             ObjectNode objectNode = value.expectObjectNode();
-            return builder()
+            ClientDiscoveredEndpointTrait result = builder()
                     .sourceLocation(value)
                     .required(objectNode.getBooleanMemberOrDefault(REQUIRED, true))
                     .build();
+            result.setNodeCache(objectNode);
+            return result;
         }
     }
 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryTrait.java
@@ -151,7 +151,9 @@ public final class ClientEndpointDiscoveryTrait extends AbstractTrait
                     .sourceLocation(value)
                     .operation(objectNode.expectStringMember(OPERATION).expectShapeId());
             objectNode.getStringMember(ERROR).ifPresent(error -> builder.error(error.expectShapeId()));
-            return builder.build();
+            ClientEndpointDiscoveryTrait result = builder.build();
+            result.setNodeCache(objectNode);
+            return result;
         }
     }
 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsJson1_0Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsJson1_0Trait.java
@@ -52,7 +52,9 @@ public final class AwsJson1_0Trait extends AwsProtocolTrait {
 
         @Override
         public AwsJson1_0Trait createTrait(ShapeId target, Node value) {
-            return builder().sourceLocation(value).fromNode(value).build();
+            AwsJson1_0Trait result = builder().fromNode(value).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsJson1_1Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsJson1_1Trait.java
@@ -52,7 +52,9 @@ public final class AwsJson1_1Trait extends AwsProtocolTrait {
 
         @Override
         public AwsJson1_1Trait createTrait(ShapeId target, Node value) {
-            return builder().sourceLocation(value).fromNode(value).build();
+            AwsJson1_1Trait result = builder().fromNode(value).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsProtocolTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsProtocolTrait.java
@@ -125,6 +125,7 @@ public abstract class AwsProtocolTrait extends AbstractTrait {
          */
         @SuppressWarnings("unchecked")
         public B fromNode(Node node) {
+            sourceLocation(node.getSourceLocation());
             ObjectNode objectNode = node.expectObjectNode();
             objectNode.getArrayMember(HTTP)
                     .map(values -> Node.loadArrayOfString(HTTP, values))

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsQueryErrorTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsQueryErrorTrait.java
@@ -52,7 +52,9 @@ public final class AwsQueryErrorTrait extends AbstractTrait implements ToSmithyB
             ObjectNode objectNode = value.expectObjectNode();
             builder.code(objectNode.expectStringMember("code").getValue());
             builder.httpResponseCode(objectNode.expectNumberMember("httpResponseCode").getValue().intValue());
-            return builder.build();
+            AwsQueryErrorTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/RestJson1Trait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/RestJson1Trait.java
@@ -50,7 +50,9 @@ public final class RestJson1Trait extends AwsProtocolTrait {
 
         @Override
         public RestJson1Trait createTrait(ShapeId target, Node value) {
-            return builder().sourceLocation(value).fromNode(value).build();
+            RestJson1Trait result = builder().fromNode(value).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/RestXmlTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/RestXmlTrait.java
@@ -89,7 +89,9 @@ public final class RestXmlTrait extends AwsProtocolTrait {
 
         @Override
         public RestXmlTrait createTrait(ShapeId target, Node value) {
-            return builder().sourceLocation(value).fromNode(value).build();
+            RestXmlTrait result = builder().fromNode(value).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AbstractTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AbstractTrait.java
@@ -30,6 +30,19 @@ import software.amazon.smithy.model.shapes.ShapeId;
  * that equality for traits that extend from this type are not based on the
  * concrete class, but rather the trait name and the trait's {@link ToNode}
  * representation.
+ *
+ * <p>The Node value of a trait can be provided when the trait is created
+ * using {@link #setNodeCache(Node)}. Note that when setting the node cache,
+ * the equality and hashcode of the trait are impacted because they are by
+ * default based on the{@link #toNode()} value of a trait. This typically
+ * isn't an issue until model transformations are performed that modify a
+ * trait. In these cases, the original node value of the trait might differ
+ * from the updated trait even if they are semantically the same value (for
+ * example, if the only change to the trait is modifying its source location,
+ * or if a property of the trait was explicitly set to false, but false is
+ * omitted when serializing the updated trait to a node value). If this use
+ * case needs to be accounted for, you must override equals and hashCode of
+ * the trait.
  */
 public abstract class AbstractTrait implements Trait {
 
@@ -46,6 +59,15 @@ public abstract class AbstractTrait implements Trait {
         this.traitId = Objects.requireNonNull(id, "id was not set on trait");
         this.traitSourceLocation = Objects.requireNonNull(sourceLocation, "sourceLocation was not set on trait")
                 .getSourceLocation();
+    }
+
+    /**
+     * @param id ID of the trait.
+     * @param nodeValue The node representation of the shape, if known and trusted.
+     */
+    public AbstractTrait(ShapeId id, Node nodeValue) {
+        this(id, nodeValue.getSourceLocation());
+        setNodeCache(nodeValue);
     }
 
     @Override
@@ -84,7 +106,7 @@ public abstract class AbstractTrait implements Trait {
     @Override
     public final Node toNode() {
         if (nodeCache == null) {
-            nodeCache = createNode();
+            setNodeCache(createNode());
         }
         return nodeCache;
     }
@@ -97,6 +119,19 @@ public abstract class AbstractTrait implements Trait {
      * @return Returns the trait as a node.
      */
     protected abstract Node createNode();
+
+    /**
+     * Sets the node cache of the trait up front, if known.
+     *
+     * <p>This is useful for maintaining a trait value exactly as provided in
+     * a model file, allowing for validation to detect extraneous properties,
+     * and removing the need to create the node again when calling createNode.
+     *
+     * @param value Value to set.
+     */
+    protected final void setNodeCache(Node value) {
+        this.nodeCache = value;
+    }
 
     /**
      * Basic provider implementation that returns the name of the

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
@@ -83,7 +83,9 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
                     builder.addTrait(ShapeId.from(string));
                 }
             });
-            return builder.build();
+            AuthDefinitionTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
@@ -82,7 +82,9 @@ public final class AuthTrait extends AbstractTrait {
             for (StringNode node : value.expectArrayNode().getElementsAs(StringNode.class)) {
                 values.add(node.expectShapeId());
             }
-            return new AuthTrait(values, value.getSourceLocation());
+            AuthTrait trait = new AuthTrait(values, value.getSourceLocation());
+            trait.setNodeCache(value);
+            return trait;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/CorsTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/CorsTrait.java
@@ -96,6 +96,27 @@ public final class CorsTrait extends AbstractTrait implements ToSmithyBuilder<Co
                         .map(Node::fromStrings));
     }
 
+    // Avoid inconsequential equality issues due to empty vs not empty sets.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof CorsTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            CorsTrait trait = (CorsTrait) other;
+            return origin.equals(trait.origin)
+                    && maxAge == trait.maxAge
+                    && additionalAllowedHeaders.equals(trait.additionalAllowedHeaders)
+                    && additionalExposedHeaders.equals(trait.additionalExposedHeaders);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), origin, maxAge, additionalAllowedHeaders, additionalExposedHeaders);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -158,7 +179,9 @@ public final class CorsTrait extends AbstractTrait implements ToSmithyBuilder<Co
             node.getArrayMember(EXPOSED_HEADERS_MEMBER_ID)
                     .map(Provider::stringSetFromNode)
                     .ifPresent(builder::additionalExposedHeaders);
-            return builder.build();
+            CorsTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
 
         private static Set<String> stringSetFromNode(ArrayNode node) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -51,7 +51,9 @@ public final class DeprecatedTrait extends AbstractTrait implements ToSmithyBuil
             String messageValue = objectNode.getMember("message")
                     .map(v -> v.expectStringNode().getValue()).orElse(null);
             builder.since(sinceValue).message(messageValue);
-            return builder.build();
+            DeprecatedTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
@@ -84,7 +84,9 @@ public final class EndpointTrait extends AbstractTrait implements ToSmithyBuilde
             EndpointTrait.Builder builder = builder().sourceLocation(value);
             ObjectNode objectNode = value.expectObjectNode();
             builder.hostPrefix(objectNode.expectStringMember("hostPrefix").getValue());
-            return builder.build();
+            EndpointTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
@@ -134,7 +134,9 @@ public final class EnumTrait extends AbstractTrait implements ToSmithyBuilder<En
             for (ObjectNode definition : value.expectArrayNode().getElementsAs(ObjectNode.class)) {
                 builder.addEnum(EnumDefinition.fromNode(definition));
             }
-            return builder.build();
+            EnumTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -293,7 +293,9 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
                     .map(Node::expectObjectNode)
                     .map(Provider::exampleFromNode)
                     .forEach(builder::addExample);
-            return builder.build();
+            ExamplesTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
 
         private static Example exampleFromNode(ObjectNode node) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExternalDocumentationTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExternalDocumentationTrait.java
@@ -122,7 +122,9 @@ public final class ExternalDocumentationTrait extends AbstractTrait
             value.expectObjectNode().getMembers().forEach((k, v) -> {
                 builder.addUrl(k.expectStringNode().getValue(), v.expectStringNode().getValue());
             });
-            return builder.build();
+            ExternalDocumentationTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java
@@ -113,7 +113,9 @@ public final class HttpApiKeyAuthTrait extends AbstractTrait implements ToSmithy
             builder.scheme(objectNode.getStringMemberOrDefault("scheme", null));
             builder.name(objectNode.expectStringMember("name").getValue());
             builder.in(Location.from(objectNode.expectStringMember("in").expectOneOf("header", "query")));
-            return builder.build();
+            HttpApiKeyAuthTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpTrait.java
@@ -43,7 +43,7 @@ public final class HttpTrait extends AbstractTrait implements ToSmithyBuilder<Ht
 
     public static final class Provider extends AbstractTrait.Provider {
         public Provider() {
-                super(ID);
+            super(ID);
         }
 
         @Override
@@ -56,7 +56,9 @@ public final class HttpTrait extends AbstractTrait implements ToSmithyBuilder<Ht
                                  .map(NumberNode::getValue)
                                  .map(Number::intValue)
                                  .orElse(200));
-            return builder.build();
+            HttpTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 
@@ -90,6 +92,26 @@ public final class HttpTrait extends AbstractTrait implements ToSmithyBuilder<Ht
     @Override
     public HttpTrait.Builder toBuilder() {
         return new Builder().sourceLocation(getSourceLocation()).method(method).uri(uri).code(code);
+    }
+
+    // Avoid inconsequential equality differences based on defaulting code to 200.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof HttpTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            HttpTrait trait = (HttpTrait) other;
+            return method.equals(trait.method)
+                    && uri.equals(trait.uri)
+                    && code == trait.code;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), method, uri, code);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdRefTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdRefTrait.java
@@ -141,7 +141,9 @@ public final class IdRefTrait extends AbstractTrait implements ToSmithyBuilder<I
             objectNode.getStringMember(ERROR_MESSAGE)
                     .map(StringNode::getValue)
                     .ifPresent(builder::errorMessage);
-            return builder.build();
+            IdRefTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
@@ -114,7 +114,9 @@ public final class LengthTrait extends AbstractTrait implements ToSmithyBuilder<
                     .map(v -> v.expectNumberNode().getValue().longValue()).orElse(null);
             Long maxValue = objectNode.getMember("max")
                     .map(v -> v.expectNumberNode().getValue().longValue()).orElse(null);
-            return builder().sourceLocation(value).min(minValue).max(maxValue).build();
+            LengthTrait result = builder().sourceLocation(value).min(minValue).max(maxValue).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
@@ -244,7 +244,9 @@ public final class PaginatedTrait extends AbstractTrait implements ToSmithyBuild
             builder.items(members.getStringMemberOrDefault("items", null));
             builder.inputToken(members.getStringMemberOrDefault("inputToken", null));
             builder.outputToken(members.getStringMemberOrDefault("outputToken", null));
-            return builder.build();
+            PaginatedTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
@@ -105,7 +105,9 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
                 }
             });
             builder.noInlineDocumentSupport(objectNode.getBooleanMemberOrDefault(NO_INLINE_DOCUMENT_SUPPORT));
-            return builder.build();
+            ProtocolDefinitionTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
@@ -115,7 +115,9 @@ public final class RangeTrait extends AbstractTrait implements ToSmithyBuilder<R
                     .map(node -> new BigDecimal(node.expectNumberNode().getValue().toString())).orElse(null);
             BigDecimal maxValue = objectNode.getMember("max")
                     .map(node -> new BigDecimal(node.expectNumberNode().getValue().toString())).orElse(null);
-            return builder().sourceLocation(value).min(minValue).max(maxValue).build();
+            RangeTrait result = builder().sourceLocation(value).min(minValue).max(maxValue).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
@@ -89,7 +89,9 @@ public final class RecommendedTrait extends AbstractTrait implements ToSmithyBui
             String reason = objectNode.getStringMember("reason")
                     .map(StringNode::getValue)
                     .orElse(null);
-            return builder().sourceLocation(value).reason(reason).build();
+            RecommendedTrait result = builder().sourceLocation(value).reason(reason).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReferencesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReferencesTrait.java
@@ -85,6 +85,24 @@ public final class ReferencesTrait extends AbstractTrait implements ToSmithyBuil
         return builder;
     }
 
+    // Ignore inconsequential toNode differences.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ReferencesTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            ReferencesTrait trait = (ReferencesTrait) other;
+            return references.equals(trait.references);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), references);
+    }
+
     /**
      * @return Returns a builder used to create a references trait.
      */
@@ -265,7 +283,9 @@ public final class ReferencesTrait extends AbstractTrait implements ToSmithyBuil
             for (ObjectNode member : refs.getElementsAs(ObjectNode.class)) {
                 builder.addReference(referenceFromNode(member));
             }
-            return builder.build();
+            ReferencesTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
 
         private static Reference referenceFromNode(ObjectNode referenceProperties) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RetryableTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RetryableTrait.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.model.traits;
 
+import java.util.Objects;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -64,6 +65,24 @@ public final class RetryableTrait extends AbstractTrait implements ToSmithyBuild
         return nodeBuilder.build();
     }
 
+    // Avoid equality issues if, for example, throttling is set explicitly to false.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof RetryableTrait)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            RetryableTrait ot = (RetryableTrait) other;
+            return throttling == ot.throttling;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), throttling);
+    }
+
     public static final class Provider implements TraitService {
         @Override
         public ShapeId getShapeId() {
@@ -74,7 +93,9 @@ public final class RetryableTrait extends AbstractTrait implements ToSmithyBuild
         public RetryableTrait createTrait(ShapeId target, Node value) {
             ObjectNode node = value.expectObjectNode();
             Builder builder = builder().sourceLocation(value.getSourceLocation());
-            return builder.throttling(node.getBooleanMemberOrDefault(THROTTLING)).build();
+            RetryableTrait result = builder.throttling(node.getBooleanMemberOrDefault(THROTTLING)).build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/StringListTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/StringListTrait.java
@@ -161,7 +161,9 @@ public abstract class StringListTrait extends AbstractTrait {
         @Override
         public T createTrait(ShapeId id, Node value) {
             List<String> values = Node.loadArrayOfString(id.toString(), value);
-            return traitFactory.apply(values, value.getSourceLocation());
+            T result = traitFactory.apply(values, value.getSourceLocation());
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/StringTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/StringTrait.java
@@ -68,7 +68,10 @@ public abstract class StringTrait extends AbstractTrait {
 
         @Override
         public T createTrait(ShapeId id, Node value) {
-            return traitFactory.apply(value.expectStringNode().getValue(), value.getSourceLocation());
+            T result = traitFactory.apply(value.expectStringNode().getValue(), value.getSourceLocation());
+            // Reuse the node instead of creating a new one.
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
@@ -142,6 +142,26 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
         return builder.build();
     }
 
+    // Avoid potential equality issues related to inconsequential toNode differences.
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof TraitDefinition)) {
+            return false;
+        } else if (other == this) {
+            return true;
+        } else {
+            TraitDefinition od = (TraitDefinition) other;
+            return selector.equals(od.selector)
+                    && conflicts.equals(od.conflicts)
+                    && Objects.equals(structurallyExclusive, od.structurallyExclusive);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toShapeId(), selector, conflicts, structurallyExclusive);
+    }
+
     /**
      * Builder to create a TraitDefinition.
      */
@@ -216,7 +236,9 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
                     .ifPresent(values -> loadArrayOfString(TraitDefinition.CONFLICTS_KEY, values)
                             .forEach(builder::addConflict));
 
-            return builder.build();
+            TraitDefinition result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlNamespaceTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlNamespaceTrait.java
@@ -110,7 +110,9 @@ public final class XmlNamespaceTrait extends AbstractTrait implements ToSmithyBu
             ObjectNode node = value.expectObjectNode();
             builder.uri(node.expectStringMember(URI).getValue());
             node.getStringMember(PREFIX).map(StringNode::getValue).ifPresent(builder::prefix);
-            return builder.build();
+            XmlNamespaceTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -745,10 +745,8 @@ public class SelectorTest {
     public void projectionsCanMatchThemselvesThroughIntersection() {
         // Any enum with tags should match it's own tags.
         Set<String> shapes1 = ids(traitModel, "[@trait|enum|(values): @{tags|(values)}=@{tags|(values)}]");
-        Set<String> shapes2 = ids(traitModel, "[@trait|enum|(values): @{tags}?=true]");
 
-        assertThat(shapes1, not(empty()));
-        assertThat(shapes2, equalTo(shapes1));
+        assertThat(shapes1, containsInAnyOrder("smithy.example#EnumString", "smithy.example#DocumentedString1"));
     }
 
     @Test

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-value/extra-trait-property.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-value/extra-trait-property.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#MyInteger: Error validating trait `range`: Invalid structure member `maxx` found for `smithy.api#range` | TraitValue

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-value/extra-trait-property.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-value/extra-trait-property.smithy
@@ -1,0 +1,7 @@
+$version: "1.0"
+
+namespace smithy.example
+
+// Notice the typo.
+@range(min: 0, maxx: 100)
+integer MyInteger

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsTrait.java
@@ -54,7 +54,10 @@ public final class HttpMalformedRequestTestsTrait extends AbstractTrait {
             ArrayNode values = value.expectArrayNode();
             List<ParameterizedHttpMalformedRequestTestCase> testCases =
                     values.getElementsAs(ParameterizedHttpMalformedRequestTestCase::fromNode);
-            return new HttpMalformedRequestTestsTrait(value.getSourceLocation(), testCases);
+            HttpMalformedRequestTestsTrait result = new HttpMalformedRequestTestsTrait(value.getSourceLocation(),
+                                                                                       testCases);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpRequestTestsTrait.java
@@ -51,7 +51,9 @@ public final class HttpRequestTestsTrait extends AbstractTrait {
         public Trait createTrait(ShapeId target, Node value) {
             ArrayNode values = value.expectArrayNode();
             List<HttpRequestTestCase> testCases = values.getElementsAs(HttpRequestTestCase::fromNode);
-            return new HttpRequestTestsTrait(value.getSourceLocation(), testCases);
+            HttpRequestTestsTrait result = new HttpRequestTestsTrait(value.getSourceLocation(), testCases);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpResponseTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpResponseTestsTrait.java
@@ -51,7 +51,9 @@ public final class HttpResponseTestsTrait extends AbstractTrait {
         public Trait createTrait(ShapeId target, Node value) {
             ArrayNode values = value.expectArrayNode();
             List<HttpResponseTestCase> testCases = values.getElementsAs(HttpResponseTestCase::fromNode);
-            return new HttpResponseTestsTrait(value.getSourceLocation(), testCases);
+            HttpResponseTestsTrait result = new HttpResponseTestsTrait(value.getSourceLocation(), testCases);
+            result.setNodeCache(value);
+            return result;
         }
     }
 

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
@@ -111,7 +111,9 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
             for (Map.Entry<String, Node> entry : node.getStringMap().entrySet()) {
                 builder.put(entry.getKey(), Waiter.fromNode(entry.getValue()));
             }
-            return builder.build();
+            WaitableTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
         }
     }
 }


### PR DESCRIPTION
This commit updates traits to use the originally provided node value in a model file so that the value is persisted as-is when calling toNode on a trait.

We don't currently do a lot, if any, validation in trait node provider methods. We then explicitly take the parts out of traits that we want and ignore the rest of the node object. This results in use dropping additional properties on traits rather than warning about their presence, which makes it harder to know when a property has a typo. For example, see https://github.com/awslabs/smithy/blob/main/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpTrait.java#L50. Notice that no additional property validation is done on the trait. This is common across most traits.

```java
    public static final class Provider extends AbstractTrait.Provider {
        public Provider() {
                super(ID);
        }

        @Override
        public Trait createTrait(ShapeId target, Node value) {
            HttpTrait.Builder builder = builder().sourceLocation(value);
            ObjectNode members = value.expectObjectNode();
            builder.uri(UriPattern.parse(members.expectStringMember("uri").getValue()));
            builder.method(members.expectStringMember("method").getValue());
            builder.code(members.getNumberMember("code")
                                 .map(NumberNode::getValue)
                                 .map(Number::intValue)
                                 .orElse(200));
            return builder.build();
        }
    }
```

By keeping the original node as-is, the [TraitValueValidator](https://github.com/awslabs/smithy/blob/main/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitValueValidator.java) can automatically detect additional properties.

In addition to validation, this change also removes the need to duplicate the work of creating node values for traits. For example, 412,359 fewer node values are created when loading all AWS models.

The tradeoff of this change is that if a trait does any kind of normalization of values or setting of defaults or if a trait has logic around omitting empty lists, false, etc, then traits may need to override `equals` and `hashCode` since relying on `toNode` equality would render two traits inequal. That generally is fine, but it may be a problem if a model transformation is performed and you need to compare two models, you need to merge two models that might contain duplicate shapes as a result of a transform, etc.

An alternative to this PR is to add things like `warnIfAdditionalProperties` to every trait provider that takes objects. A middleground could be reached too, where we keep the original  node values for scalars and lists of scalars, but recompute and normalize the node values of traits that use object nodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
