### PR TITLE
Remove @required from protocol test input

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/unions.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/unions.smithy
@@ -454,7 +454,6 @@ operation PostPlayerAction {
 
 @input
 structure PostPlayerActionInput {
-    @required
     action: PlayerAction
 }
 


### PR DESCRIPTION
*Description of changes:*
Response tests, when generated for servers, rely on invoking an operation
and mocking a response from application code, but there is no member for
request data in a response test. Removing @required allows the operation to be
invoked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
