### PR TITLE
Tighten validation around @streaming blobs

### DIFF
--- a/docs/source/1.0/spec/core/stream-traits.rst
+++ b/docs/source/1.0/spec/core/stream-traits.rst
@@ -41,6 +41,9 @@ Validation
     * The ``streaming`` trait is *structurally exclusive by target*, meaning
       only a single member of a structure can target a shape marked as
       ``streaming``.
+    * If a service supports a protocol that supports the :ref:`httpPayload-trait`,
+      any member that targets a ``streaming`` ``blob`` must also be marked as
+      ``@httpPayload``.
 
 .. code-block:: smithy
 
@@ -54,8 +57,7 @@ Validation
 
     @output
     structure StreamingOperationOutput {
-        @required
-        streamId: String
+        @httpPayload
         output: StreamingBlob,
     }
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-blob-without-httppayload.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-blob-without-httppayload.errors
@@ -1,0 +1,1 @@
+[ERROR] com.amazonaws.simple#StreamingOperationOutput$output: Member `com.amazonaws.simple#StreamingOperationOutput$output` referencing @streaming shape `com.amazonaws.simple#StreamingBlob` must have the @httpPayload trait, as service `com.amazonaws.simple#SimpleService` has a protocol that supports @httpPayload. | StreamingTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-blob-without-httppayload.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-blob-without-httppayload.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+namespace com.amazonaws.simple
+
+@protocolDefinition(traits: ["smithy.api#httpPayload", "smithy.api#http", "smithy.api#streaming"])
+@trait(selector: "service")
+structure jsonExample {}
+
+@jsonExample
+@title("SimpleService")
+service SimpleService {
+    version: "2022-01-01",
+    operations: [
+        StreamingOperation,
+    ],
+}
+
+@http(uri: "/streaming", method: "GET")
+@readonly
+operation StreamingOperation {
+    input: StreamingOperationInput,
+    output: StreamingOperationOutput,
+}
+
+@input
+structure StreamingOperationInput {}
+
+@output
+structure StreamingOperationOutput {
+    @required
+    streamId: String,
+    output: StreamingBlob,
+}
+
+@streaming
+blob StreamingBlob


### PR DESCRIPTION
Protocols that support HTTP binding can only stream a blob if it is the payload
of the request or response. The streaming trait validator will now fail models
where a service ultimately references a streaming blob and the member is not
marked as @httpPayload.

Fixes https://github.com/awslabs/smithy/issues/1075

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
