### PR TITLE
Add debug info and typed context to CodeWriter

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
@@ -111,7 +111,7 @@ public final class Symbol extends TypedPropertiesBag
     }
 
     /**
-     * Gets the unqualified name of the symbol, that is, a name with
+     * Gets the unqualified name of the symbol, that is, a name without
      * namespace.
      *
      * @return Returns the name of the symbol.

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/writer/CodegenWriter.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/writer/CodegenWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolContainer;
 import software.amazon.smithy.codegen.core.SymbolDependency;
@@ -63,6 +65,18 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * }
  * }</pre>
  *
+ *
+ * <h2>Formatting symbols with "T"</h2>
+ *
+ * <p>{@code CodegenWriter} registers a default formatter for "T" that writes
+ * {@link Symbol}s and {@link SymbolReference}s. Imports needed by these types
+ * are automatically registered with {@link #addUseImports} for a {@code Symbol}
+ * and {@link #addImport} for a {@code SymbolReference}. Programming languages
+ * that have a concept of namespaces can use {@link #setRelativizeSymbols} to
+ * the namespace of the CodegenWriter, and then the default symbol formatter
+ * will relativize symbols against that namespace using {@link Symbol#relativize}
+ * when writing the symbol as a string.
+ *
  * @param <T> The concrete type, used to provide a fluent interface.
  * @param <U> The import container used by the writer to manage imports.
  */
