### PR TITLE
Reduce copies in codegen-core and build

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/PluginContext.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/PluginContext.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.build;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,7 +30,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.model.validation.ValidationEvent;
-import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -59,7 +58,7 @@ public final class PluginContext implements ToSmithyBuilder<PluginContext> {
         events = Collections.unmodifiableList(builder.events);
         settings = builder.settings;
         pluginClassLoader = builder.pluginClassLoader;
-        sources = SetUtils.copyOf(builder.sources);
+        sources = builder.sources.copy();
     }
 
     /**
@@ -262,7 +261,7 @@ public final class PluginContext implements ToSmithyBuilder<PluginContext> {
         private ObjectNode settings = Node.objectNode();
         private FileManifest fileManifest;
         private ClassLoader pluginClassLoader;
-        private Set<Path> sources = Collections.emptySet();
+        private BuilderRef<Set<Path>> sources = BuilderRef.forOrderedSet();
 
         private Builder() {}
 
@@ -354,14 +353,15 @@ public final class PluginContext implements ToSmithyBuilder<PluginContext> {
         }
 
         /**
-         * Sets the path to models that are considered "source" models of the
+         * Replaces the path to models that are considered "source" models of the
          * package being built.
          *
          * @param sources Source models to set.
          * @return Returns the builder.
          */
         public Builder sources(Collection<Path> sources) {
-            this.sources = new HashSet<>(sources);
+            this.sources.clear();
+            this.sources.get().addAll(sources);
             return this;
         }
     }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/TransformContext.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/TransformContext.java
@@ -16,8 +16,6 @@
 package software.amazon.smithy.build;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,7 +25,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.model.validation.ValidationEvent;
-import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -52,9 +50,9 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
         transformer = builder.transformer != null ? builder.transformer : ModelTransformer.create();
         settings = builder.settings;
         originalModel = builder.originalModel;
-        sources = SetUtils.copyOf(builder.sources);
         projectionName = builder.projectionName;
-        originalModelValidationEvents = builder.originalModelValidationEvents;
+        sources = builder.sources.copy();
+        originalModelValidationEvents = builder.originalModelValidationEvents.copy();
     }
 
     /**
@@ -157,10 +155,10 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
         private ObjectNode settings = Node.objectNode();
         private Model model;
         private Model originalModel;
-        private Set<Path> sources = Collections.emptySet();
+        private BuilderRef<Set<Path>> sources = BuilderRef.forOrderedSet();
         private String projectionName = "source";
         private ModelTransformer transformer;
-        private final List<ValidationEvent> originalModelValidationEvents = new ArrayList<>();
+        private final BuilderRef<List<ValidationEvent>> originalModelValidationEvents = BuilderRef.forList();
 
         private Builder() {}
 
@@ -185,7 +183,8 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
         }
 
         public Builder sources(Set<Path> sources) {
-            this.sources = Objects.requireNonNull(sources);
+            this.sources.clear();
+            this.sources.get().addAll(sources);
             return this;
         }
 
@@ -201,7 +200,7 @@ public final class TransformContext implements ToSmithyBuilder<TransformContext>
 
         public Builder originalModelValidationEvents(List<ValidationEvent> originalModelValidationEvents) {
             this.originalModelValidationEvents.clear();
-            this.originalModelValidationEvents.addAll(originalModelValidationEvents);
+            this.originalModelValidationEvents.get().addAll(originalModelValidationEvents);
             return this;
         }
     }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
@@ -15,15 +15,12 @@
 
 package software.amazon.smithy.build.model;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.build.SmithyBuildException;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -37,10 +34,10 @@ public final class ProjectionConfig implements ToSmithyBuilder<ProjectionConfig>
     private final Map<String, ObjectNode> plugins;
 
     private ProjectionConfig(Builder builder) {
-        this.imports = ListUtils.copyOf(builder.imports);
-        this.transforms = ListUtils.copyOf(builder.transforms);
+        this.imports = builder.imports.copy();
+        this.transforms = builder.transforms.copy();
         this.isAbstract = builder.isAbstract;
-        this.plugins = MapUtils.copyOf(builder.plugins);
+        this.plugins = builder.plugins.copy();
 
         if (isAbstract && (!plugins.isEmpty() || !imports.isEmpty())) {
             throw new SmithyBuildException("Abstract projections must not define plugins or imports");
@@ -97,9 +94,9 @@ public final class ProjectionConfig implements ToSmithyBuilder<ProjectionConfig>
      */
     public static final class Builder implements SmithyBuilder<ProjectionConfig> {
         private boolean isAbstract;
-        private final List<String> imports = new ArrayList<>();
-        private final List<TransformConfig> transforms = new ArrayList<>();
-        private final Map<String, ObjectNode> plugins = new HashMap<>();
+        private final BuilderRef<List<String>> imports = BuilderRef.forList();
+        private final BuilderRef<List<TransformConfig>> transforms = BuilderRef.forList();
+        private final BuilderRef<Map<String, ObjectNode>> plugins = BuilderRef.forOrderedMap();
 
         private Builder() {}
 
@@ -126,38 +123,38 @@ public final class ProjectionConfig implements ToSmithyBuilder<ProjectionConfig>
         }
 
         /**
-         * Sets the imports of the projection.
+         * Replaces the imports of the projection.
          *
          * @param imports Imports to set.
          * @return Returns the builder.
          */
         public Builder imports(Collection<String> imports) {
             this.imports.clear();
-            this.imports.addAll(imports);
+            this.imports.get().addAll(imports);
             return this;
         }
 
         /**
-         * Sets the transforms of the projection.
+         * Replaces the transforms of the projection.
          *
          * @param transforms Transform to set.
          * @return Returns the builder.
          */
         public Builder transforms(Collection<TransformConfig> transforms) {
             this.transforms.clear();
-            this.transforms.addAll(transforms);
+            this.transforms.get().addAll(transforms);
             return this;
         }
 
         /**
-         * Sets the plugins of the projection.
+         * Replaces the plugins of the projection.
          *
          * @param plugins Map of plugin name to plugin settings.
          * @return Returns the builder.
          */
         public Builder plugins(Map<String, ObjectNode> plugins) {
             this.plugins.clear();
-            this.plugins.putAll(plugins);
+            this.plugins.get().putAll(plugins);
             return this;
         }
     }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Symbol.java
