### PR TITLE
Add a request test for sets of documents

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/documents.smithy
@@ -324,3 +324,49 @@ apply DocumentTypeAsPayload @httpResponseTests([
         }
     }
 ])
+
+/// This example serializes a set of documents as part of the payload.
+@idempotent
+@http(uri: "/DocumentTypeSets", method: "PUT")
+operation DocumentTypeSets {
+    input: DocumentTypeSetsInputOutput,
+    output: DocumentTypeSetsInputOutput
+}
+
+structure DocumentTypeSetsInputOutput {
+    documentSet: DocumentSet
+}
+
+set DocumentSet {
+    member: Document
+}
+
+apply DocumentTypeSets @httpRequestTests([
+    {
+        id: "DocumentTypeSetsConsiderNull",
+        documentation: """
+            Unlike structures, null in a document is different from the key being unspecified,
+            and therefore two documents that differ only by a null valued member are still unique.""",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/DocumentTypeSets",
+        body: """
+            { "documentSet" : [ {"a": 1, "b": null}, {"a": 1}] }
+        """,
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            documentSet: [
+                {
+                    a: 1,
+                    b: null
+                },
+                {
+                    a: 1
+                }
+            ]
+        }
+
+    }
+])
+

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -81,6 +81,7 @@ service RestJson {
         // Documents
         DocumentType,
         DocumentTypeAsPayload,
+        DocumentTypeSets,
 
         // Unions
         JsonUnions,


### PR DESCRIPTION
*Description of changes:*
Documents are deserialized as presented, unlike structures, which are
typically parsed and then specific values extracted, which can erase the
difference between a key with a null value and an undefined key. This is
particularly interesting for sets, where a null value may make a value unique
where it would not in a set of structures.

Tested these by running them in the JS v3 SDK repository after fixing smithy-typescript.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
