### PR TITLE
Fix streaming validation to not disallow mixins

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait-event.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait-event.errors
@@ -1,2 +1,2 @@
 [ERROR] ns.foo#InvalidUnion: Each member of an event stream union must target a structure shape, but the following union members do not: [b, c] | StreamingTrait
-[ERROR] ns.foo#InvalidEventStreamTargeting$member: This shape has an invalid `MEMBER_TARGET` relationship to a structure, `ns.foo#EventStreamReferencesInvalidMultiEventShapeInput`, that contains a stream | StreamingTrait
+[ERROR] ns.foo#InvalidEventStreamTargeting$member: Members cannot target structures that contain a stream, but this member targets ns.foo#EventStreamReferencesInvalidMultiEventShapeInput | StreamingTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.errors
@@ -1,3 +1,5 @@
 [ERROR] ns.foo#InvalidStreamingOperationOutput: Only a single member of a structure can target a shape marked with the `streaming` trait, but it was found on the following members: `StreamingBlob1`, `StreamingBlob2` | ExclusiveStructureMemberTrait
-[ERROR] ns.foo#InvalidNestedStream$NestedStream: This shape has an invalid `MEMBER_TARGET` relationship to a structure, `ns.foo#NestedStreamContainer`, that contains a stream | StreamingTrait
-[ERROR] ns.foo#InvalidNestedStream: This shape has an invalid `MIXIN` relationship to a structure, `ns.foo#MixinStream`, that contains a stream | StreamingTrait
+[ERROR] ns.foo#InvalidNestedStream$Body: Members cannot target structures that contain a stream, but this member targets ns.foo#NestedStreamContainer | StreamingTrait
+[ERROR] ns.foo#InvalidNestedStream$NestedStream: Members cannot target structures that contain a stream, but this member targets ns.foo#NestedStreamContainer | StreamingTrait
+[ERROR] ns.foo#NestedMixinStream$Body: Members cannot target structures that contain a stream, but this member targets ns.foo#NestedStreamContainer | StreamingTrait
+[ERROR] ns.foo#BadOperation: This shape has an invalid `ERROR` relationship to a structure, `ns.foo#BadError`, that contains a stream | StreamingTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
@@ -108,9 +108,20 @@
             },
             "mixins": [
                 {
-                    "target": "ns.foo#MixinStream"
+                    "target": "ns.foo#NestedMixinStream"
                 }
             ]
+        },
+        "ns.foo#NestedMixinStream": {
+            "type": "structure",
+            "members": {
+                "Body": {
+                    "target": "ns.foo#NestedStreamContainer"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
         },
         "ns.foo#NestedStreamContainer": {
             "type": "structure",
@@ -118,6 +129,25 @@
                 "nested": {
                     "target": "ns.foo#StreamingBlob"
                 }
+            }
+        },
+        "ns.foo#BadOperation": {
+            "type": "operation",
+            "errors": [
+                {
+                    "target": "ns.foo#BadError"
+                }
+            ]
+        },
+        "ns.foo#BadError": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "ns.foo#StreamingBlob"
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client"
             }
         }
     }


### PR DESCRIPTION
It's fine to use a mixin that refers to a streaming trait. Since mixin
members are copied to the shapes they are mixed in to, there's no need
to perform special case streaming shape validation for mixins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