@@ -71,6 +85,7 @@ public class CodegenWriter<T extends CodegenWriter<T, U>, U extends ImportContai
         extends CodeWriter implements SymbolDependencyContainer {
 
     private static final Logger LOGGER = Logger.getLogger(CodegenWriter.class.getName());
+    private static final String RELATIVIZE_SYMBOLS = "__CodegenWriterRelativizeSymbols";
 
     private final List<SymbolDependency> dependencies = new ArrayList<>();
     private final DocumentationWriter<T> documentationWriter;
@@ -83,6 +98,61 @@ public class CodegenWriter<T extends CodegenWriter<T, U>, U extends ImportContai
     public CodegenWriter(DocumentationWriter<T> documentationWriter, U importContainer) {
         this.documentationWriter = documentationWriter;
         this.importContainer = importContainer;
+
+        // Register T by default. This can be overridden as needed.
+        putFormatter('T', new DefaultSymbolFormatter());
+    }
+
+    /**
+     * The default implementation for formatting Symbols in CodegenWriter.
+     */
+    private final class DefaultSymbolFormatter implements BiFunction<Object, String, String> {
+        @Override
+        public String apply(Object type, String indent) {
+            if (type instanceof Symbol) {
+                Symbol typeSymbol = (Symbol) type;
+                addUseImports(typeSymbol);
+                String relativizeSymbols = getContext(RELATIVIZE_SYMBOLS, String.class);
+                if (relativizeSymbols != null) {
+                    return typeSymbol.relativize(relativizeSymbols);
+                } else {
+                    return typeSymbol.toString();
+                }
+            } else if (type instanceof SymbolReference) {
+                SymbolReference typeSymbol = (SymbolReference) type;
+                addImport(typeSymbol.getSymbol(), typeSymbol.getAlias(), SymbolReference.ContextOption.USE);
+                return typeSymbol.getAlias();
+            } else {
+                throw new CodegenException("Invalid type provided to $T. Expected a Symbol or SymbolReference, "
+                                           + "but found `" + type + "`");
+            }
+        }
+    }
+
+    /**
+     * Sets a string used to relativize Symbols formatted using the default {@code T}
+     * implementation used by {@code CodegenWriter} in the <em>current state</em>.
+     *
+     * <p>In many programming languages, when referring to types in the same namespace as
+     * the current scope of a CodegenWriter, the symbols written in that scope don't need
+     * to be fully-qualified. They can just reference the unqualified type name. By setting
+     * a value for {@code relativizeSymbols}, if the result of {@link Symbol#getNamespace()}
+     * is equal to {@code relativizeSymbols}, then the unqualified name of the symbol is
+     * written to the {@code CodegenWriter} when the default implementation of {@code T}
+     * is written. Symbols that refer to types in other namespaces will write the fully
+     * qualified type.
+     *
+     * <p><strong>Note:</strong> This method may have no effect if a programming language
+     * does not use namespaces or concepts like namespaces or if {@code T} has been
+     * overridden with another implementation.
+     *
+     * @param relativizeSymbols The package name, namespace, etc to relativize symbols with.
+     * @return Returns the CodegenWriter.
+     */
+    @SuppressWarnings("unchecked")
+    public T setRelativizeSymbols(String relativizeSymbols) {
+        putContext(RELATIVIZE_SYMBOLS, relativizeSymbols);
+        return (T) this;
     }
 
     /**

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -667,7 +667,7 @@ public class CodeWriter {
      *
      * @return Returns a "/" separated path to the current state.
      */
-    public final String getStateDebugPath() {
+    private String getStateDebugPath() {
         StringJoiner result = new StringJoiner("/");
 
         int i = 0;

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriterDebugInfo.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriterDebugInfo.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Provides debug information about the current state of a CodeWriter.
+ *
+ * <p>The primary use case of this class is to be included in things like
+ * exception messages thrown by {@link CodeWriter}. Additional metadata
+ * can be appended to the debug info by calling {@link #putMetadata},
+ * and this metadata will appear when {@link #toString()} is called.
+ */
+public final class CodeWriterDebugInfo {
+
+    private final Map<String, String> metadata = new LinkedHashMap<>();
+
+    /**
+     * The currently package-private constructor. We can open this up later
+     * if a use case arises. This is left package-private for now in case
+     * we decide to refactor.
+     */
+    CodeWriterDebugInfo() {}
+
+    /**
+     * Get the CodeWriter state path from which the debug information was collected.
+     *
+     * @return Returns the path as returned by {@link CodeWriter#getStateDebugPath()};
+     */
+    public String getStateDebugPath() {
+        return getMetadata("path");
+    }
+
+    /**
+     * Put additional debug metadata on the object.
+     *
+     * @param key Name of the value to set.
+     * @param value Value to set that cannot be null.
+     */
+    public void putMetadata(String key, String value) {
+        metadata.put(key, Objects.requireNonNull(value));
+    }
+
+    /**
+     * Gets debug metadata by name.
+     *
+     * @param key Value to retrieve.
+     * @return Returns the string value or null if not found.
+     */
+    public String getMetadata(String key) {
+        return metadata.get(key);
+    }
+
+    /**
+     * Returns a string representation that can be used in exception
+     * messages and when debugging.
+     *
+     * @return Returns debug info as a string.
+     */
+    @Override
+    public String toString() {
+        StringJoiner result = new StringJoiner(", ", "(Debug Info {", "})");
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            result.add(entry.getKey() + "=" + entry.getValue());
+        }
+        return result.toString();
+    }
+}

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterDebugInfoTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterDebugInfoTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+public class CodeWriterDebugInfoTest {
+    @Test
+    public void convertsToStringWhenEmpty() {
+        CodeWriterDebugInfo info = new CodeWriterDebugInfo();
+
+        assertThat(info.toString(), equalTo("(Debug Info {})"));
+    }
+
+    @Test
+    public void convertsToString() {
+        CodeWriterDebugInfo info = new CodeWriterDebugInfo();
+        info.putMetadata("path", "ROOT/a");
+        info.putMetadata("test", "true");
+
+        assertThat(info.toString(), equalTo("(Debug Info {path=ROOT/a, test=true})"));
+    }
+
+    @Test
+    public void returnsWellKnownPath() {
+        CodeWriterDebugInfo info = new CodeWriterDebugInfo();
+        info.putMetadata("path", "ROOT/a");
+
+        assertThat(info.getStateDebugPath(), equalTo("ROOT/a"));
+    }
+}

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -335,6 +335,66 @@ public class CodeWriterTest {
     }
 
     @Test
+    public void canGetTypedContextValues() {
+        CodeWriter w = new CodeWriter();
+        w.putContext("foo", "hello");
+        String value = w.getContext("foo", String.class);
+
+        assertThat(value, equalTo("hello"));
+    }
+
+    @Test
+    public void failsWhenTypedContextDoesNotMatch() {
+        CodeWriter w = new CodeWriter();
+        w.pushState("a");
+        w.putContext("foo", "hello");
+        w.write("Hello {");
+
+        ClassCastException e = Assertions.assertThrows(ClassCastException.class, () -> {
+            w.getContext("foo", Integer.class);
+        });
+
+        assertThat(e.getMessage(), equalTo("Expected CodeWriter context value 'foo' to be an instance of "
+                                           + "java.lang.Integer, but found java.lang.String "
+                                           + "(Debug Info {path=ROOT/a, near=Hello {\\n})"));
+    }
+
+    @Test
+    public void getsDebugInfoWithNoLines() {
+        CodeWriter w = new CodeWriter();
+
+        assertThat(w.getDebugInfo().toString(), equalTo("(Debug Info {path=ROOT, near=})"));
+    }
+
+    @Test
+    public void getsDebugInfoWithNoLinesAndContext() {
+        CodeWriter w = new CodeWriter();
+        w.pushState("a");
+        w.pushState("b");
+
+        assertThat(w.getDebugInfo().toString(), equalTo("(Debug Info {path=ROOT/a/b, near=})"));
+    }
+
+    @Test
+    public void getsDebugInfoWithTwoLines() {
+        CodeWriter w = new CodeWriter();
+        w.write("Hello {");
+        w.write("  hello");
+
+        assertThat(w.getDebugInfo().toString(), equalTo("(Debug Info {path=ROOT, near=Hello {\\n  hello\\n})"));
+    }
+
+    @Test
+    public void getsDebugInfoWithThreeLines() {
+        CodeWriter w = new CodeWriter();
+        w.write("Hello {");
+        w.write("  hello1");
+        w.write("  hello2");
+
+        assertThat(w.getDebugInfo().toString(), equalTo("(Debug Info {path=ROOT, near=  hello1\\n  hello2\\n})"));
+    }
+
+    @Test
     public void hasSections() {
         // Setup the code writer and section interceptors.
         CodeWriter w = CodeWriter.createDefault().putContext("testing", "123");


### PR DESCRIPTION
This commit introduces typed properties for CodeWriter, allowing context
properties to be retrieved and assert they are a specific type.

While implementing this, I realized that if there is a type mismatch, it
could be hard to track down where in the process of writing code the error
occurred. So this commit also introduces some open debugging facilities
to CodeWriter that includes information about the state of the
CodeWriter (a '/' delimited path to the current state in the stack of
pushed states), the last N lines of code written (defaults to 2), and
any additional metadata subclasses want to introduce. This information
is then presented when CodeWriterDebugInfo is cast to a string.

Most exceptions thrown by CodeWriter will now include this debug output.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
