### PR TITLE
Expose CodegenWriter's doc writer

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/writer/CodegenWriter.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/writer/CodegenWriter.java
@@ -86,6 +86,15 @@ public class CodegenWriter<T extends CodegenWriter<T, U>, U extends ImportContai
     }
 
     /**
+     * Gets the documentation writer.
+     *
+     * @return Returns the documentation writer.
+     */
+    public final DocumentationWriter<T> getDocumentationWriter() {
+        return documentationWriter;
+    }
+
+    /**
      * Gets the import container associated with the writer.
      *
      * <p>The {@link #toString()} method of the {@code CodegenWriter} should


### PR DESCRIPTION
When the doc writer is just an anonymous lambda function, it makes sense
to hide it away in the parent implementation. But when it's a class that
satisifies the interface, there may be additional things on it that the
subclasses or callers will want to use. For example, a doc formatter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
