### PR TITLE
Reproduction for rename shape issue

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProtoReservedFieldsTrait.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProtoReservedFieldsTrait.java
@@ -1,0 +1,63 @@
+package software.amazon.smithy.build;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import software.amazon.smithy.model.*;
+import software.amazon.smithy.model.node.*;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.*;
+import software.amazon.smithy.utils.ListUtils;
+
+public final class ProtoReservedFieldsTrait extends AbstractTrait {
+	public static final ShapeId ID = ShapeId.from("ns.foo#protoReservedFields");
+
+	private final List<Integer> reserved;
+
+	public ProtoReservedFieldsTrait(Builder builder) {
+		super(ID, SourceLocation.NONE);
+		this.reserved = ListUtils.copyOf(builder.reserved);
+	}
+
+	public List<Integer> getReserved() {
+		return this.reserved;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder extends AbstractTraitBuilder<ProtoReservedFieldsTrait, Builder> {
+		private final List<Integer> reserved = new ArrayList<>();
+
+		public Builder add(Integer reserved) {
+			this.reserved.add(reserved);
+			return this;
+		}
+
+		@Override
+		public ProtoReservedFieldsTrait build() {
+			return new ProtoReservedFieldsTrait(this);
+		}
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public ProtoReservedFieldsTrait createTrait(ShapeId target, Node value) {
+			Builder builder = new Builder().sourceLocation(value);
+			for (Node definition : value.expectArrayNode().getElements()) {
+				definition.asNumberNode().map(NumberNode::getValue).map(Number::intValue).ifPresent(builder::add);
+			}
+			return builder.build();
+		}
+	}
+
+	@Override
+	protected Node createNode() {
+		return Node.arrayNode();
+	}
+}

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -1,0 +1,1 @@
+software.amazon.smithy.build.ProtoReservedFieldsTrait$Provider

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/rename-shapes-broken.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/rename-shapes-broken.smithy
@@ -1,0 +1,13 @@
+namespace ns.foo
+
+string MyString
+
+@protoReservedFields([1])
+structure MyStruct {
+    value: MyString
+}
+
+@trait(selector: "structure")
+list protoReservedFields {
+  member: Integer
+}


### PR DESCRIPTION
*Issue #, if available:*

No Issue opened yet, but I stumbled on this and wondered if this was a bug, or if it was expected.

*Description of changes:*

This PR is a reproduction of an issue I had, if you can confirm it's a problem I'll open an issue.

**The problem**: when renaming shapes with the model transformers, some data is lost. In this reproduction, I have a trait where the use can specify a list of `Integer`s. After the rename, the list is empty.

**Expectation**: this list values are kept.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
