### PR TITLE
Add support for conditions and loops to AbstractCodeWriter

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
@@ -31,13 +31,13 @@ import java.util.regex.Pattern;
 /**
  * Helper class for generating code.
  *
- * <p>A CodeWriter can be used to write basically any kind of code, including
+ * <p>An AbstractCodeWriter can be used to write basically any kind of code, including
  * whitespace sensitive and brace-based.
  *
  * <p>The following example generates some Python code:
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter writer = new SimpleCodeWriter();
  * writer.write("def Foo(str):")
  *       .indent()
  *       .write("print str");
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
  * {@code write}:
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.write("Hello, $L", "there!");
  * String code = writer.toString();
  * }</pre>
@@ -60,7 +60,7 @@ import java.util.regex.Pattern;
  * <p>In the above example, {@code $L} is interpolated and replaced with the
  * relative argument {@code there!}.
  *
- * <p>A CodeWriter supports three kinds of interpolations: relative,
+ * <p>An AbstractCodeWriter supports three kinds of interpolations: relative,
  * positional, and named. Each of these kinds of interpolations pass a value
  * to a <em>formatter</em>.</p>
  *
@@ -68,7 +68,7 @@ import java.util.regex.Pattern;
  *
  * <p>Formatters are named functions that accept an object as input, accepts a
  * string that contains the current indentation (it can be ignored if not useful),
- * and returns a string as output. The {@code CodeWriter} registers two built-in
+ * and returns a string as output. {@code AbstractCodeWriter} registers two built-in
  * formatters:
  *
  * <ul>
@@ -80,14 +80,14 @@ import java.util.regex.Pattern;
  *     result of calling {@link String#valueOf}.</li>
  *
  *     <li>{@code C} (call): Runs a {@link Runnable} or {@link Consumer} argument
- *     that is expected to write to the same writer. Any text written to the CodeWriter
+ *     that is expected to write to the same writer. Any text written to the AbstractCodeWriter
  *     inside of the Runnable is used as the value of the argument. Note that a
  *     single trailing newline is removed from the captured text. If a Runnable is
- *     provided, it is required to have a reference to the CodeWriter. A Consumer
- *     is provided a reference to the CodeWriter as a single argument.
+ *     provided, it is required to have a reference to the AbstractCodeWriter. A Consumer
+ *     is provided a reference to the AbstractCodeWriter as a single argument.
  *
  *     <pre>{@code
- *     CodeWriter writer = new CodeWriter();
+ *     SimpleCodeWriter writer = new SimpleCodeWriter();
  *     writer.write("Hello, $C.", () -> writer.write("there"));
  *     assert(writer.toString().equals("Hello, there.\n"));
  *     }</pre></li>
@@ -103,7 +103,7 @@ import java.util.regex.Pattern;
  * <p>Custom formatters can be registered using {@link #putFormatter}. Custom
  * formatters can be used only within the state they were added. Because states
  * inherit the formatters of parent states, adding a formatter to the root state
- * of the CodeWriter allows the formatter to be used in any state.
+ * of the AbstractCodeWriter allows the formatter to be used in any state.
  *
  * <p>The identifier given to a formatter must match one of the following
  * characters:
@@ -122,7 +122,7 @@ import java.util.regex.Pattern;
  * interpolates the first positional argument, the second the second, etc.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.write("$L $L $L", "a", "b", "c");
  * System.out.println(writer.toString());
  * // Outputs: "a b c"
@@ -138,7 +138,7 @@ import java.util.regex.Pattern;
  * number refers to the 1-based index of the argument to interpolate.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.write("$1L $2L $3L, $3L $2L $1L", "a", "b", "c");
  * System.out.println(writer.toString());
  * // Outputs: "a b c c b a"
@@ -156,7 +156,7 @@ import java.util.regex.Pattern;
  * {@code <formatter>} is the name of a formatter.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.putContext("foo", "a");
  * writer.putContext("baz.bar", "b");
  * writer.write("$foo:L $baz.bar:L");
@@ -169,7 +169,7 @@ import java.util.regex.Pattern;
  * <p>You can escape the "$" character using two "$$".
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter().write("$$L");
+ * SimpleCodeWriter = new SimpleCodeWriter().write("$$L");
  * System.out.println(writer.toString());
  * // Outputs: "$L"
  * }</pre>
@@ -179,13 +179,13 @@ import java.util.regex.Pattern;
  * <p>The character used to start a code block expression can be customized
  * to make it easier to write code that makes heavy use of {@code $}. The
  * default character used to start an expression is, {@code $}, but this can
- * be changed for the current state of the CodeWriter by calling
+ * be changed for the current state of the AbstractCodeWriter by calling
  * {@link #setExpressionStart(char)}. A custom start character can be escaped
  * using two start characters in a row. For example, given a custom start
  * character of {@code #}, {@code #} can be escaped using {@code ##}.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.setExpressionStart('#');
  * writer.write("#L ##L $L", "hi");
  * System.out.println(writer.toString());
@@ -196,7 +196,7 @@ import java.util.regex.Pattern;
  *
  * <h2>Opening and closing blocks</h2>
  *
- * <p>{@code CodeWriter} provides a short cut for opening code blocks that
+ * <p>{@code AbstractCodeWriter} provides a short cut for opening code blocks that
  * have an opening an closing delimiter (for example, "{" and "}") and that
  * require indentation inside of the delimiters. Calling {@link #openBlock}
  * and providing the opening statement will write and format a line followed
@@ -204,7 +204,7 @@ import java.util.regex.Pattern;
  * then print a formatted statement.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter()
+ * SimpleCodeWriter = new SimpleCodeWriter()
  *       .openBlock("if ($L) {", someValue)
  *       .write("System.out.println($S);", "Hello!")
  *       .closeBlock("}");
@@ -220,22 +220,22 @@ import java.util.regex.Pattern;
  *
  * <h2>Pushing and popping state</h2>
  *
- * <p>The CodeWriter can maintain a stack of transformation states, including
+ * <p>AbstractCodeWriter can maintain a stack of transformation states, including
  * the text used to indent, a prefix to add before each line, newline character,
  * the number of times to indent, a map of context values, whether or not
  * whitespace is trimmed from the end of newlines, whether or not the automatic
  * insertion of newlines is disabled, the character used to start code
  * expressions (defaults to {@code $}), and formatters. State can be pushed onto
  * the stack using {@link #pushState} which copies the current state. Mutations
- * can then be made to the top-most state of the CodeWriter and do not affect
- * previous states. The previous transformation state of the CodeWriter can later
+ * can then be made to the top-most state of the AbstractCodeWriter and do not affect
+ * previous states. The previous transformation state of the AbstractCodeWriter can later
  * be restored using {@link #popState}.
  *
- * <p>The CodeWriter is stateful, and a prefix can be added before each line.
+ * <p>AbstractCodeWriter is stateful, and a prefix can be added before each line.
  * This is useful for doing things like create Javadoc strings:
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer
  *       .pushState()
  *       .write("/**")
@@ -260,21 +260,21 @@ import java.util.regex.Pattern;
  *   ^ Minus this escape character
  * }</pre>
  *
- * <p>The CodeWriter maintains some global state that is not affected by
+ * <p>AbstractCodeWriter maintains some global state that is not affected by
  * {@link #pushState} and {@link #popState}:
  *
  * <ul>
  *     <li>The number of successive blank lines to trim.</li>
  *     <li>Whether or not a trailing newline is inserted or removed from
- *     the result of converting the {@code CodeWriter} to a string.</li>
+ *     the result of converting the {@code AbstractCodeWriter} to a string.</li>
  * </ul>
  *
  * <h2>Limiting blank lines</h2>
  *
  * <p>Many coding standards recommend limiting the number of successive blank
- * lines. This can be handled automatically by {@code CodeWriter} by calling
+ * lines. This can be handled automatically by {@code AbstractCodeWriter} by calling
  * {@link #trimBlankLines}. The removal of blank lines is handled when the
- * {@code CodeWriter} is converted to a string. Lines that consist solely
+ * {@code AbstractCodeWriter} is converted to a string. Lines that consist solely
  * of spaces or tabs are considered blank. If the number of blank lines
  * exceeds the allowed threshold, they are omitted from the result.
  *
@@ -286,20 +286,20 @@ import java.util.regex.Pattern;
  * <p>In the following example:
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * String result = writer.trimTrailingSpaces().write("hello  ").toString();
  * }</pre>
  *
  * <p>The value of {@code result} contains {@code "hello"}
  *
- * <h2>Extending CodeWriter</h2>
+ * <h2>Extending AbstractCodeWriter</h2>
  *
- * <p>{@code CodeWriter} can be extended to add functionality for specific
+ * <p>{@code AbstractCodeWriter} can be extended to add functionality for specific
  * programming languages. For example, Java specific code generator could
  * be implemented that makes it easier to write Javadocs.
  *
  * <pre>{@code
- * class JavaCodeWriter extends CodeWriter {
+ * class JavaCodeWriter extends AbstractCodeWriter<JavaCodeWriter> {
  *     public JavaCodeWriter javadoc(Runnable runnable) {
  *         pushState()
  *         write("/**")
@@ -321,7 +321,7 @@ import java.util.regex.Pattern;
  *
  * <p>Named sections can be marked in the code writer that can be intercepted
  * and modified by <em>section interceptors</em>. This gives the
- * {@code CodeWriter} a lightweight extension system for augmenting generated
+ * {@code AbstractCodeWriter} a lightweight extension system for augmenting generated
  * code.
  *
  * <p>A section of code can be captured using a block state or an inline
@@ -335,14 +335,14 @@ import java.util.regex.Pattern;
  * inside of this state to an internal buffer. This buffer is then passed to
  * each registered interceptor for that name. These interceptors can choose
  * to use the default contents of the section or emit entirely different
- * content. Interceptors are expected to make calls to the {@code CodeWriter}
+ * content. Interceptors are expected to make calls to the {@code AbstractCodeWriter}
  * in order to emit content. Interceptors need to have a reference to the
- * {@code CodeWriter} as one is not provided to them when they are invoked.
+ * {@code AbstractCodeWriter} as one is not provided to them when they are invoked.
  * Interceptors are invoked in the order in which they are added to the
  * {@code CodeBuilder}.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.onSection("example", text -> writer.write("Intercepted: " + text));
  * writer.pushState("example");
  * writer.write("Original contents");
@@ -356,27 +356,27 @@ import java.util.regex.Pattern;
  * An inline section is created using a special {@code CodeWriter} interpolation
  * format that appends "@" followed by the section name. Inline sections are
  * function just like block sections, but they can appear inline inside of
- * other content passed in calls to {@link CodeWriter#write}. An inline section
- * that makes no calls to {@link CodeWriter#write} expands to an empty string.
+ * other content passed in calls to {@link AbstractCodeWriter#write}. An inline section
+ * that makes no calls to {@link AbstractCodeWriter#write} expands to an empty string.
  *
  * <p>Inline sections are created in a format string inside of braced arguments
  * after the formatter. For example, <code>${L@foo}</code> is an inline section
  * that uses the literal "L" value of a relative argument as the default value
- * of the section and allows interceptors registered for the "foo" section to
+ * of the section and allows AbstractCodeWriter registered for the "foo" section to
  * make calls to the {@code CodeWriter} to modify the section.
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.onSection("example", text -> writer.write("Intercepted: " + text));
  * writer.write("Leading text...${L@example}...Trailing text...", "foo");
  * System.out.println(writer.toString());
  * // Outputs: "Leading text...Intercepted: foo...Trailing text...\n"
  * }</pre>
  *
- * Inline sections are useful for composing sets or lists from any code with access to {@code CodeWriter}:
+ * Inline sections are useful for composing sets or lists from any code with access to {@code AbstractCodeWriter}:
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.onSection("example", text -> writer.write(text + "1, "));
  * writer.onSection("example", text -> writer.write(text + "2, "));
  * writer.onSection("example", text -> writer.write(text + "3"));
@@ -394,7 +394,7 @@ import java.util.regex.Pattern;
  * the closing '}' character with '|' (e.g., <code>${L|}</code>):
  *
  * <pre>{@code
- * CodeWriter writer = new CodeWriter();
+ * SimpleCodeWriter = new SimpleCodeWriter();
  * writer.write("$L: ${L|}", "Names", "Bob\nKaren\nLuis");
  * System.out.println(writer.toString());
  * // Outputs: "Names: Bob\n       Karen\n       Luis\n"
@@ -426,6 +426,142 @@ import java.util.regex.Pattern;
  *     handleA,
  *     handleB);
  * }</pre>
+ *
+ * <h3>Template conditionals and loops</h3>
+ *
+ * <p>AbstractCodeWriter is a lightweight template engine that supports conditional
+ * blocks and loops.
+ *
+ * <h4>Conditional blocks</h4>
+ *
+ * <p>Conditional blocks are defined using the following syntax:
+ *
+ * <pre>{@code
+ * ${?foo}
+ * Foo is set: ${foo:L}
+ * ${/foo}
+ * }</pre>
+ *
+ * <p>Assuming {@code foo} is truthy and set to "hi", then the above template
+ * outputs: "Foo is set: hi"
+ *
+ * <p>In the above example, "?" indicates that the expression is a conditional block
+ * to check if the named parameter "foo" is truthy. If it is, then the contents of the
+ * block up to the matching closing block, {@code ${/foo}}, are evaluated. If the
+ * condition is not satisfied, then contents of the block are skipped.
+ *
+ * <p>You can check if a named property is falsey using "^":
+ *
+ * <pre>{@code
+ * ${^foo}
+ * Foo is not set
+ * ${/foo}
+ * }</pre>
+ *
+ * <p>Assuming {@code foo} is set to "hi", then the above template outputs nothing.
+ * If {@code foo} is falsey, then the above template output "Foo is not set".
+ *
+ * <h4>Truthy and falsey</h4>
+ *
+ * <p>The following values are considered falsey:
+ *
+ * <ul>
+ *     <li>values that are not found</li>
+ *     <li>null values</li>
+ *     <li>false</li>
+ *     <li>empty {@link String}</li>
+ *     <li>empty {@link Iterable}</li>
+ *     <li>empty {@link Map}</li>
+ *     <li>empty {@link Optional}</li>
+ * </ul>
+ *
+ * <p>Values that are not falsey are considered truthy.
+ *
+ * <h4>Loops</h4>
+ *
+ * <p>Loops can be created to repeat a section of a template for each key value pair
+ * stored in a named property. Loops are created using "#".
+ *
+ * <p>The following template with a "foo" value of ["a", "b", "c"]:
+ *
+ * <pre>{@code
+ * ${#foo}
+ * - ${key:L}: ${value:L} (first: ${key.first:L}, last: ${key.last:L})
+ * ${/foo}
+ * }</pre>
+ *
+ * <p>Evaluates to:</p>
+ *
+ * <pre>{@code
+ * - 0: a (first: true, last: false)
+ * - 1: b (first: false, last: false)
+ * - 2: c (first: false, last: true)
+ * }</pre>
+ *
+ * <p>Each iteration of the loop pushes a new state in the writer that sets the following
+ * context properties:
+ *
+ * <ul>
+ *     <li>key: contains the current index of the loop or the current key of a map entry</li>
+ *     <li>value: contains the current value of the iterator or current value of a map entry</li>
+ *     <li>key.first: set to true if the loop is on the first value</li>
+ *     <li>key.false: set to true if the loop is on the last value</li>
+ * </ul>
+ *
+ * <p>A custom variable name can be used in loops. For example:
+ *
+ * <pre>{@code
+ * ${#foo as key1, value1}
+ *     - ${key1:L}: ${value1:L} (first: ${key1.first:L}, last: ${key1.last:L})
+ * ${/foo}
+ * }</pre>
+ *
+ * <h4>Whitespace control</h4>
+ *
+ * <p>Conditional blocks that occur on lines that only contain whitespace are not written
+ * to the template output. For example, if the condition in the following template evaluates
+ * to falsey, then the template expands to nothing:
+ *
+ * <pre>{@code
+ * ${?foo}
+ * Foo is set: ${foo:L}
+ * ${/foo}
+ * }</pre>
+ *
+ * <p>Whitespace that comes before an expression removed by putting "~" at the beginning of an expression.
+ *
+ * <p>Assuming that the first positional argument is "hi":
+ *
+ * <pre>{@code
+ * Greeting:
+ *     ${~L}
+ * }</pre>
+ *
+ * <p>Expands to:
+ *
+ * <pre>{@code
+ * Greeting:hi
+ * }</pre>
+ *
+ * <p>Whitespace that comes after an expression can be removed by adding "~" to the end of the expression:
+ *
+ * <pre>{@code
+ * ${L~}
+ *
+ * .
+ * }</pre>
+ *
+ * <p>Expands to:
+ *
+ * <pre>{@code
+ * hi.
+ * }</pre>
+ *
+ * <p>Leading whitespace cannot be removed when using inline block alignment ('|'). The following is invalid:
+ *
+ * <pre>{@code
+ * ${~C|}
+ * }</pre>
  */
 public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
 
