### PR TITLE
Document that requiresLength only impacts requests

### DIFF
--- a/docs/source/1.0/spec/core/stream-traits.rst
+++ b/docs/source/1.0/spec/core/stream-traits.rst
@@ -73,13 +73,18 @@ Validation
 ------------------------
 
 Summary
-    Indicates that the streaming blob MUST be finite and has a known size.
+    Indicates that the streaming blob MUST be finite and have a known
+    size when sending data from a client to a server.
 
-    In an HTTP-based protocol, for instance, this trait indicates that the
-    ``Content-Length`` header MUST be sent prior to a client or server
-    sending the payload of a message. This can be useful for services that
-    need to determine if a request will be accepted based on its size or
-    where to store data based on the size of the stream.
+    In an HTTP-based protocol, this trait indicates that the
+    ``Content-Length`` header MUST be sent prior to a client sending the
+    payload of a request. This can be useful for services that need to
+    determine if a request will be accepted based on its size or where to
+    store data based on the size of the stream.
+
+    .. note::
+
+        This trait only has an effect when used on blobs in input shapes.
 Trait selector::
     ``blob[trait|streaming]``
 


### PR DESCRIPTION
We have no use case of a server needing to be constrained by
requiresLength. We can always expand this trait later if needed since
it's an annotation trait.

Closes #1086

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
