### PR TITLE
Fix indentation bug in AbstractCodeWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 * Fixed backwards compatibility of CodeWriter and created a new basic implementation of `AbstractCodeWriter` named
   `SimpleCodeWriter`. ([#1123](https://github.com/awslabs/smithy/pull/1123))
-  
-
+* Fixed a bug in `AbstractCodeWriter` where indenting the next line would not be preserved after popping a state.
+  ([#1129](https://github.com/awslabs/smithy/pull/1129))
 ## 1.18.0 (2022-03-07)
 
 ### Breaking changes

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
@@ -832,6 +832,10 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
             }
         }
 
+        if (!popped.isInline && popped.needsIndentation) {
+            currentState.needsIndentation = true;
+        }
+
         return (T) this;
     }
 

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -844,6 +844,20 @@ public class CodeWriterTest {
     }
 
     @Test
+    public void sectionWithSucceedingIndentedWrite() {
+        CodeWriter writer = new CodeWriter();
+        writer.writeInline("ori");
+        writer.pushState();
+        writer.write("ginal");
+        writer.popState();
+        writer.setNewlinePrefix("/// ");
+        writer.write("after");
+
+        assertThat(writer.toString(), equalTo("original\n/// after\n"));
+    }
+
+
+    @Test
     public void canUnwriteMatchingStrings() {
         CodeWriter writer = new CodeWriter().insertTrailingNewline(false);
         writer.writeInline("Hello there");

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/SimpleCodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/SimpleCodeWriterTest.java
@@ -843,6 +843,32 @@ public class SimpleCodeWriterTest {
     }
 
     @Test
+    public void sectionWithSucceedingIndentedWrite() {
+        SimpleCodeWriter writer = new SimpleCodeWriter();
+        writer.writeInline("ori");
+        writer.pushState();
+        writer.write("ginal");
+        writer.popState();
+        writer.setNewlinePrefix("/// ");
+        writer.write("after");
+
+        assertThat(writer.toString(), equalTo("original\n/// after\n"));
+    }
+
+    @Test
+    public void namedSectionWithSucceedingIndentedWrite() {
+        SimpleCodeWriter writer = new SimpleCodeWriter();
+        writer.writeInline("ori");
+        writer.pushState("named");
+        writer.write("ginal");
+        writer.popState();
+        writer.setNewlinePrefix("/// ");
+        writer.write("after");
+
+        assertThat(writer.toString(), equalTo("original\n/// after\n"));
+    }
+
+    @Test
     public void canUnwriteMatchingStrings() {
         SimpleCodeWriter writer = new SimpleCodeWriter().insertTrailingNewline(false);
         writer.writeInline("Hello there");


### PR DESCRIPTION
*Description of changes:*
After calling .popState(), if the popped state required a newline + indent,
but the state being restored had not required an indent, we would lose the
popped state's required indent and emit the next line incorrectly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
