### PR TITLE
Upload test artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Clean and build
         run: ./gradlew clean build -Plog-tests
 
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: java-${{ matrix.java }}-${{ matrix.os }}-test-report
+          path: '**/build/reports/tests'
+
   build-docs:
     runs-on: ubuntu-latest
     name: Documentation Build


### PR DESCRIPTION
This updates the CI to upload the test artifacts when there's failures. `-Plog-tests` is nice and all, but there's more context we're missing out on.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
