### PR TITLE
Add malformed request tests for more set types

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-set.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-set.smithy
@@ -35,6 +35,117 @@ apply MalformedSet @httpMalformedRequestTests([
         }
     },
     {
+        id: "RestJsonMalformedSetDuplicateDocuments",
+        documentation: """
+        When the set has duplicated documents, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "docSet" : [{"a": 1}, {"b": 2, "c": 3}, {"c": 3, "b": 2}] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedSetDuplicateTimestamps",
+        documentation: """
+        When the set has duplicated timestamps, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "tsSet" : [1515531081, 1423235322, 1515531081] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedSetDuplicateBlobs",
+        documentation: """
+        When the set has duplicated blobs, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "blobSet" : ["YmxvYg==", "b3RoZXJibG9i", "YmxvYg=="] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedSetDuplicateStructures",
+        documentation: """
+        When the set has duplicated structures, the response should be a 400
+        SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "structSet" : [{"foo": "baz", "bar": 1}, {"foo": "quux", "bar": 2}, {"bar": 1, "foo": "baz"}] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedSetDuplicateStructuresWithNullValues",
+        documentation: """
+        When the set has duplicated structures, where one structure has an
+        explicit null value and the other leaves the member undefined,
+        the response should be a 400 SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedSet",
+            body: """
+            { "structSet" : [{"foo": null, "bar": 1}, {"foo": "quux", "bar": 2}, {"bar": 1}] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
         id: "RestJsonMalformedSetNullItem",
         documentation: """
         When the set contains null, the response should be a 400
@@ -59,11 +170,37 @@ apply MalformedSet @httpMalformedRequestTests([
 ])
 
 structure MalformedSetInput {
-    set: SimpleSet
+    set: SimpleSet,
+    docSet: DocumentSet,
+    tsSet: TimestampSet,
+    blobSet: BlobSet,
+    structSet: StructSet
 }
-
 
 set SimpleSet {
     member: String
 }
+
+set DocumentSet {
+    member: Document
+}
+
+set TimestampSet {
+    member: Timestamp
+}
+
+set BlobSet {
+    member: Blob
+}
+
+set StructSet {
+    member: StructForSet
+}
+
+structure StructForSet {
+    foo: String,
+    bar: Integer
+}
+
+document Document
 


### PR DESCRIPTION
*Description of changes:*
Sets of blobs, dates and documents are all valid, and may not be easily
supported in all targeted server languages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
