### PR TITLE
Allow shapes to be bound directly to a service

### DIFF
--- a/docs/source/1.0/spec/core/json-ast.rst
+++ b/docs/source/1.0/spec/core/json-ast.rst
@@ -405,6 +405,12 @@ shapes defined in JSON support the same properties as the Smithy IDL.
         closure of the service can return. Each provided shape ID MUST target
         a :ref:`structure <structure>` shape that is marked with the
         :ref:`error-trait`.
+    * - shapes
+      - [:ref:`AST shape reference <ast-shape-reference>`]
+      - Defines a list of shapes bound directly to the service. Each provided
+        shape ID MUST NOT target a :ref:`service <service>`, :ref:`resource
+        <resource>`, :ref:`operation <operation>`, :ref:`member <member>`, or
+        :ref:`trait shape <trait-shapes>`.
     * - traits
       - map of :ref:`shape ID <shape-id>` to trait values
       - Traits to apply to the service
@@ -434,6 +440,11 @@ shapes defined in JSON support the same properties as the Smithy IDL.
                 "errors": [
                     {
                         "target": "smithy.example#SomeError"
+                    }
+                ],
+                "shapes": [
+                    {
+                        "target": "smithy.example#SomeShape"
                     }
                 ],
                 "traits": {

--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -1098,6 +1098,12 @@ The service shape supports the following properties:
         closure of the service can return. Each provided shape ID MUST target
         a :ref:`structure <structure>` shape that is marked with the
         :ref:`error-trait`.
+    * - shapes
+      - [``string``]
+      - Defines a list of shapes bound directly to the service. Each provided
+        shape ID MUST NOT target a :ref:`service <service>`, :ref:`resource
+        <resource>`, :ref:`operation <operation>`, :ref:`member <member>`, or
+        :ref:`trait shape <trait-shapes>`.
     * - rename
       - map of :ref:`shape ID <shape-id>` to ``string``
       - Disambiguates shape name conflicts in the
@@ -1184,6 +1190,41 @@ that are common to every operation in the service:
             }
         }
 
+The following example defines a service shape that binds a set of shapes
+directly it:
+
+.. tabs::
+
+    .. code-tab:: smithy
+
+        namespace smithy.example
+
+        service MyService {
+            version: "2017-02-11",
+            shapes: [SomeShape]
+        }
+
+        structure SomeShape {}
+
+    .. code-tab:: json
+
+        {
+            "smithy": "1.0",
+            "shapes": {
+                "smithy.example#MyService": {
+                    "type": "service",
+                    "version": "2017-02-11",
+                    "shapes": [
+                        {
+                            "target": "smithy.example#SomeShape"
+                        }
+                    ]
+                },
+                "smithy.example#SomeShape": {
+                    "type": "structure"
+                }
+            }
+        }
 
 
 .. _service-operations:

--- a/docs/source/1.0/spec/core/selectors.rst
+++ b/docs/source/1.0/spec/core/selectors.rst
@@ -1161,6 +1161,9 @@ The table below lists the labeled directed relationships from each shape.
     * - service
       - error
       - Each error structure referenced by the service (if present).
+    * - service
+      - shape
+      - Each shape directly bound to the service.
     * - resource
       - identifier
       - The identifier referenced by the resource (if specified).

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTraitValidator.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTraitValidator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.cloudformation.traits;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.selector.PathFinder;
+import software.amazon.smithy.model.selector.Selector;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Validates that all shapes referenced by the additionalSchemas property of the
+ * {@code @cfnResource} trait are also bound to any service that the resource is
+ * bound to.
+ */
+public final class CfnResourceTraitValidator  extends AbstractValidator {
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        if (!model.isTraitApplied(CfnResourceTrait.class)) {
+            return ListUtils.of();
+        }
+
+        List<ValidationEvent> events = new ArrayList<>();
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<ServiceShape> serviceShapes = model.getServiceShapes();
+
+        for (ResourceShape resourceShape : model.getResourceShapesWithTrait(CfnResourceTrait.class)) {
+            CfnResourceTrait cfnResourceTrait = resourceShape.expectTrait(CfnResourceTrait.class);
+
+            // Short-circuit if there are no additionalSchemas for this resource.
+            if (cfnResourceTrait.getAdditionalSchemas().isEmpty()) {
+                continue;
+            }
+
+            // Validate that the for each service that contains the resource.
+            for (ServiceShape serviceShape : serviceShapes) {
+                if (!topDownIndex.getContainedResources(serviceShape).contains(resourceShape)) {
+                    continue;
+                }
+
+                events.addAll(validateAdditionalSchemaBindings(model, serviceShape, resourceShape, cfnResourceTrait));
+            }
+        }
+
+        return events;
+    }
+
+    private List<ValidationEvent> validateAdditionalSchemaBindings(
+            Model model,
+            ServiceShape service,
+            ResourceShape resource,
+            CfnResourceTrait trait
+    ) {
+        List<ValidationEvent> events = new ArrayList<>();
+
+        for (ShapeId additionalSchemaId : trait.getAdditionalSchemas()) {
+            Selector selector = Selector.parse("[id = " + additionalSchemaId + "]");
+
+            // Emit an event if we don't have a path to the additionalSchema from the
+            // service shape this resource is bound to.
+            if (PathFinder.create(model).search(service.getId(), selector).isEmpty()) {
+                events.add(error(resource, trait.getSourceLocation(), String.format("The `%s` structure listed as "
+                        + "an `additionalSchema` in the `cfnResource` trait on this resource must be bound to the "
+                        + "`%s` service that binds this resource.", additionalSchemaId, service.getId())));
+            }
+        }
+
+        return events;
+    }
+}

