### PR TITLE
Omit commas to match style guide

### DIFF
--- a/docs/source/1.0/spec/aws/aws-core.rst
+++ b/docs/source/1.0/spec/aws/aws-core.rst
@@ -1216,19 +1216,19 @@ setting the ``validationMode`` input property to "ENABLED".
         responseAlgorithms: ["CRC32C", "CRC32", "SHA1", "SHA256"]
     )
     operation PutSomething {
-        input: PutSomethingInput,
+        input: PutSomethingInput
         output: PutSomethingOutput
     }
 
     structure PutSomethingInput {
         @httpHeader("x-amz-request-algorithm")
-        checksumAlgorithm: ChecksumAlgorithm,
+        checksumAlgorithm: ChecksumAlgorithm
 
         @httpHeader("x-amz-response-validation-mode")
-        validationMode: ValidationMode,
+        validationMode: ValidationMode
 
         @httpPayload
-        content: Blob,
+        content: Blob
     }
 
     @enum([
@@ -1267,7 +1267,7 @@ behavior, will fail validation.
 
     @httpChecksum()
     operation PutSomething {
-        input: PutSomethingInput,
+        input: PutSomethingInput
         output: PutSomethingOutput
     }
 

--- a/docs/source/1.0/spec/aws/aws-iam.rst
+++ b/docs/source/1.0/spec/aws/aws-iam.rst
@@ -524,8 +524,8 @@ The following example defines two operations:
 
         @supportedPrincipalTypes(["Root", "IAMUser", "IAMRole", "FederatedUser"])
         service MyService {
-            version: "2020-07-02",
-            operations: [OperationA, OperationB],
+            version: "2020-07-02"
+            operations: [OperationA, OperationB]
         }
 
         @supportedPrincipalTypes(["Root"])
@@ -577,7 +577,7 @@ deviates from the :ref:`shape name of the shape ID <shape-id>` of the resource.
         resource SuperResource {
             identifiers: {
                 superId: String,
-            },
+            }
         }
 
 

--- a/docs/source/1.0/spec/aws/customizations/s3-customizations.rst
+++ b/docs/source/1.0/spec/aws/customizations/s3-customizations.rst
@@ -155,7 +155,7 @@ Consider the following *abridged* model of S3's ``GetBucketLocation`` operation:
     @http(uri: "/GetBucketLocation", method: "GET")
     @s3UnwrappedXmlOutput
     operation GetBucketLocation {
-        input: GetBucketLocationInput,
+        input: GetBucketLocationInput
         output: GetBucketLocationOutput
     }
 

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -436,9 +436,9 @@ so that they can be referred to using only ``Foo`` and ``Baz``.
 
     map MyMap {
         // Resolves to smithy.example#Foo
-        key: Foo,
+        key: Foo
         // Resolves to smithy.example#Baz
-        value: Baz,
+        value: Baz
     }
 
 A use statement can refer to :ref:`traits <traits>` too. The following example
@@ -493,34 +493,34 @@ to.
     structure MyStructure {
         // Resolves to smithy.example#MyString
         // There is a shape named MyString defined in the same namespace.
-        a: MyString,
+        a: MyString
 
         // Resolves to smithy.example#MyString
         // Absolute shape IDs do not perform namespace resolution.
-        b: smithy.example#MyString,
+        b: smithy.example#MyString
 
         // Resolves to foo.baz#Bar
         // The "use foo.baz#Bar" statement imported the Bar symbol,
         // allowing the shape to be referenced using a relative shape ID.
-        c: Bar,
+        c: Bar
 
         // Resolves to smithy.api#String
         // No shape named String was imported through a use statement
         // the smithy.example namespace does not contain a shape named
         // String, and the prelude model contains a shape named String.
-        d: String,
+        d: String
 
         // Resolves to smithy.example#MyBoolean.
         // There is a shape named MyBoolean defined in the same namespace.
         // Forward references are supported both within the same file and
         // across multiple files.
-        e: MyBoolean,
+        e: MyBoolean
 
         // Resolves to smithy.example#InvalidShape. A shape by this name has
         // not been imported through a use statement, a shape by this name
         // does not exist in the current namespace, and a shape by this name
         // does not exist in the prelude model.
-        f: InvalidShape,
+        f: InvalidShape
     }
 
     boolean MyBoolean
@@ -1039,8 +1039,8 @@ The following example defines a structure with two members:
         namespace smithy.example
 
         structure MyStructure {
-            foo: String,
-            baz: Integer,
+            foo: String
+            baz: Integer
         }
 
     .. code-tab:: json
@@ -1074,11 +1074,11 @@ Traits can be applied to structure members:
         structure MyStructure {
             /// This is documentation for `foo`.
             @required
-            foo: String,
+            foo: String
 
             /// This is documentation for `baz`.
             @deprecated
-            baz: Integer,
+            baz: Integer
         }
 
     .. code-tab:: json
@@ -1128,12 +1128,12 @@ The following example defines a union shape with several members:
         namespace smithy.example
 
         union MyUnion {
-            i32: Integer,
+            i32: Integer
 
             @length(min: 1, max: 100)
-            string: String,
+            string: String
 
-            time: Timestamp,
+            time: Timestamp
         }
 
     .. code-tab:: json

--- a/docs/source/1.0/spec/core/traits/http-traits.rst.template
+++ b/docs/source/1.0/spec/core/traits/http-traits.rst.template
@@ -1051,7 +1051,7 @@ disregard the value set by ``httpQueryParams``. For example, given the following
     }
 
     map MapOfStrings {
-        key: String,
+        key: String
         value: String
     }
 
@@ -1094,7 +1094,7 @@ given the following model:
         }
 
         map MapOfStrings {
-            key: String,
+            key: String
             value: String
         }
 
@@ -1317,7 +1317,7 @@ marked with the ``httpPayload`` trait:
 
     @input
     structure InvalidOperationInput {
-        invalid: MessageStream, // <-- Missing the @httpPayload trait
+        invalid: MessageStream  // <-- Missing the @httpPayload trait
     }
 
     @streaming

--- a/docs/source/1.0/spec/mqtt.rst
+++ b/docs/source/1.0/spec/mqtt.rst
@@ -170,7 +170,7 @@ The following example defines an operation that publishes messages to the
 
     @publish("foo/{bar}")
     operation PostFoo {
-        input: PostFooInput,
+        input: PostFooInput
         output: Unit
     }
 
@@ -180,7 +180,7 @@ The following example defines an operation that publishes messages to the
         @topicLabel
         bar: String
 
-        someValue: String,
+        someValue: String
         anotherValue: Boolean
     }
 


### PR DESCRIPTION
Omits commas to match updated model style guide: `Omit commas everywhere except in traits or node values defined on a single line.`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
