### PR TITLE
Add docs for inline io and mixins

### DIFF
--- a/designs/mixins.md
+++ b/designs/mixins.md
@@ -348,7 +348,7 @@ The members and traits applied to members of a mixin are copied onto the target
 shape. It is sometimes necessary to provide a more specific trait value for a
 copied member or to add traits only to a specific copy of a member. Traits can
 be added on to these members like any other member. Additionally, Traits can be
-applied to  these members in the JSON AST using the `apply` type and in the
+applied to these members in the JSON AST using the `apply` type and in the
 Smithy IDL using `apply` statements.
 
 > Note: Traits applied to shapes supersede any traits inherited from mixins.

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -188,10 +188,6 @@ The Smithy IDL is defined by the following ABNF:
                            :/ "bigDecimal" / "timestamp"
     shape_members          :"{" `ws` *(`shape_member_kvp` `ws`) "}"
     shape_member_kvp       :`trait_statements` `identifier` `ws` ":" `ws` `shape_id`
-    inlineable_properties  :"{" *(`inlineable_property` `ws`) `ws` "}"
-    inlineable_property    :`node_object_kvp` / `inline_structure`
-    inline_structure       :`node_object_key` `ws` ":=" `ws` `inline_structure_value`
-    inline_structure_value :`trait_statements` [`mixins` ws] shape_members
     list_statement :"list" `ws` `identifier` [`mixins`] `ws` `shape_members`
     set_statement :"set" `ws` `identifier` [`mixins`] `ws` `shape_members`
     map_statement :"map" `ws` `identifier` [`mixins`] `ws` `shape_members`
@@ -199,6 +195,10 @@ The Smithy IDL is defined by the following ABNF:
     union_statement :"union" `ws` `identifier` [`mixins`] `ws` `shape_members`
     service_statement :"service" `ws` `identifier` [`mixins`] `ws` `node_object`
     operation_statement :"operation" `ws` `identifier` [`mixins`] `ws` `inlineable_properties`
+    inlineable_properties  :"{" *(`inlineable_property` `ws`) `ws` "}"
+    inlineable_property    :`node_object_kvp` / `inline_structure`
+    inline_structure       :`node_object_key` `ws` ":=" `ws` `inline_structure_value`
+    inline_structure_value :`trait_statements` [`mixins` ws] shape_members
     resource_statement :"resource" `ws` `identifier` [`mixins`] `ws` `node_object`
 
 .. rubric:: Traits
@@ -255,11 +255,30 @@ The :token:`control section <smithy:control_section>` of a model contains
 :token:`control statements <smithy:control_statement>` that apply parser directives
 to a *specific IDL file*. Because control statements influence parsing, they
 MUST appear at the beginning of a file before any other statements and have
-no effect on the :ref:`semantic model <semantic-model>`
+no effect on the :ref:`semantic model <semantic-model>` The following control
+statements are currently supported:
 
-The :ref:`version <smithy-version>` statement is currently the only control
-statement defined in the Smithy IDL. Implementations MUST ignore unknown
-control statements.
+.. list-table::
+    :header-rows: 1
+    :widths: 10 10 80
+
+    * - Name
+      - Type
+      - Description
+    * - version
+      - string
+      - Defines the :ref:`version <smithy-version>` of the Smithy IDL used in
+        the model file.
+    * - operationInputSuffix
+      - string
+      - Defines the suffix used when generating names for
+        :ref:`inline operation input <idl-inline-input-output>`.
+    * - operationOutputSuffix
+      - string
+      - Defines the suffix used when generating names for
+        :ref:`inline operation output <idl-inline-input-output>`.
+
+Implementations MUST ignore unknown control statements.
 
 
 .. _smithy-version:
@@ -1156,28 +1175,28 @@ can potentially return the ``Unavailable`` or ``BadRequest``
 Inline input / output shapes
 ++++++++++++++++++++++++++++
 
-In addition to targeting an existing shape id when defining an operation's
-input or output property, an inline structure definition may also be used.
+The input and output properties of operations can be defined using a more
+succinct, inline syntax.
 
-A structure defined this way automatically has the :ref:`input-trait` for
-inputs and the :ref:`output-trait` for outputs.
+A structure defined using inline syntax is automatically marked with the
+:ref:`input-trait` for inputs and the :ref:`output-trait` for outputs.
 
