### PR TITLE
Update restJson1 error serialization docs

### DIFF
--- a/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source/1.0/spec/aws/aws-restjson1-protocol.rst
@@ -312,10 +312,13 @@ Operation error serialization
 
 Error responses in the ``restJson1`` protocol are serialized identically to
 standard responses with one additional component to distinguish which error
-is contained. The component MUST be one of the following: an additional header
-with the name ``X-Amzn-Errortype``, a body field with the name ``code``, or a
-body field named ``__type``. The value of this component SHOULD contain only
-the :token:`shape name <smithy:identifier>` of the error's :ref:`shape-id`.
+is contained. New server-side protocol implementations MUST use a header field
+named ``X-Amzn-Errortype``. Clients MUST accept any one of the following: an
+additional header with the name ``X-Amzn-Errortype``, a body field with the
+name ``__type``, or a body field named ``code
+``. The value of this component
+SHOULD contain only the :token:`shape name <smithy:identifier>` of the error's
+:ref:`shape-id`.
 
 Legacy server-side protocol implementations sometimes include additional
 information in this value. New server-side protocol implementations SHOULD NOT


### PR DESCRIPTION
This updates the error serialization docs for restJson1 to call out what new server implementations must do vs what clients must accept.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
