### PR TITLE
Add mavenCentral as plugin reposiroty

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
gradlePluginPortal() uses jcenter which takes time to get latest releases. Using mavenCentral will make them available sooner.

The CI was seeing failures before this change, but is fixed by this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