-A structure defined this way is given an a generated shape name. For inputs,
-the generated name will be the name of the operation shape with the suffix
-``Input`` added. For outputs, the generated name will be the name of the
-operation shape with the ``Output`` suffix added.
+A structure defined using inline syntax is given a generated shape name. For
+inputs, the generated name is the name of the operation shape with the suffix
+``Input`` added. For outputs, the generated name is the name of the operation
+shape with the ``Output`` suffix added.
 
 For example, the following model:
 
 .. code-block:: smithy
 
     operation GetUser {
-        // The shape name generated will be GetUserInput
+        // The generated shape name is GetUserInput
         input := {
             userId: String
         }
 
-        // The shape name generated will be GetUserOutput
+        // The generated shape name is GetUserOutput
         output := {
             username: String
             userId: String
@@ -1204,7 +1223,7 @@ Is equivalent to:
         userId: String
     }
 
-Traits and mixins can be applied:
+Traits and mixins can be applied to the inline structure:
 
 .. code-block:: smithy
 
@@ -1241,12 +1260,12 @@ The suffixes for the generated names can be customized using the
     namespace smithy.example
 
     operation GetUser {
-        // The shape name generated will be GetUserRequest
+        // The generated shape name is GetUserRequest
         input := {
             userId: String
         }
 
-        // The shape name generated will be GetUserResponse
+        // The generated shape name is GetUserResponse
         output := {
             username: String
             userId: String
@@ -1305,7 +1324,8 @@ Mixins
 ------
 
 :ref:`Mixins <mixins>` can be added to a shape using the optional
-:token:`smithy:mixins` statement as part of the shape type's statement.
+:token:`smithy:mixins` clause of a shape definition.
+
 For example:
 
 .. code-block:: smithy
@@ -1323,8 +1343,8 @@ For example:
     @sensitive
     string SensitiveString
 
-    @pattern("[a-zA-Z\.]*")
-    string SensitiveText with SensitiveString
+    @pattern("^[a-zA-Z\.]*$")
+    string SensitiveText with [SensitiveString]
 
 
 .. _documentation-comment:

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -1104,8 +1104,8 @@ Operation shape
 ---------------
 
 An operation shape is defined using an :token:`smithy:operation_statement` and the
-provided :token:`smithy:node_object` supports the same properties defined in the
-:ref:`operation specification <operation>`.
+provided :token:`smithy:inlineable_properties` supports the same properties defined
+in the :ref:`operation specification <operation>`.
 
 The following example defines an operation shape that accepts an input
 structure named ``Input``, returns an output structure named ``Output``, and
@@ -1148,6 +1148,109 @@ can potentially return the ``Unavailable`` or ``BadRequest``
                 }
             }
         }
+
+
+.. _idl-inline-input-output:
+
+Inline input / output shapes
+++++++++++++++++++++++++++++
+
+In addition to targeting an existing shape id when defining an operation's
+input or output property, an inline structure definition may also be used.
+
+A structure defined this way automatically has the :ref:`input-trait` for
+inputs and the :ref:`output-trait` for outputs.
+
+A structure defined this way is given an a generated shape name. For inputs,
+the generated name will be the name of the operation shape with the suffix
+``Input`` added. For outputs, the generated name will be the name of the
+operation shape with the ``Output`` suffix added.
+
+For example, the following model:
+
+.. code-block:: smithy
+
+    operation GetUser {
+        // The shape name generated will be GetUserInput
+        input := {
+            userId: String
+        }
+
+        // The shape name generated will be GetUserOutput
+        output := {
+            username: String
+            userId: String
+        }
+    }
+
+Is equivalent to:
+
+.. code-block:: smithy
+
+    operation GetUser {
+        input: GetUserInput
+        output: GetUserOutput
+    }
+
+    @input
+    structure GetUserInput {
+        userId: String
+    }
+
+    @output
+    structure GetUserOutput {
+        username: String
+        userId: String
+    }
+
+Traits and mixins can be applied:
+
+.. code-block:: smithy
+
+    @mixin
+    structure BaseUser {
+        userId: String
+    }
+
+    operation GetUser {
+        input := @references([{resource: User}]) {
+            userId: String
+        }
+
+        output := with [BaseUser] {
+            username: String
+        }
+    }
+
+    operation PutUser {
+        input :=
+            @references([{resource: User}])
+            with [BaseUser] {}
+    }
+
+The suffixes for the generated names can be customized using the
+``operationInputSuffix`` and ``operationOutputSuffix`` control statements.
+
+.. code-block:: smithy
+
+    $version: "2.0"
+    $operationInputSuffix: "Request"
+    $operationInputSuffix: "Response"
+
+    namespace smithy.example
+
+    operation GetUser {
+        // The shape name generated will be GetUserRequest
+        input := {
+            userId: String
+        }
+
+        // The shape name generated will be GetUserResponse
+        output := {
+            username: String
+            userId: String
+        }
+    }
 
 
 .. _idl-resource:

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -187,13 +187,17 @@ The Smithy IDL is defined by the following ABNF:
                            :/ "bigDecimal" / "timestamp"
     shape_members          :"{" `ws` *(`shape_member_kvp` `ws`) "}"
     shape_member_kvp       :`trait_statements` `identifier` `ws` ":" `ws` `shape_id`
+    inlineable_properties  :"{" *(`inlineable_property` `ws`) `ws` "}"
+    inlineable_property    :`node_object_kvp` / `inline_structure`
+    inline_structure       :`node_object_key` `ws` ":=" `ws` `inline_structure_value`
+    inline_structure_value :`trait_statements` [`mixins` ws] shape_members
     list_statement :"list" `ws` `identifier` `ws` `shape_members`
     set_statement :"set" `ws` `identifier` `ws` `shape_members`
     map_statement :"map" `ws` `identifier` `ws` `shape_members`
     structure_statement     :"structure" `ws` `identifier` `ws` `shape_members`
     union_statement :"union" `ws` `identifier` `ws` `shape_members`
     service_statement :"service" `ws` `identifier` `ws` `node_object`
-    operation_statement :"operation" `ws` `identifier` `ws` `node_object`
+    operation_statement :"operation" `ws` `identifier` `ws` `inlineable_properties`
     resource_statement :"resource" `ws` `identifier` `ws` `node_object`
 
 .. rubric:: Traits

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -180,7 +180,8 @@ The Smithy IDL is defined by the following ABNF:
                                  :/ `service_statement`
                                  :/ `operation_statement`
                                  :/ `resource_statement`
