### PR TITLE
Add interface for codegen integration and settings

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/CodegenContext.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/CodegenContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.model.Model;
+
+/**
+ * A context object that can be used during code generation and is used by
+ * {@link SmithyIntegration}.
+ *
+ * @param <S> The settings object used to configure the generator.
+ */
+public interface CodegenContext<S extends SmithyCodegenSettings> {
+    /**
+     * @return Gets the model being code generated.
+     */
+    Model model();
+
+    /**
+     * @return Gets code generation settings.
+     */
+    S settings();
+
+    /**
+     * @return Gets the SymbolProvider used for code generation.
+     */
+    SymbolProvider symbolProvider();
+
+    /**
+     * @return Gets the FileManifest being written to for code generation.
+     */
+    FileManifest fileManifest();
+}

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
@@ -27,7 +27,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.logging.Logger;
 
-final class IntegrationTopologicalSort<S extends SmithyCodegenSettings, I extends SmithyIntegration<S>> {
+final class IntegrationTopologicalSort<S extends SmithyCodegenSettings, I extends SmithyIntegration<S, ?>> {
 
     private static final Logger LOGGER = Logger.getLogger(IntegrationTopologicalSort.class.getName());
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
@@ -27,7 +27,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.logging.Logger;
 
-final class IntegrationTopologicalSort<S extends SmithyCodegenSettings, I extends SmithyIntegration<S, ?>> {
+final class IntegrationTopologicalSort<S extends SmithyCodegenSettings, I extends SmithyIntegration<S, ?, ?>> {
 
     private static final Logger LOGGER = Logger.getLogger(IntegrationTopologicalSort.class.getName());
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
@@ -76,10 +76,11 @@ final class IntegrationTopologicalSort<S extends SmithyCodegenSettings, I extend
         I previous = this.integrationLookup.put(integration.name(), integration);
         insertionOrder.put(integration.name(), insertionOrder.size());
         if (previous != null) {
-            throw new IllegalArgumentException("Conflicting SmithyIntegration names detected for "
-                                               + integration.name() + ": "
-                                               + integration.getClass().getCanonicalName() + " and "
-                                               + previous.getClass().getCanonicalName());
+            throw new IllegalArgumentException(String.format(
+                    "Conflicting SmithyIntegration names detected for '%s': %s and %s",
+                    integration.name(),
+                    integration.getClass().getCanonicalName(),
+                    previous.getClass().getCanonicalName()));
         }
     }
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSort.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.logging.Logger;
+
+final class IntegrationTopologicalSort<S extends SmithyCodegenSettings, I extends SmithyIntegration<S>> {
+
+    private static final Logger LOGGER = Logger.getLogger(IntegrationTopologicalSort.class.getName());
+
+    private final Map<String, I> integrationLookup = new LinkedHashMap<>();
+    private final Map<String, Integer> insertionOrder = new HashMap<>();
+    private final Map<String, Set<String>> forwardDependencies = new LinkedHashMap<>();
+    private final Map<String, Set<String>> reverseDependencies = new LinkedHashMap<>();
+
+    private final Queue<String> satisfied = new PriorityQueue<>((left, right) -> {
+        I leftIntegration = integrationLookup.get(left);
+        I rightIntegration = integrationLookup.get(right);
+        // Priority order is used to sort first.
+        int byteResult = Byte.compare(rightIntegration.priority(), leftIntegration.priority());
+        // If priority is a tie, then sort based on insertion order of integrations.
+        // This makes the order deterministic.
+        return byteResult == 0
+               ? Integer.compare(insertionOrder.get(left), insertionOrder.get(right))
+               : byteResult;
+    });
+
+    IntegrationTopologicalSort(Iterable<I> integrations) {
+        // Validate name conflicts and register integrations with the lookup table + insertion order table.
+        for (I integration : integrations) {
+            addIntegration(integration);
+        }
+
+        // Validate missing dependencies and add found dependencies.
+        for (I integration : integrations) {
+            for (String before : getValidatedDependencies("before", integration.name(), integration.runBefore())) {
+                addDependency(before, integration.name());
+            }
+            for (String after : getValidatedDependencies("after", integration.name(), integration.runAfter())) {
+                addDependency(integration.name(), after);
+            }
+        }
+
+        // Offer satisfied dependencies.
+        for (I integration : integrations) {
+            if (!forwardDependencies.containsKey(integration.name())) {
+                satisfied.offer(integration.name());
+            }
+        }
+    }
+
+    private void addIntegration(I integration) {
+        I previous = this.integrationLookup.put(integration.name(), integration);
+        insertionOrder.put(integration.name(), insertionOrder.size());
+        if (previous != null) {
+            throw new IllegalArgumentException("Conflicting SmithyIntegration names detected for "
+                                               + integration.name() + ": "
+                                               + integration.getClass().getCanonicalName() + " and "
+                                               + previous.getClass().getCanonicalName());
+        }
+    }
+
+    private List<String> getValidatedDependencies(String descriptor, String what, List<String> dependencies) {
+        if (dependencies.isEmpty()) {
+            return dependencies;
+        } else {
+            List<String> filtered = new ArrayList<>(dependencies);
+            filtered.removeIf(value -> {
+                if (integrationLookup.containsKey(value)) {
+                    return false;
+                } else {
+                    LOGGER.warning(what  + " is supposed to run " + descriptor + " an integration that could "
+                                   + "not be found, '" + value + "'");
+                    return true;
+                }
+            });
+            return filtered;
+        }
+    }
+
+    private void addDependency(String what, String dependsOn) {
+        forwardDependencies.computeIfAbsent(what, n -> new LinkedHashSet<>()).add(dependsOn);
+        reverseDependencies.computeIfAbsent(dependsOn, n -> new LinkedHashSet<>()).add(what);
+    }
+
+    List<I> sort() {
+        List<I> result = new ArrayList<>();
+
+        while (!satisfied.isEmpty()) {
+            String current = satisfied.poll();
+            forwardDependencies.remove(current);
+            result.add(integrationLookup.get(current));
+
+            for (String dependent : reverseDependencies.getOrDefault(current, Collections.emptySet())) {
+                Set<String> dependentDependencies = forwardDependencies.get(dependent);
+                dependentDependencies.remove(current);
+                if (dependentDependencies.isEmpty()) {
+                    satisfied.offer(dependent);
+                }
+            }
+        }
+
+        if (!forwardDependencies.isEmpty()) {
+            throw new IllegalArgumentException("SmithyIntegration cycles detected among "
+                                               + forwardDependencies.keySet());
+        }
+
+        return result;
+    }
+}

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyCodegenSettings.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyCodegenSettings.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Base interface used to represent the settings of a code generator.
+ *
+ * <p>This interface is currently unstable as more requirements
+ * may be added in the future.
+ */
+@SmithyUnstableApi
+public interface SmithyCodegenSettings {
+    /**
+     * Gets the service configured for the code generator.
+     *
+     * @return Returns the service shape ID to generate.
+     */
+    ShapeId service();
+}

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * This interface provides the base concept of an "Integration" to
+ * Smithy code generators.
+ *
+ * <p>This class provides the bare minimum that most Smithy code generators
+ * can implement as a tool to customize generators. Code generators are
+ * expected to extend this interface to add various hooks to their generator
+ * (e.g., register protocol generators, register auth scheme integrations,
+ * attach middleware, intercept and augment CodeWriter sections, etc).
+ *
+ * <p>This interface is currently unstable as more requirements
+ * may be added in the future.
+ *
+ * @param <S> The settings object used to configure the generator.
+ */
+@SmithyUnstableApi
+public interface SmithyIntegration<S extends SmithyCodegenSettings> {
+    /**
+     * Preprocess the model before code generation.
+     *
+     * <p>This can be used to remove unsupported features, remove traits
+     * from shapes (e.g., make members optional), etc.
+     *
+     * <p>By default, this method will return the given {@code model} as-is.
+     *
+     * @param model Model being generated.
+     * @param settings Setting used to generate code.
+     * @return Returns the updated model.
+     */
+    default Model preprocessModel(Model model, S settings) {
+        return model;
+    }
+
+    /**
+     * Updates the {@link SymbolProvider} used when generating code.
+     *
+     * <p>This can be used to customize the names of shapes, the package
+     * that code is generated into, add dependencies, add imports, etc.
+     *
+     * <p>By default, this method will return the given {@code symbolProvider}
+     * as-is.
+     *
+     * @param model Model being generated.
+     * @param settings Setting used to generate.
+     * @param symbolProvider The original {@code SymbolProvider}.
+     * @return The decorated {@code SymbolProvider}.
+     */
+    default SymbolProvider decorateSymbolProvider(Model model, S settings, SymbolProvider symbolProvider) {
+        return symbolProvider;
+    }
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
@@ -38,7 +38,11 @@ public class IntegrationTopologicalSortTest {
         }
     }
 
-    private static final class MyIntegration implements SmithyIntegration<MySettings, CodeWriter> {
+    private static final class MyIntegration implements SmithyIntegration<
+            MySettings,
+            CodeWriter,
+            CodegenContext<MySettings>
+    > {
         private final String name;
         private final byte priority;
         private final List<String> runBefore;
@@ -89,7 +93,9 @@ public class IntegrationTopologicalSortTest {
         }
     }
 
-    static List<String> toStrings(List<? extends SmithyIntegration<MySettings, CodeWriter>> integrations) {
+    static List<String> toStrings(
+            List<? extends SmithyIntegration<MySettings, CodeWriter, CodegenContext<MySettings>>> integrations
+    ) {
         return SmithyIntegration.sort(integrations).stream()
                 .map(SmithyIntegration::name)
                 .collect(Collectors.toList());

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
@@ -203,7 +203,7 @@ public class IntegrationTopologicalSortTest {
         RuntimeException e = Assertions.assertThrows(IllegalArgumentException.class,
                                                      () -> SmithyIntegration.sort(integrations));
         assertThat(e.getMessage(), equalTo(
-                "Conflicting SmithyIntegration names detected for a: software.amazon.smithy.codegen.core.IntegrationTopologicalSortTest.MyIntegration "
+                "Conflicting SmithyIntegration names detected for 'a': software.amazon.smithy.codegen.core.IntegrationTopologicalSortTest.MyIntegration "
                 + "and software.amazon.smithy.codegen.core.IntegrationTopologicalSortTest.MyIntegration"));
     }
 

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.ListUtils;
+
+public class IntegrationTopologicalSortTest {
+
+    private static final class MySettings implements SmithyCodegenSettings {
+        @Override
+        public ShapeId service() {
+            return ShapeId.from("smithy.example#MyService");
+        }
+    }
+
+    private static final class MyIntegration implements SmithyIntegration<MySettings> {
+        private final String name;
+        private final byte priority;
+        private final List<String> runBefore;
+        private final List<String> runAfter;
+
+        MyIntegration(String name) {
+            this(name, (byte) 0);
+        }
+
+        MyIntegration(String name, byte priority) {
+            this(name, priority, Collections.emptyList());
+        }
+
+        MyIntegration(String name, byte priority, List<String> runBefore) {
+            this(name, priority, runBefore, Collections.emptyList());
+        }
+
+        MyIntegration(String name, byte priority, List<String> runBefore, List<String> runAfter) {
+            this.name = name;
+            this.priority = priority;
+            this.runBefore = runBefore;
+            this.runAfter = runAfter;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public byte priority() {
+            return priority;
+        }
+
+        @Override
+        public List<String> runBefore() {
+            return runBefore;
+        }
+
+        @Override
+        public List<String> runAfter() {
+            return runAfter;
+        }
+
+        @Override
+        public String toString() {
+            return name();
+        }
+    }
+
+    static List<String> toStrings(List<? extends SmithyIntegration<MySettings>> integrations) {
+        return SmithyIntegration.sort(integrations).stream()
+                .map(SmithyIntegration::name)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void sortsIntegrationsWithAllDefaults() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a"));
+        integrations.add(new MyIntegration("b"));
+        integrations.add(new MyIntegration("c"));
+        integrations.add(new MyIntegration("d"));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        // Note that insertion order is maintained.
+        assertThat(result, contains("a", "b", "c", "d"));
+    }
+
+    @Test
+    public void sortsIntegrationsBasedOnlyOnPriority1() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a", (byte) 0));
+        integrations.add(new MyIntegration("b", (byte) 1));
+        integrations.add(new MyIntegration("c", (byte) 2));
+        integrations.add(new MyIntegration("d", (byte) 3));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        assertThat(result, contains("d", "c", "b", "a"));
+    }
+
+    @Test
+    public void sortsIntegrationsBasedOnlyOnPriority2() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a", (byte) 2));
+        integrations.add(new MyIntegration("b", (byte) 0));
+        integrations.add(new MyIntegration("c", (byte) 1));
+        integrations.add(new MyIntegration("d", (byte) 3));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        assertThat(result, contains("d", "a", "c", "b"));
+    }
+
+    @Test
+    public void sortsIntegrationsBasedOnBefore() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a", (byte) 0, ListUtils.of("b")));
+        integrations.add(new MyIntegration("b", (byte) 0, ListUtils.of("c")));
+        integrations.add(new MyIntegration("c", (byte) 0, ListUtils.of("d")));
+        integrations.add(new MyIntegration("d", (byte) 0));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        assertThat(result, contains("a", "b", "c", "d"));
+    }
+
+    @Test
+    public void sortsIntegrationsBasedOnAfterAndPriority() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a", (byte) 0, ListUtils.of(), ListUtils.of("b")));
+        integrations.add(new MyIntegration("b"));
+        integrations.add(new MyIntegration("c", (byte) 50, ListUtils.of(), ListUtils.of("b")));
+        integrations.add(new MyIntegration("d", (byte) -50, ListUtils.of(), ListUtils.of("b")));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        assertThat(result, contains("b", "c", "a", "d"));
+    }
+
+    @Test
+    public void sortsIntegrationsBasedOnBeforeAfterAndPriority() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        // c (before d) -> a (before b) -> b (before d) -> d
+        integrations.add(new MyIntegration("a", (byte) 0, ListUtils.of("b"), ListUtils.of("c")));
+        integrations.add(new MyIntegration("b", (byte) 0, ListUtils.of("d"), ListUtils.of("c")));
+        integrations.add(new MyIntegration("c", (byte) 50, ListUtils.of("d")));
+        integrations.add(new MyIntegration("d", (byte) -50, ListUtils.of(), ListUtils.of("a")));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        assertThat(result, contains("c", "a", "b", "d"));
+    }
+
+    @Test
+    public void detectsCycles() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a", (byte) 0, ListUtils.of("b"), ListUtils.of("c")));
+        integrations.add(new MyIntegration("b", (byte) 0, ListUtils.of("d"), ListUtils.of("c")));
+        integrations.add(new MyIntegration("c", (byte) 0, ListUtils.of("d")));
+        integrations.add(new MyIntegration("d", (byte) 0, ListUtils.of("b"), ListUtils.of("a")));
+
+        RuntimeException e = Assertions.assertThrows(IllegalArgumentException.class,
+                                                     () -> SmithyIntegration.sort(integrations));
+        assertThat(e.getMessage(), equalTo("SmithyIntegration cycles detected among [b, d]"));
+    }
+
+    @Test
+    public void detectsConflictingNames() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a"));
+        integrations.add(new MyIntegration("a"));
+
+        RuntimeException e = Assertions.assertThrows(IllegalArgumentException.class,
+                                                     () -> SmithyIntegration.sort(integrations));
+        assertThat(e.getMessage(), equalTo(
+                "Conflicting SmithyIntegration names detected for a: software.amazon.smithy.codegen.core.IntegrationTopologicalSortTest.MyIntegration "
+                + "and software.amazon.smithy.codegen.core.IntegrationTopologicalSortTest.MyIntegration"));
+    }
+
+    @Test
+    public void dependenciesAreSoft() {
+        List<MyIntegration> integrations = new ArrayList<>();
+        integrations.add(new MyIntegration("a", (byte) 0, ListUtils.of("foo"), ListUtils.of("baz")));
+        integrations.add(new MyIntegration("b", (byte) 10, ListUtils.of("bam"), ListUtils.of("boo")));
+
+        List<String> result = toStrings(SmithyIntegration.sort(integrations));
+
+        assertThat(result, contains("b", "a"));
+    }
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.CodeWriter;
 import software.amazon.smithy.utils.ListUtils;
 
 public class IntegrationTopologicalSortTest {
@@ -37,7 +38,7 @@ public class IntegrationTopologicalSortTest {
         }
     }
 
-    private static final class MyIntegration implements SmithyIntegration<MySettings> {
+    private static final class MyIntegration implements SmithyIntegration<MySettings, CodeWriter> {
         private final String name;
         private final byte priority;
         private final List<String> runBefore;
@@ -88,7 +89,7 @@ public class IntegrationTopologicalSortTest {
         }
     }
 
-    static List<String> toStrings(List<? extends SmithyIntegration<MySettings>> integrations) {
+    static List<String> toStrings(List<? extends SmithyIntegration<MySettings, CodeWriter>> integrations) {
         return SmithyIntegration.sort(integrations).stream()
                 .map(SmithyIntegration::name)
                 .collect(Collectors.toList());

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SmithyIntegrationTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SmithyIntegrationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.ListUtils;
+
+// This test basically just ensures the generics used in SmithyIntegration work
+// like we expect.
+public class SmithyIntegrationTest {
+
+    private static final class MySettings implements SmithyCodegenSettings {
+        @Override
+        public ShapeId service() {
+            return ShapeId.from("smithy.example#MyService");
+        }
+    }
+
+    private static final class MyIntegration implements SmithyIntegration<MySettings, CodeWriter> {
+        private final String name;
+
+        MyIntegration(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public List<? extends CodeInterceptor<? extends CodeSection, CodeWriter>> interceptors(
+                Model model, MySettings settings, SymbolProvider symbolProvider) {
+            return ListUtils.of(new MyInterceptor1(), new MyInterceptor2());
+        }
+    }
+
+    private static final class SomeSection implements CodeSection {}
+
+    private static final class MyInterceptor1 implements CodeInterceptor.Appender<SomeSection, CodeWriter> {
+        @Override
+        public Class<SomeSection> sectionType() {
+            return SomeSection.class;
+        }
+
+        @Override
+        public void append(CodeWriter writer, SomeSection section) {
+            writer.write("Hi1");
+        }
+    }
+
+    private static final class MyInterceptor2 implements CodeInterceptor.Appender<SomeSection, CodeWriter> {
+        @Override
+        public Class<SomeSection> sectionType() {
+            return SomeSection.class;
+        }
+
+        @Override
+        public void append(CodeWriter writer, SomeSection section) {
+            writer.write("Hi2");
+        }
+    }
+
+    @Test
+    public void canRegisterInterceptors() {
+        MyIntegration integration = new MyIntegration("Foo");
+    }
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SmithyIntegrationTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SmithyIntegrationTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.codegen.core;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.CodeInterceptor;
@@ -35,7 +36,30 @@ public class SmithyIntegrationTest {
         }
     }
 
-    private static final class MyIntegration implements SmithyIntegration<MySettings, CodeWriter> {
+    private static final class MyContext implements CodegenContext<MySettings> {
+        @Override
+        public Model model() {
+            return null;
+        }
+
+        @Override
+        public MySettings settings() {
+            return null;
+        }
+
+        @Override
+        public SymbolProvider symbolProvider() {
+            return null;
+        }
+
+        @Override
+        public FileManifest fileManifest() {
+            return null;
+        }
+    }
+
+    private static final class MyIntegration implements SmithyIntegration<
+            MySettings, CodeWriter, MyContext> {
         private final String name;
 
         MyIntegration(String name) {
@@ -48,8 +72,7 @@ public class SmithyIntegrationTest {
         }
 
         @Override
-        public List<? extends CodeInterceptor<? extends CodeSection, CodeWriter>> interceptors(
-                Model model, MySettings settings, SymbolProvider symbolProvider) {
+        public List<? extends CodeInterceptor<? extends CodeSection, CodeWriter>> interceptors(MyContext context) {
             return ListUtils.of(new MyInterceptor1(), new MyInterceptor2());
         }
     }


### PR DESCRIPTION
Codegen integrations typically all follow a similar format -- they
provide hooks for modifying the code generator and are discovered using
SPI. This commit adds a base interface for codegen integrations and
settings objects. The integration object is as minimal as possible
whill still providing some utility and conformity across
implementations, and the settings object just provides a minimal
`getService` method. Each Java implementation of Smithy codegen has such
a method in their settings object, and so does the Kotlin based Rust
generator.

The integration interface is very simimlar to both TypeScript and Go
integrations, though not exactly the same as either. The TypeScript
generator passes the entire PluginContext to preprocessModel, but that
is never actually needed and makes it harder to mock (Go does not
require the full context, only the Model so it can take this change).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