@@ -15,11 +15,10 @@
 
 package software.amazon.smithy.codegen.core;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -70,14 +69,14 @@ public final class Symbol extends TypedPropertiesBag
     private final List<SymbolDependency> dependencies;
 
     private Symbol(Builder builder) {
-        super(builder.properties);
+        super(builder);
         this.namespace = builder.namespace;
         this.namespaceDelimiter = builder.namespaceDelimiter;
         this.name = builder.name;
         this.declarationFile = builder.declarationFile;
         this.definitionFile = !builder.definitionFile.isEmpty() ? builder.definitionFile : declarationFile;
-        this.references = ListUtils.copyOf(builder.references);
-        this.dependencies = ListUtils.copyOf(builder.dependencies);
+        this.references = builder.references.copy();
+        this.dependencies = builder.dependencies.copy();
     }
 
     /**
@@ -252,8 +251,8 @@ public final class Symbol extends TypedPropertiesBag
         private String namespaceDelimiter = "";
         private String definitionFile = "";
         private String declarationFile = "";
-        private final List<SymbolReference> references = new ArrayList<>();
-        private final List<SymbolDependency> dependencies = new ArrayList<>();
+        private final BuilderRef<List<SymbolReference>> references = BuilderRef.forList();
+        private final BuilderRef<List<SymbolDependency>> dependencies = BuilderRef.forList();
 
         @Override
         public Symbol build() {
@@ -345,7 +344,7 @@ public final class Symbol extends TypedPropertiesBag
          * @return Returns the builder.
          */
         public Builder addReference(SymbolReference reference) {
-            references.add(Objects.requireNonNull(reference));
+            references.get().add(Objects.requireNonNull(reference));
             return this;
         }
 