-    simple_shape_statement :`simple_type_name` `ws` `identifier`
+    mixins                 :`sp` "with" `ws` "[" 1*(`ws` `shape_id`) `ws` "]"
+    simple_shape_statement :`simple_type_name` `ws` `identifier` [`mixins`]
     simple_type_name       :"blob" / "boolean" / "document" / "string"
                            :/ "byte" / "short" / "integer" / "long"
                            :/ "float" / "double" / "bigInteger"
@@ -191,14 +192,14 @@ The Smithy IDL is defined by the following ABNF:
     inlineable_property    :`node_object_kvp` / `inline_structure`
     inline_structure       :`node_object_key` `ws` ":=" `ws` `inline_structure_value`
     inline_structure_value :`trait_statements` [`mixins` ws] shape_members
-    list_statement :"list" `ws` `identifier` `ws` `shape_members`
-    set_statement :"set" `ws` `identifier` `ws` `shape_members`
-    map_statement :"map" `ws` `identifier` `ws` `shape_members`
-    structure_statement     :"structure" `ws` `identifier` `ws` `shape_members`
-    union_statement :"union" `ws` `identifier` `ws` `shape_members`
-    service_statement :"service" `ws` `identifier` `ws` `node_object`
-    operation_statement :"operation" `ws` `identifier` `ws` `inlineable_properties`
-    resource_statement :"resource" `ws` `identifier` `ws` `node_object`
+    list_statement :"list" `ws` `identifier` [`mixins`] `ws` `shape_members`
+    set_statement :"set" `ws` `identifier` [`mixins`] `ws` `shape_members`
+    map_statement :"map" `ws` `identifier` [`mixins`] `ws` `shape_members`
+    structure_statement     :"structure" `ws` `identifier` [`mixins`] `ws` `shape_members`
+    union_statement :"union" `ws` `identifier` [`mixins`] `ws` `shape_members`
+    service_statement :"service" `ws` `identifier` [`mixins`] `ws` `node_object`
+    operation_statement :"operation" `ws` `identifier` [`mixins`] `ws` `inlineable_properties`
+    resource_statement :"resource" `ws` `identifier` [`mixins`] `ws` `node_object`
 
 .. rubric:: Traits
 
@@ -1296,6 +1297,34 @@ and defines a :ref:`read <read-lifecycle>` operation:
                 }
             }
         }
+
+
+.. _idl-mixins:
+
+Mixins
+------
+
+:ref:`Mixins <mixins>` can be added to a shape using the optional
+:token:`smithy:mixins` statement as part of the shape type's statement.
+For example:
+
+.. code-block:: smithy
+
+    @mixin
+    structure BaseUser {
+        userId: String
+    }
+
+    structure UserDetails with [BaseUser] {
+        username: String
+    }
+
+    @mixin
+    @sensitive
+    string SensitiveString
+
+    @pattern("[a-zA-Z\.]*")
+    string SensitiveText with SensitiveString
 
 
 .. _documentation-comment:

--- a/docs/source/1.0/spec/core/json-ast.rst
+++ b/docs/source/1.0/spec/core/json-ast.rst
@@ -638,6 +638,50 @@ The following example defines an operation, its input, output, and errors:
     }
 
 
+.. ast-mixins:
+
+------
+Mixins
+------
+
+All shapes in the ``shapes`` map can contain a ``mixins`` property that
+defines the :ref:`mixins` that are added to the shape. ``mixins`` is an
+array of :ref:`shape references <ast-shape-reference>` that target shapes
+with the :ref:`mixin trait <mixin-trait>`.
+
+.. code-block:: json
+
+    {
+        "smithy": "2.0",
+        "shapes": {
+            "smithy.example#BaseUser": {
+                "type": "structure",
+                "members": {
+                    "userId": {
+                        "target": "smithy.api#String"
+                    }
+                },
+                "traits": {
+                    "smithy.api#mixin": {}
+                }
+            },
+            "smithy.example#UserDetails": {
+                "type": "structure",
+                "members": {
+                    "username": {
+                        "target": "smithy.api#String"
+                    }
+                },
+                "mixins": [
+                    {
+                        "target": "smithy.example#BaseUser"
+                    }
+                ]
+            }
+        }
+    }
+
+
 .. _ast-apply:
 
 --------------

--- a/docs/source/1.0/spec/core/json-ast.rst
+++ b/docs/source/1.0/spec/core/json-ast.rst
@@ -647,7 +647,7 @@ Mixins
 All shapes in the ``shapes`` map can contain a ``mixins`` property that
 defines the :ref:`mixins` that are added to the shape. ``mixins`` is an
 array of :ref:`shape references <ast-shape-reference>` that target shapes
-with the :ref:`mixin trait <mixin-trait>`.
+marked with the :ref:`mixin trait <mixin-trait>`.
 
 .. code-block:: json
 

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -2692,6 +2692,602 @@ after adding a member to the ``foo`` trait:
         }
 
 