@@ -440,7 +576,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     private int trimBlankLines = -1;
 
     /**
-     * Creates a new CodeWriter that uses "\n" for a newline, four spaces
+     * Creates a new SimpleCodeWriter that uses "\n" for a newline, four spaces
      * for indentation, does not strip trailing whitespace, does not flatten
      * multiple successive blank lines into a single blank line, and adds no
      * trailing new line.
@@ -455,24 +591,24 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Copies settings from the given CodeWriter into this CodeWriter.
+     * Copies settings from the given AbstractCodeWriter into this AbstractCodeWriter.
      *
-     * <p>The settings of the {@code other} CodeWriter will overwrite
-     * both global and state-based settings of this CodeWriter. Formatters of
-     * the {@code other} CodeWriter will be merged with the formatters of this
-     * CodeWriter, and in the case of conflicts, the formatters of the
+     * <p>The settings of the {@code other} AbstractCodeWriter will overwrite
+     * both global and state-based settings of this AbstractCodeWriter. Formatters of
+     * the {@code other} AbstractCodeWriter will be merged with the formatters of this
+     * AbstractCodeWriter, and in the case of conflicts, the formatters of the
      * {@code other} will take precedence.
      *
-     * <p>Stateful settings of the {@code other} CodeWriter are copied into
-     * the <em>current</em> state of this CodeWriter. Only the settings of
+     * <p>Stateful settings of the {@code other} AbstractCodeWriter are copied into
+     * the <em>current</em> state of this AbstractCodeWriter. Only the settings of
      * the top-most state is copied. Other states, and the contents of the
      * top-most state are not copied.
      *
      * <pre>{@code
-     * CodeWriter a = new CodeWriter();
+     * SimpleCodeWritera = new SimpleCodeWriter();
      * a.setExpressionStart('#');
      *
-     * CodeWriter b = new CodeWriter();
+     * SimpleCodeWriterb = new SimpleCodeWriter();
      * b.copySettingsFrom(a);
      *
      * assert(b.getExpressionStart() == '#');
@@ -519,7 +655,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
 
     /**
      * Adds a custom formatter expression to the current state of the
-     * {@code CodeWriter}.
+     * {@code AbstractCodeWriter}.
      *
      * <p>The provided {@code identifier} string must match the following ABNF:
      *
@@ -534,7 +670,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param formatFunction Formatter function that formats the given object as a String.
      *                       The formatter is give the value to format as an object
      *                       (use .toString to access the string contents) and the
-     *                       current indentation string of the CodeWriter.
+     *                       current indentation string of the AbstractCodeWriter.
      * @return Returns self.
      */
     @SuppressWarnings("unchecked")
