### PR TITLE
Forbid using requiresLength with output

### DIFF
--- a/docs/source/1.0/spec/core/stream-traits.rst
+++ b/docs/source/1.0/spec/core/stream-traits.rst
@@ -81,16 +81,15 @@ Summary
     payload of a request. This can be useful for services that need to
     determine if a request will be accepted based on its size or where to
     store data based on the size of the stream.
-
-    .. note::
-
-        This trait only has an effect when used on blobs in input shapes.
 Trait selector::
     ``blob[trait|streaming]``
 
     *A blob shape marked with the streaming trait*
 Value type
     ``structure``
+Validation
+    * ``requiresLength`` shapes can only be referenced from top-level members
+      of operation input structures.
 
 .. tabs::
 

--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -105,8 +105,7 @@ blob StreamingBlob
 /// not a structure or a union type.
 @http(uri: "/StreamingTraitsRequireLength", method: "POST")
 operation StreamingTraitsRequireLength {
-    input: StreamingTraitsRequireLengthInputOutput,
-    output: StreamingTraitsRequireLengthInputOutput
+    input: StreamingTraitsRequireLengthInput
 }
 
 apply StreamingTraitsRequireLength @httpRequestTests([
@@ -147,43 +146,8 @@ apply StreamingTraitsRequireLength @httpRequestTests([
     },
 ])
 
-apply StreamingTraitsRequireLength @httpResponseTests([
-    {
-        id: "RestJsonStreamingTraitsRequireLengthWithBlob",
-        documentation: "Serializes a blob in the HTTP payload with a required length",
-        protocol: restJson1,
-        code: 200,
-        body: "blobby blob blob",
-        bodyMediaType: "application/octet-stream",
-        headers: {
-            "X-Foo": "Foo",
-            "Content-Type": "application/octet-stream"
-        },
-        requireHeaders: [
-            "Content-Length"
-        ],
-        params: {
-            foo: "Foo",
-            blob: "blobby blob blob"
-        }
-    },
-    {
-        id: "RestJsonStreamingTraitsRequireLengthWithNoBlobBody",
-        documentation: "Serializes an empty blob in the HTTP payload",
-        protocol: restJson1,
-        code: 200,
-        body: "",
-        bodyMediaType: "application/octet-stream",
-        headers: {
-            "X-Foo": "Foo"
-        },
-        params: {
-            foo: "Foo"
-        }
-    }
-])
-
-structure StreamingTraitsRequireLengthInputOutput {
+@input
+structure StreamingTraitsRequireLengthInput {
     @httpHeader("X-Foo")
     foo: String,
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/requiresLength-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/requiresLength-validator.errors
@@ -1,0 +1,1 @@
+[ERROR] ns.foo#InvalidStreamingOperation: Structures that contain a reference to a stream marked with the @requiresLength trait can only be used as operation inputs, but this structure is referenced from `ns.foo#InvalidStreamingOperation` as output | StreamingTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/requiresLength-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/requiresLength-validator.json
@@ -1,0 +1,46 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "ns.foo#Blob": {
+            "type": "blob"
+        },
+        "ns.foo#InvalidStreamingOperation": {
+            "type": "operation",
+            "input": {
+                "target": "ns.foo#InvalidStreamingOperationInput"
+            },
+            "output": {
+                "target": "ns.foo#InvalidStreamingOperationOutput"
+            }
+        },
+        "ns.foo#InvalidStreamingOperationInput": {
+            "type": "structure",
+            "members": {
+                "Body": {
+                    "target": "ns.foo#StreamingBlob"
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "ns.foo#InvalidStreamingOperationOutput": {
+            "type": "structure",
+            "members": {
+                "Body": {
+                    "target": "ns.foo#StreamingBlob"
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "ns.foo#StreamingBlob": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#streaming": {},
+                "smithy.api#requiresLength": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit does not allow using the requiresLength trait with streaming
blobs used in output shapes. We can lift this restriction in the future
if a use case ever arises, but by forbidding this use case now,
implementations are free to treat blobs marked with the requiresLength
trait as a specialization of a stream that affects the generated type.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