--- a/smithy-aws-cloudformation-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-aws-cloudformation-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,2 +1,3 @@
 software.amazon.smithy.aws.cloudformation.traits.CfnMutabilityTraitValidator
 software.amazon.smithy.aws.cloudformation.traits.CfnResourcePropertyValidator
+software.amazon.smithy.aws.cloudformation.traits.CfnResourceTraitValidator

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-conflict.errors
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-conflict.errors
@@ -1,3 +1,2 @@
 [ERROR] smithy.example#AdditionalSchemasConflictResource: The `bar` property of the generated `AdditionalSchemasConflictResource` CloudFormation resource targets multiple shapes: [smithy.api#Boolean, smithy.api#String]. Reusing member names that target different shapes can cause confusion for users of the API. This target discrepancy must either be resolved in the model or one of the members must be excluded from the conversion. | CfnResourceProperty
-[NOTE] smithy.example#AdditionalSchemasConflictProperties: The structure shape is not connected to from any service shape. | UnreferencedShape
 [WARNING] smithy.example#AdditionalSchemasConflictResource: This shape applies a trait that is unstable: aws.cloudformation#cfnResource | UnstableTrait

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-conflict.smithy
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-conflict.smithy
@@ -6,9 +6,8 @@ use aws.cloudformation#cfnResource
 
 service AdditionalSchemasConflict {
     version: "2020-07-02",
-    resources: [
-        AdditionalSchemasConflictResource,
-    ],
+    resources: [AdditionalSchemasConflictResource],
+    shapes: [AdditionalSchemasConflictProperties],
 }
 
 @cfnResource(additionalSchemas: [AdditionalSchemasConflictProperties])

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-not-bound.errors
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-not-bound.errors
@@ -1,0 +1,2 @@
+[WARNING] smithy.example#AdditionalSchemasNotBoundResource: This shape applies a trait that is unstable: aws.cloudformation#cfnResource | UnstableTrait
+[ERROR] smithy.example#AdditionalSchemasNotBoundResource: The `smithy.example#AdditionalSchemasNotBoundProperties` structure listed as an `additionalSchema` in the `cfnResource` trait on this resource must be bound to the `smithy.example#AdditionalSchemasNotBound` service that binds this resource. | CfnResourceTrait

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-not-bound.smithy
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/additionalschemas-not-bound.smithy
@@ -1,0 +1,41 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use aws.cloudformation#cfnResource
+
+service AdditionalSchemasNotBound {
+    version: "2020-07-02",
+    resources: [AdditionalSchemasNotBoundResource],
+}
+
+@cfnResource(additionalSchemas: [AdditionalSchemasNotBoundProperties])
+resource AdditionalSchemasNotBoundResource {
+    identifiers: {
+        fooId: String,
+    },
+    create: CreateAdditionalSchemasNotBoundResource,
+}
+
+operation CreateAdditionalSchemasNotBoundResource {
+    input: CreateAdditionalSchemasNotBoundResourceRequest,
+    output: CreateAdditionalSchemasNotBoundResourceResponse
+}
+
+@input
+structure CreateAdditionalSchemasNotBoundResourceRequest {
+    baz: String,
+}
+
+structure AdditionalSchemasNotBoundProperties {
+    bar: Boolean,
+}
+
+@output
+structure CreateAdditionalSchemasNotBoundResourceResponse {}
+
+service AdditionalSchemasBound {
+    version: "2020-07-02",
+    resources: [AdditionalSchemasNotBoundResource],
+    shapes: [AdditionalSchemasNotBoundProperties],
+}

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/deconflict-by-excluding.errors
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/deconflict-by-excluding.errors
@@ -1,3 +1,2 @@
-[NOTE] smithy.example#AdditionalSchemasDeconflictedProperties: The structure shape is not connected to from any service shape. | UnreferencedShape
 [WARNING] smithy.example#CreateAdditionalSchemasDeconflictedResourceRequest$bar: This shape applies a trait that is unstable: aws.cloudformation#cfnExcludeProperty | UnstableTrait
 [WARNING] smithy.example#AdditionalSchemasDeconflictedResource: This shape applies a trait that is unstable: aws.cloudformation#cfnResource | UnstableTrait

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/deconflict-by-excluding.smithy
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/deconflict-by-excluding.smithy
@@ -7,9 +7,8 @@ use aws.cloudformation#cfnExcludeProperty
 
 service AdditionalSchemasDeconflicted {
     version: "2020-07-02",
-    resources: [
-        AdditionalSchemasDeconflictedResource,
-    ],
+    resources: [AdditionalSchemasDeconflictedResource],
+    shapes: [AdditionalSchemasDeconflictedProperties],
 }
 
 @cfnResource(additionalSchemas: [AdditionalSchemasDeconflictedProperties])

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/CfnConfig.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/CfnConfig.java
@@ -68,7 +68,6 @@ public final class CfnConfig extends JsonSchemaConfig {
         // https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L166-L177
         super.setMapStrategy(MapStrategy.PATTERN_PROPERTIES);
 
-        //
         // CloudFormation Resource Schemas MUST use the oneOf schema property for
         // unions. Invoke the parent class's method directly since we override it
         // to lock this functionality.
@@ -76,10 +75,6 @@ public final class CfnConfig extends JsonSchemaConfig {
         // https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L210
         // https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L166
         super.setUnionStrategy(UnionStrategy.ONE_OF);
-
-        // @cfnResource's additionalSchemas property references shapes that aren't in the service closure
-        // so conversions must be able to reference those shapes
-        super.setEnableOutOfServiceReferences(true);
     }
 
     @Override

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/complex-resource.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/complex-resource.smithy
@@ -7,9 +7,8 @@ use aws.cloudformation#cfnMutability
 
 service TestService {
     version: "2020-07-02",
-    resources: [
-        Foo,
-    ],
+    resources: [Foo],
+    shapes: [FooProperties],
 }
 
 /// Definition of Example::TestService::Foo Resource Type

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/create-and-read-mutability.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/create-and-read-mutability.smithy
@@ -5,7 +5,8 @@ use aws.cloudformation#cfnResource
 
 service TestService {
     version: "2020-07-02",
-    resources: [CreateAndRead]
+    resources: [CreateAndRead],
+    shapes: [FooProperties],
 }
 
 @cfnResource(additionalSchemas: [FooProperties])

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/full-mutability.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/full-mutability.smithy
@@ -5,7 +5,8 @@ use aws.cloudformation#cfnResource
 
 service TestService {
     version: "2020-07-02",
-    resources: [Full]
+    resources: [Full],
+    shapes: [FooProperties],
 }
 
 @cfnResource(additionalSchemas: [FooProperties])

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/put-lifecycle.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/put-lifecycle.smithy
@@ -5,7 +5,8 @@ use aws.cloudformation#cfnResource
 
 service TestService {
     version: "2020-07-02",
-    resources: [PutResource]
+    resources: [PutResource],
+    shapes: [FooProperties],
 }
 
 @cfnResource(additionalSchemas: [FooProperties])

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/queue-example.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/queue-example.smithy
@@ -10,9 +10,8 @@ use aws.cloudformation#cfnMutability
 
 service TestService {
     version: "2012-11-05",
-    resources: [
-        Queue,
-    ]
+    resources: [Queue],
+    shapes: [GetQueueUrlResult, AttributeStructure],
 }
 
 /// Definition of Smithy::TestService::Queue Resource Type

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/read-mutability.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/read-mutability.smithy
@@ -5,7 +5,8 @@ use aws.cloudformation#cfnResource
 
 service TestService {
     version: "2020-07-02",
-    resources: [Read]
+    resources: [Read],
+    shapes: [FooProperties],
 }
 
 @cfnResource(additionalSchemas: [FooProperties])

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/write-mutability.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/write-mutability.smithy
@@ -5,7 +5,8 @@ use aws.cloudformation#cfnResource
 
 service TestService {
     version: "2020-07-02",
-    resources: [Write]
+    resources: [Write],
+    shapes: [FooProperties],
 }
 
 @cfnResource(additionalSchemas: [FooProperties])

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedServiceBoundShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedServiceBoundShape.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.smithy.diff.ChangedShape;
+import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Emits a note when a shape is bound to a service.
+ */
+public final class AddedServiceBoundShape extends AbstractDiffEvaluator {
+    @Override
+    public List<ValidationEvent> evaluate(Differences differences) {
+        return differences.changedShapes(ServiceShape.class)
+                .flatMap(change -> createShapeBindingEvents(change).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<ValidationEvent> createShapeBindingEvents(ChangedShape<ServiceShape> change) {
+        if (change.getOldShape().getShapes().equals(change.getNewShape().getShapes())) {
+            return Collections.emptyList();
+        }
+
+        List<ValidationEvent> events = new ArrayList<>();
+        for (ShapeId id : change.getNewShape().getShapes()) {
+            if (!change.getOldShape().getShapes().contains(id)) {
+                events.add(note(change.getNewShape(), String.format(
+                        "The `%s` shape was added to the `%s` service.",
+                        id, change.getShapeId())));
+            }
+        }
+
+        return events;
+    }
+}

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedServiceBoundShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedServiceBoundShape.java
@@ -44,8 +44,9 @@ public final class RemovedServiceBoundShape extends AbstractDiffEvaluator {
         List<ValidationEvent> events = new ArrayList<>();
         for (ShapeId id : change.getOldShape().getShapes()) {
             if (!change.getNewShape().getShapes().contains(id)) {
-                events.add(warning(change.getNewShape(), String.format(
-                        "The `%s` shape was unbound from the `%s` service.",
+                events.add(danger(change.getNewShape(), String.format(
+                        "The `%s` shape was unbound from the `%s` service. It may no longer be in the service "
+                        + "closure if it hasn't been bound through another shape.",
                         id, change.getShapeId())));
             }
         }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedServiceBoundShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedServiceBoundShape.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.smithy.diff.ChangedShape;
+import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Emits a warning when a service is unbound from a service.
+ */
+public final class RemovedServiceBoundShape extends AbstractDiffEvaluator {
+    @Override
+    public List<ValidationEvent> evaluate(Differences differences) {
+        return differences.changedShapes(ServiceShape.class)
+                .flatMap(change -> createShapeBindingEvents(change).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<ValidationEvent> createShapeBindingEvents(ChangedShape<ServiceShape> change) {
+        if (change.getOldShape().getShapes().equals(change.getNewShape().getShapes())) {
+            return Collections.emptyList();
+        }
+
+        List<ValidationEvent> events = new ArrayList<>();
+        for (ShapeId id : change.getOldShape().getShapes()) {
+            if (!change.getNewShape().getShapes().contains(id)) {
+                events.add(warning(change.getNewShape(), String.format(
+                        "The `%s` shape was unbound from the `%s` service.",
+                        id, change.getShapeId())));
+            }
+        }
+
+        return events;
+    }
+}

--- a/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
+++ b/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
@@ -1,6 +1,7 @@
 software.amazon.smithy.diff.evaluators.AddedEntityBinding
 software.amazon.smithy.diff.evaluators.AddedMetadata
 software.amazon.smithy.diff.evaluators.AddedOperationError
+software.amazon.smithy.diff.evaluators.AddedServiceBoundShape
 software.amazon.smithy.diff.evaluators.AddedServiceError
 software.amazon.smithy.diff.evaluators.AddedShape
 software.amazon.smithy.diff.evaluators.AddedTraitDefinition
@@ -19,6 +20,7 @@ software.amazon.smithy.diff.evaluators.RemovedAuthenticationScheme
 software.amazon.smithy.diff.evaluators.RemovedEntityBinding
 software.amazon.smithy.diff.evaluators.RemovedMetadata
 software.amazon.smithy.diff.evaluators.RemovedOperationError
+software.amazon.smithy.diff.evaluators.RemovedServiceBoundShape
 software.amazon.smithy.diff.evaluators.RemovedServiceError
 software.amazon.smithy.diff.evaluators.RemovedShape
 software.amazon.smithy.diff.evaluators.RemovedTraitDefinition

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedServiceBoundShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedServiceBoundShapeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.diff.ModelDiff;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class AddedServiceBoundShapeTest {
+    @Test
+    public void detectsAddedShapeBindings() {
+        Shape s1 = StructureShape.builder()
+                .id("foo.baz#S1")
+                .build();
+        Shape s2 = StructureShape.builder()
+                .id("foo.baz#S2")
+                .build();
+        ServiceShape service1 = ServiceShape.builder().id("foo.baz#Service").build();
+        ServiceShape service2 = service1.toBuilder().addShape(s1.getId()).addShape(s2.getId()).build();
+        Model modelA = Model.assembler().addShapes(service1, s1, s2).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, s1, s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "AddedServiceBoundShape").size(), equalTo(2));
+    }
+}

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedServiceBoundShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedServiceBoundShapeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.diff.ModelDiff;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class RemovedServiceBoundShapeTest {
+    @Test
+    public void detectsRemovedShapeBindings() {
+        Shape s1 = StructureShape.builder()
+                .id("foo.baz#S1")
+                .build();
+        Shape e2 = StructureShape.builder()
+                .id("foo.baz#S2")
+                .build();
+        ServiceShape service1 = ServiceShape.builder()
+                .id("foo.baz#Service")
+                .version("X")
+                .addShape(s1)
+                .addShape(e2)
+                .build();
+        ServiceShape service2 = service1.toBuilder().clearShapes().build();
+        Model modelA = Model.assembler().addShapes(service1, s1, e2).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, s1, e2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        // Emits one even for both removals.
+        assertThat(TestHelper.findEvents(events, "RemovedServiceBoundShape").size(), equalTo(2));
+    }
+}

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -95,6 +96,8 @@ public class JsonSchemaConfig {
             return stringValue;
         }
     }
+
+    private static final Logger LOGGER = Logger.getLogger(JsonSchemaConfig.class.getName());
 
     private boolean alphanumericOnlyRefs;
     private boolean useJsonName;
@@ -368,7 +371,12 @@ public class JsonSchemaConfig {
         this.supportNonNumericFloats = supportNonNumericFloats;
     }
 
+    @Deprecated
     public boolean isEnableOutOfServiceReferences() {
+        if (enableOutOfServiceReferences) {
+            LOGGER.warning("Deprecated JSON Schema setting `enableOutOfServiceReferences` enabled. "
+                    + "Bind shapes directly to the service instead.");
+        }
         return enableOutOfServiceReferences;
     }
 
@@ -381,6 +389,7 @@ public class JsonSchemaConfig {
      *
      * @param enableOutOfServiceReferences true if out-of-service references should be allowed. default: false
      */
+    @Deprecated
     public void setEnableOutOfServiceReferences(boolean enableOutOfServiceReferences) {
         this.enableOutOfServiceReferences = enableOutOfServiceReferences;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -84,7 +84,7 @@ enum AstModelLoader {
             TYPE, "create", "read", "update", "delete", "list", "put",
             "identifiers", "resources", "operations", "collectionOperations", TRAITS);
     private static final Set<String> SERVICE_PROPERTIES = SetUtils.of(
-            TYPE, "version", "operations", "resources", "rename", ERRORS, TRAITS);
+            TYPE, "version", "operations", "resources", "rename", ERRORS, SHAPES, TRAITS);
 
     ModelFile load(TraitFactory traitFactory, ObjectNode model) {
         FullyResolvedModelFile modelFile = new FullyResolvedModelFile(traitFactory);
@@ -286,6 +286,7 @@ enum AstModelLoader {
         builder.resources(loadOptionalTargetList(modelFile, id, node, "resources"));
         loadServiceRenameIntoBuilder(builder, node);
         builder.addErrors(loadOptionalTargetList(modelFile, id, node, ERRORS));
+        builder.addShapes(loadOptionalTargetList(modelFile, id, node, SHAPES));
         modelFile.onShape(builder);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -90,12 +90,13 @@ final class IdlModelParser extends SimpleParser {
     private static final String VERSION_KEY = "version";
     private static final String TYPE_KEY = "type";
     private static final String ERRORS_KEYS = "errors";
+    private static final String SHAPES_KEY = "shapes";
 
     static final Collection<String> RESOURCE_PROPERTY_NAMES = ListUtils.of(
             TYPE_KEY, CREATE_KEY, READ_KEY, UPDATE_KEY, DELETE_KEY, LIST_KEY,
             IDENTIFIERS_KEY, RESOURCES_KEY, OPERATIONS_KEY, PUT_KEY, COLLECTION_OPERATIONS_KEY);
     static final List<String> SERVICE_PROPERTY_NAMES = ListUtils.of(
-            TYPE_KEY, VERSION_KEY, OPERATIONS_KEY, RESOURCES_KEY, RENAME_KEY);
+            TYPE_KEY, VERSION_KEY, OPERATIONS_KEY, RESOURCES_KEY, RENAME_KEY, SHAPES_KEY);
     private static final Collection<String> OPERATION_PROPERTY_NAMES = ListUtils.of("input", "output", "errors");
     private static final Set<String> SHAPE_TYPES = new HashSet<>();
 
@@ -564,6 +565,7 @@ final class IdlModelParser extends SimpleParser {
         optionalIdList(shapeNode, OPERATIONS_KEY, builder::addOperation);
         optionalIdList(shapeNode, RESOURCES_KEY, builder::addResource);
         optionalIdList(shapeNode, ERRORS_KEYS, builder::addError);
+        optionalIdList(shapeNode, SHAPES_KEY, builder::addShape);
         AstModelLoader.loadServiceRenameIntoBuilder(builder, shapeNode);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborVisitor.java
@@ -75,6 +75,10 @@ final class NeighborVisitor extends ShapeVisitor.Default<List<Relationship>> imp
         for (ShapeId errorId : shape.getErrors()) {
             result.add(relationship(shape, RelationshipType.ERROR, errorId));
         }
+        // Add SHAPE relationships from service -> shapes.
+        for (ShapeId shapeId : shape.getShapes()) {
+            result.add(relationship(shape, RelationshipType.SHAPE, shapeId));
+        }
         return result;
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/RelationshipType.java
@@ -47,6 +47,13 @@ public enum RelationshipType {
     OPERATION("operation", RelationshipDirection.DIRECTED),
 
     /**
+     * Relationships that exist between a service and the shapes bound
+     * directly to it. They reference shapes that are not service, operation,
+     * resource, members, or shapes that are traits.
+     */
+    SHAPE("shape", RelationshipDirection.DIRECTED),
+
+    /**
      * A collection operation relationship exists between a resource and the
      * operations bound to the resource in the "collectionOperations", "create",
      * and "list" properties.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -258,6 +258,7 @@ public final class ModelSerializer {
             serviceBuilder.withOptionalMember("operations", createOptionalIdList(shape.getOperations()));
             serviceBuilder.withOptionalMember("resources", createOptionalIdList(shape.getResources()));
             serviceBuilder.withOptionalMember("errors", createOptionalIdList(shape.getErrors()));
+            serviceBuilder.withOptionalMember("shapes", createOptionalIdList(shape.getShapes()));
 
             if (!shape.getRename().isEmpty()) {
                 ObjectNode.Builder renameBuilder = Node.objectNodeBuilder();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -31,12 +31,14 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
     private final String version;
     private final Map<ShapeId, String> rename;
     private final List<ShapeId> errors;
+    private final List<ShapeId> shapes;
 
     private ServiceShape(Builder builder) {
         super(builder);
         version = builder.version;
         rename = builder.rename.copy();
         errors = builder.errors.copy();
+        shapes = builder.shapes.copy();
     }
 
     public static Builder builder() {
@@ -50,6 +52,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
                 .version(version)
                 .errors(errors)
                 .rename(rename)
+                .shapes(shapes)
                 .operations(getOperations())
                 .resources(getResources());
     }
@@ -73,7 +76,8 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
         ServiceShape o = (ServiceShape) other;
         return version.equals(o.version)
                && rename.equals(o.rename)
-               && errors.equals(o.errors);
+               && errors.equals(o.errors)
+               && shapes.equals(o.shapes);
     }
 
     @Override
@@ -113,6 +117,15 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
     }
 
     /**
+     * <p>Gets a list of the shapes that are directly bound to the service.</p>
+     *
+     * @return Returns the shapes.
+     */
+    public List<ShapeId> getShapes() {
+        return shapes;
+    }
+
+    /**
      * Gets the contextual name of a shape within the closure.
      *
      * <p>If there is a rename property entry for the given shape ID, then
@@ -138,6 +151,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
         private String version = "";
         private final BuilderRef<Map<ShapeId, String>> rename = BuilderRef.forOrderedMap();
         private final BuilderRef<List<ShapeId>> errors = BuilderRef.forList();
+        private final BuilderRef<List<ShapeId>> shapes = BuilderRef.forList();
 
         @Override
         public ServiceShape build() {
@@ -241,6 +255,71 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
          */
         public Builder clearErrors() {
             errors.clear();
+            return this;
+        }
+
+        /**
+         * Sets and replaces the shapes bound to the service.
+         *
+         * @param boundShapeIds Shape IDs to set.
+         * @return Returns the builder.
+         */
+        public Builder shapes(Collection<ShapeId> boundShapeIds) {
+            shapes.clear();
+            boundShapeIds.forEach(this::addShape);
+            return this;
+        }
+
+        /**
+         * Adds a shape directly bound to the service.
+         *
+         * @param boundShapeId Shape ID to bind.
+         * @return Returns the builder.
+         */
+        public Builder addShape(ToShapeId boundShapeId) {
+            shapes.get().add(boundShapeId.toShapeId());
+            return this;
+        }
+
+        /**
+         * Adds a shape directly bound to the service.
+         *
+         * @param boundShapeId Shape ID to bind.
+         * @return Returns the builder.
+         * @throws ShapeIdSyntaxException if the shape ID is invalid.
+         */
+        public Builder addShape(String boundShapeId) {
+            return addShape(ShapeId.from(boundShapeId));
+        }
+
+        /**
+         * Adds shapes directly bound to the service.
+         *
+         * @param boundShapeIds Shape IDs to bind.
+         * @return Returns the builder.
+         */
+        public Builder addShapes(List<ShapeId> boundShapeIds) {
+            shapes.get().addAll(Objects.requireNonNull(boundShapeIds));
+            return this;
+        }
+
+        /**
+         * Removes a bound shape by Shape ID.
+         *
+         * @param boundShapeId Shape ID to remove.
+         * @return Returns the builder.
+         */
+        public Builder removeShape(ToShapeId boundShapeId) {
+            shapes.get().remove(boundShapeId.toShapeId());
+            return this;
+        }
+
+        /**
+         * Removes all directly bound shapes.
+         * @return Returns the builder.
+         */
+        public Builder clearShapes() {
+            shapes.clear();
             return this;
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -434,6 +434,7 @@ public final class SmithyIdlModelSerializer {
             codeWriter.writeOptionalIdList("operations", shape.getOperations());
             codeWriter.writeOptionalIdList("resources", shape.getResources());
             codeWriter.writeOptionalIdList("errors", shape.getErrors());
+            codeWriter.writeOptionalIdList("shapes", shape.getShapes());
             if (!shape.getRename().isEmpty()) {
                 codeWriter.openBlock("rename: {", "}", () -> {
                     for (Map.Entry<ShapeId, String> entry : shape.getRename().entrySet()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
@@ -50,6 +50,8 @@ public final class TargetValidator extends AbstractValidator {
     private static final int MAX_EDIT_DISTANCE_FOR_SUGGESTIONS = 2;
     private static final Set<ShapeType> INVALID_MEMBER_TARGETS = SetUtils.of(
             ShapeType.SERVICE, ShapeType.RESOURCE, ShapeType.OPERATION, ShapeType.MEMBER);
+    private static final Set<ShapeType> INVALID_SERVICE_SHAPE_TARGETS = SetUtils.of(
+            ShapeType.SERVICE, ShapeType.RESOURCE, ShapeType.OPERATION, ShapeType.MEMBER);
 
     @Override
     public List<ValidationEvent> validate(Model model) {
@@ -97,6 +99,14 @@ public final class TargetValidator extends AbstractValidator {
             case OPERATION:
                 if (target.getType() != ShapeType.OPERATION) {
                     return Optional.of(badType(shape, target, relType, ShapeType.OPERATION));
+                }
+                return Optional.empty();
+            case SHAPE:
+                // Service shape relationships cannot target members, services, operations, or resource shapes.
+                if (INVALID_SERVICE_SHAPE_TARGETS.contains(target.getType())) {
+                    return Optional.of(error(shape, format(
+                            "Services cannot directly bind %s shapes through the `shapes` property, but found %s",
+                            target.getType(), target)));
                 }
                 return Optional.empty();
             case INPUT:

--- a/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/neighbor/NeighborVisitorTest.java
@@ -231,6 +231,24 @@ public class NeighborVisitorTest {
     }
 
     @Test
+    public void shapesBoundToService() {
+        ServiceShape service = ServiceShape.builder()
+                .id("ns.foo#Svc")
+                .version("2017-01-17")
+                .addShape("ns.foo#Common1")
+                .build();
+        StructureShape structure = StructureShape.builder()
+                .id("ns.foo#Common1")
+                .build();
+        Model model = Model.builder().addShapes(service, structure).build();
+        NeighborVisitor neighborVisitor = new NeighborVisitor(model);
+        List<Relationship> relationships = service.accept(neighborVisitor);
+
+        assertThat(relationships, contains(
+                Relationship.create(service, RelationshipType.SHAPE, structure)));
+    }
+
+    @Test
     public void resourceShape() {
         ServiceShape parent = ServiceShape.builder()
                 .id("ns.foo#Svc")

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -1027,7 +1027,7 @@ public class SelectorTest {
     }
 
     @Test
-    public void canPathToErrorsOfStructure() {
+    public void canPathToErrorsOfService() {
         ServiceShape service = ServiceShape.builder()
                 .id("ns.foo#Svc")
                 .version("2017-01-17")
@@ -1043,5 +1043,23 @@ public class SelectorTest {
         Set<Shape> result = selector.select(model);
 
         assertThat(result, containsInAnyOrder(errorShape));
+    }
+
+    @Test
+    public void canPathToShapesOfService() {
+        ServiceShape service = ServiceShape.builder()
+                .id("ns.foo#Svc")
+                .version("2017-01-17")
+                .addShape("ns.foo#Common1")
+                .build();
+        StructureShape structure = StructureShape.builder()
+                .id("ns.foo#Common1")
+                .build();
+        Model model = Model.builder().addShapes(service, structure).build();
+
+        Selector selector = Selector.parse("service -[shape]-> structure");
+        Set<Shape> result = selector.select(model);
+
+        assertThat(result, containsInAnyOrder(structure));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ServiceShapeTest.java
@@ -87,4 +87,23 @@ public class ServiceShapeTest {
 
         assertThat(shape, equalTo(shape2));
     }
+
+    @Test
+    public void hasShapes() {
+        ServiceShape shape = ServiceShape.builder()
+                .id("com.foo#Example")
+                .version("x")
+                .addShape("com.foo#Common1")
+                .addShape(ShapeId.from("com.foo#Common2"))
+                .build();
+
+        assertThat(shape, equalTo(shape));
+        assertThat(shape, equalTo(shape.toBuilder().build()));
+
+        ServiceShape shape2 = shape.toBuilder()
+                .shapes(Arrays.asList(ShapeId.from("com.foo#Common1"), ShapeId.from("com.foo#Common2")))
+                .build();
+
+        assertThat(shape, equalTo(shape2));
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-shapes.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-shapes.errors
@@ -1,0 +1,6 @@
+[ERROR] ns.foo#InvalidService1: service shape has a `shape` relationship to an unresolved shape `ns.foo#NotFound` | Target
+[ERROR] ns.foo#InvalidService2: Services cannot directly bind service shapes through the `shapes` property, but found (service: `ns.foo#InvalidService1`) | Target
+[ERROR] ns.foo#InvalidService3: Services cannot directly bind resource shapes through the `shapes` property, but found (resource: `ns.foo#Resource`) | Target
+[ERROR] ns.foo#InvalidService4: Services cannot directly bind operation shapes through the `shapes` property, but found (operation: `ns.foo#CreateResource`) | Target
+[ERROR] ns.foo#InvalidService5: Services cannot directly bind member shapes through the `shapes` property, but found (member: `ns.foo#CreateResourceInput$name`) | Target
+[ERROR] ns.foo#InvalidService6: Found a SHAPE reference to trait definition `smithy.api#sensitive`. Trait definitions cannot be targeted by members or referenced by shapes in any other context other than applying them as traits. | Target

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/target-validator-service-shapes.smithy
@@ -1,0 +1,46 @@
+namespace ns.foo
+
+service InvalidService1 {
+    version: "2020-07-02",
+    shapes: [NotFound]
+}
+
+service InvalidService2 {
+    version: "2020-07-02",
+    shapes: [InvalidService1]
+}
+
+service InvalidService3 {
+    version: "2020-07-02",
+    shapes: [Resource]
+}
+
+service InvalidService4 {
+    version: "2020-07-02",
+    shapes: [CreateResource]
+}
+
+service InvalidService5 {
+    version: "2020-07-02",
+    shapes: [CreateResourceInput$name]
+}
+
+service InvalidService6 {
+    version: "2020-07-02",
+    shapes: [smithy.api#sensitive]
+}
+
+resource Resource {
+    identifiers: {
+        id: String,
+    },
+    create: CreateResource,
+}
+
+operation CreateResource {
+    input: CreateResourceInput,
+}
+
+structure CreateResourceInput {
+    name: String,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-shapes.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-shapes.json
@@ -1,0 +1,24 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "ns.foo#Common1": {
+            "type": "structure",
+            "members": {}
+        },
+        "ns.foo#Common2": {
+            "type": "string"
+        },
+        "ns.foo#ShapedService": {
+            "type": "service",
+            "version": "2020-07-02",
+            "shapes": [
+                {
+                    "target": "ns.foo#Common1"
+                },
+                {
+                    "target": "ns.foo#Common2"
+                }
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/service-with-shapes.smithy
@@ -1,0 +1,15 @@
+$version: "1.0"
+
+namespace ns.foo
+
+service ShapedService {
+    version: "2020-07-02",
+    shapes: [
+        Common1,
+        Common2,
+    ],
+}
+
+structure Common1 {}
+
+string Common2

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
@@ -14,6 +14,9 @@ service MyService {
     resources: [
         MyResource,
     ],
+    shapes: [
+        SimpleString,
+    ],
 }
 
 resource EmptyResource {
@@ -79,3 +82,5 @@ structure InputOutput {}
 structure ResourceOperationInput {
     id: String,
 }
+
+string SimpleString

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeVisitor;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
@@ -83,6 +84,11 @@ public final class RemoveUnusedComponents implements OpenApiMapper {
 
         // Remove all found "$ref" pointers from the set, leaving only unreferenced.
         pointers.removeAll(findAllRefs(openapi.toNode().expectObjectNode()));
+
+        // Remove all schemas that were explicitly bound to the service.
+        for (ShapeId shapeId : context.getService().getShapes()) {
+            pointers.remove(context.getPointer(shapeId));
+        }
 
         if (pointers.isEmpty()) {
             return openapi;

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -530,4 +530,20 @@ public class OpenApiConverterTest {
 
         Node.assertEquals(result, expectedNode);
     }
+
+    @Test
+    public void generatesOpenApiWithBoundShapes() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("service-with-shapes.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#MyService"));
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("service-with-shapes.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-shapes.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-shapes.openapi.json
@@ -1,0 +1,26 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "MyService",
+        "version": "2020-07-02"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "GetSomething",
+                "responses": {
+                    "200": {
+                        "description": "GetSomething 200 response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "OtherStructure": {
+                "type": "object"
+            }
+        }
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-shapes.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/service-with-shapes.smithy
@@ -1,0 +1,19 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@aws.protocols#restJson1
+service MyService {
+    version: "2020-07-02",
+    operations: [GetSomething],
+    shapes: [OtherStructure],
+}
+
+@http(method: "GET", uri: "/")
+operation GetSomething {
+    output: GetSomethingOutput,
+}
+
+structure GetSomethingOutput {}
+
+structure OtherStructure {}


### PR DESCRIPTION
This feature allows shapes to be directly bound to a service, meaning
that the service closure can now contain shapes not bound through its
resources or operations. This is useful for vending shapes that match
other integrations, like CloudWatch events or SNS messages. It can
also provide shapes that match known schemas for document contents.

It also updates the `@cfnResource` trait to require that any shape
listed as an `additionalSchema` is within the closure of any service
that contains the resource.

Existing code generation tooling will need to be updated to handle
generating these shapes and [de]serialization code for them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
