### PR TITLE
Reset ModelAssembler's validationEventListener to default

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -166,7 +166,7 @@ public final class ModelAssembler {
         documentNodes.clear();
         disablePrelude = false;
         disableValidation = false;
-        validationEventListener = null;
+        validationEventListener = DEFAULT_EVENT_LISTENER;
         return this;
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -684,4 +684,27 @@ public class ModelAssemblerTest {
         assertThat(model.expectShape(stringShape.getId()).expectTrait(OriginalShapeIdTrait.class).getOriginalId(),
                    equalTo(originalId));
     }
+
+    @Test
+    public void resetDoesNotBarf() {
+        ModelAssembler assembler = new ModelAssembler();
+        assembler.assemble();
+        assembler.reset();
+        assembler.assemble();
+    }
+
+    // reset() affects multiple properties of the ModelAssembler. The test asserts one of them (shapes).
+    @Test
+    public void reset() {
+        ModelAssembler assembler = new ModelAssembler();
+
+        StringShape shape = StringShape.builder().id("ns.foo#Bar").build();
+        assembler.addShape(shape);
+        ValidatedResult<Model> result = assembler.assemble();
+        assertThat(result.unwrap().getShape(ShapeId.from("ns.foo#Bar")), is(Optional.of(shape)));
+
+        assembler.reset();
+        result = assembler.assemble();
+        assertThat(result.unwrap().getShape(ShapeId.from("ns.foo#Bar")), is(Optional.empty()));
+    }
 }


### PR DESCRIPTION
The `resetDoesNotBarf` test would throw NPE before the change and now passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
