### PR TITLE
Fix migration guide file name

### DIFF
--- a/docs/source/1.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source/1.0/guides/migrating-idl-1-to-2.rst
@@ -16,7 +16,7 @@ Update the model file version
 For each model file you are upgrading, change the version from ``1`` or
 ``1.0`` to ``2.0``. In the IDL this is controlled with the
 :ref:`version statement <smithy-version>`, and in the AST it is controlled
-with the ``smithy`` :ref:`top level property <top-level-properties>`. For
+with the ``smithy`` :ref:`top level property <ast-top-level-properties>`. For
 example, the following model:
 
 .. code-block:: smithy


### PR DESCRIPTION
There was a typo in the filename for the migration guide, as well as a broken ref. Not sure how I didn't catch those before.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
