### PR TITLE
chore: Expand Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Smithy CLI using latest JDK
-FROM gradle:7-jdk17 AS build
+FROM public.ecr.aws/docker/library/gradle:7-jdk17 AS build
 WORKDIR /build
 COPY . .
 
@@ -16,7 +16,7 @@ RUN ./gradlew :smithy-validation-model:jar --stacktrace
 RUN ./gradlew :smithy-cli:runtime --stacktrace
 
 # Run Smithy CLI in AL2 container
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 WORKDIR /smithy
 COPY --from=build /build/smithy-cli/build/image/smithy-cli-linux-x86_64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,45 @@
+# Build Smithy CLI using latest JDK
+FROM gradle:7-jdk17 AS build
+WORKDIR /build
+COPY . .
+
+# Generate all traits
+RUN ./gradlew :smithy-aws-apigateway-traits:jar --stacktrace
+RUN ./gradlew :smithy-aws-cloudformation-traits:jar --stacktrace
+RUN ./gradlew :smithy-aws-iam-traits:jar --stacktrace
+RUN ./gradlew :smithy-aws-traits:jar --stacktrace
+RUN ./gradlew :smithy-mqtt-traits:jar --stacktrace
+RUN ./gradlew :smithy-protocol-test-traits:jar --stacktrace
+RUN ./gradlew :smithy-validation-model:jar --stacktrace
+
+# Build the CLI
+RUN ./gradlew :smithy-cli:runtime --stacktrace
+
+# Run Smithy CLI in AL2 container
 FROM amazonlinux:2
-ADD smithy-cli/build/image/smithy-cli-linux-x86_64 /smithy
+
 WORKDIR /smithy
+COPY --from=build /build/smithy-cli/build/image/smithy-cli-linux-x86_64 .
+
+# Copy in all traits
+COPY --from=build /build/smithy-aws-apigateway-traits/build/libs/*.jar /smithy/lib/traits/
+COPY --from=build /build/smithy-aws-cloudformation-traits/build/libs/*.jar /smithy/lib/traits/
+COPY --from=build /build/smithy-aws-iam-traits/build/libs/*.jar /smithy/lib/traits/
+COPY --from=build /build/smithy-aws-traits/build/libs/*.jar /smithy/lib/traits/
+COPY --from=build /build/smithy-mqtt-traits/build/libs/*.jar /smithy/lib/traits/
+COPY --from=build /build/smithy-protocol-test-traits/build/libs/*.jar /smithy/lib/traits/
+COPY --from=build /build/smithy-validation-model/build/libs/*.jar /smithy/lib/traits/
 
 # Build application class data sharing archive using smithy validate as the baseline.
 RUN SMITHY_OPTS="-XX:DumpLoadedClassList=/smithy/lib/smithy.lst" \
     /smithy/bin/smithy validate
 RUN SMITHY_OPTS="-Xshare:dump -XX:SharedArchiveFile=/smithy/lib/smithy.jsa -XX:SharedClassListFile=/smithy/lib/smithy.lst" \
     /smithy/bin/smithy validate
+
+# Fixes UTF-8 issues in stdout
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 ENTRYPOINT [ "/smithy/bin/smithy" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ FROM public.ecr.aws/docker/library/gradle:7-jdk17 AS build
 WORKDIR /build
 COPY . .
 
-# Generate all traits
-RUN ./gradlew :smithy-aws-apigateway-traits:jar --stacktrace
-RUN ./gradlew :smithy-aws-cloudformation-traits:jar --stacktrace
-RUN ./gradlew :smithy-aws-iam-traits:jar --stacktrace
-RUN ./gradlew :smithy-aws-traits:jar --stacktrace
-RUN ./gradlew :smithy-mqtt-traits:jar --stacktrace
-RUN ./gradlew :smithy-protocol-test-traits:jar --stacktrace
-RUN ./gradlew :smithy-validation-model:jar --stacktrace
-
-# Build the CLI
-RUN ./gradlew :smithy-cli:runtime --stacktrace
+RUN \
+    # Generate all traits
+    ./gradlew :smithy-aws-apigateway-traits:jar --stacktrace && \
+    ./gradlew :smithy-aws-cloudformation-traits:jar --stacktrace && \
+    ./gradlew :smithy-aws-iam-traits:jar --stacktrace && \
+    ./gradlew :smithy-aws-traits:jar --stacktrace && \
+    ./gradlew :smithy-mqtt-traits:jar --stacktrace && \
+    ./gradlew :smithy-protocol-test-traits:jar --stacktrace && \
+    ./gradlew :smithy-validation-model:jar --stacktrace && \
+    # Build the CLI
+    ./gradlew :smithy-cli:runtime --stacktrace
 
 # Run Smithy CLI in AL2 container
 FROM public.ecr.aws/amazonlinux/amazonlinux:2


### PR DESCRIPTION
*Issue #, if available:*
The current Dockerfile expects a pre-built CLI artifact and does not bundle trait JARs.

*Description of changes:*
- Compile Smithy CLI and traits in separate Docker stage
- Include trait jars in exec stage

## Example usage

To build:

`docker build -t smithy .`

Then, given I'm in a directory with some Smithy files:

```
./main.smithy
./user.smithy
```

To print AST:

`docker run --rm -v $PWD:/models smithy ast -d /smithy/lib/traits /models`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
