### PR TITLE
docs: fix example trait for the `idRef` example

### DIFF
--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -221,7 +221,7 @@ contain a valid shape ID that targets an integer shape in the model.
 
         @trait
         @idRef(failWhenMissing: true, selector: "integer")
-        string IntegerRefTraitValue
+        string integerRef
 
     .. code-tab:: json
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
