### PR TITLE
Add presignable trait to Smithy

### DIFF
--- a/docs/source/1.0/spec/aws/aws-auth.rst
+++ b/docs/source/1.0/spec/aws/aws-auth.rst
@@ -142,6 +142,41 @@ literal string ``UNSIGNED-PAYLOAD`` is used when constructing a
 `canonical request`_, and the same value is sent in the
 `x-amz-content-sha256`_ header when sending an HTTP request.
 
+.. smithy-trait:: aws.auth#presignable
+.. _aws.auth#presignable-trait:
+
+------------------------------
+``aws.auth#presignable`` trait
+------------------------------
+
+Trait Summary
+    Indicates that an operation can be presigned. A presigner is a client-side utility 
+    that generates a presigned request for a given operation invocation that may be 
+    used in contexts where direct calls may be difficult or impossible. This trait 
+    indicates that a client presigner can be generated for the given operation.
+Trait selector
+    ``operation``
+Trait value
+    Annotation trait.
+
+The following example defines a service operation for which presigned requests can be generated.
+
+.. code-block:: smithy
+
+    service WeatherService {
+        version: "2017-02-11",
+        operations: [PingServer]
+    }
+
+    @presignable
+    operation PingServer {}
+
+
+Given this model, a client-side code generator MAY generate a function that 
+presigns a `PingServer` request. Generation of an operation presigner will
+vary based on the auth scheme that the service utilizes. Many AWS services
+use `sigv4`. [Here are details](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)
+for how requests can be signed using `sigv4`.
 
 .. _aws.auth#cognitoUserPools-trait:
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/PresignableTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/PresignableTrait.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.traits.auth;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+
+public final class PresignableTrait extends AnnotationTrait {
+    public static final ShapeId ID = ShapeId.from("aws.auth#presignable");
+
+    public PresignableTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public PresignableTrait() {
+        this(Node.objectNode());
+    }
+
+    public static final class Provider extends AnnotationTrait.Provider<PresignableTrait> {
+        public Provider() {
+            super(ID, PresignableTrait::new);
+        }
+    }
+}

--- a/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-aws-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -6,6 +6,7 @@ software.amazon.smithy.aws.traits.DataPlaneTrait$Provider
 software.amazon.smithy.aws.traits.DataTrait$Provider
 software.amazon.smithy.aws.traits.ServiceTrait$Provider
 software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait$Provider
+software.amazon.smithy.aws.traits.auth.PresignableTrait$Provider
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryTrait$Provider
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryIdTrait$Provider
 software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientDiscoveredEndpointTrait$Provider

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.json
@@ -42,6 +42,15 @@
                 "smithy.api#documentation": "Indicates that the request payload of a signed request is not to be used as part of the signature."
             }
         },
+        "aws.auth#presignable": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "operation"
+                },
+                "smithy.api#documentation": "Indicates that an operation can be presigned."
+            }
+        },
         "aws.auth#cognitoUserPools": {
             "type": "structure",
             "members": {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Adds an annotation trait that provides context about which specific service operations may have client-side presigners.  This state is currently modeled in customizations in various SDKs.  Some samples: Java v2 (in code, eg [S3](https://github.com/aws/aws-sdk-java-v2/blob/8586a54bf926316e3236a6f11d8142287c97fcc7/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java)), [Go v2](https://github.com/aws/aws-sdk-go-v2/blob/4f7aaaf16d6d6c59223bbbf069ddc9c862c52095/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/AwsHttpPresignURLClientGenerator.java#L83), and [Kotlin SDKs](https://github.com/awslabs/aws-sdk-kotlin/blob/72828c24da95eab7093739922618cd172c529487/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/PresignableOperations.kt#L12).

NOTE: this trait only models a specific use case for presigners: generators.  It does *not* model "presign url autofill parameters" of some services due to current migration away from this to other approaches.

NOTE: This PR was initially created [here](https://github.com/awslabs/smithy/pull/897), but moved to personal fork as repo rights were removed during PR work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