@@ -550,8 +686,8 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * <p>By default, {@code $} is used to start expressions (for example
      * {@code $L}. However, some programming languages frequently give
      * syntactic meaning to {@code $}, making this an inconvenient syntactic
-     * character for the CodeWriter. In these cases, the character used to
-     * start a CodeWriter expression can be changed. Just like {@code $}, the
+     * character for the AbstractCodeWriter. In these cases, the character used to
+     * start a AbstractCodeWriter expression can be changed. Just like {@code $}, the
      * custom start character can be escaped using two subsequent start
      * characters (e.g., {@code $$}).
      *
@@ -584,7 +720,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     /**
      * Gets the contents of the generated code.
      *
-     * <p>The result will have an appended newline if the CodeWriter is
+     * <p>The result will have an appended newline if the AbstractCodeWriter is
      * configured to always append a newline. A newline is only appended
      * in these cases if the result does not already end with a newline.
      *
@@ -616,7 +752,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
             return trailingNewline ? currentState.newline : "";
         }
 
-        // This accounts for cases where the only write on the CodeWriter was
+        // This accounts for cases where the only write on the AbstractCodeWriter was
         // an inline write, but the write ended with spaces.
         if (currentState.trimTrailingSpaces) {
             result = StringUtils.stripEnd(result, " ");
@@ -637,10 +773,10 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * Copies and pushes the current state to the state stack.
      *
      * <p>This method is used to prepare for a corresponding {@link #popState}
-     * operation later. It stores the current state of the CodeWriter into a
+     * operation later. It stores the current state of the AbstractCodeWriter into a
      * stack and keeps it active. After pushing, mutations can be made to the
-     * state of the CodeWriter without affecting the previous state on the
-     * stack. Changes to the state of the CodeWriter can be undone by using
+     * state of the AbstractCodeWriter without affecting the previous state on the
+     * stack. Changes to the state of the AbstractCodeWriter can be undone by using
      * {@link #popState()}, which Returns self state to the state
      * it was in before calling {@code pushState}.
      *
@@ -660,9 +796,9 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      *
      * <p>The text written while in this state is buffered and passed to each
      * state interceptor. If no text is written by the section or an
-     * interceptor, nothing is changed on the {@code CodeWriter}. This
+     * interceptor, nothing is changed on the {@code AbstractCodeWriter}. This
      * behavior allows for placeholder sections to be added into
-     * {@code CodeWriter} generators in order to provide extension points
+     * {@code AbstractCodeWriter} generators in order to provide extension points
      * that can be otherwise empty.
      *
      * @param sectionName Name of the section to set on the state.
@@ -703,7 +839,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
 
     /**
      * Gets the debug path to the current state so that errors encountered while
-     * using CodeWriter are easier to track down.
+     * using AbstractCodeWriter are easier to track down.
      *
      * <p>For example, if state "Foo" is entered, and then an unnamed state is
      * entered, the return value is "ROOT/Foo/UNNAMED".
@@ -720,11 +856,11 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Gets debug information about the current state of the CodeWriter, including
+     * Gets debug information about the current state of the AbstractCodeWriter, including
      * the path to the current state as returned by {@link #getStateDebugPath()},
-     * and up to the last two lines of text written to the CodeWriter.
+     * and up to the last two lines of text written to the AbstractCodeWriter.
      *
-     * <p>This debug information is used in most exceptions thrown by CodeWriter to
+     * <p>This debug information is used in most exceptions thrown by AbstractCodeWriter to
      * provide additional context when something goes wrong. It can also be used
      * by subclasses and collaborators to aid in debugging codegen issues.
      *
@@ -736,7 +872,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Gets debug information about the current state of the CodeWriter.
+     * Gets debug information about the current state of the AbstractCodeWriter.
      *
      * <p>This method can be overridden in order to add more metadata to the created
      * debug info object.
@@ -746,8 +882,8 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @see #getDebugInfo
      */
     public CodeWriterDebugInfo getDebugInfo(int numberOfContextLines) {
-        // Implementer's note: a snapshot of CodeWriter is used rather than just
-        // querying data from CodeWriter from within CodeWriterDebugInfo each time
+        // Implementer's note: a snapshot of AbstractCodeWriter is used rather than just
+        // querying data from AbstractCodeWriter from within CodeWriterDebugInfo each time
         // toString is called on it. This ensures that debug info is immutable, at
         // least in terms of the state path and the most recent lines written.
         CodeWriterDebugInfo info = new CodeWriterDebugInfo();
@@ -790,10 +926,10 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Pops the current CodeWriter state from the state stack.
+     * Pops the current AbstractCodeWriter state from the state stack.
      *
      * <p>This method is used to reverse a previous {@link #pushState}
-     * operation. It configures the current CodeWriter state to what it was
+     * operation. It configures the current AbstractCodeWriter state to what it was
      * before the last preceding {@code pushState} call.
      *
      * @return Returns self.
@@ -802,7 +938,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     @SuppressWarnings("unchecked")
     public T popState() {
         if (states.size() == 1) {
-            throw new IllegalStateException("Cannot pop CodeWriter state because at the root state");
+            throw new IllegalStateException("Cannot pop writer state because at the root state");
         }
 
         State popped = states.pop();
@@ -849,21 +985,21 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
 
     /**
      * Registers a function that intercepts the contents of a section and
-     * writes to the {@code CodeWriter} with the updated contents.
+     * writes to the {@code AbstractCodeWriter} with the updated contents.
      *
      * <p>The {@code interceptor} function is expected to have a reference to
-     * the {@code CodeWriter} and to mutate it when they are invoked. Each
+     * the {@code AbstractCodeWriter} and to mutate it when they are invoked. Each
      * interceptor is invoked in their own isolated pushed/popped states.
      *
      * <p>The text provided to {@code interceptor} does not contain a trailing
      * new line. A trailing new line is expected to be injected automatically
      * when the results of intercepting the contents are written to the
-     * {@code CodeWriter}. A result is only written if the interceptors write
+     * {@code AbstractCodeWriter}. A result is only written if the interceptors write
      * a non-null, non-empty string, allowing for empty placeholders to be
      * added that don't affect the resulting layout of the code.
      *
      * <pre>{@code
-     * CodeWriter writer = new CodeWriter();
+     * SimpleCodeWriter = new SimpleCodeWriter();
      *
      * // Prepend text to a section named "foo".
      * writer.onSectionPrepend("foo", () -> writer.write("A"));
@@ -907,9 +1043,9 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * using {@link #removeTrailingNewline(String)}.
      *
      * <pre>{@code
-     * CodeWriter writer = new CodeWriter();
+     * SimpleCodeWriter = new SimpleCodeWriter();
      *
-     * CodeInterceptor<CodeSection, CodeWriter> interceptor = CodeInterceptor.forName(sectionName, (w, p) -> {
+     * CodeInterceptor<CodeSection, SimpleCodeWriter> interceptor = CodeInterceptor.forName(sectionName, (w, p) -> {
      *     String trimmedContent = removeTrailingNewline(p);
      *     interceptor.accept(trimmedContent);
      * })
@@ -934,15 +1070,15 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * Intercepts a section of code emitted for a strongly typed {@link CodeSection}.
      *
      * <p>These section interceptors provide a kind of event-based hook system for
-     * CodeWriters that add extension points when generating code. The function has
+     * AbstractCodeWriters that add extension points when generating code. The function has
      * the ability to completely ignore the original contents of the section, to
      * prepend text to it, and append text to it. Intercepting functions are
-     * expected to have a reference to the {@code CodeWriter} and to mutate it
+     * expected to have a reference to the {@code AbstractCodeWriter} and to mutate it
      * when they are invoked. Each interceptor is invoked in their own
      * isolated pushed/popped states.
      *
      * <p>Interceptors are registered on the current state of the
-     * {@code CodeWriter}. When the state to which an interceptor is registered
+     * {@code AbstractCodeWriter}. When the state to which an interceptor is registered
      * is popped, the interceptor is no longer in scope.
      *
      * @param interceptor A consumer that takes the writer and strongly typed section.
@@ -1105,7 +1241,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
 
     /**
      * Returns the number of allowed consecutive newlines that are not
-     * trimmed by the CodeWriter when written to a string.
+     * trimmed by the AbstractCodeWriter when written to a string.
      *
      * @return Returns the number of allowed consecutive newlines. -1 means
      *   that no newlines are trimmed. 0 allows no blank lines. 1 or more
@@ -1116,7 +1252,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Configures the CodeWriter to always append a newline at the end of
+     * Configures the AbstractCodeWriter to always append a newline at the end of
      * the text if one is not already present.
      *
      * <p>This setting is not captured as part of push/popState.
@@ -1128,7 +1264,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Configures the CodeWriter to always append a newline at the end of
+     * Configures the AbstractCodeWriter to always append a newline at the end of
      * the text if one is not already present.
      *
      * <p>This setting is not captured as part of push/popState.
@@ -1144,7 +1280,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Checks if the CodeWriter inserts a trailing newline (if necessary) when
+     * Checks if the AbstractCodeWriter inserts a trailing newline (if necessary) when
      * converted to a string.
      *
      * @return The newline behavior (true to insert a trailing newline).
@@ -1236,7 +1372,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      *
      * <pre>
      * {@code
-     * String result = new CodeWriter()
+     * String result = new SimpleCodeWriter()
      *         .openBlock("public final class $L {", "Foo")
      *             .openBlock("public void main(String[] args) {")
      *                 .write("System.out.println(args[0]);")
@@ -1248,7 +1384,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      *
      * @param textBeforeNewline Text to write before writing a newline and indenting.
      * @param args String arguments to use for formatting.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, Object... args) {
         return write(textBeforeNewline, args).indent();
@@ -1260,7 +1396,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * syntax by writing a newline, dedenting, then writing {@code textAfterNewline}.
      *
      * <pre>{@code
-     * CodeWriter writer = new CodeWriter();
+     * SimpleCodeWriter = new SimpleCodeWriter();
      * writer.openBlock("public final class $L {", "}", "Foo", () -> {
      *     writer.openBlock("public void main(String[] args) {", "}", () -> {
      *         writer.write("System.out.println(args[0]);");
@@ -1271,7 +1407,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param textBeforeNewline Text to write before writing a newline and indenting.
      * @param textAfterNewline Text to write after writing a newline and indenting.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, String textAfterNewline, Runnable f) {
         return openBlock(textBeforeNewline, textAfterNewline, new Object[]{}, f);
@@ -1286,7 +1422,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param textAfterNewline Text to write after writing a newline and indenting.
      * @param arg1 First positional argument to substitute into {@code textBeforeNewline}.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, String textAfterNewline, Object arg1, Runnable f) {
         return openBlock(textBeforeNewline, textAfterNewline, new Object[]{arg1}, f);
@@ -1302,7 +1438,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param arg1 First positional argument to substitute into {@code textBeforeNewline}.
      * @param arg2 Second positional argument to substitute into {@code textBeforeNewline}.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, String textAfterNewline,
                        Object arg1, Object arg2, Runnable f) {
@@ -1320,7 +1456,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param arg2 Second positional argument to substitute into {@code textBeforeNewline}.
      * @param arg3 Third positional argument to substitute into {@code textBeforeNewline}.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, String textAfterNewline,
                        Object arg1, Object arg2, Object arg3, Runnable f) {
@@ -1339,7 +1475,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param arg3 Third positional argument to substitute into {@code textBeforeNewline}.
      * @param arg4 Fourth positional argument to substitute into {@code textBeforeNewline}.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, String textAfterNewline,
                        Object arg1, Object arg2, Object arg3, Object arg4, Runnable f) {
@@ -1359,7 +1495,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param arg4 Fourth positional argument to substitute into {@code textBeforeNewline}.
      * @param arg5 Fifth positional argument to substitute into {@code textBeforeNewline}.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T openBlock(String textBeforeNewline, String textAfterNewline,
                        Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Runnable f) {
@@ -1375,7 +1511,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * @param textAfterNewline Text to write after writing a newline and indenting.
      * @param args Arguments to substitute into {@code textBeforeNewline}.
      * @param f Runnable function to execute inside of the block.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     @SuppressWarnings("unchecked")
     public T openBlock(String textBeforeNewline, String textAfterNewline, Object[] args, Runnable f) {
@@ -1390,14 +1526,14 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      *
      * @param textAfterNewline Text to write after writing a newline and dedenting.
      * @param args String arguments to use for formatting.
-     * @return Returns the {@code CodeWriter}.
+     * @return Returns this.
      */
     public T closeBlock(String textAfterNewline, Object... args) {
         return dedent().write(textAfterNewline, args);
     }
 
     /**
-     * Writes text to the CodeWriter and appends a newline.
+     * Writes text to the AbstractCodeWriter and appends a newline.
      *
      * <p>The provided text does not use any kind of expression formatting.
      *
@@ -1414,7 +1550,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Writes inline text to the CodeWriter with no formatting.
+     * Writes inline text to the AbstractCodeWriter with no formatting.
      *
      * <p>The provided text does not use any kind of expression formatting.
      * Indentation and the newline prefix is only prepended if the writer's
@@ -1434,16 +1570,16 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * arguments.
      *
      * <p>Important: if the formatters that are executed while formatting the
-     * given {@code content} string mutate the CodeWriter, it could leave the
-     * CodeWriter in an inconsistent state. For example, some CodeWriter
+     * given {@code content} string mutate the AbstractCodeWriter, it could leave the
+     * SimpleCodeWriterin an inconsistent state. For example, some AbstractCodeWriter
      * implementations manage imports and dependencies automatically based on
      * code that is referenced by formatters. If such an expression is used
      * with this format method but the returned String is never written to the
-     * CodeWriter, then the CodeWriter might be mutated to track dependencies
+     * AbstractCodeWriter, then the AbstractCodeWriter might be mutated to track dependencies
      * that aren't actually necessary.
      *
      * <pre>{@code
-     * CodeWriter writer = new CodeWriter();
+     * SimpleCodeWriter = new SimpleCodeWriter();
      * String name = "Person";
      * String formatted = writer.format("Hello, $L", name);
      * assert(formatted.equals("Hello, Person"));
@@ -1490,7 +1626,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * conditional writes without breaking method chaining.
      *
      * @param task Method to invoke.
-     * @return Returns the CodeWriter.
+     * @return Returns this.
      */
     @SuppressWarnings("unchecked")
     public T call(Runnable task) {
@@ -1499,7 +1635,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Writes text to the CodeWriter and appends a newline.
+     * Writes text to the AbstractCodeWriter and appends a newline.
      *
      * <p>The provided text is automatically formatted using variadic
      * arguments.
@@ -1519,7 +1655,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Writes text to the CodeWriter without appending a newline.
+     * Writes text to the AbstractCodeWriter without appending a newline.
      *
      * <p>The provided text is automatically formatted using variadic
      * arguments.
@@ -1560,7 +1696,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Optionally writes text to the CodeWriter and appends a newline
+     * Optionally writes text to the AbstractCodeWriter and appends a newline
      * if a value is present.
      *
      * <p>If the provided {@code content} value is {@code null}, nothing is
@@ -1568,7 +1704,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * {@code Optional}, nothing is written. If the result of calling
      * {@code toString} on {@code content} results in an empty string,
      * nothing is written. Finally, if the value is a non-empty string,
-     * the content is written to the {@code CodeWriter} at the current
+     * the content is written to the {@code AbstractCodeWriter} at the current
      * level of indentation, and a newline is appended.
      *
      * @param content Content to write if present.
@@ -1587,7 +1723,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     }
 
     /**
-     * Remove the most recent text written to the CodeWriter if and only
+     * Remove the most recent text written to the AbstractCodeWriter if and only
      * if the last written text is exactly equal to the given expanded
      * content string.
      *
@@ -1595,20 +1731,20 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      * trailing commas from lists of values.
      *
      * <p>For example, the following will remove ", there." from the
-     * end of the CodeWriter:
+     * end of the AbstractCodeWriter:
      *
      * <pre>{@code
-     * CodeWriter writer = new CodeWriter();
+     * SimpleCodeWriter = new SimpleCodeWriter();
      * writer.writeInline("Hello, there.");
      * writer.unwrite(", there.");
      * assert(writer.toString().equals("Hello\n"));
      * }</pre>
      *
      * <p>However, the following call to unwrite will do nothing because
-     * the last text written to the CodeWriter does not match:
+     * the last text written to the AbstractCodeWriter does not match:
      *
      * <pre>{@code
-     * CodeWriter writer = new CodeWriter();
+     * SimpleCodeWriter = new SimpleCodeWriter();
      * writer.writeInline("Hello.");
      * writer.unwrite("there.");
      * assert(writer.toString().equals("Hello.\n"));
@@ -1774,7 +1910,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
 
         /**
          * Inline states are created when formatting text. They aren't written
-         * directly to the CodeWriter, but rather captured as part of the
+         * directly to the AbstractCodeWriter, but rather captured as part of the
          * process of expanding a template argument.
          */
         private boolean isInline;
@@ -1898,7 +2034,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
             if (levels == Integer.MIN_VALUE) {
                 indentation = 0;
             } else if (levels + indentation < 0) {
-                throw new IllegalStateException(String.format("Cannot dedent CodeWriter %d levels", levels));
+                throw new IllegalStateException(String.format("Cannot dedent writer %d levels", levels));
             } else {
                 indentation += levels;
             }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
@@ -479,10 +479,10 @@ import java.util.regex.Pattern;
  *
  * <h4>Loops</h4>
  *
- * <p>Loops can be created to repeat a section of a template for each key value pair
- * stored in a named property. Loops are created using "#".
+ * <p>Loops can be created to repeat a section of a template for each value stored in
+ * a list or each each key value pair stored in a map. Loops are created using "#".
  *
- * <p>The following template with a "foo" value of ["a", "b", "c"]:
+ * <p>The following template with a "foo" value of {"key1": "a", "key2": "b", "key3": "c"}:
  *
  * <pre>{@code
  * ${#foo}
@@ -493,19 +493,19 @@ import java.util.regex.Pattern;
  * <p>Evaluates to:</p>
  *
  * <pre>{@code
- * - 0: a (first: true, last: false)
- * - 1: b (first: false, last: false)
- * - 2: c (first: false, last: true)
+ * - key1: a (first: true, last: false)
+ * - key2: b (first: false, last: false)
+ * - key3: c (first: false, last: true)
  * }</pre>
  *
  * <p>Each iteration of the loop pushes a new state in the writer that sets the following
  * context properties:
  *
  * <ul>
- *     <li>key: contains the current index of the loop or the current key of a map entry</li>
- *     <li>value: contains the current value of the iterator or current value of a map entry</li>
- *     <li>key.first: set to true if the loop is on the first value</li>
- *     <li>key.false: set to true if the loop is on the last value</li>
+ *     <li>key: contains the current 0-based index of an iterator or the current key of a map entry</li>
+ *     <li>value: contains the current value of an iterator or current value of a map entry</li>
+ *     <li>key.first: set to true if the loop is on the first iteration</li>
+ *     <li>key.false: set to true if the loop is on the last iteration</li>
  * </ul>
  *
  * <p>A custom variable name can be used in loops. For example:
@@ -520,7 +520,7 @@ import java.util.regex.Pattern;
  *
  * <p>Conditional blocks that occur on lines that only contain whitespace are not written
  * to the template output. For example, if the condition in the following template evaluates
- * to falsey, then the template expands to nothing:
+ * to falsey, then the template expands to an empty string:
  *
  * <pre>{@code
  * ${?foo}
@@ -528,7 +528,7 @@ import java.util.regex.Pattern;
  * ${/foo}
  * }</pre>
  *
- * <p>Whitespace that comes before an expression removed by putting "~" at the beginning of an expression.
+ * <p>Whitespace that comes before an expression can be removed by putting "~" at the beginning of an expression.
  *
  * <p>Assuming that the first positional argument is "hi":
  *

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
@@ -16,9 +16,18 @@
 package software.amazon.smithy.utils;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @SmithyInternalApi
 final class CodeFormatter {
@@ -26,42 +35,43 @@ final class CodeFormatter {
     private CodeFormatter() {}
 
     static void run(Appendable sink, AbstractCodeWriter<?> writer, String template, Object[] args) {
-        ColumnTrackingAppendable wrappedSink = new ColumnTrackingAppendable(sink);
-        List<Operation> program = new Parser(writer, template, args).parse();
         try {
-            for (Operation op : program) {
-                op.apply(wrappedSink, writer, wrappedSink.column);
-            }
+            TrackingAppendable wrappedSink = new TrackingAppendable(sink);
+            Operation block = new Parser(writer, template, args).parse();
+            block.apply(wrappedSink, writer);
         } catch (IOException e) {
             throw new RuntimeException("Error appending to CodeWriter template: " + e, e);
         }
     }
 
-    private abstract static class DecoratedAppendable implements Appendable {
+    private static class TrackingAppendable implements Appendable {
+        int column = 0;
+        private final Appendable delegate;
+
+        TrackingAppendable(Appendable delegate) {
+            this.delegate = delegate;
+        }
+
         @Override
-        public Appendable append(CharSequence csq) throws IOException {
+        public final String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public final TrackingAppendable append(CharSequence csq) throws IOException {
             return append(csq, 0, csq.length());
         }
 
         @Override
-        public Appendable append(CharSequence csq, int start, int end) throws IOException {
+        public final TrackingAppendable append(CharSequence csq, int start, int end) throws IOException {
             for (int i = start; i < end; i++) {
                 append(csq.charAt(i));
             }
             return this;
         }
-    }
-
-    private static final class ColumnTrackingAppendable extends DecoratedAppendable {
-        int column = 0;
-        private final Appendable delegate;
-
-        ColumnTrackingAppendable(Appendable delegate) {
-            this.delegate = delegate;
-        }
 
         @Override
-        public Appendable append(char c) throws IOException {
+        public TrackingAppendable append(char c) throws IOException {
             if (c == '\r' || c == '\n') {
                 column = 0;
             } else {
@@ -70,28 +80,45 @@ final class CodeFormatter {
             delegate.append(c);
             return this;
         }
+
+        public int column() {
+            return column;
+        }
     }
 
     @FunctionalInterface
     private interface Operation {
-        void apply(Appendable sink, AbstractCodeWriter<?> writer, int column) throws IOException;
+        void apply(TrackingAppendable sink, AbstractCodeWriter<?> writer) throws IOException;
 
         // Writes literal segments of the input string.
         static Operation stringSlice(String source, int start, int end) {
-            return (sink, writer, column) -> sink.append(source, start, end);
+            return (sink, writer) -> sink.append(source, start, end);
         }
 
-        // An operation that writes a resolved variable to the writer (e.g., positional arguments).
-        static Operation staticValue(String value) {
-            return (sink, writer, column) -> sink.append(value);
+        // Evaluates a formatter using the provided writer. This is done lazily because formatters
+        // should only be evaluated inside conditions that evaluate to true. This ensures that formatters
+        // with side effects don't have their side effects enacted when a condition is not evaluated.
+        static Operation formatted(
+                Function<AbstractCodeWriter<?>, Object> valueGetter,
+                char formatter,
+                Supplier<String> errorMessage
+        ) {
+            return (sink, writer) -> {
+                Object value = valueGetter.apply(writer);
+                String result = writer.applyFormatter(formatter, value);
+                if (result == null) {
+                    throw new RuntimeException(errorMessage.get());
+                }
+                sink.append(result);
+            };
         }
 
         // Expands inline sections.
         static Operation inlineSection(String sectionName, Operation delegate) {
-            return (sink, writer, column) -> {
+            return (sink, writer) -> {
                 // First capture the given default value.
-                StringBuilder buffer = new StringBuilder();
-                delegate.apply(buffer, writer, column);
+                TrackingAppendable buffer = new TrackingAppendable(new StringBuilder());
+                delegate.apply(buffer, writer);
                 String defaultValue = buffer.toString();
                 // Create an interceptable code section for the inline section.
                 CodeSection section = CodeSection.forName(sectionName);
@@ -108,26 +135,32 @@ final class CodeFormatter {
 
         // Used for "|". Wraps another operation and ensures newlines are properly indented.
         static Operation block(Operation delegate, String staticWhitespace) {
-            return (sink, writer, column) -> delegate.apply(
-                    new BlockAppender(sink, column, staticWhitespace), writer, column);
+            return (sink, writer) -> delegate.apply(new BlockAppender(sink, staticWhitespace), writer);
         }
     }
 
-    private static final class BlockAppender extends DecoratedAppendable {
-        private final Appendable delegate;
+    private static final class BlockAppender extends TrackingAppendable {
+        private final TrackingAppendable delegate;
         private final int spaces;
         private final String staticWhitespace;
         private boolean previousIsCarriageReturn;
         private boolean previousIsNewline;
 
-        BlockAppender(Appendable delegate, int spaces, String staticWhitespace) {
+        BlockAppender(TrackingAppendable delegate, String staticWhitespace) {
+            super(delegate);
             this.delegate = delegate;
-            this.spaces = spaces;
+            this.spaces = delegate.column();
             this.staticWhitespace = staticWhitespace;
         }
 
         @Override
-        public Appendable append(char c) throws IOException {
+        public int column() {
+            // Note: this is never called because this appended is never used as a delegate.
+            return super.column() + spaces;
+        }
+
+        @Override
+        public TrackingAppendable append(char c) throws IOException {
             if (previousIsNewline) {
                 writeSpaces();
                 previousIsNewline = false;
@@ -159,6 +192,143 @@ final class CodeFormatter {
         }
     }
 
+    /**
+     * ParseBlocks are used to track the state of a template. When a condition or loop is parsed,
+     * it pushes a new ParseBlock. Any operations that need to be performed in that pushed block
+     * are tracked within the block and only executed if the block is valid, or executed N times
+     * for the value of a loop.
+     */
+    private abstract static class ParseBlock implements Operation {
+        private final String variable;
+
+        ParseBlock(String variable) {
+            this.variable = variable;
+        }
+
+        final String variable() {
+            return variable;
+        }
+
+        abstract void push(Operation operation);
+
+        /**
+         * A ParseBlock that always runs.
+         */
+        static class Unconditional extends ParseBlock {
+            private final int line;
+            private final int column;
+            private final List<Operation> operations = new ArrayList<>();
+
+            Unconditional(String variable, int line, int column) {
+                super(variable);
+                this.line = line;
+                this.column = column;
+            }
+
+            @Override
+            public void apply(TrackingAppendable sink, AbstractCodeWriter<?> writer) throws IOException {
+                for (Operation operation : operations) {
+                    operation.apply(sink, writer);
+                }
+            }
+
+            @Override
+            public void push(Operation operation) {
+                operations.add(operation);
+            }
+        }
+
+        /**
+         * A ParseBlock that only runs if the referenced variable matches the condition.
+         */
+        static final class Conditional extends Unconditional {
+            private final boolean negate;
+
+            Conditional(String variable, boolean negate, int line, int column) {
+                super(variable, line, column);
+                this.negate = negate;
+            }
+
+            @Override
+            public void apply(TrackingAppendable sink, AbstractCodeWriter<?> writer) throws IOException {
+                Object value = writer.getContext(variable());
+                if (!isConditionTruthy(value) == negate) {
+                    super.apply(sink, writer);
+                }
+            }
+        }
+
+        /**
+         * A ParseBlock that repeats a template for each value referenced by the block. Each iteration pushes
+         * a state to the writer that includes a "currentKey" and "currentValue" context property representing
+         * the current index or key and the current value.
+         */
+        static final class Loop extends Unconditional {
+            Loop(String variableName, int line, int column) {
+                super(variableName, line, column);
+            }
+
+            @Override
+            public void apply(TrackingAppendable sink, AbstractCodeWriter<?> writer) throws IOException {
+                Object value = writer.getContext(variable());
+                Iterator<? extends Map.Entry<?, ?>> iterator = getValueIterator(value);
+                boolean isFirst = true;
+                while (iterator.hasNext()) {
+                    Map.Entry<?, ?> current = iterator.next();
+                    writer.pushState();
+                    writer.putContext("currentKey", current.getKey());
+                    writer.putContext("currentValue", current.getValue());
+                    writer.putContext("currentIsFirst", isFirst);
+                    writer.putContext("currentIsLast", !iterator.hasNext());
+                    isFirst = false;
+                    super.apply(sink, writer);
+                    writer.popState();
+                }
+            }
+        }
+    }
+
+    private static boolean isConditionTruthy(Object value) {
+        if (value == null) {
+            return false;
+        } else if (value instanceof Optional) {
+            return ((Optional<?>) value).isPresent();
+        } else if (value instanceof Boolean) {
+            return (Boolean) value;
+        } else if (value instanceof Iterable) {
+            return ((Iterable<?>) value).iterator().hasNext();
+        } else if (value instanceof Map) {
+            return !((Map<?, ?>) value).isEmpty();
+        } else if (value instanceof String) {
+            return !((String) value).isEmpty();
+        } else {
+            return true;
+        }
+    }
+
+    private static Iterator<? extends Map.Entry<?, ?>> getValueIterator(Object value) {
+        if (value instanceof Map) {
+            return ((Map<?, ?>) value).entrySet().iterator();
+        } else if (value instanceof Iterable) {
+            Iterator<?> iter = ((Iterable<?>) value).iterator();
+            return new Iterator<Map.Entry<?, ?>>() {
+                int position = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return iter.hasNext();
+                }
+
+                @Override
+                public Map.Entry<?, ?> next() {
+                    return Pair.of(position++, iter.next());
+                }
+            };
+        } else {
+            return Collections.emptyIterator();
+        }
+    }
+
     private static final class Parser {
         private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z]+[a-zA-Z0-9_.#$]*$");
 
@@ -168,8 +338,8 @@ final class CodeFormatter {
         private final AbstractCodeWriter<?> writer;
         private final Object[] arguments;
         private final boolean[] positionals;
-        private final List<Operation> operations = new ArrayList<>();
         private int relativeIndex = 0;
+        private final Deque<ParseBlock> blocks = new ArrayDeque<>();
 
         Parser(AbstractCodeWriter<?> writer, String template, Object[] arguments) {
             this.template = template;
@@ -178,17 +348,22 @@ final class CodeFormatter {
             this.parser = new SimpleParser(template);
             this.arguments = arguments;
             this.positionals = new boolean[arguments.length];
+            blocks.add(new ParseBlock.Unconditional("", 1, 1));
         }
 
         private void pushOperation(Operation op) {
-            operations.add(op);
+            blocks.getFirst().push(op);
         }
 
         private RuntimeException error(String message) {
-            return parser.syntax(message + " (template: " + template + ") " + writer.getDebugInfo());
+            return parser.syntax(createErrorMessage(message));
         }
 
-        private List<Operation> parse() {
+        private String createErrorMessage(String message) {
+            return message + " (template: " + template + ") " + writer.getDebugInfo();
+        }
+
+        private Operation parse() {
             boolean parsingLiteral = false;
             int literalStartCharacter = 0;
 
@@ -205,17 +380,14 @@ final class CodeFormatter {
                     parsingLiteral = true;
                     literalStartCharacter = parser.position();
                 } else {
-                    if (parsingLiteral) {
-                        // If previously parsing literal text, then add that to the operation (not including '$').
-                        pushOperation(Operation.stringSlice(template, literalStartCharacter, parser.position() - 1));
-                        parsingLiteral = false;
-                    }
-                    pushOperation(parseArgument());
+                    int pendingTextStart = parsingLiteral ? literalStartCharacter : -1;
+                    parsingLiteral = false;
+                    parseArgument(pendingTextStart);
                     literalStartCharacter = parser.position();
                 }
             }
 
-            if (parsingLiteral && literalStartCharacter < parser.position() && parser.position() > 0) {
+            if (parsingLiteral) {
                 pushOperation(Operation.stringSlice(template, literalStartCharacter, parser.position()));
             }
 
@@ -226,7 +398,18 @@ final class CodeFormatter {
                 throw error(String.format("Found %d unused relative format arguments", unusedCount));
             }
 
-            return operations;
+            if (blocks.size() == 1) {
+                return blocks.getFirst();
+            }
+
+            throw new IllegalArgumentException(
+                    "Unclosed parse conditional blocks: ["
+                    + blocks.stream()
+                            // Don't include the root block.
+                            .filter(b -> !b.variable().isEmpty())
+                            .map(ParseBlock::variable)
+                            .collect(Collectors.joining(", "))
+                    + "]");
         }
 
         private void ensureAllPositionalArgumentsWereUsed() {
@@ -241,16 +424,39 @@ final class CodeFormatter {
             }
         }
 
-        private Operation parseArgument() {
-            return parser.peek() == '{' ? parseBracedArgument() : parseNormalArgument();
+        private void parseArgument(int pendingTextStart) {
+            if (parser.peek() == '{') {
+                parseBracedArgument(pendingTextStart);
+            } else {
+                if (pendingTextStart > -1) {
+                    pushOperation(Operation.stringSlice(parser.expression(), pendingTextStart, parser.position() - 1));
+                }
+                pushOperation(parseNormalArgument());
+            }
         }
 
-        private Operation parseBracedArgument() {
+        private void parseBracedArgument(int pendingTextStart) {
             // Track the starting position of the interpolation (here minus the opening '$').
             int startPosition = parser.position() - 1;
+            int startLine = parser.line();
             int startColumn = parser.column() - 2;
 
             parser.expect('{');
+
+            if (parser.peek() == '?' || parser.peek() == '^' || parser.peek() == '#') {
+                pushBlock(pendingTextStart, startPosition, startLine, startColumn, parser.peek());
+                return;
+            }
+
+            if (parser.peek() == '/') {
+                popBlock(pendingTextStart, startPosition, startColumn);
+                return;
+            }
+
+            if (pendingTextStart > -1) {
+                pushOperation(Operation.stringSlice(parser.expression(), pendingTextStart, startPosition));
+            }
+
             Operation operation = parseNormalArgument();
 
             if (parser.peek() == '@') {
@@ -272,7 +478,7 @@ final class CodeFormatter {
 
             parser.expect('}');
 
-            return operation;
+            pushOperation(operation);
         }
 
         private boolean isAllLeadingWhitespaceOnLine(int startPosition, int startColumn) {
@@ -285,30 +491,102 @@ final class CodeFormatter {
             return true;
         }
 
+        private void pushBlock(int pendingTextStart, int startPosition, int startLine, int startColumn, char c) {
+            parser.expect(c);
+            String name = parseArgumentName();
+            parser.expect('}');
+            handleConditionalOnLine(pendingTextStart, startPosition, startColumn);
+            blocks.push(createBlockForChar(c, name, startLine, startColumn));
+        }
+
+        private ParseBlock createBlockForChar(char c, String name, int line, int column) {
+            switch (c) {
+                case '#':
+                    return new ParseBlock.Loop(name, line, column);
+                case '^':
+                    return new ParseBlock.Conditional(name, true, line, column);
+                case '?':
+                default:
+                    return new ParseBlock.Conditional(name, false, line, column);
+            }
+        }
+
+        private void handleConditionalOnLine(int pendingTextStart, int startPosition, int startColumn) {
+            // If the expression is not followed directly by a newline, then all leading text.
+            if (parser.peek() != '\r' && parser.peek() != '\n' && parser.peek() != Character.MIN_VALUE) {
+                if (pendingTextStart > -1) {
+                    pushOperation(Operation.stringSlice(parser.expression(), pendingTextStart, startPosition));
+                }
+            } else if (isAllLeadingWhitespaceOnLine(startPosition, startColumn)) {
+                if (pendingTextStart > -1) {
+                    pushOperation(Operation.stringSlice(parser.expression(), pendingTextStart,
+                                                        startPosition - startColumn));
+                }
+                parser.skip();
+            } else if (pendingTextStart > -1) {
+                pushOperation(Operation.stringSlice(parser.expression(), pendingTextStart, startPosition));
+            }
+        }
+
+        private void popBlock(int pendingTextStart, int startPosition, int startColumn) {
+            parser.expect('/');
+            String name = parseArgumentName();
+            parser.expect('}');
+
+            if (blocks.size() == 1) {
+                throw new IllegalArgumentException("Attempted to close unopened tag: '" + name + "'");
+            }
+
+            handleConditionalOnLine(pendingTextStart, startPosition, startColumn);
+
+            ParseBlock block = blocks.pop();
+            if (!block.variable().equals(name)) {
+                throw new IllegalArgumentException("Invalid closing tag: '" + name + "'. Expected: '"
+                                                   + block.variable() + "'");
+            }
+
+            blocks.getFirst().push(block);
+        }
+
         private Operation parseNormalArgument() {
             char c = parser.peek();
 
-            Object value;
+            // Create the appropriate function for retrieving the value. Positional and relative arguments
+            // are known statically, but getting context properties is deferring until it's time to write.
+            // This allows things like loops to populate loop control variables.
+            Function<AbstractCodeWriter<?>, Object> getter;
             if (Character.isLowerCase(c)) {
-                value = parseNamedArgument();
+                String name = parseNamedArgumentName();
+                getter = w -> w.getContext(name);
             } else if (Character.isDigit(c)) {
-                value = parsePositionalArgument();
+                getter = parsePositionalArgumentGetter();
             } else {
-                value = parseRelativeArgument();
+                getter = parseRelativeArgumentGetter();
             }
 
             // Parse the formatter and apply it.
-            String formatted = consumeAndApplyFormatterIdentifier(value);
-            return Operation.staticValue(formatted);
+            int line = parser.line();
+            int column = parser.column();
+            char identifier = parser.expect(CodeWriterFormatterContainer.VALID_FORMATTER_CHARS);
+
+            // The error message needs to be created here and given to the operation in way that it can
+            // throw with an appropriate message.
+            return Operation.formatted(getter, identifier, () -> createErrorMessage(String.format(
+                    "Syntax error at line %d column %d: Unknown formatter `%c` found in format string",
+                    line, column, identifier)));
         }
 
-        private Object parseNamedArgument() {
-            // Expand a named context value: "$" key ":" identifier
+        private String parseArgumentName() {
             int start = parser.position();
-            parser.consumeUntilNoLongerMatches(c -> c != ':');
+            parser.consumeUntilNoLongerMatches(c -> c != ':' && c != '}');
             String name = parser.sliceFrom(start);
             ensureNameIsValid(name);
+            return name;
+        }
 
+        private String parseNamedArgumentName() {
+            // Expand a named context value: "$" key ":" identifier
+            String name = parseArgumentName();
             parser.expect(':');
 
             // Consume the character after the colon.
@@ -316,25 +594,17 @@ final class CodeFormatter {
                 throw error("Expected an identifier after the ':' in a named argument");
             }
 
-            return writer.getContext(name);
+            return name;
         }
 
-        private String consumeAndApplyFormatterIdentifier(Object value) {
-            char identifier = parser.expect(CodeWriterFormatterContainer.VALID_FORMATTER_CHARS);
-            String result = writer.applyFormatter(identifier, value);
-            if (result == null) {
-                throw error(String.format("Unknown formatter `%c` found in format string", identifier));
-            }
-            return result;
-        }
-
-        private Object parseRelativeArgument() {
+        private Function<AbstractCodeWriter<?>, Object> parseRelativeArgumentGetter() {
             if (relativeIndex == -1) {
                 throw error("Cannot mix positional and relative arguments");
             }
 
             relativeIndex++;
-            return getPositionalArgument(relativeIndex - 1);
+            Object result = getPositionalArgument(relativeIndex - 1);
+            return w -> result;
         }
 
         private Object getPositionalArgument(int index) {
@@ -348,7 +618,7 @@ final class CodeFormatter {
             }
         }
 
-        private Object parsePositionalArgument() {
+        private Function<AbstractCodeWriter<?>, Object> parsePositionalArgumentGetter() {
             // Expand a positional argument: "$" 1*digit identifier
             if (relativeIndex > 0) {
                 throw error("Cannot mix positional and relative arguments");
@@ -365,7 +635,8 @@ final class CodeFormatter {
                         index, arguments.length));
             }
 
-            return getPositionalArgument(index);
+            Object value = getPositionalArgument(index);
+            return w -> value;
         }
 
         private void ensureNameIsValid(String name) {

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriterFormatterContainer.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriterFormatterContainer.java
@@ -28,9 +28,9 @@ final class CodeWriterFormatterContainer {
 
     // Must be sorted for binary search to work.
     static final char[] VALID_FORMATTER_CHARS = {
-            '!', '#', '%', '&', '*', '+', ',', '-', '.', '/', ';', '=', '?', '@',
+            '!', '%', '&', '*', '+', ',', '-', '.', ';', '=', '@',
             'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
-            'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '^', '_', '`', '~'};
+            'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '_', '`'};
 
     private final Map<Character, BiFunction<Object, String, String>> formatters = new HashMap<>();
     private final CodeWriterFormatterContainer parent;

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/CodeWriterTest.java
@@ -1189,7 +1189,7 @@ public class CodeWriterTest {
                 .insertTrailingNewline(false);
         writer.putContext("foo", Arrays.asList("a", "b", "c"));
         writer.write("${#foo}\n"
-                     + " - ${currentKey:L}: ${currentValue:L}\n"
+                     + " - ${key:L}: ${value:L}\n"
                      + "${/foo}");
 
         assertThat(writer.toString(), equalTo(" - 0: a\n - 1: b\n - 2: c\n"));
@@ -1202,9 +1202,9 @@ public class CodeWriterTest {
                 .insertTrailingNewline(false);
         writer.putContext("foo", Arrays.asList("a", "", "b"));
         writer.write("${#foo}\n"
-                     + " ${?currentValue}\n"
-                     + " - ${currentKey:L}: ${currentValue:L}\n"
-                     + " ${/currentValue}\n"
+                     + " ${?value}\n"
+                     + " - ${key:L}: ${value:L}\n"
+                     + " ${/value}\n"
                      + "${/foo}\n");
 
         assertThat(writer.toString(), equalTo(" - 0: a\n - 2: b\n"));
@@ -1217,13 +1217,32 @@ public class CodeWriterTest {
                 .insertTrailingNewline(false);
         writer.putContext("foo", Arrays.asList("a", "b", "c"));
         writer.write("${#foo}\n"
-                     + "${?currentIsFirst}\n"
+                     + "${?key.first}\n"
                      + "[\n"
-                     + "${/currentIsFirst}\n"
-                     + "    ${currentValue:L}${^currentIsLast},${/currentIsLast}\n"
-                     + "${?currentIsLast}\n"
+                     + "${/key.first}\n"
+                     + "    ${value:L}${^key.last},${/key.last}\n"
+                     + "${?key.last}\n"
                      + "]\n"
-                     + "${/currentIsLast}\n"
+                     + "${/key.last}\n"
+                     + "${/foo}\n");
+
+        assertThat(writer.toString(), equalTo("[\n    a,\n    b,\n    c\n]\n"));
+    }
+
+    @Test
+    public void canGetFirstAndLastFromIteratorWithCustomName() {
+        SimpleCodeWriter writer = new SimpleCodeWriter()
+                .trimTrailingSpaces(false)
+                .insertTrailingNewline(false);
+        writer.putContext("foo", Arrays.asList("a", "b", "c"));
+        writer.write("${#foo as i, value}\n"
+                     + "${?i.first}\n"
+                     + "[\n"
+                     + "${/i.first}\n"
+                     + "    ${value:L}${^i.last},${/i.last}\n"
+                     + "${?i.last}\n"
+                     + "]\n"
+                     + "${/i.last}\n"
                      + "${/foo}\n");
 
         assertThat(writer.toString(), equalTo("[\n    a,\n    b,\n    c\n]\n"));
@@ -1267,7 +1286,7 @@ public class CodeWriterTest {
     @MethodSource("iterationTestCases")
     public void handlesIteration(Object fooValue, String expected) {
         String template = "${#foo}\n"
-                          + "k: ${currentKey:L}, v: ${currentValue:L}, f: ${currentIsFirst:L}, l: ${currentIsLast:L}\n"
+                          + "k: ${key:L}, v: ${value:L}, f: ${key.first:L}, l: ${key.last:L}\n"
                           + "${/foo}";
         String actual = new SimpleCodeWriter()
                 .trimTrailingSpaces(false)


### PR DESCRIPTION
AbstractCodeWriter now supports Mustache-like behavior by allowing conditions and loops to be evaluated in templates. Note that this does disallow using '/', '?', '^', and '#' as formatters.

Conditions are defined using `${?foo}` where "foo" is the writer named parameter to evaluate. `?` is used to check if a value is truthy.

The following template with a "foo" value set to "Noid":

```
${?foo}
Hello, ${foo:L}!
${/foo}
```

Evaluates to:

```
Hello, Noid!
```

`^` can be used to check if a value is falsey. The following template with no set "baz" value:

```
${?baz}
  Yes baz
${/baz}
${^baz}
  No baz
${/baz}
```

Evaluates to:

```
  No baz
```

A variable is falsey if it is Boolean false, an empty Iterable, an empty Optional, an empty Map, or an empty String. A variable is truthy if it is not falsey.

If a conditional expression or loop expression is the non-whitespace text on a line and is immediately followed by a `\r` or `\n`, then the entire line is omitted from the output.

Loops can be created using `${#foo}`. Each value contained in the referenced named parameter is sent through the contained template, one after the other.

The following template with a "foo" value of ["a", "b"]:

```
${#foo}
- ${currentKey:L}: ${currentValue:L}
${/foo}
```

Evaluates to:

```
- 0: a
- 1: b
```

Each iteration of the loop creates a new state in the writer that sets a named parameter named `key` that contains the current index of the loop or the current key of a map entry; `value` containing the current value of the iterable or current value of a map entry; `key.first` is set to true when the first value is being evaluated, and `key.last` is set to true when the last value is being evaluated.

```
SimpleCodeWriter writer = new SimpleCodeWriter()
        .trimTrailingSpaces(false)
        .insertTrailingNewline(false);
writer.putContext("foo", Arrays.asList("a", "b", "c"));
writer.write("""
        ${#foo}
        ${?key.first}
        [
        ${/key.first}
            ${value:L}${^key.last},${/key.last}
        ${?key.last}
        ]
        ${/key.last}
        ${/foo}""");

assertThat(writer.toString(), equalTo("""
        [
            a,
            b,
            c
        ]
        """);
```

A custom variable name can be used in loops. For example:

```
${#foo as key1, value1}
    - ${key1:L}: ${value1:L} (first: ${key1.first:L}, last: ${key.last:L}
${/foo}
```

Whitespace that comes before an expression removed by putting `~` at the beginning of an expression.

Assuming that the first positional argument is "hi":

```
Greeting:
    ${~L}
```

Expands to:

```
Greeting:hi
```

Whitespace that comes after an expression can be removed by adding `~` to the end of the expression:

```
${L~}

.    
```

Expands to:

```
hi.
```

Leading whitespace cannot be removed when using inline block alignment ('|'). The following is *invalid*:

```
    ${~C|}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
