### PR TITLE
Migration tool

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ include ":smithy-linters"
 include ":smithy-mqtt-traits"
 include ":smithy-jsonschema"
 include ":smithy-openapi"
+include ":smithy-upgrade-tool"
 include ":smithy-utils"
 include ":smithy-protocol-test-traits"
 include ':smithy-jmespath'

--- a/smithy-upgrade-tool/build.gradle
+++ b/smithy-upgrade-tool/build.gradle
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+plugins {
+    id "application"
+    id "org.beryx.runtime" version "1.12.7"
+}
+
+description = "This module implements the Smithy command line interface."
+
+ext {
+    displayName = "Smithy :: CLI"
+    moduleName = "software.amazon.smithy.cli"
+    imageJreVersion = "17"
+    correttoRoot = "https://corretto.aws/downloads/latest/amazon-corretto-${imageJreVersion}"
+}
+
+// Detect which OS and arch is running to create an application class data sharing
+// archive for the current platform.
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    ext.set("imageOs", "win64")
+} else if (Os.isFamily(Os.FAMILY_MAC)) {
+    if (Os.isArch("aarch64")) {
+        ext.set("imageOs", "osx-aarch_64")
+    } else if (Os.isArch("x86_64")) {
+        ext.set("imageOs", "osx-x86_64")
+    } else {
+        println("No JDK for ${System.getProperty("os.arch")}")
+        ext.set("imageOs", "")
+    }
+} else if (Os.isFamily(Os.FAMILY_UNIX)) {
+    if (Os.isArch("aarch")) {
+        ext.set("imageOs", "linux-aarch_64")
+    } else if (Os.isArch("x86_64")) {
+        ext.set("imageOs", "linux-x86_64")
+    } else {
+        println("No JDK for ${System.getProperty("os.arch")}")
+        ext.set("imageOs", "")
+    }
+} else {
+    println("Unknown OS and arch: ${System.getProperty("os.name")}")
+    ext.set("imageOs", "")
+}
+
+dependencies {
+    api project(":smithy-model")
+}
+
+application {
+    mainClass = "software.amazon.smithy.upgrade.SmithyUpgradeCli"
+    applicationName = "smithy-upgrade"
+}
+
+runtime {
+    addOptions("--compress", "0", "--strip-debug", "--no-header-files", "--no-man-pages")
+    addModules("java.logging", "java.xml")
+
+    launcher {
+        jvmArgs = [
+                '-Xshare:auto',
+                '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
+        ]
+    }
+
+    targetPlatform("linux-x86_64") {
+        jdkHome = jdkDownload("${correttoRoot}-x64-linux-jdk.tar.gz")
+    }
+
+    targetPlatform("linux-aarch_64") {
+        jdkHome = jdkDownload("${correttoRoot}-aarch64-linux-jdk.tar.gz")
+    }
+
+    targetPlatform("osx-x86_64") {
+        jdkHome = jdkDownload("${correttoRoot}-x64-macos-jdk.tar.gz")
+    }
+
+    targetPlatform("osx-aarch_64") {
+        jdkHome = jdkDownload("${correttoRoot}-aarch64-macos-jdk.tar.gz")
+    }
+
+    targetPlatform("win64") {
+        jdkHome = jdkDownload("${correttoRoot}-x64-windows-jdk.zip")
+    }
+}

--- a/smithy-upgrade-tool/src/main/java/software/amazon/smithy/upgrade/SmithyUpgradeCli.java
+++ b/smithy-upgrade-tool/src/main/java/software/amazon/smithy/upgrade/SmithyUpgradeCli.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.upgrade;
+
+public final class SmithyUpgradeCli {
+    private SmithyUpgradeCli() {}
+
+    public static void main(String... args) {
+
+    }
+}

