### PR TITLE
Re-add annotation trait location test case

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/trait-locations.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/trait-locations.smithy
@@ -14,33 +14,45 @@ document documentTrait
 @trait
 string stringTrait
 
-/// Documentation
-@sensitive
-@internal()
-@deprecated(
+@trait
+structure annotationTrait {}
+
+// This is used to test that trait locations are properly set for a variety of
+// trait types. The locations for annotation traits in particular used to be
+// fraught. To ensure there's no regressions, do not remove any traits from
+// here. If a trait absolutely must be removed, replace it with a custom
+// trait that looks exactly the same, like those above. At minimum there
+// should be one trait for each Node type, including a case for every syntactic
+// variation.
+
+/// Documentation trait using the doc comment syntax
+@annotationTrait     // Annotation trait without parens
+@internal()          // Annotation trait with parens
+@deprecated(         // Structured trait with no braces
     since: "1.0"
 )
-@tags(["foo"])
-@unstable({})
-@stringTrait("foo")
+@tags(["foo"])       // List trait
+@unstable({})        // Structured trait with braces
+@stringTrait("foo")  // String trait using normal string syntax
 @since("""
-    0.9""")
-@numberTrait(1)
-@boolTrait(true)
-@documentTrait(null)
+    0.9""")          // String trait using block syntax
+@numberTrait(1)      // Number trait
+@boolTrait(true)     // Boolean trait
+@documentTrait(null) // Null value trait
 structure TraitBearer {
-    /// Documentation
-    @internal()
-    @deprecated(
+    /// Documentation trait using the doc comment syntax
+    @annotationTrait     // Annotation trait without parens
+    @internal()          // Annotation trait with parens
+    @deprecated(         // Structured trait with no braces
         since: "1.0"
     )
-    @tags(["foo"])
-    @unstable({})
-    @pattern("foo")
+    @tags(["foo"])       // List trait
+    @unstable({})        // Structured trait with braces
+    @stringTrait("foo")  // String trait using normal string syntax
     @since("""
-        0.9""")
-    @numberTrait(1)
-    @boolTrait(true)
-    @documentTrait(null)
+        0.9""")          // String trait using block syntax
+    @numberTrait(1)      // Number trait
+    @boolTrait(true)     // Boolean trait
+    @documentTrait(null) // Null value trait
     member: String
 }


### PR DESCRIPTION
This re-adds a test case for annotation trait source locations without parens. It also adds in a detailed explanation of what the cases are doing since it wasn't clear before.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
