### PR TITLE
Implement comparable, add static compare method

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/FromSourceLocation.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/FromSourceLocation.java
@@ -30,13 +30,13 @@ public interface FromSourceLocation {
     }
 
     /**
-     * Compares two SourceLocations.
+     * Compares two FromSourceLocations.
      *
-     * @param s1 the first SourceLocation to compare.
-     * @param s2 the second SourceLocation to compare.
+     * @param s1 the first FromSourceLocation to compare.
+     * @param s2 the second FromSourceLocation to compare.
      * @return the value 0 if s1 == s2; a value less than 0 if s1 < s2; and a value greater than 0 if s1 > s2.
      */
-    static int compare(SourceLocation s1, SourceLocation s2) {
-        return s1.compareTo(s2);
+    static int compare(FromSourceLocation s1, FromSourceLocation s2) {
+        return s1.getSourceLocation().compareTo(s2.getSourceLocation());
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/FromSourceLocation.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/FromSourceLocation.java
@@ -28,4 +28,15 @@ public interface FromSourceLocation {
     default SourceLocation getSourceLocation() {
         return SourceLocation.none();
     }
+
+    /**
+     * Compares two SourceLocations.
+     *
+     * @param s1 the first SourceLocation to compare.
+     * @param s2 the second SourceLocation to compare.
+     * @return the value 0 if s1 == s2; a value less than 0 if s1 < s2; and a value greater than 0 if s1 > s2.
+     */
+    static int compare(SourceLocation s1, SourceLocation s2) {
+        return s1.compareTo(s2);
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/SourceLocation.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/SourceLocation.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 /**
  * Represents the source location of a model component.
  */
-public final class SourceLocation implements FromSourceLocation {
+public final class SourceLocation implements FromSourceLocation, Comparable<SourceLocation> {
 
     public static final SourceLocation NONE = new SourceLocation("N/A");
 
@@ -96,5 +96,19 @@ public final class SourceLocation implements FromSourceLocation {
         }
 
         return h;
+    }
+
+    @Override
+    public int compareTo(SourceLocation o) {
+        if (!this.getFilename().equals(o.getFilename())) {
+            return this.getFilename().compareTo(o.getFilename());
+        }
+
+        int lineComparison = Integer.compare(this.getLine(), o.getLine());
+        if (lineComparison != 0) {
+            return lineComparison;
+        }
+
+        return Integer.compare(this.getColumn(), o.getColumn());
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/SourceLocationTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/SourceLocationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StringShape;
+
+public class SourceLocationTest {
+    @Test
+    public void sortsSourceLocations() {
+        Model model = Model.builder()
+                .addShape(StringShape.builder()
+                        .id("smithy.example#First")
+                        .source(new SourceLocation("a.smithy", 1, 1))
+                        .build())
+                .addShape(StringShape.builder()
+                        .id("smithy.example#Second")
+                        .source(new SourceLocation("a.smithy", 1, 2))
+                        .build())
+                .addShape(StringShape.builder()
+                        .id("smithy.example#Third")
+                        .source(new SourceLocation("a.smithy", 2, 1))
+                        .build())
+                .addShape(StringShape.builder()
+                        .id("smithy.example#Fourth")
+                        .source(new SourceLocation("b.smithy", 1, 1))
+                        .build())
+                .build();
+
+        List<Shape> shapes = model.shapes()
+                .sorted(Comparator.comparing(Shape::getSourceLocation))
+                .collect(Collectors.toList());
+        assertEquals("First", shapes.get(0).getId().getName());
+        assertEquals("Second", shapes.get(1).getId().getName());
+        assertEquals("Third", shapes.get(2).getId().getName());
+        assertEquals("Fourth", shapes.get(3).getId().getName());
+    }
+}


### PR DESCRIPTION
This CR implements Comparable on SourceLocation and adds a `compare` static method to FromSourceLocation for comparing SourceLocations.

This can be used to compare and sort shapes or traits, replacing the `SourceLocationSorter` and `TraitSorter` added in https://github.com/awslabs/smithy/pull/1175. It will also be used to sort shapes in the Smithy Language Server (https://github.com/awslabs/smithy-language-server/pull/35).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
