### PR TITLE
Set AWS SDK for Rust Language to Rust

### DIFF
--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -225,7 +225,7 @@ AWS specific
       - 1.x
       - The AWS SDK for Go v2 is built with Smithy.
     * - `AWS SDK for Rust <https://github.com/awslabs/aws-sdk-rust>`_
-      - Kotlin
+      - Rust
       - 0.x
       - The AWS SDK for Rust is built with Smithy.
     * - :ref:`smithy-to-cloudformation`


### PR DESCRIPTION
*Description of changes:*

The AWS SDK for Rust language was marked as Kotlin, but looking at the [Github repository page](https://github.com/awslabs/aws-sdk-rust) the implementation is entirely in Rust. I've updated the language entry to Rust from Kotlin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
