### PR TITLE
Use python3 for building docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = Smithy
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -10,14 +10,14 @@ help:
 	@echo "  openhtml    to preview the built index.html"
 
 install:
-	pip install -r requirements.txt .
-	pip install -e .
+	pip3 install -r requirements.txt .
+	pip3 install -e .
 
 clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-server:
-	pip install -r requirements-server.txt
+	pip3 install -r requirements-server.txt
 
 serve: clean
 	sphinx-autobuild source build/html

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ This package is the Smithy website, specification, and project documentation.
 ## Building
 
 The Smithy docs are built using [Sphinx](https://www.sphinx-doc.org/en/master),
-which requires python.
+which requires python3.
 
-Once you have python installed, you need to install the dependencies and local
+Once you have python3 installed, you need to install the dependencies and local
 modules:
 
 ```


### PR DESCRIPTION
Use python3 and pip3 to build docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
