### PR TITLE
Rewrite code writer formatting to allow for Runnable evaluation

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
@@ -15,369 +15,323 @@
 
 package software.amazon.smithy.utils;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 
-/**
- * TODO: Rewrite the formatter parser to use a custom {@link SimpleParser}.
- */
+@SmithyInternalApi
 final class CodeFormatter {
-    private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z]+[a-zA-Z0-9_.#$]*$");
-    private static final Set<Character> VALID_FORMATTER_CHARS = SetUtils.of(
-            '!', '#', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@',
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
-            'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[', ']', '^', '_', '`', '{', '|', '}', '~');
 
-    private final Map<Character, BiFunction<Object, String, String>> formatters = new HashMap<>();
-    private final CodeFormatter parentFormatter;
+    private CodeFormatter() {}
 
-    CodeFormatter() {
-        this(null);
-    }
-
-    /**
-     * Create a CodeFormatter that also uses formatters of a parent CodeFormatter.
-     *
-     * @param parentFormatter Optional parent CodeFormatter to query when expanding formatters.
-     */
-    CodeFormatter(CodeFormatter parentFormatter) {
-        this.parentFormatter = parentFormatter;
-    }
-
-    void putFormatter(Character identifier, BiFunction<Object, String, String> formatFunction) {
-        if (!VALID_FORMATTER_CHARS.contains(identifier)) {
-            throw new IllegalArgumentException("Invalid formatter identifier: " + identifier);
-        }
-
-        formatters.put(identifier, formatFunction);
-    }
-
-    /**
-     * Gets a formatter function for a specific character.
-     *
-     * @param identifier Formatter identifier.
-     * @return Returns the found formatter, or null.
-     */
-    BiFunction<Object, String, String> getFormatter(char identifier) {
-        BiFunction<Object, String, String> result = formatters.get(identifier);
-
-        if (result == null && parentFormatter != null) {
-            result = parentFormatter.getFormatter(identifier);
-        }
-
-        return result;
-    }
-
-    String format(CodeWriter writer, Object content, Object... args) {
-        String expression = String.valueOf(content);
-        char expressionStart = writer.getExpressionStart();
-        String indent = writer.getIndentText();
-
-        // Simple case of no arguments and no expressions.
-        if (args.length == 0 && expression.indexOf(expressionStart) == -1) {
-            return expression;
-        }
-
-        return parse(writer, new State(content, indent, writer, args));
-    }
-
-    private String parse(CodeWriter writer, State state) {
-        char expressionStart = writer.getExpressionStart();
-
-        while (!state.eof()) {
-            char c = state.c();
-            state.next();
-            if (c == expressionStart) {
-                parseArgumentWrapper(writer, state);
-            } else {
-                state.append(c);
+    static void run(Appendable sink, CodeWriter writer, String template, Object[] args) {
+        ColumnTrackingAppendable wrappedSink = new ColumnTrackingAppendable(sink);
+        List<Operation> program = new Parser(writer, template, args).parse();
+        try {
+            for (Operation op : program) {
+                op.apply(wrappedSink, writer, wrappedSink.column);
             }
-        }
-
-        if (state.relativeIndex == -1) {
-            ensureAllPositionalArgumentsWereUsed(writer, state.expression, state.positionals);
-        } else if (state.relativeIndex < state.args.length) {
-            throw error(writer, String.format(
-                    "Found %d unused relative format arguments: %s",
-                    state.args.length - state.relativeIndex, state.expression));
-        }
-
-        return state.result.toString();
-    }
-
-    // Provides debug context in each thrown error.
-    public static IllegalArgumentException error(CodeWriter writer, String message) {
-        return new IllegalArgumentException(message + " " + writer.getDebugInfo());
-    }
-
-    private void parseArgumentWrapper(CodeWriter writer, State state) {
-        if (state.eof()) {
-            throw error(writer, "Invalid format string: " + state);
-        }
-
-        char expressionStart = writer.getExpressionStart();
-        char c = state.c();
-        if (c == expressionStart) {
-            // $$ -> $
-            state.append(expressionStart);
-            state.next();
-        } else if (c == '{') {
-            parseBracedArgument(writer, state);
-        } else {
-            parseArgument(writer, state, -1);
+        } catch (IOException e) {
+            throw new RuntimeException("Error appending to CodeWriter template: " + e, e);
         }
     }
 
-    private void parseBracedArgument(CodeWriter writer, State state) {
-        int startingBraceColumn = state.column;
-        state.next(); // Skip "{"
-        parseArgument(writer, state, startingBraceColumn);
-
-        if (state.eof() || state.c() != '}') {
-            throw error(writer, "Unclosed expression argument: " + state);
+    private abstract static class DecoratedAppendable implements Appendable {
+        @Override
+        public Appendable append(CharSequence csq) throws IOException {
+            return append(csq, 0, csq.length());
         }
 
-        state.next(); // Skip "}"
-    }
-
-    private void parseArgument(CodeWriter writer, State state, int startingBraceColumn) {
-        if (state.eof()) {
-            throw error(writer, "Invalid format string: " + state);
-        }
-
-        char c = state.c();
-        if (Character.isLowerCase(c)) {
-            parseNamedArgument(writer, state, startingBraceColumn);
-        } else if (Character.isDigit(c)) {
-            parsePositionalArgument(writer, state, startingBraceColumn);
-        } else {
-            parseRelativeArgument(writer, state, startingBraceColumn);
-        }
-    }
-
-    private void parseNamedArgument(CodeWriter writer, State state, int startingBraceColumn) {
-        // Expand a named context value: "$" key ":" identifier
-        String name = parseNameUntil(writer, state, ':');
-        state.next();
-
-        // Consume the character after the colon.
-        if (state.eof()) {
-            throw error(writer, "Expected an identifier after the ':' in a named argument: " + state);
-        }
-
-        char identifier = consumeFormatterIdentifier(state);
-        state.append(applyFormatter(writer, state, identifier, state.writer.getContext(name), startingBraceColumn));
-    }
-
-    private char consumeFormatterIdentifier(State state) {
-        char identifier = state.c();
-        state.next();
-        return identifier;
-    }
-
-    private void parsePositionalArgument(CodeWriter writer, State state, int startingBraceColumn) {
-        // Expand a positional argument: "$" 1*digit identifier
-        expectConsistentRelativePositionals(writer, state, state.relativeIndex <= 0);
-        state.relativeIndex = -1;
-        int startPosition = state.position;
-        while (state.next() && Character.isDigit(state.c()));
-        int index = Integer.parseInt(state.expression.substring(startPosition, state.position)) - 1;
-
-        if (index < 0 || index >= state.args.length) {
-            throw error(writer, String.format(
-                    "Positional argument index %d out of range of provided %d arguments in "
-                    + "format string: %s", index, state.args.length, state));
-        }
-
-        Object arg = getPositionalArgument(writer, state.expression, index, state.args);
-        state.positionals[index] = true;
-        char identifier = consumeFormatterIdentifier(state);
-        state.append(applyFormatter(writer, state, identifier, arg, startingBraceColumn));
-    }
-
-    private void parseRelativeArgument(CodeWriter writer, State state, int startingBraceColumn) {
-        // Expand to a relative argument.
-        expectConsistentRelativePositionals(writer, state, state.relativeIndex > -1);
-        state.relativeIndex++;
-        Object argument = getPositionalArgument(writer, state.expression, state.relativeIndex - 1, state.args);
-        char identifier = consumeFormatterIdentifier(state);
-        state.append(applyFormatter(writer, state, identifier, argument, startingBraceColumn));
-    }
-
-    private String parseNameUntil(CodeWriter writer, State state, char endToken) {
-        int endIndex = state.expression.indexOf(endToken, state.position);
-
-        if (endIndex == -1) {
-            throw error(writer, "Invalid named format argument: " + state);
-        }
-
-        String name = state.expression.substring(state.position, endIndex);
-        ensureNameIsValid(writer, state, name);
-        state.position = endIndex;
-        return name;
-    }
-
-    private static void expectConsistentRelativePositionals(CodeWriter writer, State state, boolean expectation) {
-        if (!expectation) {
-            throw error(writer, "Cannot mix positional and relative arguments: " + state);
-        }
-    }
-
-    private static void ensureAllPositionalArgumentsWereUsed(
-            CodeWriter writer,
-            String expression,
-            boolean[] positionals
-    ) {
-        int unused = 0;
-
-        for (boolean b : positionals) {
-            if (!b) {
-                unused++;
+        @Override
+        public Appendable append(CharSequence csq, int start, int end) throws IOException {
+            for (int i = start; i < end; i++) {
+                append(csq.charAt(i));
             }
-        }
-
-        if (unused > 0) {
-            throw error(writer, String.format(
-                    "Found %d unused positional format arguments: %s", unused, expression));
+            return this;
         }
     }
 
-    private Object getPositionalArgument(CodeWriter writer, String content, int index, Object[] args) {
-        if (index >= args.length) {
-            throw error(writer, String.format(
-                    "Given %d arguments but attempted to format index %d: %s", args.length, index, content));
-        }
-
-        return args[index];
-    }
-
-    private String applyFormatter(
-            CodeWriter writer,
-            State state,
-            char formatter,
-            Object argument,
-            int startingBraceColumn
-    ) {
-        BiFunction<Object, String, String> formatFunction = getFormatter(formatter);
-
-        if (formatFunction == null) {
-            throw error(writer, String.format(
-                    "Unknown formatter `%s` found in format string: %s", formatter, state));
-        }
-
-        String result = formatFunction.apply(argument, state.indent);
-
-        if (!state.eof() && state.c() == '@') {
-            if (startingBraceColumn == -1) {
-                throw error(writer, "Inline blocks can only be created inside braces: " + state);
-            }
-            result = expandInlineSection(writer, state, result);
-        }
-
-        // Only look for alignment when inside a brace interpolation.
-        if (startingBraceColumn != -1 && !state.eof() && state.c() == '|') {
-            state.next(); // skip '|', which should precede '}'.
-
-            String repeated = StringUtils.repeat(' ', startingBraceColumn);
-            StringBuilder aligned = new StringBuilder();
-
-            for (int i = 0; i < result.length(); i++) {
-                char c = result.charAt(i);
-                if (c == '\n') {
-                    aligned.append('\n').append(repeated);
-                } else if (c == '\r') {
-                    aligned.append('\r');
-                    if (i + 1 < result.length() && result.charAt(i + 1) == '\n') {
-                        aligned.append('\n');
-                        i++; // Skip \n
-                    }
-                    aligned.append(repeated);
-                } else {
-                    aligned.append(c);
-                }
-            }
-            result = aligned.toString();
-        }
-
-        return result;
-    }
-
-    private String expandInlineSection(CodeWriter writer, State state, String argument) {
-        state.next(); // Skip "@"
-        String sectionName = parseNameUntil(writer, state, '}');
-        ensureNameIsValid(writer, state, sectionName);
-        return state.writer.expandSection(sectionName, argument, s -> state.writer.write(s));
-    }
-
-    private static void ensureNameIsValid(CodeWriter writer, State state, String name) {
-        if (!NAME_PATTERN.matcher(name).matches()) {
-            throw error(writer, String.format(
-                    "Invalid format expression name `%s` at position %d of: %s",
-                    name, state.position + 1, state));
-        }
-    }
-
-    private static final class State {
-        StringBuilder result = new StringBuilder();
-        int position = 0;
-        int relativeIndex = 0;
-        CodeWriter writer;
-        String expression;
-        String indent;
-        Object[] args;
-        boolean[] positionals;
+    private static final class ColumnTrackingAppendable extends DecoratedAppendable {
         int column = 0;
+        private final Appendable delegate;
 
-        State(Object expression, String indent, CodeWriter writer, Object[] args) {
-            this.expression = String.valueOf(expression);
-            this.indent = indent;
-            this.writer = writer;
-            this.args = args;
-            this.positionals = new boolean[args.length];
+        ColumnTrackingAppendable(Appendable delegate) {
+            this.delegate = delegate;
         }
 
-        char c() {
-            return expression.charAt(position);
-        }
-
-        boolean eof() {
-            return position >= expression.length();
-        }
-
-        boolean next() {
-            return ++position < expression.length() - 1;
-        }
-
-        void append(char c) {
+        @Override
+        public Appendable append(char c) throws IOException {
             if (c == '\r' || c == '\n') {
                 column = 0;
             } else {
                 column++;
             }
-            result.append(c);
+            delegate.append(c);
+            return this;
+        }
+    }
+
+    @FunctionalInterface
+    private interface Operation {
+        void apply(Appendable sink, CodeWriter writer, int column) throws IOException;
+
+        // Writes literal segments of the input string.
+        static Operation stringSlice(String source, int start, int end) {
+            return (sink, writer, column) -> sink.append(source, start, end);
         }
 
-        void append(String string) {
-            int lastNewline = string.lastIndexOf('\n');
-            if (lastNewline == -1) {
-                lastNewline = string.lastIndexOf('\r');
-            }
-            if (lastNewline == -1) {
-                // if no newline was found, then the column is the length of the string.
-                column = string.length();
-            } else {
-                // Otherwise, it's the length minus the last newline.
-                column = string.length() - lastNewline;
-            }
-            result.append(string);
+        // An operation that writes a resolved variable to the writer (e.g., positional arguments).
+        static Operation staticValue(String value) {
+            return (sink, writer, column) -> sink.append(value);
+        }
+
+        // Expands inline sections.
+        static Operation inlineSection(String sectionName, Operation delegate) {
+            return (sink, writer, column) -> {
+                StringBuilder buffer = new StringBuilder();
+                delegate.apply(buffer, writer, column);
+                sink.append(writer.expandSection(sectionName, buffer.toString(), writer::writeWithNoFormatting));
+            };
+        }
+
+        // Used for "|". Wraps another operation and ensures newlines are properly indented.
+        static Operation block(Operation delegate) {
+            return (sink, writer, column) -> delegate.apply(new BlockAppender(sink, column), writer, column);
+        }
+    }
+
+    private static final class BlockAppender extends DecoratedAppendable {
+        private final Appendable delegate;
+        private final int spaces;
+        private boolean previousIsCarriageReturn;
+
+        BlockAppender(Appendable delegate, int spaces) {
+            this.delegate = delegate;
+            this.spaces = spaces;
         }
 
         @Override
-        public String toString() {
-            return expression;
+        public Appendable append(char c) throws IOException {
+            if (c == '\n') {
+                delegate.append('\n');
+                writeSpaces();
+                previousIsCarriageReturn = false;
+            } else {
+                if (previousIsCarriageReturn) {
+                    writeSpaces();
+                }
+                previousIsCarriageReturn = c == '\r';
+                delegate.append(c);
+            }
+
+            return this;
+        }
+
+        private void writeSpaces() throws IOException {
+            for (int i = 0; i < spaces; i++) {
+                delegate.append(' ');
+            }
+        }
+    }
+
+    private static final class Parser {
+        private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z]+[a-zA-Z0-9_.#$]*$");
+
+        private final String template;
+        private final SimpleParser parser;
+        private final char expressionStart;
+        private final CodeWriter writer;
+        private final Object[] arguments;
+        private final boolean[] positionals;
+        private final List<Operation> operations = new ArrayList<>();
+        private int relativeIndex = 0;
+
+        Parser(CodeWriter writer, String template, Object[] arguments) {
+            this.template = template;
+            this.writer = writer;
+            this.expressionStart = writer.getExpressionStart();
+            this.parser = new SimpleParser(template);
+            this.arguments = arguments;
+            this.positionals = new boolean[arguments.length];
+        }
+
+        private void pushOperation(Operation op) {
+            operations.add(op);
+        }
+
+        private RuntimeException error(String message) {
+            return parser.syntax(message + " (template: " + template + ") " + writer.getDebugInfo());
+        }
+
+        private List<Operation> parse() {
+            boolean parsingLiteral = false;
+            int literalStartCharacter = 0;
+
+            while (!parser.eof()) {
+                char c = parser.peek();
+                parser.skip();
+
+                if (c != expressionStart) {
+                    parsingLiteral = true;
+                } else if (parser.peek() == expressionStart) {
+                    // Don't write escaped expression starts.
+                    pushOperation(Operation.stringSlice(template, literalStartCharacter, parser.position()));
+                    parser.expect(expressionStart);
+                    parsingLiteral = true;
+                    literalStartCharacter = parser.position();
+                } else {
+                    if (parsingLiteral) {
+                        // If previously parsing literal text, then add that to the operation (not including '$').
+                        pushOperation(Operation.stringSlice(template, literalStartCharacter, parser.position() - 1));
+                        parsingLiteral = false;
+                    }
+                    pushOperation(parseArgument());
+                    literalStartCharacter = parser.position();
+                }
+            }
+
+            if (parsingLiteral && literalStartCharacter < parser.position() && parser.position() > 0) {
+                pushOperation(Operation.stringSlice(template, literalStartCharacter, parser.position()));
+            }
+
+            if (relativeIndex == -1) {
+                ensureAllPositionalArgumentsWereUsed();
+            } else if (relativeIndex < arguments.length) {
+                int unusedCount = arguments.length - relativeIndex;
+                throw error(String.format("Found %d unused relative format arguments", unusedCount));
+            }
+
+            return operations;
+        }
+
+        private void ensureAllPositionalArgumentsWereUsed() {
+            int unused = 0;
+            for (boolean b : positionals) {
+                if (!b) {
+                    unused++;
+                }
+            }
+            if (unused > 0) {
+                throw error(String.format("Found %d unused positional format arguments", unused));
+            }
+        }
+
+        private Operation parseArgument() {
+            return parser.peek() == '{' ? parseBracedArgument() : parseNormalArgument();
+        }
+
+        private Operation parseBracedArgument() {
+            parser.expect('{');
+            Operation operation = parseNormalArgument();
+
+            if (parser.peek() == '@') {
+                parser.skip();
+                int start = parser.position();
+                parser.consumeUntilNoLongerMatches(c -> c != '}' && c != '|');
+                String sectionName = parser.sliceFrom(start);
+                ensureNameIsValid(sectionName);
+                operation = Operation.inlineSection(sectionName, operation);
+            }
+
+            if (parser.peek() == '|') {
+                parser.expect('|');
+                operation = Operation.block(operation);
+            }
+
+            parser.expect('}');
+
+            return operation;
+        }
+
+        private Operation parseNormalArgument() {
+            char c = parser.peek();
+
+            Object value;
+            if (Character.isLowerCase(c)) {
+                value = parseNamedArgument();
+            } else if (Character.isDigit(c)) {
+                value = parsePositionalArgument();
+            } else {
+                value = parseRelativeArgument();
+            }
+
+            // Parse the formatter and apply it.
+            String formatted = consumeFormatterIdentifier().apply(value, writer.getIndentText());
+            return Operation.staticValue(formatted);
+        }
+
+        private Object parseNamedArgument() {
+            // Expand a named context value: "$" key ":" identifier
+            int start = parser.position();
+            parser.consumeUntilNoLongerMatches(c -> c != ':');
+            String name = parser.sliceFrom(start);
+            ensureNameIsValid(name);
+
+            parser.expect(':');
+
+            // Consume the character after the colon.
+            if (parser.eof()) {
+                throw error("Expected an identifier after the ':' in a named argument");
+            }
+
+            return writer.getContext(name);
+        }
+
+        private BiFunction<Object, String, String> consumeFormatterIdentifier() {
+            char identifier = parser.expect(CodeWriterFormatterContainer.VALID_FORMATTER_CHARS);
+            BiFunction<Object, String, String> formatter = writer.getFormatter(identifier);
+            if (formatter == null) {
+                throw error(String.format("Unknown formatter `%c` found in format string", identifier));
+            }
+            return formatter;
+        }
+
+        private Object parseRelativeArgument() {
+            if (relativeIndex == -1) {
+                throw error("Cannot mix positional and relative arguments");
+            }
+
+            relativeIndex++;
+            return getPositionalArgument(relativeIndex - 1);
+        }
+
+        private Object getPositionalArgument(int index) {
+            if (index >= arguments.length) {
+                throw error(String.format("Given %d arguments but attempted to format index %d",
+                                          arguments.length, index));
+            } else {
+                // Track the usage of the positional argument.
+                positionals[index] = true;
+                return arguments[index];
+            }
+        }
+
+        private Object parsePositionalArgument() {
+            // Expand a positional argument: "$" 1*digit identifier
+            if (relativeIndex > 0) {
+                throw error("Cannot mix positional and relative arguments");
+            }
+
+            relativeIndex = -1;
+            int startPosition = parser.position();
+            parser.consumeUntilNoLongerMatches(Character::isDigit);
+            int index = Integer.parseInt(parser.sliceFrom(startPosition)) - 1;
+
+            if (index < 0 || index >= arguments.length) {
+                throw error(String.format(
+                        "Positional argument index %d out of range of provided %d arguments in format string",
+                        index, arguments.length));
+            }
+
+            return getPositionalArgument(index);
+        }
+
+        private void ensureNameIsValid(String name) {
+            if (!NAME_PATTERN.matcher(name).matches()) {
+                throw error(String.format("Invalid format expression name `%s`", name));
+            }
         }
     }
 }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
@@ -257,9 +257,17 @@ final class CodeFormatter {
                 value = parseRelativeArgument();
             }
 
+            if (value instanceof Runnable) {
+                value = evaluateRunnableArgument((Runnable) value);
+            }
+
             // Parse the formatter and apply it.
             String formatted = consumeFormatterIdentifier().apply(value, writer.getIndentText());
             return Operation.staticValue(formatted);
+        }
+
+        private String evaluateRunnableArgument(Runnable value) {
+            return writer.expandSection("__anonymous_inline_" + Math.random(), "", ignore -> value.run());
         }
 
         private Object parseNamedArgument() {

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java
@@ -62,6 +62,17 @@ import java.util.regex.Pattern;
  * <p>In the above example, {@code $L} is interpolated and replaced with the
  * relative argument {@code there!}.
  *
+ * <p>Passing a {@link Runnable} as an argument to a formatter can be used to
+ * break up large templates. Any text written to the CodeWriter inside of the
+ * Runnable is used as the value of the argument. Note that a single trailing
+ * newline is removed from the captured text.
+ *
+ * <pre>{@code
+ * CodeWriter writer = new CodeWriter();
+ * writer.write("Hello, $L.", () -> writer.write("there"));
+ * assert(writer.toString().equals("Hello, there.\n"));
+ * }</pre>
+ *
  * <p>A CodeWriter supports three kinds of interpolations: relative,
  * positional, and named. Each of these kinds of interpolations pass a value
  * to a <em>formatter</em>.</p>
@@ -97,7 +108,7 @@ import java.util.regex.Pattern;
  * characters:
  *
  * <pre>
- *    "!" / "#" / "%" / "&" / "*" / "+" / "," / "-" / "." / "/" / ";"
+ *    "!" / "#" / "%" / "&amp;" / "*" / "+" / "," / "-" / "." / "/" / ";"
  *  / "=" / "?" / "@" / "A" / "B" / "C" / "D" / "E" / "F" / "G" / "H"
  *  / "I" / "J" / "K" / "L" / "M" / "N" / "O" / "P" / "Q" / "R" / "S"
  *  / "T" / "U" / "V" / "W" / "X" / "Y" / "Z" / "^" / "_" / "`" / "~"

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriterFormatterContainer.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriterFormatterContainer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * A container for formatters registered with CodeWriter.
+ */
+@SmithyInternalApi
+final class CodeWriterFormatterContainer {
+
+    static final char[] VALID_FORMATTER_CHARS = {
+            '!', '#', '%', '&', '*', '+', ',', '-', '.', '/', ';', '=', '?', '@',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+            'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '^', '_', '`', '~'};
+
+    private final Map<Character, BiFunction<Object, String, String>> formatters = new HashMap<>();
+    private final CodeWriterFormatterContainer parent;
+
+    CodeWriterFormatterContainer() {
+        this(null);
+    }
+
+    CodeWriterFormatterContainer(CodeWriterFormatterContainer parent) {
+        this.parent = parent;
+    }
+
+    void putFormatter(Character identifier, BiFunction<Object, String, String> formatFunction) {
+        boolean matched = false;
+        for (char c : VALID_FORMATTER_CHARS) {
+            if (c == identifier) {
+                matched = true;
+                break;
+            }
+        }
+
+        if (!matched) {
+            throw new IllegalArgumentException("Invalid formatter identifier: " + identifier);
+        }
+
+        formatters.put(identifier, formatFunction);
+    }
+
+    BiFunction<Object, String, String> getFormatter(char identifier) {
+        BiFunction<Object, String, String> result = formatters.get(identifier);
+
+        if (result == null && parent != null) {
+            result = parent.getFormatter(identifier);
+        }
+
+        return result;
+    }
+}

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
@@ -35,9 +35,9 @@ public class CodeFormatterTest {
     @Test
     public void formatsDollarLiterals() {
         CodeWriter writer = createWriter();
-        String result = writer.format("hello $$");
+        String result = writer.format("hello $$.");
 
-        assertThat(result, equalTo("hello $"));
+        assertThat(result, equalTo("hello $."));
     }
 
     @Test
@@ -60,17 +60,17 @@ public class CodeFormatterTest {
 
     @Test
     public void requiresTextAfterOpeningBrace() {
-        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.format("hello ${", "there");
         });
 
-        assertThat(e.getMessage(), containsString("Invalid format string: hello ${ (Debug Info {path=ROOT, near=})"));
+        assertThat(e.getMessage(), containsString("expected one of the following tokens: '!'"));
     }
 
     @Test
     public void requiresBraceIsClosed() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello ${L .", "there");
@@ -97,7 +97,7 @@ public class CodeFormatterTest {
 
     @Test
     public void ensuresAllRelativeArgumentsWereUsed() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $L", "a", "b", "c");
@@ -106,7 +106,7 @@ public class CodeFormatterTest {
 
     @Test
     public void performsRelativeBoundsChecking() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $L");
@@ -115,7 +115,7 @@ public class CodeFormatterTest {
 
     @Test
     public void validatesThatDollarIsNotAtEof() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $");
@@ -124,7 +124,7 @@ public class CodeFormatterTest {
 
     @Test
     public void validatesThatCustomStartIsNotAtEof() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.setExpressionStart('#');
             writer.format("hello #");
@@ -180,7 +180,7 @@ public class CodeFormatterTest {
 
     @Test
     public void performsPositionalBoundsChecking() {
-        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.write("Foo!");
             writer.putFormatter('L', CodeFormatterTest::valueOf);
@@ -188,13 +188,12 @@ public class CodeFormatterTest {
         });
 
         assertThat(e.getMessage(), containsString("Positional argument index 0 out of range of provided 0 arguments "
-                                                  + "in format string: hello $1L "
-                                                  + "(Debug Info {path=ROOT, near=Foo!\\n})"));
+                                                  + "in format string"));
     }
 
     @Test
     public void performsPositionalBoundsCheckingNotZero() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $0L", "a");
@@ -203,7 +202,7 @@ public class CodeFormatterTest {
 
     @Test
     public void validatesThatPositionalIsNotAtEof() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $2");
@@ -212,7 +211,7 @@ public class CodeFormatterTest {
 
     @Test
     public void validatesThatAllPositionalsAreUsed() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $2L $3L", "a", "b", "c", "d");
@@ -221,7 +220,7 @@ public class CodeFormatterTest {
 
     @Test
     public void cannotMixPositionalAndRelative() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $1L, $L", "there");
@@ -230,7 +229,7 @@ public class CodeFormatterTest {
 
     @Test
     public void cannotMixRelativeAndPositional() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $L, $1L", "there");
@@ -261,7 +260,7 @@ public class CodeFormatterTest {
 
     @Test
     public void ensuresNamedValuesHasColon() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $abc foo");
@@ -270,7 +269,7 @@ public class CodeFormatterTest {
 
     @Test
     public void ensuresNamedValuesHasFormatterAfterColon() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("hello $abc:");
@@ -289,7 +288,7 @@ public class CodeFormatterTest {
 
     @Test
     public void ensuresNamedValuesMatchRegex() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('L', CodeFormatterTest::valueOf);
             writer.format("$nope!:L");
@@ -298,7 +297,7 @@ public class CodeFormatterTest {
 
     @Test
     public void formattersMustNotBeLowercase() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('a', CodeFormatterTest::valueOf);
         });
@@ -306,7 +305,7 @@ public class CodeFormatterTest {
 
     @Test
     public void formattersMustNotBeNumbers() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('1', CodeFormatterTest::valueOf);
         });
@@ -314,7 +313,7 @@ public class CodeFormatterTest {
 
     @Test
     public void formattersMustNotBeDollar() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.putFormatter('$', CodeFormatterTest::valueOf);
         });
@@ -322,7 +321,7 @@ public class CodeFormatterTest {
 
     @Test
     public void ensuresFormatterIsValid() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.format("$E", "hi");
         });
@@ -372,15 +371,14 @@ public class CodeFormatterTest {
 
     @Test
     public void cannotExpandInlineSectionOutsideOfBrace() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            CodeWriter writer = createWriter();
-            writer.write("Foo $L@hello baz", "default");
-        });
+        CodeWriter writer = createWriter();
+        writer.write("Foo $L@hello baz", "default");
+        assertThat(writer.toString(), equalTo("Foo default@hello baz\n"));
     }
 
     @Test
     public void inlineSectionNamesMustBeValid() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.write("${L@foo!}", "default");
         });
@@ -396,7 +394,7 @@ public class CodeFormatterTest {
 
     @Test
     public void detectsBlockAlignmentEof() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             CodeWriter writer = createWriter();
             writer.write("${L|", "default");
         });

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeFormatterTest.java
@@ -452,4 +452,52 @@ public class CodeFormatterTest {
 
         assertThat(writer.toString(), equalTo("| method() {\n|     // this\n|     // is a test.\n| }\n"));
     }
+
+    @Test
+    public void defaultCFormatterRequiresRunnable() {
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, () -> new CodeWriter().write("$C", "hi"));
+
+        assertThat(e.getMessage(), containsString(
+                "Expected CodeWriter value for 'C' formatter to be a Runnable, but found java.lang.String"));
+    }
+
+    @Test
+    public void alignsBlocksWithStaticWhitespace() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$1L() {\n" +
+                     "\t\t${2L|}\n" +
+                     "}", "method", "hi\nthere");
+
+        assertThat(writer.toString(), equalTo("method() {\n\t\thi\n\t\tthere\n}\n"));
+    }
+
+    @Test
+    public void alignsBlocksWithStaticAndSpecificWhitespace() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$1L() {\n" +
+                     "\t\t  ${2L|}\n" +
+                     "}", "method", "hi\nthere");
+
+        assertThat(writer.toString(), equalTo("method() {\n\t\t  hi\n\t\t  there\n}\n"));
+    }
+
+    @Test
+    public void canAlignNestedBlocks() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("$L() {\n\t\t${C|}\n}", "a", (Runnable) () -> {
+            writer.write("$L() {\n\t\t${C|}\n}", "b", (Runnable) () -> {
+                writer.write("$L() {\n\t\t  ${C|}\n}", "c", (Runnable) () -> {
+                    writer.write("d");
+                });
+            });
+        });
+
+        assertThat(writer.toString(), equalTo("a() {\n"
+                                              + "\t\tb() {\n"
+                                              + "\t\t\t\tc() {\n"
+                                              + "\t\t\t\t\t\t  d\n"
+                                              + "\t\t\t\t}\n"
+                                              + "\t\t}\n"
+                                              + "}\n"));
+    }
 }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -956,7 +956,7 @@ public class CodeWriterTest {
     @Test
     public void canPassRunnableToFormatters() {
         CodeWriter writer = new CodeWriter();
-        writer.write("Hi, $L.", (Runnable) () -> writer.write("TheName"));
+        writer.write("Hi, $C.", (Runnable) () -> writer.write("TheName"));
         assertThat(writer.toString(), equalTo("Hi, TheName.\n"));
     }
 
@@ -968,7 +968,7 @@ public class CodeWriterTest {
             writer.write(text + " (name)");
         });
 
-        writer.write("Hi, $L.", (Runnable) () -> {
+        writer.write("Hi, $C.", (Runnable) () -> {
             writer.pushState("Name");
             writer.write("TheName");
             writer.popState();
@@ -980,7 +980,7 @@ public class CodeWriterTest {
     @Test
     public void canPassRunnableAndKeepTrailingNewline() {
         CodeWriter writer = new CodeWriter();
-        writer.write("Hi, $L.", (Runnable) () -> writer.write("TheName\n"));
+        writer.write("Hi, $C.", (Runnable) () -> writer.write("TheName\n"));
         assertThat(writer.toString(), equalTo("Hi, TheName\n.\n"));
     }
 }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -952,4 +952,35 @@ public class CodeWriterTest {
         assertThat(b.toString(), equalTo("Hello\n"));
         assertThat(a.toString(), equalTo("\n"));
     }
+
+    @Test
+    public void canPassRunnableToFormatters() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("Hi, $L.", (Runnable) () -> writer.write("TheName"));
+        assertThat(writer.toString(), equalTo("Hi, TheName.\n"));
+    }
+
+    @Test
+    public void canPassRunnableToFormattersAndEvenCreateInlineSections() {
+        CodeWriter writer = new CodeWriter();
+
+        writer.onSection("Name", text -> {
+            writer.write(text + " (name)");
+        });
+
+        writer.write("Hi, $L.", (Runnable) () -> {
+            writer.pushState("Name");
+            writer.write("TheName");
+            writer.popState();
+        });
+
+        assertThat(writer.toString(), equalTo("Hi, TheName (name).\n"));
+    }
+
+    @Test
+    public void canPassRunnableAndKeepTrailingNewline() {
+        CodeWriter writer = new CodeWriter();
+        writer.write("Hi, $L.", (Runnable) () -> writer.write("TheName\n"));
+        assertThat(writer.toString(), equalTo("Hi, TheName\n.\n"));
+    }
 }


### PR DESCRIPTION
CodeWriter's formatter was rewritten to make it easier to understand, maintain, and evolve. As part of this evolution, this change adds the ability to pass a Runnable into a CodeWriter 'C' formatter (meaning "call"). When encountered, CodeWriter will invoke the Runnable and expect it to make calls to mutate the writer. Any text written is captured and used as the parameter value. This allows larger templates to be defined but still delegate functionality to separate methods. When coupled with text blocks in newer versions of Java, this largely makes things like openBlock/closeBlock irrelevant.

This change also is technically backward incompatible because it removes the ability to register a CodeWriter formatter using '[',']', '{', '}', '|', '<', '>'. Registering a formatter with these characters would either not work at all (e.g., '{'), or would be highly unreadable. By reserving these characters, we can also evolve CodeWriter's functionality as needed with additional sigils.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