--- a/smithy-upgrade-tool/src/main/java/software/amazon/smithy/upgrade/Upgrader.java
+++ b/smithy-upgrade-tool/src/main/java/software/amazon/smithy/upgrade/Upgrader.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.upgrade;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.SmithyIdlModelSerializer;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.model.validation.ValidatedResultException;
+import software.amazon.smithy.utils.IoUtils;
+
+final class Upgrader {
+    private static final Pattern VERSION = Pattern.compile("(?m)^\\s*\\$\\s*version:\\s*\"1\\.0\"\\s*$");
+
+    private Upgrader() {
+    }
+
+    static String upgradeFile(Path astPath, Path filePath) {
+        Model completeModel = Model.assembler()
+                .addImport(astPath)
+                .assemble()
+                .unwrap();
+
+        ValidatedResult<Model> optionalModel = Model.assembler()
+                .addImport(filePath)
+                .assemble();
+
+        if (!optionalModel.getResult().isPresent()) {
+            try {
+                optionalModel.unwrap();
+            } catch (ValidatedResultException e) {
+                throw new RuntimeException(String.format("Unable to load model file: %s\n\n%s", filePath, e));
+            }
+            throw new RuntimeException(String.format("Unable to load model file: %s", filePath));
+        }
+
+        // We use this partial model just to be sure about the source locations
+        Model partialModel = optionalModel.getResult().get();
+
+        ShapeUpgradeVisitor visitor = new ShapeUpgradeVisitor(completeModel, IoUtils.readUtf8File(filePath));
+
+        partialModel.shapes()
+                .filter(shape -> shape.getSourceLocation().getFilename().equals(filePath.toString()))
+                // Apply updates to the shapes at the bottom of the file first.
+                // This lets us modify the file without invalidating the existing
+                // source locations.
+                .sorted(new SourceLocationSorter().reversed())
+                .forEach(shape -> shape.accept(visitor));
+
+        return updateVersion(visitor.getModelString());
+    }
+
+    private static String updateVersion(String modelString) {
+        Matcher matcher = VERSION.matcher(modelString);
+        if (matcher.find()) {
+            return matcher.replaceFirst("\\$version: \"2.0\"\n");
+        }
+        return "$version: \"2.0\"\n\n" + modelString;
+    }
+
+    // Sorts shapes in the order they appear in the file.
+    private static class SourceLocationSorter implements Comparator<FromSourceLocation> {
+        @Override
+        public int compare(FromSourceLocation s1, FromSourceLocation s2) {
+            SourceLocation sourceLocation = s1.getSourceLocation();
+            SourceLocation otherSourceLocation = s2.getSourceLocation();
+
+            if (!sourceLocation.getFilename().equals(otherSourceLocation.getFilename())) {
+                return sourceLocation.getFilename().compareTo(otherSourceLocation.getFilename());
+            }
+
+            int lineComparison = Integer.compare(sourceLocation.getLine(), otherSourceLocation.getLine());
+            if (lineComparison != 0) {
+                return lineComparison;
+            }
+
+            return Integer.compare(sourceLocation.getColumn(), otherSourceLocation.getColumn());
+        }
+    }
+
+    private static class TraitSorter implements Comparator<Trait> {
+        @Override
+        public int compare(Trait o1, Trait o2) {
+            return new SourceLocationSorter().compare(o1.getSourceLocation(), o2.getSourceLocation());
+        }
+    }
+
+    private static class ShapeUpgradeVisitor extends ShapeVisitor.Default<Void> {
+        private final Model completeModel;
+        private String modelString;
+
+        ShapeUpgradeVisitor(Model completeModel, String modelString) {
+            this.completeModel = completeModel;
+            this.modelString = modelString;
+        }
+
+        String getModelString() {
+            if (!modelString.endsWith("\n")) {
+                modelString = modelString + "\n";
+            }
+            return modelString;
+        }
+
+        @Override
+        protected Void getDefault(Shape shape) {
+            return null;
+        }
+
+        @Override
+        public Void stringShape(StringShape shape) {
+            if (!shape.hasTrait(EnumTrait.class)) {
+                return null;
+            }
+
+            EnumTrait enumTrait = shape.expectTrait(EnumTrait.class);
+            if (!enumTrait.getValues().iterator().next().getName().isPresent()) {
+                return null;
+            }
+
+            insertLine(shape.getSourceLocation().getLine() + 1, writeEnum(shape));
+            eraseLine(shape.getSourceLocation().getLine());
+            eraseTrait(shape, enumTrait);
+
+            return null;
+        }
+
+        private void insertLine(int lineNumber, String line) {
+            List<String> lines = new ArrayList<>(Arrays.asList(modelString.split("\n")));
+            lines.add(lineNumber - 1, line);
+            modelString = String.join("\n", lines);
+        }
+
+        private void eraseLine(int lineNumber) {
+            List<String> lines = new ArrayList<>(Arrays.asList(modelString.split("\n")));
+            lines.remove(lineNumber - 1);
+            modelString = String.join("\n", lines);
+        }
+
+        private void eraseTrait(Shape shape, Trait trait) {
+            SourceLocation from = findRealTraitStart(trait.getSourceLocation());
+            SourceLocation to = findLocationAfterTrait(shape, trait.getClass());
+            erase(from, to);
+        }
+
+        private void erase(SourceLocation from, SourceLocation to) {
+            int fromIndex = sourceLocationToIndex(from);
+            int toIndex = sourceLocationToIndex(to);
+            modelString = modelString.substring(0, fromIndex) + modelString.substring(toIndex);
+        }
+
+        // The SourceLocation that traits report is actually the location of
+        // their value node, so we need to look backwards from that to find
+        // where the trait definition actually begins.
+        private SourceLocation findRealTraitStart(SourceLocation location) {
+            // Annotation traits don't necessarily have the right column, so we
+            // move back a column even before a rewind so we don't get index
+            // errors.
+            location = new SourceLocation(location.getFilename(), location.getLine(), location.getColumn() - 1);
+            return rewindUntil(location, index -> modelString.charAt(index) == '@');
+        }
+
+        private SourceLocation rewindUntil(SourceLocation location, Function<Integer, Boolean> condition) {
+            int index = sourceLocationToIndex(location);
+            while (!condition.apply(index)) {
+                index--;
+            }
+            return indexToSourceLocation(index, location.getFilename());
+        }
+
+        private int sourceLocationToIndex(SourceLocation location) {
+            int line = 1;
+            int column = 1;
+            for (int i = 0; i < modelString.length(); i++) {
+                if (modelString.charAt(i) == '\n') {
+                    line++;
+                    column = 1;
+                    continue;
+                }
+                if (line == location.getLine() && column == location.getColumn()) {
+                    return i;
+                }
+                column++;
+            }
+            throw new IllegalStateException(String.format("Unable to find location: %s", location));
+        }
+
+        private SourceLocation indexToSourceLocation(int index, String fileName) {
+            int line = 1;
+            int column = 1;
+            for (int i = 0; i <= index; i++) {
+                if (modelString.charAt(i) == '\n') {
+                    line++;
+                    column = 1;
+                    continue;
+                }
+                if (index == i) {
+                    return new SourceLocation(fileName, line, column);
+                }
+                column++;
+            }
+            throw new IllegalStateException(String.format(
+                    "Unable to convert model string index %d to a source location.", index));
+        }
+
+        private SourceLocation findLocationAfterTrait(Shape shape, Class<? extends Trait> target) {
+            boolean haveSeenTarget = false;
+            List<Trait> traits = new ArrayList<>(shape.getIntroducedTraits().values());
+            traits.sort(new TraitSorter());
+            for (Trait trait : traits) {
+                if (target.isInstance(trait)) {
+                    haveSeenTarget = true;
+                } else if (haveSeenTarget && !trait.getSourceLocation().equals(SourceLocation.NONE)) {
+                    return findRealTraitStart(trait.getSourceLocation());
+                }
+            }
+            return shape.getSourceLocation();
+        }
+
+        private String writeEnum(StringShape shape) {
+            // Strip all the traits from the shape except the enum trait.
+            // We're leaving the other traits where they are in the model
+            // string to preserve things like comments as much as is possible.
+            StringShape stripped = shape.toBuilder()
+                    .clearTraits()
+                    .addTrait(shape.expectTrait(EnumTrait.class))
+                    .build();
+
+            // Build a faux model that only contains the enum we want to wrte.
+            Model model = Model.assembler()
+                    .addShapes(stripped)
+                    .assemble().unwrap();
+
+            // Use existing conversion tools to convert it to an enum shape,
+            // then serialize it using the idl serializer.
+            model = ModelTransformer.create().changeStringEnumsToEnumShapes(model);
+            Map<Path, String> files = SmithyIdlModelSerializer.builder().build().serialize(model);
+
+            // There's only one shape, so there should only be one file.
+            String serialized = files.values().iterator().next();
+
+            // The serialized file will contain things we don't want, like the
+            // namespace and version statements, so here we strip everything
+            // we find before the enum statement.
+            ArrayList<String> lines = new ArrayList<>();
+            boolean foundEnum = false;
+            for (String line : serialized.split("\n")) {
+                if (foundEnum) {
+                    lines.add(line);
+                } else if (line.startsWith("enum")) {
+                    lines.add(line);
+                    foundEnum = true;
+                }
+            }
+
+            return String.join("\n", lines);
+        }
+    }
+}

