### PR TITLE
docs: `length` trait counts number of Unicode scalar values for strings

### DIFF
--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -360,7 +360,7 @@ Shape        Length constrains
 list         The number of members
 set          The number of members
 map          The number of key-value pairs
-string       The number of Unicode code points
+string       The number of `Unicode scalar values <https://www.unicode.org/glossary/#unicode_scalar_value>`__
 blob         The size of the blob in bytes
 ===========  =====================================
 


### PR DESCRIPTION
Since Smithy defines string shapes to be UTF-8 encoded, it is more
correct for the spec to explicitly say the `length` trait counts the
number of Unicode scalar values when applied to strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
