### PR TITLE
Revert "Remove invalid but extant base64 protocol test case"

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-blob.smithy
@@ -34,7 +34,7 @@ apply MalformedBlob @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            value: ["blob", "\"xyz\"", "[98, 108, 11, 98]",
+            value: ["blob", "\"xyz\"", "\"YmxvYg=\"", "[98, 108, 11, 98]",
                     "[\"b\", \"l\",\"o\",\"b\"]", "981081198", "true", "[][]", "-_=="]
         }
     },

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-string.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-string.smithy
@@ -37,6 +37,8 @@ apply MalformedString @httpMalformedRequestTests([
             value: [
                 // Insufficient padding
                 "xyz",
+                // Extant, but also insufficient padding
+                "YmxvYg=",
                 // Invalid characters
                 "[][]",
                 // Invalid characters which are commonly used as filename-safe


### PR DESCRIPTION
This reverts commit e7d090c9992ec453b776359bb72ffe5c88601c80.

Based on the followup discussion in the original PR https://github.com/awslabs/smithy/pull/1168

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
