### PR TITLE
Add multi-code-unit characters to length validation tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
@@ -92,8 +92,8 @@ apply MalformedLength @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            value: ["a", "abcdefghijklmnopqrstuvwxyz"],
-            inputLength: ["1", "26"]
+            value: ["a", "abcdefghijklmnopqrstuvwxyz", "👍"],
+            inputLength: ["1", "26", "1"]
         }
     },
     {
@@ -409,8 +409,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            value: ["abc", "abcdefg"],
-            inputLength: ["3", "7"]
+            value: ["abc", "abcdefg", "👍👍👍"],
+            inputLength: ["3", "7", "3"]
         }
     },
     {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/smithy/issues/1090

*Description of changes:*
Server implementations that naively use code units instead of code points to
evaluate length constraints will give incorrect results. This adds parameters
to the existing string length tests that use multi-code-unit characters to
generate strings that will meet the constraints if code units are counted,
but properly fail the constraints if code points are counted.

I tested this by running them without the fixes in https://github.com/awslabs/smithy-typescript/pull/510 and observing that they fail, and then running them with the fixes and observing that they pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
