### PR TITLE
Return deserialized settings from CodegenDirector

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -156,10 +156,13 @@ public final class CodegenDirector<
      *
      * @param settingsType Settings type to deserialize into.
      * @param settingsNode Settings node value to deserialize.
+     * @return Returns the deserialized settings as this is needed to provide a service shape ID.
      */
-    public void settings(Class<S> settingsType, Node settingsNode) {
+    public S settings(Class<S> settingsType, Node settingsNode) {
         LOGGER.fine(() -> "Loading codegen settings from node value: " + settingsNode.getSourceLocation());
-        settings(new NodeMapper().deserialize(settingsNode, settingsType));
+        S deserialized = new NodeMapper().deserialize(settingsNode, settingsType);
+        settings(deserialized);
+        return deserialized;
     }
 
     /**


### PR DESCRIPTION
The settings deserialized from the provided helper method are useful for
providing the service shape ID to CodegenDirector.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
