### PR TITLE
Clarify defaulting behavior of response code binding

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -1145,7 +1145,8 @@ Conflicts with
 
 Marking an output ``structure`` member with this trait can be used to provide
 different response codes for an operation, like a 200 or 201 for a PUT
-operation.
+operation. If this member isn't provided, server implementations MUST default
+to the `code` set by the :ref:`http-trait`.
 
 .. rubric:: ``httpResponseCode`` is only used on output
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -40,6 +40,25 @@ apply HttpResponseCode @httpResponseTests([
         }
     },
     {
+        id: "RestJsonHttpResponseCodeDefaultsToModeledCode",
+        documentation: """
+                Binds the http response code to the http trait's code if the
+                code isn't explicitly set. A client would be parsing the
+                http response code, so this would always be present, but
+                a server doesn't require it to be set to serialize a request.""",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: "{}",
+        bodyMediaType: "application/json",
+        // A client would parse the http response code, and so for clients it
+        // will always be present, but a server doesn't require it to be set.
+        params: {},
+        appliesTo: "server"
+    },
+    {
         id: "RestJsonHttpResponseCodeWithNoPayload",
         documentation: """
                 This test ensures that clients gracefully handle cases where


### PR DESCRIPTION
Resolves #1098 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
