### PR TITLE
Fix JMESPath and evaluation

### DIFF
--- a/smithy-jmespath/src/main/java/software/amazon/smithy/jmespath/TypeChecker.java
+++ b/smithy-jmespath/src/main/java/software/amazon/smithy/jmespath/TypeChecker.java
@@ -217,17 +217,10 @@ final class TypeChecker implements ExpressionVisitor<LiteralExpression> {
     @Override
     public LiteralExpression visitAnd(AndExpression expression) {
         LiteralExpression leftResult = expression.getLeft().accept(this);
-
         // Visit right side regardless of the evaluation of the left side to validate the result.
-        TypeChecker checker = new TypeChecker(leftResult, problems);
-        LiteralExpression rightResult = expression.getRight().accept(checker);
-
-        // Return a proper result based on the evaluation.
-        if (leftResult.isTruthy() && rightResult.isTruthy()) {
-            return rightResult;
-        } else {
-            return NULL;
-        }
+        LiteralExpression rightResult = expression.getRight().accept(this);
+        // If LHS is falsey, return LHS. Otherwise, return RHS.
+        return leftResult.isTruthy() ? rightResult : leftResult;
     }
 
     @Override

--- a/smithy-jmespath/src/test/java/software/amazon/smithy/jmespath/TypeCheckerTest.java
+++ b/smithy-jmespath/src/test/java/software/amazon/smithy/jmespath/TypeCheckerTest.java
@@ -311,7 +311,7 @@ public class TypeCheckerTest {
         assertThat(check("length(`null` == `null` && 'hi')"), empty());
         assertThat(check("length(`null` != `null` || 'hi')"), empty());
         assertThat(check("length(`null` != `null` && 'hi')"), contains(
-                "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:25)"));
+                "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found boolean (1:25)"));
         assertThat(check("length(`null` > `null` && 'hi')"), containsInAnyOrder(
                 "[WARNING] Invalid comparator '>' for null (1:17)",
                 "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:24)"));
@@ -336,7 +336,7 @@ public class TypeCheckerTest {
         assertThat(check("length(`[1,2]` == `[1,2]` && 'hi')"), empty());
         assertThat(check("length(`[1]` != `[1,2]` && 'hi')"), empty());
         assertThat(check("length(`[1]` != `[1]` && 'hi')"), contains(
-                "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:23)"));
+                "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found boolean (1:23)"));
         assertThat(check("length(`[1]` > `[2]` && 'hi')"), containsInAnyOrder(
                 "[WARNING] Invalid comparator '>' for array (1:16)",
                 "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:22)"));
@@ -356,7 +356,7 @@ public class TypeCheckerTest {
         assertThat(check("length(`{}` == `{}` && 'hi')"), empty());
         assertThat(check("length(`{\"foo\":true}` != `{}` && 'hi')"), empty());
         assertThat(check("length(`[1]` != `[1]` && 'hi')"), contains(
-                "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:23)"));
+                "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found boolean (1:23)"));
         assertThat(check("length(`{\"foo\":true}` > `{}` && 'hi')"), containsInAnyOrder(
                 "[WARNING] Invalid comparator '>' for object (1:25)",
                 "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:30)"));
@@ -369,5 +369,19 @@ public class TypeCheckerTest {
         assertThat(check("length(`{\"foo\":true}` <= `{}` && 'hi')"), containsInAnyOrder(
                 "[WARNING] Invalid comparator '<=' for object (1:26)",
                 "[ERROR] length function argument 0 error: Expected one of [string, array, object], but found null (1:31)"));
+    }
+
+    @Test
+    public void falseyLhsIsReturnedFromAnd() {
+        assertThat(check("ceil(`[]` && `0.9`)"), contains(
+                "[ERROR] ceil function argument 0 error: Expected argument to be number, but found array (1:11)"));
+        assertThat(check("ceil(`{}` && `0.9`)"), contains(
+                "[ERROR] ceil function argument 0 error: Expected argument to be number, but found object (1:11)"));
+        assertThat(check("ceil(`\"\"` && `0.9`)"), contains(
+                "[ERROR] ceil function argument 0 error: Expected argument to be number, but found string (1:11)"));
+        assertThat(check("ceil(`false` && `0.9`)"), contains(
+                "[ERROR] ceil function argument 0 error: Expected argument to be number, but found boolean (1:14)"));
+        assertThat(check("ceil(`null` && `0.9`)"), contains(
+                "[ERROR] ceil function argument 0 error: Expected argument to be number, but found null (1:13)"));
     }
 }

--- a/smithy-waiters/src/test/resources/software/amazon/smithy/waiters/errorfiles/input-output-and-bug-test.smithy
+++ b/smithy-waiters/src/test/resources/software/amazon/smithy/waiters/errorfiles/input-output-and-bug-test.smithy
@@ -1,0 +1,29 @@
+namespace smithy.example
+
+use smithy.waiters#waitable
+
+@waitable(
+    A: {
+        documentation: "A",
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    inputOutput: {
+                        path: "(input.Status == 'failed') && (output.Status == 'failed')",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    }
+)
+operation WaitersTest {
+    input: WaitersTestInputOutput,
+    output: WaitersTestInputOutput
+}
+
+structure WaitersTestInputOutput {
+    Status: String
+}


### PR DESCRIPTION
The result of the LHS is returned if it is falsey. The previous
implementation incorrectly passed the result of LHS to RHS.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
