### PR TITLE
Validate that http.code is between 100 and 999

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -50,7 +50,8 @@ The ``http`` trait is a structure that supports the following members:
     * - code
       - ``integer``
       - The HTTP status code of a successful response. Defaults to ``200`` if
-        not provided.
+        not provided. The provided value SHOULD be between 100 and 599, and
+        it MUST be between 100 and 999.
 
 The following example defines an operation that uses HTTP bindings:
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -570,7 +570,8 @@ structure http {
     /// The HTTP status code of a successful response.
     ///
     /// Defaults to 200 if not provided.
-    code: PrimitiveInteger,
+    @range(min: 100, max: 999)
+    code: Integer,
 }
 
 /// Binds an operation input structure member to an HTTP label.


### PR DESCRIPTION
While HTTP response codes are only documented as between 100 and 599, various applications use custom codes > 500. This commit ensures that the code of the http trait is in the range of 100 and 999.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
