### PR TITLE
Remove invalid but extant base64 protocol test case

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
@@ -34,7 +34,7 @@ apply MalformedBlob @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            value: ["blob", "\"xyz\"", "\"YmxvYg=\"", "[98, 108, 11, 98]",
+            value: ["blob", "\"xyz\"", "[98, 108, 11, 98]",
                     "[\"b\", \"l\",\"o\",\"b\"]", "981081198", "true", "[][]", "-_=="]
         }
     },

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-string.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-string.smithy
@@ -37,8 +37,6 @@ apply MalformedString @httpMalformedRequestTests([
             value: [
                 // Insufficient padding
                 "xyz",
-                // Extant, but also insufficient padding
-                "YmxvYg=",
                 // Invalid characters
                 "[][]",
                 // Invalid characters which are commonly used as filename-safe


### PR DESCRIPTION
While `YmxvyG=` is _technically_ invalid base64 according to the spec
(its Unicode code point length is not divisible by 4), it can always be
unambiguously decoded, even over a network protocol that concatenates
base64-encoded strings and that would hence require padding characters.

Some off the shelf base 64 implementations, like the canonical `base64`
Rust crate (https://docs.rs/base64/latest/base64/), decode this case
successfully.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