@@ -379,7 +378,7 @@ public final class Symbol extends TypedPropertiesBag
          * @return Returns the builder.
          */
         public Builder addDependency(SymbolDependencyContainer dependency) {
-            dependencies.addAll(dependency.getDependencies());
+            dependencies.get().addAll(dependency.getDependencies());
             return this;
         }
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java
@@ -75,7 +75,7 @@ public final class SymbolDependency extends TypedPropertiesBag
     private final String version;
 
     private SymbolDependency(Builder builder) {
-        super(builder.properties);
+        super(builder);
         this.dependencyType = builder.dependencyType == null ? "" : builder.dependencyType;
         this.packageName = SmithyBuilder.requiredState("packageName", builder.packageName);
         this.version = SmithyBuilder.requiredState("version", builder.version);

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolReference.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolReference.java
@@ -16,11 +16,12 @@
 package software.amazon.smithy.codegen.core;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import software.amazon.smithy.utils.BuilderRef;
+import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -90,19 +91,15 @@ public final class SymbolReference
     }
 
     private SymbolReference(Builder builder) {
-        super(builder.properties);
+        super(builder);
         this.symbol = SmithyBuilder.requiredState("symbol", builder.symbol);
         this.alias = builder.alias == null ? builder.symbol.getName() : builder.alias;
 
-        Set<Option> opts = new HashSet<>(builder.options.size() + 2);
-        if (builder.options.size() == 0) {
-            opts.add(ContextOption.USE);
-            opts.add(ContextOption.DECLARE);
+        if (!builder.options.hasValue() || builder.options.peek().isEmpty()) {
+            this.options = SetUtils.of(ContextOption.USE, ContextOption.DECLARE);
         } else {
-            opts.addAll(builder.options);
+            this.options = builder.options.copy();
         }
-
-        this.options = Collections.unmodifiableSet(opts);
     }
 
     /**
@@ -209,7 +206,7 @@ public final class SymbolReference
             implements SmithyBuilder<SymbolReference> {
 
         private Symbol symbol;
-        private Set<Option> options = new HashSet<>();
+        private final BuilderRef<Set<Option>> options = BuilderRef.forUnorderedSet();
         private String alias;
 
         private Builder() {}
@@ -231,25 +228,26 @@ public final class SymbolReference
         }
 
         /**
-         * Adds a Set of Options to the SymbolReference.
+         * Replaces the Set of Options to the SymbolReference.
          *
          * @param options Options to add.
          * @return Returns the builder.
          */
         public Builder options(Set<Option> options) {
-            this.options = options;
+            this.options.clear();
+            this.options.get().addAll(options);
             return this;
         }
 
         /**
-         * Adds an array of Options to the SymbolReference.
+         * Replaces the array of Options in the SymbolReference.
          *
          * @param options Options to add.
          * @return Returns the builder.
          */
         public Builder options(Option... options) {
-            this.options = new HashSet<>();
-            Collections.addAll(this.options, options);
+            this.options.clear();
+            Collections.addAll(this.options.get(), options);
             return this;
         }
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
@@ -15,18 +15,17 @@
 
 package software.amazon.smithy.codegen.core;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.BuilderRef;
 
 class TypedPropertiesBag {
 
     private final Map<String, Object> properties;
 
-    TypedPropertiesBag(Map<String, Object> properties) {
-        this.properties = MapUtils.copyOf(properties);
+    TypedPropertiesBag(Builder<?> bagBuilder) {
+        this.properties = bagBuilder.properties.copy();
     }
 
     /**
@@ -117,8 +116,8 @@ class TypedPropertiesBag {
     /**
      * Builds a SymbolReference.
      */
-    abstract static class Builder<T extends Builder> {
-        Map<String, Object> properties = new HashMap<>();
+    abstract static class Builder<T extends Builder<T>> {
+        BuilderRef<Map<String, Object>> properties = BuilderRef.forOrderedMap();
 
         /**
          * Sets a specific custom property.
@@ -129,7 +128,7 @@ class TypedPropertiesBag {
          */
         @SuppressWarnings("unchecked")
         public T putProperty(String key, Object value) {
-            properties.put(key, value);
+            properties.get().put(key, value);
             return (T) this;
         }
 
@@ -141,7 +140,7 @@ class TypedPropertiesBag {
          */
         @SuppressWarnings("unchecked")
         public T removeProperty(String key) {
-            properties.remove(key);
+            properties.get().remove(key);
             return (T) this;
         }
 
@@ -154,7 +153,7 @@ class TypedPropertiesBag {
         @SuppressWarnings("unchecked")
         public T properties(Map<String, Object> properties) {
             this.properties.clear();
-            this.properties.putAll(properties);
+            this.properties.get().putAll(properties);
             return (T) this;
         }
     }


### PR DESCRIPTION
This commit makes use of BuilderRef to reduce copies of lists, maps, and
sets created from builders. Most builders are one-time-use, so this
prevents needing to allocate a copy of lists/maps/sets created from
builders and instead has the builder create copies at the point in which
a copied reference is reused.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
