### PR TITLE
Fix trait source locations

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -897,7 +897,10 @@ final class IdlModelParser extends SimpleParser {
     }
 
     NumberNode parseNumberNode() {
-        SourceLocation location = currentLocation();
+        return parseNumberNode(currentLocation());
+    }
+
+    NumberNode parseNumberNode(SourceLocation location) {
         String lexeme = ParserUtils.parseNumber(this);
 
         if (lexeme.contains("e") || lexeme.contains("E")  || lexeme.contains(".")) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlNodeParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlNodeParser.java
@@ -37,17 +37,20 @@ final class IdlNodeParser {
     private IdlNodeParser() {}
 
     static Node parseNode(IdlModelParser parser) {
+        return parseNode(parser, parser.currentLocation());
+    }
+
+    static Node parseNode(IdlModelParser parser, SourceLocation location) {
         char c = parser.peek();
         switch (c) {
             case '{':
-                return parseObjectNode(parser, "object node");
+                return parseObjectNode(parser, "object node", location);
             case '[':
-                return parseArrayNode(parser);
+                return parseArrayNode(parser, location);
             case '"': {
                 if (peekTextBlock(parser)) {
-                    return parseTextBlock(parser);
+                    return parseTextBlock(parser, location);
                 } else {
-                    SourceLocation location = parser.currentLocation();
                     return new StringNode(IdlTextParser.parseQuotedString(parser), location);
                 }
             }
@@ -62,9 +65,8 @@ final class IdlNodeParser {
             case '8':
             case '9':
             case '-':
-                return parser.parseNumberNode();
+                return parser.parseNumberNode(location);
             default: {
-                SourceLocation location = parser.currentLocation();
                 return parseNodeTextWithKeywords(parser, location, ParserUtils.parseShapeId(parser));
             }
         }
@@ -107,8 +109,7 @@ final class IdlNodeParser {
                && parser.peek(2) == '"';
     }
 
-    static Node parseTextBlock(IdlModelParser parser) {
-        SourceLocation location = parser.currentLocation();
+    static Node parseTextBlock(IdlModelParser parser, SourceLocation location) {
         parser.expect('"');
         parser.expect('"');
         parser.expect('"');
@@ -116,8 +117,11 @@ final class IdlNodeParser {
     }
 
     static ObjectNode parseObjectNode(IdlModelParser parser, String parent) {
+        return parseObjectNode(parser, parent, parser.currentLocation());
+    }
+
+    static ObjectNode parseObjectNode(IdlModelParser parser, String parent, SourceLocation location) {
         parser.increaseNestingLevel();
-        SourceLocation location = parser.currentLocation();
         ObjectNode.Builder builder = ObjectNode.builder()
                 .sourceLocation(location);
         parser.expect('{');
@@ -160,9 +164,8 @@ final class IdlNodeParser {
         }
     }
 
-    private static ArrayNode parseArrayNode(IdlModelParser parser) {
+    private static ArrayNode parseArrayNode(IdlModelParser parser, SourceLocation location) {
         parser.increaseNestingLevel();
-        SourceLocation location = parser.currentLocation();
         ArrayNode.Builder builder = ArrayNode.builder()
                 .sourceLocation(location);
         parser.expect('[');

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTraitParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTraitParser.java
@@ -42,12 +42,13 @@ final class IdlTraitParser {
 
     static IdlModelParser.TraitEntry parseTraitValue(IdlModelParser parser) {
         // "@" shape_id
+        SourceLocation location = parser.currentLocation();
         parser.expect('@');
         String id = ParserUtils.parseShapeId(parser);
 
         // No (): it's an annotation trait.
         if (parser.peek() != '(') {
-            return new IdlModelParser.TraitEntry(id, new NullNode(parser.currentLocation()), true);
+            return new IdlModelParser.TraitEntry(id, new NullNode(location), true);
         }
 
         parser.expect('(');
@@ -56,41 +57,40 @@ final class IdlTraitParser {
         // (): it's also an annotation trait.
         if (parser.peek() == ')') {
             parser.expect(')');
-            return new IdlModelParser.TraitEntry(id, new NullNode(parser.currentLocation()), true);
+            return new IdlModelParser.TraitEntry(id, new NullNode(location), true);
         }
 
         // The trait has a value between the '(' and ')'.
-        Node value = parseTraitValueBody(parser);
+        Node value = parseTraitValueBody(parser, location);
         parser.ws();
         parser.expect(')');
 
         return new IdlModelParser.TraitEntry(id, value, false);
     }
 
-    private static Node parseTraitValueBody(IdlModelParser parser) {
-        SourceLocation keyLocation = parser.currentLocation();
+    private static Node parseTraitValueBody(IdlModelParser parser, SourceLocation location) {
         char c = parser.peek();
         switch (c) {
             case '{':
             case '[':
                 // {} and [] are always node values.
-                return IdlNodeParser.parseNode(parser);
+                return IdlNodeParser.parseNode(parser, location);
             case '"': {
                 // Text blocks are always node values.
                 if (IdlNodeParser.peekTextBlock(parser)) {
-                    return IdlNodeParser.parseTextBlock(parser);
+                    return IdlNodeParser.parseTextBlock(parser, location);
                 }
                 // It's a quoted string, so check if it's a KVP key or a node_value.
                 String key = IdlTextParser.parseQuotedString(parser);
-                return parseTraitValueBodyIdentifierOrQuotedString(parser, keyLocation, key, false);
+                return parseTraitValueBodyIdentifierOrQuotedString(parser, location, key, false);
             } default: {
                 // Parser numbers.
                 if (c == '-' || ParserUtils.isDigit(c)) {
-                    return parser.parseNumberNode();
+                    return parser.parseNumberNode(location);
                 } else {
                     // Parse unquoted strings or possibly a structured trait.
                     String key = ParserUtils.parseIdentifier(parser);
-                    return parseTraitValueBodyIdentifierOrQuotedString(parser, keyLocation, key, true);
+                    return parseTraitValueBodyIdentifierOrQuotedString(parser, location, key, true);
                 }
             }
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -35,9 +35,11 @@ import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.DynamicTrait;
 import software.amazon.smithy.model.traits.StringTrait;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
@@ -66,6 +68,26 @@ public class IdlModelLoaderTest {
                 assertThat(shape.getSourceLocation().getColumn(), equalTo(1));
             }
         });
+    }
+
+    @Test
+    public void loadsAppropriateTraitSourceLocations() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("valid/trait-locations.smithy"))
+                .assemble()
+                .unwrap();
+
+        Shape shape = model.expectShape(ShapeId.from("com.example#TraitBearer"));
+
+        for (Trait trait : shape.getAllTraits().values()) {
+            assertThat(trait.getSourceLocation().getColumn(), equalTo(1));
+        }
+
+        for (MemberShape member : shape.members()) {
+            for (Trait trait : member.getAllTraits().values()) {
+                assertThat(trait.getSourceLocation().getColumn(), equalTo(5));
+            }
+        }
     }
 
     @Test

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/trait-locations.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/trait-locations.smithy
@@ -1,0 +1,47 @@
+$version: "1.0"
+
+namespace com.example
+
+@trait
+integer numberTrait
+
+@trait
+boolean boolTrait
+
+@trait
+document documentTrait
+
+@trait
+string stringTrait
+
+/// Documentation
+@sensitive
+@internal()
+@deprecated(
+    since: "1.0"
+)
+@tags(["foo"])
+@unstable({})
+@stringTrait("foo")
+@since("""
+    0.9""")
+@numberTrait(1)
+@boolTrait(true)
+@documentTrait(null)
+structure TraitBearer {
+    /// Documentation
+    @sensitive
+    @internal()
+    @deprecated(
+        since: "1.0"
+    )
+    @tags(["foo"])
+    @unstable({})
+    @pattern("foo")
+    @since("""
+        0.9""")
+    @numberTrait(1)
+    @boolTrait(true)
+    @documentTrait(null)
+    member: String
+}


### PR DESCRIPTION
This fixes trait source locations from the IDL to start at the trait
itself rather than at the start of the trait's node definition. This
is particularly important for annotation traits where the source
location previously pointed to the column *after* the trait, which
doesn't necessarily even exist.

The following shows where the source location used to point:

```
@annotation
           ^

@annotationWithParens()
                       ^

@listTrait(["foo"])
           ^

@structuredTrait({
                 ^
    "foo": "bar"
})

@structuredTraitWithoutBraces(
    foo: "bar"
    ^
)

@primitiveTrait(true)
                ^
```

And this shows where they point now:

```
@annotation
^

@annotationWithParens()
^

@listTrait(["foo"])
^

@structuredTrait({
^
    "foo": "bar"
})

@structuredTraitWithoutBraces(
^
    foo: "bar"
)

@primitiveTrait(true)
^
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
