### PR TITLE
Add note about escaping backslash in pattern trait

### DIFF
--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -427,6 +427,12 @@ languages.
     string matches the regular expression, whereas ``@pattern("^\\w+$")``
     requires that the entire string matches the regular expression.
 
+.. note::
+
+    Pattern values that contain ``\`` need to :ref:`escape it <string-escape-characters>`.
+    For example, the regular expression ``^\w+$`` would be specified as
+    ``@pattern("^\\w+$")``.
+
 .. tabs::
 
     .. code-tab:: smithy


### PR DESCRIPTION
Some customers have seen failures because of not escaping the backslash.

I added it as a Note, and after the existing Warning/Important.

This is what it would look like
![Screen Shot 2022-02-14 at 11 56 35 AM](https://user-images.githubusercontent.com/5666661/153936825-e179f0fc-00e8-4256-b049-125b65eb8fa7.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
