### PR TITLE
Improve SmithyBuilder error messages

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -289,6 +289,9 @@ final class SmithyBuildImpl {
                         "The model could not be merged with the following imports: [%s]",
                         projection.getImports()));
                 return ProjectionResult.builder()
+                        // Create an empty model so that ProjectionResult can be created when
+                        // the Model can't be assembled.
+                        .model(Model.builder().build())
                         .projectionName(projectionName)
                         .events(baseModel.getValidationEvents())
                         .build();

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/test-bad-trait-serializer-config.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/test-bad-trait-serializer-config.json
@@ -1,0 +1,8 @@
+{
+    "version": "1.0",
+    "projections": {
+        "foo": {
+            "imports": ["test-bad-trait-serializer-import.smithy"]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/test-bad-trait-serializer-import.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/test-bad-trait-serializer-import.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace smithy.test
+
+@trait
+string badTrait
+
+@badTrait
+string shape

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/test-bad-trait-serializer.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/test-bad-trait-serializer.smithy
@@ -1,0 +1,3 @@
+$version: "1.0"
+
+namespace smithy.test

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/SmithyBuilder.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/SmithyBuilder.java
@@ -41,7 +41,16 @@ public interface SmithyBuilder<T> {
      */
     static <T> T requiredState(String method, T value) {
         if (value == null) {
-            throw new IllegalStateException(method + " was not set on the builder");
+            StringBuilder message = new StringBuilder(method).append(" was not set on the builder");
+
+            // Include the builder class that could not be built.
+            StackTraceElement[] elements = Thread.currentThread().getStackTrace();
+            if (elements.length >= 2) {
+                String builder = elements[2].getClassName();
+                message.append(" (builder class is probably ").append(builder).append(')');
+            }
+
+            throw new IllegalStateException(message.toString());
         }
         return value;
     }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/SmithyBuilderTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/SmithyBuilderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SmithyBuilderTest {
+    @Test
+    public void includesCallingClassName() {
+        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () -> new Foo().test());
+
+        assertThat(e.getMessage(), equalTo("foo was not set on the builder (builder class is probably "
+                                           + "software.amazon.smithy.utils.SmithyBuilderTest$Foo)"));
+    }
+
+    private static final class Foo {
+        public void test() {
+            SmithyBuilder.requiredState("foo", null);
+        }
+    }
+}


### PR DESCRIPTION
When a SmithyBuilder implementation is missing a required property, the
name of the class that was missing the property will be included in the
error message. This is derived by looking at the stacktrace on error, so
it's an inference. But even an inference of the builder class is better
than having no idea which builder encountered an error when the stack
trace of the IllegalStateException is elided for whatever reason.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
