### PR TITLE
Warn when update operations use default values

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DefaultValueInUpdateValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DefaultValueInUpdateValidator.java
@@ -1,0 +1,76 @@
+package software.amazon.smithy.model.validation.validators;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.SetUtils;
+
+/**
+ * Finds operations that are meant to partially update a resource, but that use
+ * members with default values in their input shapes, making it impossible
+ * to know if the member was provided explicitly or defaulted.
+ */
+public final class DefaultValueInUpdateValidator extends AbstractValidator {
+
+    // Look for operation names that start with update or patch.
+    private static final Set<String> OPERATION_NAMES_TO_CHECK = SetUtils.of("update", "patch");
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        Set<String> defaultedMembers = new TreeSet<>();
+
+        for (OperationShape operation : identifyOperations(model)) {
+            StructureShape input = model.expectShape(operation.getInputShape(), StructureShape.class);
+
+            for (MemberShape member : input.getAllMembers().values()) {
+                if (member.hasTrait(DefaultTrait.class)) {
+                    defaultedMembers.add(member.getMemberName());
+                }
+            }
+
+            if (!defaultedMembers.isEmpty()) {
+                events.add(warning(operation, "This update style operation has top-level input members marked with "
+                                              + "the @default trait. It will be impossible to tell if the member was "
+                                              + "omitted or explicitly provided. Affected members: "
+                                              + defaultedMembers));
+                defaultedMembers.clear();
+            }
+        }
+
+        return events;
+    }
+
+    private Set<OperationShape> identifyOperations(Model model) {
+        Set<OperationShape> operationsToCheck = new HashSet<>();
+
+        // Look for operations that have an update lifecycle.
+        for (ResourceShape resource : model.getResourceShapes()) {
+            resource.getUpdate().ifPresent(id -> operationsToCheck.add(model.expectShape(id, OperationShape.class)));
+        }
+
+        // Look for operations based on their names.
+        for (OperationShape operation : model.getOperationShapes()) {
+            String name = operation.getId().getName().toLowerCase(Locale.ENGLISH);
+            for (String prefix : OPERATION_NAMES_TO_CHECK) {
+                if (name.startsWith(prefix)) {
+                    operationsToCheck.add(operation);
+                    break;
+                }
+            }
+        }
+
+        return operationsToCheck;
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,4 +1,5 @@
 software.amazon.smithy.model.validation.validators.AuthTraitValidator
+software.amazon.smithy.model.validation.validators.DefaultValueInUpdateValidator
 software.amazon.smithy.model.validation.validators.DeprecatedTraitValidator
 software.amazon.smithy.model.validation.validators.EnumTraitValidator
 software.amazon.smithy.model.validation.validators.EventPayloadTraitValidator

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-patch-by-name-with-default.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-patch-by-name-with-default.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#PatchFoo: This update style operation has top-level input members marked with the @default trait. It will be impossible to tell if the member was omitted or explicitly provided. Affected members: [description] | DefaultValueInUpdate

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-patch-by-name-with-default.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-patch-by-name-with-default.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation PatchFoo {
+    input := {
+        @required
+        id: String
+
+        @default
+        description: String
+    }
+    output := {}
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-resource-update-with-default.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-resource-update-with-default.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#UpdateFoo: This update style operation has top-level input members marked with the @default trait. It will be impossible to tell if the member was omitted or explicitly provided. Affected members: [description] | DefaultValueInUpdate

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-resource-update-with-default.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-resource-update-with-default.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+namespace smithy.example
+
+resource Foo {
+    identifiers: {
+        id: String
+    }
+    update: UpdateFoo
+}
+
+operation UpdateFoo {
+    input := {
+        @required
+        id: String
+
+        @default
+        description: String
+    }
+    output := {}
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-update-by-name-with-default.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-update-by-name-with-default.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#UpdateFoo: This update style operation has top-level input members marked with the @default trait. It will be impossible to tell if the member was omitted or explicitly provided. Affected members: [description] | DefaultValueInUpdate

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-update-by-name-with-default.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/default-value-in-update/finds-update-by-name-with-default.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation UpdateFoo {
+    input := {
+        @required
+        id: String
+
+        @default
+        description: String
+    }
+    output := {}
+}


### PR DESCRIPTION
Partial update style operations should not use default values in their
top-level input members because it makes it impossible for the service
to know if the member was provided explicitly and meant to update the
value, or if the value was automatically set to its default zero value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.