### PR TITLE
Fix quoted string headers restJson1 response protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -207,11 +207,10 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-StringList": """
-            "b,c","\"def\"",a"""
+            "X-StringList": "\"b,c\", \"\\\"def\\\"\", a"
         },
         params: {
-            headerStringList: ["a", "b,c", "\"def\""]
+            headerStringList: ["b,c", "\"def\"", "a"]
         }
     },
     {


### PR DESCRIPTION
I'm not sure how I missed this when working on https://github.com/awslabs/smithy/pull/1035 (I suspect human error with test exclusions), but the response test is also broken. Tested this fix against smithy-rs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
