### PR TITLE
Remove sensitive trait from member target that is no longer valid.

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/trait-locations.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/trait-locations.smithy
@@ -30,7 +30,6 @@ string stringTrait
 @documentTrait(null)
 structure TraitBearer {
     /// Documentation
-    @sensitive
     @internal()
     @deprecated(
         since: "1.0"


### PR DESCRIPTION
*Issue: *
Failing unit test has a Smithy 1.0 model that applies the @sensitive trait to a member which is no longer valid.

*Description of changes:*
* Remove @sensitive trait from member.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