+.. _mixins:
+
+------
+Mixins
+------
+
+A mixin is a shape that has the :ref:`mixin-trait`. Adding a mixin to a shape
+causes the members and traits of the mixin shape to be copied into the local
+shape.
+
+.. code-block:: smithy
+
+    @mixin
+    structure UserIdentifiers {
+        id: String
+    }
+
+    structure UserDetails with [UserIdentifiers] {
+        alias: String
+    }
+
+Multiple mixins can be applied:
+
+.. code-block:: smithy
+
+    @mixin
+    structure UserIdentifiers {
+        id: String
+    }
+
+    @mixin
+    structure AccessDetails {
+        firstAccess: Timestamp
+        lastAccess: Timestamp
+    }
+
+    structure UserDetails with [
+        UserIdentifiers
+        AccessDetails
+    ] {
+        alias: String
+    }
+
+Mixins can be composed of other mixins:
+
+.. code-block:: smithy
+
+    @mixin
+    structure MixinA {
+        a: String
+    }
+
+    @mixin
+    structure MixinB with [MixinA] {
+        b: String
+    }
+
+    structure C with [MixinB] {
+        c: String
+    }
+
+When a member is copied from a mixin into a target shape, the shape ID of the
+copied member takes on the containing shape ID of the target shape. This
+ensures that members defined via mixins are treated the same way as members
+defined directly in a shape, and it allows members of a shape to be backward
+compatibly refactored and moved into a mixin or for a shape to remove a mixin
+and replace it with members defined directly in the shape.
+
+The above `C` structure is equivalent to the following flattened structure
+without mixins:
+
+.. code-block:: smithy
+
+    structure C {
+        a: String
+        b: String
+        c: String
+    }
+
+Mixins be any shape type, but they MUST NOT be applied to a shape of a
+different type. For example, a string mixin can be applied to a string
+shape, but not to a blob shape.
+
+.. code-block:: smithy
+
+    @mixin
+    @pattern("[a-zA-Z0-1]*")
+    string AlphaNumeric
+
+    @length(min: 8, max: 32)
+    string Username with [AlphaNumeric]
+
+
+Traits and mixins
+=================
+
+Shapes that use mixins inherit the traits applied to their mixins, except for
+the :ref:`mixin-trait` and *mixin local traits*. Traits applied directly to a
+shape take precedence over traits applied to its mixins.
+
+For example, the definition of ``UserSummary`` in the following model:
+
+.. code-block:: smithy
+
+    /// Generic mixin documentation.
+    @tags(["a"])
+    @mixin
+    structure UserInfo {
+        userId: String
+    }
+
+    structure UserSummary with [UserInfo] {}
+
+Is equivalent to the following flattened structure because it inherits the
+traits of ``UserInfo``:
+
+.. code-block:: smithy
+
+    /// Generic mixin documentation.
+    @tags(["a"])
+    structure UserSummary {
+        userId: String
+    }
+
+The definition of ``UserSummary`` in the following model:
+
+.. code-block:: smithy
+
+    /// Generic mixin documentation.
+    @tags(["a"])
+    @mixin
+    structure UserInfo {
+        userId: String
+    }
+
+    /// Specific documentation
+    @tags(["replaced-tags"])
+    structure UserSummary with [UserInfo] {}
+
+Is equivalent to the following flattened structure because it inherits the
+traits of ``UserInfo`` and traits applied to ``UserSummary`` take precedence
+over traits it inherits:
+
+.. code-block:: smithy
+
+    /// Specific documentation
+    @tags(["replaced-tags"])
+    structure UserSummary {
+        userId: String
+    }
+
+The order in which mixins are applied to a shape controls the inheritance
+precedence of traits. For each mixin applied to a shape, traits applied
+directly to the mixin override traits applied to any of its mixins. Traits
+applied to mixins that come later in the list of mixins applied to a shape take
+precedence over traits applied to mixins that come earlier in the list of
+mixins. For example, the definition of `StructD` in the following model:
+
+.. code-block:: smithy
+
+    /// A
+    @foo(1)
+    @oneTrait
+    @mixin
+    structure StructA {}
+
+    /// B
+    @foo(2)
+    @twoTrait
+    @mixin
+    structure StructB {}
+
+    /// C
+    @threeTrait
+    @mixin
+    structure StructC with [StructA, StructB] {}
+
+    /// D
+    @fourTrait
+    structure StructD with [StructC] {}
+
+Is equivalent to the following flattened structure:
+
+.. code-block:: smithy
+
+    // (1)
+    /// D
+    @fourTrait    // (2)
+    @threeTrait   // (3)
+    @foo(2)       // (4)
+    @twoTrait     // (5)
+    @oneTrait     // (6)
+    structure StructD {}
+
+1. The :ref:`documentation-trait` applied to ``StructD`` takes precedence over
+   any inherited traits.
+2. ``fourTrait`` is applied directly to ``StructD``.
+3. ``threeTrait`` is applied to ``StructC``, ``StructC`` is a mixin of
+   ``StructD``, and `StructD` inherits the resolved traits of each applied
+   mixin.
+4. Because the `StructB` mixin applied to ``StructC`` comes after the
+   ``StructA`` mixin in the list of mixins applied to ``StructC``, ``foo(2)``
+   takes precedence over ``foo(1)``.
+5. ``StructC`` inherits the resolved traits of ``StructB``.
+6. ``StructC`` inherits the resolved traits of ``StructA``.
+
+
+Mixin local traits
+------------------
+
+Sometimes it's necessary to apply traits to a mixin that are not copied onto
+shapes that use the mixin. For example, if a mixin is an implementation detail
+of a model, then it is recommended to apply the :ref:`private-trait` to the
+mixin so that shapes outside of the namespace the mixin is defined within
+cannot refer to the mixin. However, every shape that uses the mixin doesn't
+necessarily need to be marked as private. The ``localTraits`` property of
+the :ref:`mixin-trait` can be used to ensure that a list of traits applied to
+the mixin are not copied onto shapes that use the mixin (note that this has
+no effect on the traits applied to members contained within a mixin).
+
+Consider the following model:
+
+.. code-block:: smithy
+
+    namespace smithy.example
+
+    @private
+    @mixin(localTraits: [private])
+    structure PrivateMixin {
+        foo: String
+    }
+
+    structure PublicShape with [PrivateMixin] {}
+
+``PublicShape`` is equivalent to the following flattened structure:
+
+.. code-block:: smithy
+
+    structure PublicShape {
+        foo: String
+    }
+
+The ``PrivateMixin`` shape can only be referenced from the ``smithy.example``
+namespace. Because the :ref:`private-trait` is present in the ``localTraits``
+property of the :ref:`mixin-trait`, ``PublicShape`` is not marked with the
+:ref:`private-trait` and can be referred to outside of ``smithy.example``.
+
+
+Adding and replacing traits on copied members
+---------------------------------------------
+
+The members and traits applied to members of a mixin are copied onto the target
+shape. It is sometimes necessary to provide a more specific trait value for a
+copied member or to add traits only to a specific copy of a member. Traits can
+be added on to these members like any other member. Additionally, traits can be
+applied to these members in the JSON AST using the :ref:`apply type <ast-apply>`
+and in the Smithy IDL using :ref:`apply statements <apply-statement>`.
+
+.. note::
+
+    Traits applied to shapes supersede any traits inherited from mixins.
+
+For example:
+
+.. code-block:: smithy
+
+    $version: "2.0"
+    namespace smithy.example
+
+    @mixin
+    structure MyMixin {
+        /// Generic docs
+        mixinMember: String
+    }
+
+    structure MyStruct with [MyMixin] {}
+    apply MyStruct$mixinMember @documentation("Specific docs")
+
+Alternatively, the member can be redefined if it targets the same shape:
+
+.. code-block::
+
+    $version: "2.0"
+    namespace smithy.example
+
+    @mixin
+    structure MyMixin {
+        /// Generic docs
+        mixinMember: String
+    }
+
+    structure MyStruct with [MyMixin] {
+        /// Specific docs
+        mixinMember: String
+    }
+
+
+Mixins are not code generated
+=============================
+
+Mixins are an implementation detail of models and are only intended to reduce
+duplication in Smithy shape definitions. Shapes marked with the
+:ref:`mixin-trait` MUST NOT be code generated. Mixins *do not* provide any kind
+of runtime polymorphism for types generated from Smithy models. Generating code
+from mixins removes the ability for modelers to introduce and even remove
+mixins over time as a model is refactored.
+
+
+Mixins cannot be referenced other than as mixins to other shapes
+================================================================
+
+To ensure that mixins are not code generated, mixins MUST NOT be referenced
+from any other shapes except to mix them into other shapes. Mixins MUST NOT be
+used as operation input, output, or errors, and they MUST NOT be targeted by
+members.
+
+The following model is invalid because a structure member targets a mixin:
+
+.. code-block:: smithy
+
+    @mixin
+    structure GreetingMixin {
+        greeting: String
+    }
+
+    structure InvalidStructure {
+        notValid: GreetingMixin // <- this is invalid
+    }
+
+The following model is invalid because an operation attempts to use a mixin
+as input:
+
+.. code-block:: smithy
+
+    @mixin
+    structure InputMixin {}
+
+    operation InvalidOperation {
+        input: InputMixin // <- this is invalid
+    }
+
+
+Mixins MUST NOT introduce cycles
+================================
+
+Mixins MUST NOT introduce circular references. The following model is invalid:
+
+.. code-block:: smithy
+
+    @mixin
+    structure CycleA with [CycleB] {}
+
+    @mixin
+    structure CycleB with [CycleA] {}
+
+
+Mixin members MUST NOT conflict
+===============================
+
+The list of mixins applied to a structure or union MUST NOT attempt to define
+members that use the same member name with different targets. The following
+model is invalid:
+
+.. code-block:: smithy
+
+    @mixin
+    structure A1 {
+        a: String
+    }
+
+    @mixin
+    structure A2 {
+        a: Integer
+    }
+
+    structure Invalid with [A1, A2] {}
+
+The following model is also invalid, but not specifically because of mixins.
+This model is invalid because the member name ``a`` and ``A`` case
+insensitively conflict.
+
+.. code-block:: smithy
+
+    @mixin
+    structure A1 {
+        a: String
+    }
+
+    @mixin
+    structure A2 {
+        A: Integer
+    }
+
+    structure Invalid with [A1, A2] {}
+
+Members that are mixed into shapes MAY be redefined if and only if each
+redefined member targets the same shape. Traits applied to redefined members
+supersede any traits inherited from mixins.
+
+.. code-block:: smithy
+
+    @mixin
+    structure A1 {
+        @private
+        a: String
+    }
+
+    @mixin
+    structure A2 {
+        @required
+        a: String
+    }
+
+    structure Valid with [A1, A2] {}
+
+
+Member ordering
+===============
+
+The order of structure and union members is important for languages like C
+that require a stable ABI. Mixins provide a deterministic member ordering.
+Members inherited from mixins come before members defined directly in the
+shape.
+
+Members are ordered in a kind of depth-first, preorder traversal of mixins
+that are applied to a structure or union. To resolve the member order of a
+shape, iterate over each mixin applied to the shape in the order in which they
+are applied, from left to right. For each mixin, iterate over the mixins
+applied to the mixin in the order in which mixins are applied. When the
+evaluated shape has no mixins, the members of that shape are added to the
+resolved list of ordered members. After evaluating all the mixins of a shape,
+the members of the shape are added onto the resolved list of ordered members.
+This process continues until all mixins and the members of the starting shape
+are added to the ordered list.
+
+Given the following model:
+
+
+.. code-block:: smithy
+
+    @mixin
+    structure FilteredByName {
+        nameFilter: String
+    }
+
+    @mixin
+    structure PaginatedInput {
+        nextToken: String
+        pageSize: Integer
+    }
+
+    structure ListSomethingInput with [
+        PaginatedInput
+        FilteredByName
+    ] {
+        sizeFilter: Integer
+    }
+
+The members are ordered as follows:
+
+1. ``nextToken``
+2. ``pageSize``
+3. ``nameFilter``
+4. ``sizeFilter``
+
+
+Mixins on shapes with non-member properties
+===========================================
+
+Some shapes don't have members, but do have other properties. Adding a mixin
+to such a shape merges the properties of each mixin into the local shape. Only
+certain properties may be defined in the mixin shapes. See the sections below
+for which properties are permitted for each shape type.
+
+Scalar properties defined in the local shape are kept, and non-scalar
+properties are merged. When merging map properties, the values for local keys
+are kept. The ordering of merged lists / sets follows the same ordering as
+members.
+
+Service mixins
+--------------
+
+Service shapes with the :ref:`mixin-trait` may define any property. For
+example, in the following model:
+
+.. code-block:: smithy
+
+    operation OperationA {}
+
+    @mixin
+    service A {
+        version: "A"
+        operations: [OperationA]
+    }
+
+    operation OperationB {}
+
+    @mixin
+    service B with [A] {
+        version: "B"
+        rename: {
+            "smithy.example#OperationA": "OperA"
+            "smithy.example#OperationB": "OperB"
+        }
+        operations: [OperationB]
+    }
+
+    operation OperationC {}
+
+    service C with [B] {
+        version: "C"
+        rename: {
+            "smithy.example#OperationA": "OpA"
+            "smithy.example#OperationC": "OpC"
+        }
+        operations: [OperationC]
+    }
+
+The ``version`` property of the local shape is kept and the ``rename`` and
+``operations`` properties are merged. This is equivalent to the following:
+
+.. code-block:: smithy
+
+    operation OperationA {}
+
+    operation OperationB {}
+
+    operation OperationC {}
+
+    service C {
+        version: "C"
+        rename: {
+            "smithy.example#OperationA": "OpA"
+            "smithy.example#OperationB": "OperB"
+            "smithy.example#OperationC": "OpC"
+        }
+        operations: [OperationA, OperationB, OperationC]
+    }
+
+
+Resource mixins
+---------------
+
+Resource shapes with the :ref:`mixin-trait` MAY NOT define any properties. This
+is because every property of a resource shape is intrinsically tied to its set
+of identifiers. Changing these identifiers would invalidate every other
+property of a given resource. For example:
+
+.. code-block:: smithy
+
+    @mixin
+    @internal
+    resource MixinResource {}
+
+    resource MixedResource with [MixinResource] {}
+
+
+Operation mixins
+----------------
+
+Operation shapes with the :ref:`mixin-trait` MAY NOT define an ``input`` or
+``output`` shape other than the :ref:`unit-type`. This is because allowing
+input and output shapes to be shared goes against the goal of the
+:ref:`input-trait` and :ref:`output-trait`.
+
+Operation shapes with the :ref:`mixin-trait` MAY define the errors shape.
+
+.. code-block:: smithy
+
+    @mixin
+    operation MixinOperation {
+        errors: [MixinError]
+    }
+
+    operation MixedOperation with [MixinOperation] {
+        error: [MixedError]
+    }
+
+    @error("client")
+    structure MixinError {}
+
+    @error("client")
+    structure MixedError {}
+
+
+Mixins in conversion tooling
+============================
+
+When converting Smithy models to OpenAPI, JSON Schema, and other models that
+do not directly support the same mixin semantics as Smithy, tooling MUST
+remove all traces of mixins by flattening mixins into their target shapes.
+This removes the risk of consumers relying on mixins as normal types and still
+retains the flexibility modelers need in order to refactor mixins in and out
+of shapes.
+
+
 .. _metadata:
 
 --------------

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -2705,11 +2705,11 @@ shape.
 .. code-block:: smithy
 
     @mixin