--- a/smithy-upgrade-tool/src/test/java/software/amazon/smithy/upgrade/TestUpgrader.java
+++ b/smithy-upgrade-tool/src/test/java/software/amazon/smithy/upgrade/TestUpgrader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.upgrade;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.utils.IoUtils;
+
+public class TestUpgrader {
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("source")
+    public void testUpgrade(Path initialPath, String name) {
+        Path parentDir = initialPath.getParent();
+        String expectedFileName = initialPath.getFileName().toString().replace(".v1.smithy", ".v2.smithy");
+        Path expectedPath = parentDir.resolve(expectedFileName);
+
+        String completeFileName = initialPath.getFileName().toString().replace(".v1.smithy", ".complete.json");
+        Path completePath = parentDir.resolve(completeFileName);
+        if (!Files.exists(completePath)) {
+            completePath = initialPath;
+        }
+
+        String actual = Upgrader.upgradeFile(initialPath, completePath);
+        String expected = IoUtils.readUtf8File(expectedPath);
+        assertThat(actual, equalTo(expected));
+    }
+
+    public static Stream<Arguments> source() throws Exception {
+        Path start = Paths.get(TestUpgrader.class.getResource("cases").toURI());
+        return Files.walk(start)
+                .filter(path -> path.getFileName().toString().endsWith(".v1.smithy"))
+                .map(path -> Arguments.of(path, path.getFileName().toString().replace(".v1.smithy", "")));
+    }
+}

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum-with-traits.v1.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum-with-traits.v1.smithy
@@ -1,0 +1,42 @@
+$version: "1.0"
+
+namespace com.example
+
+@enum([
+    {
+        name: "FOO",
+        value: "foo",
+    },
+    {
+        name: "BAR",
+        value: "bar",
+    }
+])
+@internal
+string TraitAfterEnum
+
+@internal
+@enum([
+    {
+        name: "FOO",
+        value: "foo",
+    },
+    {
+        name: "BAR",
+        value: "bar",
+    }
+])
+string TraitBeforeEnum
+
+@enum([
+    {
+        name: "FOO",
+        value: "foo",
+    },
+    {
+        name: "BAR",
+        value: "bar",
+    }
+])
+@internal()
+string AnnotationTraitWithParens

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum-with-traits.v2.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum-with-traits.v2.smithy
@@ -1,0 +1,27 @@
+$version: "2.0"
+
+namespace com.example
+
+@internal
+enum TraitAfterEnum {
+    @enumValue("foo")
+    FOO
+    @enumValue("bar")
+    BAR
+}
+
+@internal
+enum TraitBeforeEnum {
+    @enumValue("foo")
+    FOO
+    @enumValue("bar")
+    BAR
+}
+
+@internal()
+enum AnnotationTraitWithParens {
+    @enumValue("foo")
+    FOO
+    @enumValue("bar")
+    BAR
+}

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum.v1.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum.v1.smithy
@@ -1,0 +1,15 @@
+$version: "1.0"
+
+namespace com.example
+
+@enum([
+    {
+        name: "FOO",
+        value: "foo",
+    },
+    {
+        name: "BAR",
+        value: "bar",
+    }
+])
+string EnumString

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum.v2.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/enum.v2.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace com.example
+
+enum EnumString {
+    @enumValue("foo")
+    FOO
+    @enumValue("bar")
+    BAR
+}

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/multiple-enums.v1.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/multiple-enums.v1.smithy
@@ -1,0 +1,27 @@
+$version: "1.0"
+
+namespace com.example
+
+@enum([
+    {
+        name: "FOO",
+        value: "foo",
+    },
+    {
+        name: "BAR",
+        value: "bar",
+    }
+])
+string First
+
+@enum([
+    {
+        name: "FOO",
+        value: "foo",
+    },
+    {
+        name: "BAR",
+        value: "bar",
+    }
+])
+string Second

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/multiple-enums.v2.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/multiple-enums.v2.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace com.example
+
+enum First {
+    @enumValue("foo")
+    FOO
+    @enumValue("bar")
+    BAR
+}
+
+enum Second {
+    @enumValue("foo")
+    FOO
+    @enumValue("bar")
+    BAR
+}

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/non-convertible-enum.v1.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/non-convertible-enum.v1.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+
+namespace com.example
+
+@enum([
+    {
+        value: "\tfoo",
+    },
+    {
+        value: "\tbar",
+    }
+])
+string EnumString

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/non-convertible-enum.v2.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/non-convertible-enum.v2.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace com.example
+
+@enum([
+    {
+        value: "\tfoo",
+    },
+    {
+        value: "\tbar",
+    }
+])
+string EnumString

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/version.v1.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/version.v1.smithy
@@ -1,0 +1,3 @@
+namespace com.example
+
+string Foo

--- a/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/version.v2.smithy
+++ b/smithy-upgrade-tool/src/test/resources/software/amazon/smithy/upgrade/cases/version.v2.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+
+namespace com.example
+
+string Foo


### PR DESCRIPTION
This is a draft for a basic migration tool, to a branch dedicated for it. I don't know where the code will live in the end, but a pr here is as good as anywhere else.

In the current state, it can upgrade enums and change the version, both inline.

This is intended to be a standalone command-line tool, and there is some plumbing for that, but the actual command parts aren't yet there. The intended UI is something like:

```
$ smithy-upgrade --built-source-projection /path/to/source.json --model-dir /path/to/models
```

It does unfortunately need a built version of the model since it can't build it itself. It'd be neat if it could, but we can't rely on a particular build system. So it uses the local file for source locations, and the ast file for other stuff where needing full context is required.

An alternative to that approach would be to make this a build plugin, so that sort of thing isn't necessary. The only real downside of that is we couldn't do an in-place upgrade, but maybe that's fine?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