-    structure UserIdentifiers {
+    structure UserIdentifiersMixin {
         id: String
     }
 
-    structure UserDetails with [UserIdentifiers] {
+    structure UserDetails with [UserIdentifiersMixin] {
         alias: String
     }
 
@@ -2718,19 +2718,19 @@ Multiple mixins can be applied:
 .. code-block:: smithy
 
     @mixin
-    structure UserIdentifiers {
+    structure UserIdentifiersMixin {
         id: String
     }
 
     @mixin
-    structure AccessDetails {
+    structure AccessDetailsMixin {
         firstAccess: Timestamp
         lastAccess: Timestamp
     }
 
     structure UserDetails with [
-        UserIdentifiers
-        AccessDetails
+        UserIdentifiersMixin
+        AccessDetailsMixin
     ] {
         alias: String
     }
@@ -2779,10 +2779,10 @@ shape, but not to a blob shape.
 
     @mixin
     @pattern("[a-zA-Z0-1]*")
-    string AlphaNumeric
+    string AlphaNumericMixin
 
     @length(min: 8, max: 32)
-    string Username with [AlphaNumeric]
+    string Username with [AlphaNumericMixin]
 
 
 Traits and mixins
@@ -2799,11 +2799,11 @@ For example, the definition of ``UserSummary`` in the following model:
     /// Generic mixin documentation.
     @tags(["a"])
     @mixin
-    structure UserInfo {
+    structure UserInfoMixin {
         userId: String
     }
 
-    structure UserSummary with [UserInfo] {}
+    structure UserSummary with [UserInfoMixin] {}
 
 Is equivalent to the following flattened structure because it inherits the
 traits of ``UserInfo``:
@@ -2823,13 +2823,13 @@ The definition of ``UserSummary`` in the following model:
     /// Generic mixin documentation.
     @tags(["a"])
     @mixin
-    structure UserInfo {
+    structure UserInfoMixin {
         userId: String
     }
 
     /// Specific documentation
     @tags(["replaced-tags"])
-    structure UserSummary with [UserInfo] {}
+    structure UserSummary with [UserInfoMixin] {}
 
 Is equivalent to the following flattened structure because it inherits the
 traits of ``UserInfo`` and traits applied to ``UserSummary`` take precedence
@@ -2989,15 +2989,14 @@ Alternatively, the member can be redefined if it targets the same shape:
     }
 
 
-Mixins are not code generated
-=============================
+Mixins are an implementation detail of the model
+================================================
 
 Mixins are an implementation detail of models and are only intended to reduce
-duplication in Smithy shape definitions. Shapes marked with the
-:ref:`mixin-trait` MUST NOT be code generated. Mixins *do not* provide any kind
-of runtime polymorphism for types generated from Smithy models. Generating code
-from mixins removes the ability for modelers to introduce and even remove
-mixins over time as a model is refactored.
+duplication in Smithy shape definitions. Mixins do not provide any kind of
+runtime polymorphism for types generated from Smithy models. Smithy model
+transformations like code generation or converting to other model formats
+like OpenAPI SHOULD completely elide mixins by flattening the model.
 
 
 Mixins cannot be referenced other than as mixins to other shapes
@@ -3051,9 +3050,9 @@ Mixins MUST NOT introduce circular references. The following model is invalid:
 Mixin members MUST NOT conflict
 ===============================
 
-The list of mixins applied to a structure or union MUST NOT attempt to define
-members that use the same member name with different targets. The following
-model is invalid:
+The list of mixins applied to a shape MUST NOT attempt to define members that
+use the same member name with different targets. The following model is
+invalid:
 
 .. code-block:: smithy
 
@@ -3129,23 +3128,22 @@ are added to the ordered list.
 
 Given the following model:
 
-
 .. code-block:: smithy
 
     @mixin
-    structure FilteredByName {
+    structure FilteredByNameMixin {
         nameFilter: String
     }
 
     @mixin
-    structure PaginatedInput {
+    structure PaginatedInputMixin {
         nextToken: String
         pageSize: Integer
     }
 
     structure ListSomethingInput with [
-        PaginatedInput
-        FilteredByName
+        PaginatedInputMixin
+        FilteredByNameMixin
     ] {
         sizeFilter: Integer
     }
@@ -3210,8 +3208,7 @@ example, in the following model:
         operations: [OperationC]
     }
 
-The ``version`` property of the local shape is kept and the ``rename`` and
-``operations`` properties are merged. This is equivalent to the following:
+The flattened equivalent of ``C`` with no mixins is:
 
 .. code-block:: smithy
 
@@ -3257,35 +3254,30 @@ Operation shapes with the :ref:`mixin-trait` MAY NOT define an ``input`` or
 input and output shapes to be shared goes against the goal of the
 :ref:`input-trait` and :ref:`output-trait`.
 
-Operation shapes with the :ref:`mixin-trait` MAY define the errors shape.
+Operation shapes with the :ref:`mixin-trait` MAY define errors.
 
 .. code-block:: smithy
 
     @mixin
-    operation MixinOperation {
-        errors: [MixinError]
-    }
-
-    operation MixedOperation with [MixinOperation] {
-        error: [MixedError]
+    operation ValidatedOperation {
+        errors: [ValidationError]
     }
 
     @error("client")
-    structure MixinError {}
+    structure ValidationError {}
+
+    operation GetUsername with [ValidatedOperation] {
+        input := {
+            id: String
+        }
+        output := {
+            name: String
+        }
+        error: [NotFoundError]
+    }
 
     @error("client")
-    structure MixedError {}
-
-
-Mixins in conversion tooling
-============================
-
-When converting Smithy models to OpenAPI, JSON Schema, and other models that
-do not directly support the same mixin semantics as Smithy, tooling MUST
-remove all traces of mixins by flattening mixins into their target shapes.
-This removes the risk of consumers relying on mixins as normal types and still
-retains the flexibility modelers need in order to refactor mixins in and out
-of shapes.
+    structure NotFoundError {}
 
 
 .. _metadata:

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -2998,6 +2998,11 @@ runtime polymorphism for types generated from Smithy models. Smithy model
 transformations like code generation or converting to other model formats
 like OpenAPI SHOULD completely elide mixins by flattening the model.
 
+It is a backward compatible change to remove a mixin from a shape as long as
+equivalent traits and members of the mixin are applied directly to the shape.
+Such a change should have no impact on generated artifacts like code or
+OpenAPI models.
+
 
 Mixins cannot be referenced other than as mixins to other shapes
 ================================================================

--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -1237,12 +1237,12 @@ The table below lists the labeled directed relationships from each shape.
         mixins. Note that these are not the shapes targeted by the member.
     * - structure
       - member
-      - Each structure member, including members from mixins. Note that these
-        are not the shapes targeted by the members.
+      - Each structure member, including members inherited from mixins. Note
+        that these are not the shapes targeted by the members.
     * - union
       - member
-      - Each union member, including members from mixins. Note that these are
-        not the shapes targeted by the members.
+      - Each union member, including members inherited from mixins. Note that
+        these are not the shapes targeted by the members.
     * - member
       -
       - The shape targeted by the member. Note that member targets have no

--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -1229,20 +1229,20 @@ The table below lists the labeled directed relationships from each shape.
       - Each error structure referenced by the operation (if present).
     * - list
       - member
-      - The :ref:`member` of the list. Note that this is not the shape targeted
-        by the member.
+      - The :ref:`member` of the list, including if it was inherited from a
+        mixin. Note that this is not the shape targeted by the member.
     * - map
       - member
-      - The key and value members of the map. Note that these are not the
-        shapes targeted by the member.
+      - The key and value members of the map, including those inherited from
+        mixins. Note that these are not the shapes targeted by the member.
     * - structure
       - member
-      - Each structure member. Note that these are not the shapes targeted by
-        the members.
+      - Each structure member, including members from mixins. Note that these
+        are not the shapes targeted by the members.
     * - union
       - member
-      - Each union member. Note that these are not the shapes targeted by
-        the members.
+      - Each union member, including members from mixins. Note that these are
+        not the shapes targeted by the members.
     * - member
       -
       - The shape targeted by the member. Note that member targets have no
@@ -1253,6 +1253,14 @@ The table below lists the labeled directed relationships from each shape.
         defines the trait. This kind of relationship is only traversed if the
         ``trait`` relationship is explicitly stated as a desired directed
         neighbor relationship type.
+    * - ``*``
+      - mixin
+      - Every mixin applied to the shape.
+
+        .. note::
+
+            A normal ``member`` relationship exists from a given shape to all
+            its inherited mixin members.
 
 .. important::
 

--- a/docs/source/1.0/spec/core/type-refinement-traits.rst
+++ b/docs/source/1.0/spec/core/type-refinement-traits.rst
@@ -306,13 +306,12 @@ The mixin trait is a structure that contains the following members:
 
         .. note::
 
-            The ``mixin`` trait is considered implicitly present in the this
-            property and so does not need to be explicitly added.
-
-See the :ref:`Smithy spec <mixins>` for details on how mixins work.
+            The ``mixin`` trait is considered implicitly present in this
+            property and does not need to be explicitly added.
 
 .. code-block:: smithy
 
+    @mixin
     structure BaseUser {
         id: String
     }
@@ -321,5 +320,9 @@ See the :ref:`Smithy spec <mixins>` for details on how mixins work.
         alias: String
         email: String
     }
+
+.. seealso::
+
+    The :ref:`Smithy spec <mixins>` for details on how mixins work.
 
 .. _Option type: https://doc.rust-lang.org/std/option/enum.Option.html

--- a/docs/source/1.0/spec/core/type-refinement-traits.rst
+++ b/docs/source/1.0/spec/core/type-refinement-traits.rst
@@ -274,4 +274,52 @@ The following example defines a :ref:`map <map>` shape that MAY contain
             }
         }
 
+.. _mixin-trait:
+
+---------------
+``mixin`` trait
+---------------
+
+Summary
+    Indicates that the targeted shape is a mixin.
+Trait selector
+    ``:not(member)``
+Value type
+    ``structure``
+
+The mixin trait is a structure that contains the following members:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 10 80
+
+    * - Property
+      - Type
+      - Description
+    * - ``localTraits``
+      - [:ref:`shape-id`]
+      - A list of shape IDs which MUST reference valid traits that are applied
+        directly to the mixin. The traits in the list are not copied onto
+        shapes that use the mixin. This only affects traits applied to the
+        mixin container shape and has no impact on the members contained within
+        a mixin.
+
+        .. note::
+
+            The ``mixin`` trait is considered implicitly present in the this
+            property and so does not need to be explicitly added.
+
+See the :ref:`Smithy spec <mixins>` for details on how mixins work.
+
+.. code-block:: smithy
+
+    structure BaseUser {
+        id: String
+    }
+
+    structure UserDetails with [BaseUser] {
+        alias: String
+        email: String
+    }
+
 .. _Option type: https://doc.rust-lang.org/std/option/enum.Option.html


### PR DESCRIPTION
This adds documentation for inline io and mixins. This documentation was mostly pulled from the design docs, but was updated in a number of places to better fit with the rest of the smithy docs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
