### PR TITLE
Add breakingChanges  property to `@trait`

### DIFF
--- a/docs/source/1.0/spec/core/model.rst
+++ b/docs/source/1.0/spec/core/model.rst
@@ -2493,6 +2493,9 @@ The following example defines a trait with a :ref:`shape ID <shape-id>` of
         member of a structure can be marked with the trait. When set to
         "target", only a single member of a structure can target a shape
         marked with this trait.
+    * - breakingChanges
+      - [:ref:`BreakingChangeRule <trait-breaking-change-rules>`]
+      - Defines the backward compatibility rules of the trait.
 
 The following example defines two custom traits: ``beta`` and
 ``structuredTrait``:
@@ -2693,6 +2696,263 @@ after adding a member to the ``foo`` trait:
                 }
             }
         }
+
+
+.. _trait-breaking-change-rules:
+
+Trait breaking change rules
+---------------------------
+
+Backward compatibility rules of a trait can be defined in the ``breakingChanges``
+member of a trait definition. This member is a list of diff rules. Smithy
+tooling that performs semantic diff analysis between two versions of the same
+model can use these rules to detect breaking or risky changes.
+
+.. note::
+
+    Not every kind of breaking change can be described using the
+    ``breakingChanges`` property. Such backward compatibility rules SHOULD
+    instead be described through documentation and ideally enforced through
+    custom diff tooling.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - change
+      - ``string``
+      - **Required**. The type of change. This value can be set to one of the
+        following:
+
+        - ``add``: The trait or value at the given path was added.
+        - ``remove``: The trait or value at the given path was removed.
+        - ``update``: The trait or value at the given path was changed.
+        - ``any``: The trait or value at the given path was added, removed,
+          or changed.
+        - ``presence``: The trait or value at the given path was either
+          added or removed.
+    * - path
+      - ``string``
+      - A JSON pointer as described in :rfc:`6901` that points to the values
+        to compare from the original model to the updated model. If omitted
+        or if an empty string is provided (``""``), the entire trait is used
+        as the value for comparison. The provided pointer MUST correctly
+        correspond to shapes in the model.
+    * - severity
+      - ``string``
+      - Defines the severity of the change. This value can be set to:
+
+        - ``ERROR``: The change is backward incompatible. This is the default
+          assumed severity.
+        - ``DANGER``: The change is very likely backward incompatible.
+        - ``WARNING``: The change might be backward incompatible.
+        - ``NOTICE``: The change is likely ok, but should be noted during
+          things like code reviews.
+    * - message
+      - ``string``
+      - Provides an optional plain text message that provides information about
+        why the detected change could be problematic.
+
+It is a backward incompatible change to add the following trait to an
+existing shape:
+
+.. code-block:: smithy
+
+    @trait(breakingChanges: [{change: "add"}])
+    structure cannotAdd {}
+
+.. note::
+
+    The above trait definition is equivalent to the following:
+
+    .. code-block:: smithy
+
+        @trait(
+            breakingChanges: [
+                {
+                    change: "add",
+                    path: "",
+                    severity: "ERROR"
+                }
+            ]
+        )
+        structure cannotAdd {}
+
+It is a backward incompatible change to add or remove the following trait from
+an existing shape:
+
+.. code-block:: smithy
+
+    @trait(breakingChanges: [{change: "presence"}])
+    structure cannotToAddOrRemove {}
+
+It is very likely backward incompatible to change the "foo" member of the
+following trait or to remove the "baz" member:
+
+.. code-block:: smithy
+
+    @trait(
+        breakingChanges: [
+            {
+                change: "update",
+                path: "/foo",
+                severity: "DANGER"
+            },
+            {
+                change: "remove",
+                path: "/baz",
+                severity: "DANGER"
+            }
+        ]
+    )
+    structure fooBaz {
+        foo: String,
+        baz: String
+    }
+
+So for example, if the following shape:
+
+.. code-block:: smithy
+
+    @fooBaz(foo: "a", baz: "b")
+    string Example
+
+Is changed to:
+
+.. code-block:: smithy
+
+    @fooBaz(foo: "b")
+    string Example
+
+Then the change to the ``foo`` member from "a" to "b" is backward
+incompatible, as is the removal of the ``baz`` member.
+
+.. rubric:: Referring to list and set members
+
+The JSON pointer can path into the members of a list or set using a ``member``
+segment.
+
+In the following example, it is a breaking change to change values of lists
+or sets in instances of the ``names`` trait:
+
+.. code-block:: smithy
+
+    @trait(
+        breakingChanges: [
+            {
+                change: "update",
+                path: "/names/member"
+            }
+        ]
+    )
+    structure names {
+        names: NameList
+    }
+
+    @private
+    list NameList {
+        member: String
+    }
+
+So for example, if the following shape:
+
+.. code-block:: smithy
+
+    @names(names: ["Han", "Luke"])
+    string Example
+
+Is changed to:
+
+.. code-block:: smithy
+
+    @names(names: ["Han", "Chewy"])
+    string Example
+
+Then the change to the second value of the ``names`` member is
+backward incompatible because it changed from ``Luke`` to ``Chewy``.
+
+.. rubric:: Referring to map members
+
+Members of a map shape can be referenced in a JSON pointer using
+``key`` and ``value``.
+
+The following example defines a trait where it is backward incompatible
+to remove a key value pair from a map:
+
+.. code-block:: smithy
+
+    @trait(
+        breakingChanges: [
+            {
+                change: "remove",
+                path: "/key"
+            }
+        ]
+    )
+    map jobs {
+        key: String,
+        value: String
+    }
+
+So for example, if the following shape:
+
+.. code-block:: smithy
+
+    @jobs(Han: "Smuggler", Luke: "Jedi")
+    string Example
+
+Is changed to:
+
+.. code-block:: smithy
+
+    @jobs(Luke: "Jedi")
+    string Example
+
+Then the removal of the "Han" entry of the map is flagged as backward
+incompatible.
+
+The following example detects when values of a map change.
+
+.. code-block:: smithy
+
+    @trait(
+        breakingChanges: [
+            {
+                change: "update",
+                path: "/value"
+            }
+        ]
+    )
+    map jobs {
+        key: String,
+        value: String
+    }
+
+So for example, if the following shape:
+
+.. code-block:: smithy
+
+    @jobs(Han: "Smuggler", Luke: "Jedi")
+    string Example
+
+Is changed to:
+
+.. code-block:: smithy
+
+    @jobs(Han: "Smuggler", Luke: "Ghost")
+    string Example
+
+Then the change to Luke's mapping from "Jedi" to "Ghost" is
+backward incompatible.
+
+.. note::
+
+    * Using the "update" ``change`` type with a map key has no effect.
+    * Using any ``change`` type other than "update" with map values has no
+      effect.
 
 
 .. _metadata:

--- a/smithy-aws-cloudformation-traits/src/main/resources/META-INF/smithy/aws.cloudformation.smithy
+++ b/smithy-aws-cloudformation-traits/src/main/resources/META-INF/smithy/aws.cloudformation.smithy
@@ -7,16 +7,18 @@ namespace aws.cloudformation
 @unstable
 @trait(
     selector: "structure > :test(member > string)",
-    conflicts: [cfnExcludeProperty]
+    conflicts: [cfnExcludeProperty],
+    breakingChanges: [{change: "remove"}]
 )
-@tags(["diff.error.remove"])
 structure cfnAdditionalIdentifier {}
 
 /// The cloudFormationName trait allows a CloudFormation resource property name
 /// to differ from a structure member name used in the model.
 @unstable
-@trait(selector: "structure > member")
-@tags(["diff.error.const"])
+@trait(
+    selector: "structure > member",
+    breakingChanges: [{change: "any"}]
+)
 string cfnName
 
 /// Indicates that a structure member should not be included in generated
@@ -27,9 +29,9 @@ string cfnName
     conflicts: [
         cfnAdditionalIdentifier,
         cfnMutability,
-    ]
+    ],
+    breakingChanges: [{change: "add"}]
 )
-@tags(["diff.error.add"])
 structure cfnExcludeProperty {}
 
 /// Indicates an explicit CloudFormation mutability of the structure member
@@ -88,8 +90,10 @@ string cfnMutability
 
 /// Indicates that a Smithy resource is a CloudFormation resource.
 @unstable
-@trait(selector: "resource")
-@tags(["diff.error.add", "diff.error.remove"])
+@trait(
+    selector: "resource",
+    breakingChanges: [{change: "presence"}]
+)
 structure cfnResource {
     /// Provides a custom CloudFormation resource name.
     name: String,

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.json
@@ -212,9 +212,13 @@
             },
             "traits": {
                 "smithy.api#trait": {
-                    "selector": "structure [trait|error]"
+                    "selector": "structure [trait|error]",
+                    "breakingChanges": [
+                        {
+                            "change": "any"
+                        }
+                    ]
                 },
-                "smithy.api#tags": ["diff.error.const"],
                 "smithy.api#documentation": "Provides the value in the 'Code' distinguishing field and HTTP response code for an operation error."
             }
         },

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/TraitBreakingChange.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/TraitBreakingChange.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.traits.TraitDefinition;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Finds breaking changes related to when a trait is added, removed, or
+ * updated based on the breakingChanges property of traits.
+ */
+public final class TraitBreakingChange extends AbstractDiffEvaluator {
+
+    private static final List<TraitDefinition.ChangeType> ANY_TYPES = Arrays.asList(
+            TraitDefinition.ChangeType.ADD,
+            TraitDefinition.ChangeType.REMOVE,
+            TraitDefinition.ChangeType.UPDATE);
+
+    private static final List<TraitDefinition.ChangeType> PRESENCE_TYPES = Arrays.asList(
+            TraitDefinition.ChangeType.ADD,
+            TraitDefinition.ChangeType.REMOVE);
+
+    @Override
+    public List<ValidationEvent> evaluate(Differences differences) {
+        List<ValidationEvent> events = new ArrayList<>();
+
+        differences.changedShapes().forEach(changedShape -> {
+            changedShape.getTraitDifferences().forEach((traitId, oldTraitNewTraitPair) -> {
+                Trait oldTrait = oldTraitNewTraitPair.left;
+                Trait newTrait = oldTraitNewTraitPair.right;
+                // Use the breaking changes rules of the new trait.
+                differences.getNewModel().getShape(traitId).ifPresent(traitShape -> {
+                    List<TraitDefinition.BreakingChangeRule> rules = traitShape
+                            .expectTrait(TraitDefinition.class)
+                            .getBreakingChanges();
+                    for (TraitDefinition.BreakingChangeRule rule : rules) {
+                        PathChecker checker = new PathChecker(differences.getNewModel(), traitShape,
+                                                              changedShape.getNewShape(), rule, events);
+                        checker.check(Node.from(oldTrait), Node.from(newTrait));
+                    }
+                });
+            });
+        });
+
+        return events;
+    }
+
+    private static final class PathChecker {
+        private final Model model;
+        private final Shape trait;
+        private final Shape targetShape;
+        private final TraitDefinition.BreakingChangeRule rule;
+        private final List<ValidationEvent> events;
+        private final List<String> segements;
+
+        PathChecker(
+                Model model,
+                Shape trait,
+                Shape targetShape,
+                TraitDefinition.BreakingChangeRule rule,
+                List<ValidationEvent> events
+        ) {
+            this.model = model;
+            this.trait = trait;
+            this.targetShape = targetShape;
+            this.rule = rule;
+            this.events = events;
+            this.segements = rule.getDefaultedPath().getParts();
+        }
+
+        private void check(Node left, Node right) {
+            // Only perform nested diffs if the right node was found.
+            if (right.isNullNode() && !segements.isEmpty()) {
+                return;
+            }
+
+            Map<String, Node> leftValues = new TreeMap<>();
+            Map<String, Node> rightValues = new TreeMap<>();
+            extract(leftValues, trait, 0, left, "");
+            extract(rightValues, trait, 0, right, "");
+
+            // Compare values that exist only in left or in both.
+            for (Map.Entry<String, Node> entry : leftValues.entrySet()) {
+                Node rightValue = rightValues.getOrDefault(entry.getKey(), Node.nullNode());
+                compareResult(entry.getKey(), entry.getValue(), rightValue);
+            }
+
+            // Find newly added values.
+            for (Map.Entry<String, Node> entry : rightValues.entrySet()) {
+                if (!leftValues.containsKey(entry.getKey())) {
+                    compareResult(entry.getKey(), Node.nullNode(), entry.getValue());
+                }
+            }
+        }
+
+        private void extract(
+                Map<String, Node> result,
+                Shape currentShape,
+                int segmentPosition,
+                Node currentValue,
+                String path
+        ) {
+            // Don't keep crawling when a "" segment is hit or the last segment is hit.
+            if (segmentPosition >= segements.size() || segements.get(segmentPosition).isEmpty()) {
+                result.put(path, currentValue);
+                return;
+            }
+
+            String segment = segements.get(segmentPosition);
+            currentShape.getMember(segment).flatMap(m -> model.getShape(m.getTarget())).ifPresent(nextShape -> {
+                if (currentShape instanceof CollectionShape) {
+                    currentValue.asArrayNode().ifPresent(v -> {
+                        for (int i = 0; i < v.size(); i++) {
+                            Node value = v.get(i).get();
+                            extract(result, nextShape, segmentPosition + 1, value, path + "/" + i);
+                        }
+                    });
+                } else if (currentShape instanceof MapShape) {
+                    currentValue.asObjectNode().ifPresent(v -> {
+                        for (Map.Entry<String, Node> entry : v.getStringMap().entrySet()) {
+                            extract(result, nextShape, segmentPosition + 1,
+                                    entry.getValue(), path + "/" + entry.getKey());
+                        }
+                    });
+                } else if (currentShape.isStructureShape() || currentShape.isUnionShape()) {
+                    currentValue.asObjectNode().ifPresent(v -> {
+                        extract(result, nextShape, segmentPosition + 1, v.getMember(segment).orElse(Node.nullNode()),
+                                path + "/" + segment);
+                    });
+                }
+            });
+        }
+
+        private void compareResult(String path, Node left, Node right) {
+            if (!left.isNullNode() || !right.isNullNode()) {
+                TraitDefinition.ChangeType type = isChangeBreaking(rule.getChange(), left, right);
+                if (type != null) {
+                    String message = createBreakingMessage(type, path, left, right);
+                    if (rule.getMessage().isPresent()) {
+                        if (!message.endsWith(".")) {
+                            message = message + "; ";
+                        }
+                        message = message + rule.getMessage().get();
+                    }
+                    FromSourceLocation location = !right.isNullNode() ? right : targetShape;
+                    events.add(ValidationEvent.builder()
+                                       .id(TraitBreakingChange.class.getSimpleName())
+                                       .severity(rule.getDefaultedSeverity())
+                                       .shape(targetShape)
+                                       .sourceLocation(location)
+                                       .message(message)
+                                       .build());
+                }
+            }
+        }
+
+        // Check if a breaking change was encountered, and return the type of breaking change.
+        private TraitDefinition.ChangeType isChangeBreaking(TraitDefinition.ChangeType type, Node left, Node right) {
+            switch (type) {
+                case ADD:
+                    return left.isNullNode() && !right.isNullNode() ? type : null;
+                case REMOVE:
+                    return right.isNullNode() && !left.isNullNode() ? type : null;
+                case UPDATE:
+                    return !left.isNullNode() && !right.isNullNode() && !left.equals(right) ? type : null;
+                case ANY:
+                    for (TraitDefinition.ChangeType checkType : ANY_TYPES) {
+                        if (isChangeBreaking(checkType, left, right) != null) {
+                            return checkType;
+                        }
+                    }
+                    return null;
+                case PRESENCE:
+                    for (TraitDefinition.ChangeType checkType : PRESENCE_TYPES) {
+                        if (isChangeBreaking(checkType, left, right) != null) {
+                            return checkType;
+                        }
+                    }
+                default:
+                    return null;
+            }
+        }
+
+        private String createBreakingMessage(TraitDefinition.ChangeType type, String path, Node left, Node right) {
+            String leftPretty = Node.prettyPrintJson(left.toNode());
+            String rightPretty = Node.prettyPrintJson(right.toNode());
+
+            switch (type) {
+                case ADD:
+                    if (!path.isEmpty()) {
+                        return String.format("Added trait contents to `%s` at path `%s` with value %s",
+                                             trait.getId(), path, rightPretty);
+                    } else if (rightPretty.equals("{}")) {
+                        return String.format("Added trait `%s`", trait.getId());
+                    } else {
+                        return String.format("Added trait `%s` with value %s", trait.getId(), rightPretty);
+                    }
+                case REMOVE:
+                    if (!path.isEmpty()) {
+                        return String.format("Removed trait contents from `%s` at path `%s`. Removed value: %s",
+                                             trait.getId(), path, leftPretty);
+                    } else if (leftPretty.equals("{}")) {
+                        return String.format("Removed trait `%s`", trait.getId());
+                    } else {
+                        return String.format("Removed trait `%s`. Previous trait value: %s",
+                                             trait.getId(), leftPretty);
+                    }
+                case UPDATE:
+                    if (!path.isEmpty()) {
+                        return String.format("Changed trait contents of `%s` at path `%s` from %s to %s",
+                                             trait.getId(), path, leftPretty, rightPretty);
+                    } else {
+                        return String.format("Changed trait `%s` from %s to %s",
+                                             trait.getId(), leftPretty, rightPretty);
+                    }
+                default:
+                    throw new UnsupportedOperationException("Expected add, remove, update: " + type);
+            }
+        }
+    }
+}

--- a/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
+++ b/smithy-diff/src/main/resources/META-INF/services/software.amazon.smithy.diff.DiffEvaluator
@@ -23,3 +23,4 @@ software.amazon.smithy.diff.evaluators.RemovedServiceError
 software.amazon.smithy.diff.evaluators.RemovedShape
 software.amazon.smithy.diff.evaluators.RemovedTraitDefinition
 software.amazon.smithy.diff.evaluators.ServiceRename
+software.amazon.smithy.diff.evaluators.TraitBreakingChange

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedRequiredTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedRequiredTraitTest.java
@@ -41,7 +41,7 @@ public class AddedRequiredTraitTest {
         Model modelB = Model.assembler().addShapes(shapeA2, member2, target).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "ModifiedTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "TraitBreakingChange").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, member1.getId()).size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
     }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedPaginatedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedPaginatedTraitTest.java
@@ -55,7 +55,7 @@ public class ChangedPaginatedTraitTest {
                 .removeTraitsIf(model, (shape, trait) -> trait instanceof PaginatedTrait);
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
     }
@@ -70,7 +70,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
@@ -87,7 +87,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(oldModel, model);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
@@ -104,7 +104,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
@@ -121,7 +121,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
@@ -138,7 +138,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(oldModel, model);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents, empty());
     }
@@ -153,7 +153,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
@@ -169,7 +169,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
@@ -185,7 +185,7 @@ public class ChangedPaginatedTraitTest {
         });
 
         List<ValidationEvent> events = ModelDiff.compare(model, newModel);
-        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "ModifiedTrait");
+        List<ValidationEvent> changedTraitEvents = TestHelper.findEvents(events, "TraitBreakingChange");
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -123,7 +123,7 @@ public class ModifiedTraitTest {
 
         assertThat(messages, containsInAnyOrder(
                 "Changed trait `smithy.example#b` from \"hello\" to \"hello!\"",
-                "Removed trait `smithy.example#a`. Removed value: {}",
+                "Removed trait `smithy.example#a`. Previous trait value: {}",
                 "Added trait `smithy.example#c` with value \"foo\""
         ));
     }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/TraitBreakingChangeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/TraitBreakingChangeTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.diff.evaluators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.diff.ModelDiff;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.DynamicTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.ListUtils;
+
+public class TraitBreakingChangeTest {
+
+    private static final ShapeId EXAMPLE_SHAPE = ShapeId.from("smithy.example#Example");
+    private static final ShapeId EXAMPLE_TRAIT = ShapeId.from("smithy.example#exampleTrait");
+
+    @Test
+    public void detectsBreakingChangeWhenRemoved() {
+        validate("trait-removed.smithy", shape -> shape.removeTrait(EXAMPLE_TRAIT).build(), events -> {
+            assertThat(events, hasSize(1));
+            assertThat(events.get(0).getSeverity(), equalTo(Severity.ERROR));
+            assertThat(events.get(0).getMessage(), equalTo("Removed trait `smithy.example#exampleTrait`"));
+        });
+    }
+
+    private void validate(
+            String modelFile,
+            Function<StringShape.Builder, Shape> mapper,
+            Consumer<List<ValidationEvent>> consumer
+    ) {
+        Model modelA = Model.assembler()
+                .addImport(getClass().getResource("trait-breaking-change/" + modelFile))
+                .assemble()
+                .unwrap();
+
+        // Find the example shape, transform it, and create a new model.
+        StringShape example = modelA.expectShape(EXAMPLE_SHAPE, StringShape.class);
+        Shape updated = mapper.apply(example.toBuilder());
+        Model modelB = ModelTransformer.create().replaceShapes(modelA, ListUtils.of(updated));
+
+        List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "TraitBreakingChange");
+
+        consumer.accept(events);
+    }
+
+    @Test
+    public void detectsBreakingChangeWhenAdded() {
+        validate(
+            "trait-added.smithy",
+            shape -> shape.addTrait(new DynamicTrait(EXAMPLE_TRAIT, Node.objectNode())).build(),
+            events -> {
+                assertThat(events, hasSize(1));
+                assertThat(events.get(0).getMessage(), equalTo("Added trait `smithy.example#exampleTrait`"));
+            }
+        );
+    }
+
+    @Test
+    public void detectsBreakingChangePresence() {
+        validate("trait-presence.smithy", shape -> shape.removeTrait(EXAMPLE_TRAIT).build(), events -> {
+            assertThat(events, hasSize(1));
+            assertThat(events.get(0).getMessage(), equalTo("Removed trait `smithy.example#exampleTrait`"));
+        });
+    }
+
+    @Test
+    public void detectsBreakingChangeAny() {
+        validate("trait-any.smithy", shape -> shape.removeTrait(EXAMPLE_TRAIT).build(), events -> {
+            assertThat(events, hasSize(1));
+            assertThat(events.get(0).getMessage(), equalTo("Removed trait `smithy.example#exampleTrait`"));
+        });
+    }
+
+    @Test
+    public void canChangeSeverity() {
+        validate("trait-severity.smithy", shape -> shape.removeTrait(EXAMPLE_TRAIT).build(), events -> {
+            assertThat(events, hasSize(1));
+            assertThat(events.get(0).getSeverity(), equalTo(Severity.WARNING));
+        });
+    }
+
+    @Test
+    public void canIncludeCustomMessage() {
+        validate("trait-message.smithy", shape -> shape.removeTrait(EXAMPLE_TRAIT).build(), events -> {
+            assertThat(events, hasSize(1));
+            assertThat(events.get(0).getMessage(),
+                       equalTo("Removed trait `smithy.example#exampleTrait`; This is bad!"));
+        });
+    }
+
+    @Test
+    public void canPathIntoListMembers() {
+        validate(
+            "trait-list-members.smithy",
+            shape -> shape.addTrait(new DynamicTrait(EXAMPLE_TRAIT, Node.fromStrings("a", "B", "c"))).build(),
+            events -> {
+                assertThat(events, hasSize(1));
+                assertThat(events.get(0).getMessage(),
+                           equalTo("Changed trait contents of `smithy.example#exampleTrait` at path `/1` "
+                                   + "from \"b\" to \"B\""));
+            }
+        );
+    }
+
+    @Test
+    public void canPathIntoMapKeys() {
+        validate(
+                "trait-map-keys.smithy",
+                shape -> shape.addTrait(new DynamicTrait(EXAMPLE_TRAIT, Node.objectNode().withMember("a", "A")))
+                        .build(),
+                events -> {
+                    assertThat(events, hasSize(1));
+                    assertThat(events.get(0).getMessage(),
+                               equalTo("Removed trait contents from `smithy.example#exampleTrait` at path `/b`. "
+                                       + "Removed value: \"B\""));
+                }
+        );
+    }
+
+    @Test
+    public void canPathIntoMapValues() {
+        validate(
+            "trait-map-values.smithy",
+            shape -> {
+                Trait trait = new DynamicTrait(EXAMPLE_TRAIT,
+                                               Node.objectNode().withMember("a", "A").withMember("b", "_B_"));
+                return shape.addTrait(trait).build();
+            },
+            events -> {
+                assertThat(events, hasSize(1));
+                assertThat(events.get(0).getMessage(),
+                           equalTo("Changed trait contents of `smithy.example#exampleTrait` at path `/b` "
+                                   + "from \"B\" to \"_B_\""));
+            }
+        );
+    }
+
+    @Test
+    public void canPathIntoStructureMembers() {
+        validate(
+            "trait-structure-members.smithy",
+            shape -> {
+                Trait trait = new DynamicTrait(EXAMPLE_TRAIT, Node.objectNode());
+                return shape.addTrait(trait).build();
+            },
+            events -> {
+                assertThat(events, hasSize(1));
+                assertThat(events.get(0).getMessage(),
+                           equalTo("Removed trait contents from `smithy.example#exampleTrait` at path "
+                                   + "`/foo/bar`. Removed value: \"hi\""));
+            }
+        );
+    }
+
+    @Test
+    public void canPathIntoUnionMembers() {
+        validate(
+            "trait-union-members.smithy",
+            shape -> {
+                Trait trait = new DynamicTrait(EXAMPLE_TRAIT, Node.objectNode().withMember("foo", "bye"));
+                return shape.addTrait(trait).build();
+            },
+            events -> {
+                assertThat(events, hasSize(1));
+                assertThat(events.get(0).getMessage(),
+                           equalTo("Changed trait contents of `smithy.example#exampleTrait` at path "
+                                   + "`/foo` from \"hi\" to \"bye\""));
+            }
+        );
+    }
+}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-added.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-added.smithy
@@ -1,0 +1,8 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "add"}])
+structure exampleTrait {}
+
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-any.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-any.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "any"}])
+structure exampleTrait {}
+
+@exampleTrait
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-list-members.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-list-members.smithy
@@ -1,0 +1,11 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "update", path: "/member"}])
+list exampleTrait {
+    member: String
+}
+
+@exampleTrait(["a", "b", "c"])
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-map-keys.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-map-keys.smithy
@@ -1,0 +1,12 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "remove", path: "/key"}])
+map exampleTrait {
+    key: String,
+    value: String
+}
+
+@exampleTrait(a: "A", b: "B")
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-map-values.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-map-values.smithy
@@ -1,0 +1,12 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "update", path: "/value"}])
+map exampleTrait {
+    key: String,
+    value: String
+}
+
+@exampleTrait(a: "A", b: "B")
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-message.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-message.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "presence", message: "This is bad!"}])
+structure exampleTrait {}
+
+@exampleTrait
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-presence.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-presence.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "presence"}])
+structure exampleTrait {}
+
+@exampleTrait
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-removed.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-removed.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "remove"}])
+structure exampleTrait {}
+
+@exampleTrait
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-severity.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-severity.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "presence", severity: "WARNING"}])
+structure exampleTrait {}
+
+@exampleTrait
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-structure-members.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-structure-members.smithy
@@ -1,0 +1,16 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "presence", path: "/foo/bar"}])
+structure exampleTrait {
+    foo: Nested
+}
+
+@private
+structure Nested {
+    bar: String
+}
+
+@exampleTrait(foo: {bar: "hi"})
+string Example

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-union-members.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/trait-breaking-change/trait-union-members.smithy
@@ -1,0 +1,11 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{change: "update", path: "/foo"}])
+union exampleTrait {
+    foo: String
+}
+
+@exampleTrait(foo: "hi")
+string Example

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -196,6 +196,16 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Create a Node from a potentially null {@link ToNode} value.
+     *
+     * @param value Value to create a node from.
+     * @return Returns the created Node.
+     */
+    public static Node from(ToNode value) {
+        return value == null ? Node.nullNode() : value.toNode();
+    }
+
+    /**
      * Creates an {@link ArrayNode} from a Collection of Node values.
      *
      * @param values String values to add to the ArrayNode.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodePointer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodePointer.java
@@ -32,13 +32,40 @@ import java.util.logging.Logger;
 public final class NodePointer {
 
     private static final Logger LOGGER = Logger.getLogger(NodePointer.class.getName());
+    private static final NodePointer EMPTY = new NodePointer("", Collections.emptyList());
 
-    private String originalString;
-    private List<String> parts;
+    private final String originalString;
+    private final List<String> parts;
 
     private NodePointer(String originalString, List<String> parts) {
         this.originalString = originalString;
         this.parts = parts;
+    }
+
+    /**
+     * Gets an empty Node pointer.
+     *
+     * @return Returns a node pointer with a value of "".
+     */
+    public static NodePointer empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Creates a NodePointer from a Node value.
+     *
+     * @param node Node value to parse.
+     * @return Returns the parsed NodePointer.
+     * @throws ExpectationNotMetException if the pointer cannot be parsed.
+     */
+    public static NodePointer fromNode(Node node) {
+        try {
+            String value = node.expectStringNode().getValue();
+            return NodePointer.parse(value);
+        } catch (RuntimeException e) {
+            String message = "Expected a string containing a valid JSON pointer: " + e.getMessage();
+            throw new ExpectationNotMetException(message, node);
+        }
     }
 
     /**
@@ -66,7 +93,7 @@ public final class NodePointer {
      * @throws IllegalArgumentException if the pointer does not start with slash (/).
      */
     public static NodePointer parse(String pointer) {
-        return new NodePointer(pointer, parseJsonPointer(pointer));
+        return pointer.isEmpty() ? empty() : new NodePointer(pointer, parseJsonPointer(pointer));
     }
 
     private static List<String> parseJsonPointer(String pointer) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.model.shapes;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.smithy.utils.SmithyBuilder;
 
@@ -46,6 +47,11 @@ public abstract class CollectionShape extends Shape {
      */
     public final MemberShape getMember() {
         return member;
+    }
+
+    @Override
+    public final Optional<MemberShape> getMember(String name) {
+        return name.equals("member") ? Optional.of(member) : Optional.empty();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
@@ -99,6 +99,18 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
     }
 
     @Override
+    public Optional<MemberShape> getMember(String name) {
+        switch (name) {
+            case "key":
+                return Optional.of(key);
+            case "value":
+                return Optional.of(value);
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (!super.equals(other)) {
             return false;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMembersShape.java
@@ -77,13 +77,8 @@ abstract class NamedMembersShape extends Shape {
         return names;
     }
 
-    /**
-     * Get a specific member by name.
-     *
-     * @param name Name of the member to retrieve.
-     * @return Returns the optional member.
-     */
-    public Optional<MemberShape> getMember(String name) {
+    @Override
+    public final Optional<MemberShape> getMember(String name) {
         return Optional.ofNullable(members.get(name));
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -569,6 +569,18 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
         return Collections.emptyList();
     }
 
+    /**
+     * Get a specific member by name.
+     *
+     * <p>Shapes with no members return an empty Optional.
+     *
+     * @param name Name of the member to retrieve.
+     * @return Returns the optional member.
+     */
+    public Optional<MemberShape> getMember(String name) {
+        return Optional.empty();
+    }
+
     @Override
     public ShapeId toShapeId() {
         return id;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -17,16 +17,21 @@ package software.amazon.smithy.model.traits;
 
 import static software.amazon.smithy.model.node.Node.loadArrayOfString;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodePointer;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -37,7 +42,7 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
     public static final ShapeId ID = ShapeId.from("smithy.api#trait");
 
     /** The structural exclusion semantics of the trait. */
-    public enum StructurallyExclusive {
+    public enum StructurallyExclusive implements ToNode {
         /** The trait can only be applied to a single member of a structure. */
         MEMBER,
 
@@ -48,21 +53,168 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
         public String toString() {
             return super.toString().toLowerCase(Locale.ENGLISH);
         }
+
+        @Override
+        public Node toNode() {
+            return Node.from(toString());
+        }
+
+        public static StructurallyExclusive fromNode(Node node) {
+            String value = node.expectStringNode().expectOneOf(
+                    StructurallyExclusive.MEMBER.toString(),
+                    StructurallyExclusive.TARGET.toString());
+            return StructurallyExclusive.valueOf(value.toUpperCase(Locale.ENGLISH));
+        }
     }
 
-    public static final String SELECTOR_KEY = "selector";
-    public static final String STRUCTURALLY_EXCLUSIVE_KEY = "structurallyExclusive";
-    public static final String CONFLICTS_KEY = "conflicts";
+    /**
+     * Represents an individual trait diff rule to define backward compatibility rules.
+     */
+    public static final class BreakingChangeRule implements ToNode {
+        private final NodePointer path;
+        private final Severity severity;
+        private final ChangeType change;
+        private final String message;
+
+        public BreakingChangeRule(NodePointer path, Severity severity, ChangeType change, String message) {
+            this.path = path;
+            this.severity = severity;
+            this.change = change;
+            this.message = message;
+        }
+
+        public Optional<NodePointer> getPath() {
+            return Optional.ofNullable(path);
+        }
+
+        public NodePointer getDefaultedPath() {
+            return path == null ? NodePointer.empty() : path;
+        }
+
+        public Optional<Severity> getSeverity() {
+            return Optional.ofNullable(severity);
+        }
+
+        public Severity getDefaultedSeverity() {
+            return severity == null ? Severity.ERROR : severity;
+        }
+
+        public ChangeType getChange() {
+            return change;
+        }
+
+        public Optional<String> getMessage() {
+            return Optional.ofNullable(message);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(path, severity, change, message);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof BreakingChangeRule) {
+                BreakingChangeRule other = (BreakingChangeRule) obj;
+                return Objects.equals(path, other.path)
+                       && Objects.equals(severity, other.severity)
+                       && Objects.equals(message, other.message)
+                       && change == other.change;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return super.toString();
+        }
+
+        @Override
+        public Node toNode() {
+            return Node.objectNodeBuilder()
+                    .withOptionalMember("path", getPath().map(NodePointer::toString).map(Node::from))
+                    .withOptionalMember("severity", getSeverity().map(Severity::toNode))
+                    .withMember("change", change.toNode())
+                    .withOptionalMember("message", getMessage().map(Node::from))
+                    .build();
+        }
+
+        /**
+         * Creates a TraitDiffRule from a Node.
+         *
+         * @param node Node to deserialize.
+         * @return Returns the created TraitDiffRule.
+         * @throws ExpectationNotMetException if the node is invalid.
+         */
+        public static BreakingChangeRule fromNode(Node node) {
+            ObjectNode obj = node.expectObjectNode();
+            NodePointer path = obj.getStringMember("path").map(NodePointer::fromNode).orElse(null);
+            Severity severity = obj.getStringMember("severity").map(Severity::fromNode).orElse(null);
+            ChangeType change = ChangeType.fromNode(obj.expectStringMember("change"));
+            String message = obj.getStringMemberOrDefault("message", null);
+            if (severity == Severity.SUPPRESSED) {
+                throw new ExpectationNotMetException("Invalid severity", obj.expectMember("severity"));
+            }
+            return new BreakingChangeRule(path, severity, change, message);
+        }
+    }
+
+    public enum ChangeType implements ToNode {
+
+        /** Emit when a trait or value is added that previously did not exist. */
+        ADD,
+
+        /** Emit when a trait or value is removed. */
+        REMOVE,
+
+        /** Emit when a trait is added or removed. */
+        PRESENCE,
+
+        /** Emit when a trait already existed, continues to exist, but it is modified. */
+        UPDATE,
+
+        /** Emit when any change occurs. */
+        ANY;
+
+        /**
+         * Creates a ChangeType value from a node.
+         *
+         * @param node Node to parse.
+         * @return Returns the parsed ChangeType.
+         * @throws ExpectationNotMetException if the node is invalid.
+         */
+        public static ChangeType fromNode(Node node) {
+            try {
+                return ChangeType.valueOf(node.expectStringNode().getValue().toUpperCase(Locale.ENGLISH));
+            } catch (RuntimeException e) {
+                String message = "Expected a string containing a valid trait diff type: " + e.getMessage();
+                throw new ExpectationNotMetException(message, node);
+            }
+        }
+
+        @Override
+        public Node toNode() {
+            return Node.from(toString());
+        }
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase(Locale.ENGLISH);
+        }
+    }
 
     private final Selector selector;
     private final List<ShapeId> conflicts;
     private final StructurallyExclusive structurallyExclusive;
+    private final List<BreakingChangeRule> breakingChanges;
 
     public TraitDefinition(TraitDefinition.Builder builder) {
         super(ID, builder.sourceLocation);
         selector = builder.selector;
         conflicts = builder.conflicts.copy();
         structurallyExclusive = builder.structurallyExclusive;
+        breakingChanges = builder.breakingChanges.copy();
     }
 
     public static Builder builder() {
@@ -74,7 +226,8 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
         Builder builder = builder()
                 .sourceLocation(getSourceLocation())
                 .selector(selector)
-                .structurallyExclusive(structurallyExclusive);
+                .structurallyExclusive(structurallyExclusive)
+                .breakingChanges(breakingChanges);
         conflicts.forEach(builder::addConflict);
         return builder;
     }
@@ -120,24 +273,36 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
         return structurallyExclusive == StructurallyExclusive.TARGET;
     }
 
+    /**
+     * @return Returns the breaking change rules of the trait.
+     */
+    public List<BreakingChangeRule> getBreakingChanges() {
+        return breakingChanges;
+    }
+
     @Override
     protected Node createNode() {
         ObjectNode.Builder builder = Node.objectNodeBuilder().sourceLocation(getSourceLocation());
 
         if (selector != Selector.IDENTITY) {
-            builder.withMember(SELECTOR_KEY, selector.toString());
+            builder.withMember("selector", selector.toString());
         }
 
         if (!conflicts.isEmpty()) {
-            builder.withMember(CONFLICTS_KEY, conflicts.stream()
+            builder.withMember("conflicts", conflicts.stream()
                     .map(ShapeId::toString)
                     .map(Node::from)
                     .collect(ArrayNode.collect()));
         }
 
-        builder.withOptionalMember(
-                STRUCTURALLY_EXCLUSIVE_KEY,
-                getStructurallyExclusive().map(StructurallyExclusive::toString).map(Node::from));
+        builder.withOptionalMember("structurallyExclusive",
+                                   getStructurallyExclusive().map(StructurallyExclusive::toNode));
+
+        if (!breakingChanges.isEmpty()) {
+            List<Node> result = new ArrayList<>(breakingChanges.size());
+            breakingChanges.forEach(d -> result.add(d.toNode()));
+            builder.withMember("breakingChanges", Node.fromNodes(result));
+        }
 
         return builder.build();
     }
@@ -153,13 +318,14 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
             TraitDefinition od = (TraitDefinition) other;
             return selector.equals(od.selector)
                     && conflicts.equals(od.conflicts)
-                    && Objects.equals(structurallyExclusive, od.structurallyExclusive);
+                    && Objects.equals(structurallyExclusive, od.structurallyExclusive)
+                    && breakingChanges.equals(od.breakingChanges);
         }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(toShapeId(), selector, conflicts, structurallyExclusive);
+        return Objects.hash(toShapeId(), selector, conflicts, structurallyExclusive, breakingChanges);
     }
 
     /**
@@ -169,6 +335,7 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
         private Selector selector = Selector.IDENTITY;
         private final BuilderRef<List<ShapeId>> conflicts = BuilderRef.forList();
         private StructurallyExclusive structurallyExclusive;
+        private final BuilderRef<List<BreakingChangeRule>> breakingChanges = BuilderRef.forList();
 
         private Builder() {}
 
@@ -198,6 +365,22 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
             return this;
         }
 
+        public Builder breakingChanges(List<BreakingChangeRule> diff) {
+            clearBreakingChanges();
+            diff.forEach(this::addBreakingChange);
+            return this;
+        }
+
+        public Builder clearBreakingChanges() {
+            this.breakingChanges.clear();
+            return this;
+        }
+
+        public Builder addBreakingChange(BreakingChangeRule rule) {
+            this.breakingChanges.get().add(Objects.requireNonNull(rule));
+            return this;
+        }
+
         @Override
         public TraitDefinition build() {
             return new TraitDefinition(this);
@@ -220,21 +403,22 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
 
             Builder builder = builder().sourceLocation(value);
 
-            members.getMember(TraitDefinition.SELECTOR_KEY)
+            members.getMember("selector")
                     .map(Selector::fromNode)
                     .ifPresent(builder::selector);
 
-            members.getStringMember(TraitDefinition.STRUCTURALLY_EXCLUSIVE_KEY)
-                    .map(node -> node.expectOneOf(
-                            StructurallyExclusive.MEMBER.toString(),
-                            StructurallyExclusive.TARGET.toString()))
-                    .map(string -> string.toUpperCase(Locale.ENGLISH))
-                    .map(StructurallyExclusive::valueOf)
+            members.getStringMember("structurallyExclusive")
+                    .map(StructurallyExclusive::fromNode)
                     .ifPresent(builder::structurallyExclusive);
 
-            members.getMember(TraitDefinition.CONFLICTS_KEY)
-                    .ifPresent(values -> loadArrayOfString(TraitDefinition.CONFLICTS_KEY, values)
-                            .forEach(builder::addConflict));
+            members.getMember("conflicts")
+                    .ifPresent(values -> loadArrayOfString("conflicts", values).forEach(builder::addConflict));
+
+            members.getArrayMember("breakingChanges").ifPresent(d -> {
+                for (ObjectNode entry : d.getElementsAs(ObjectNode.class)) {
+                    builder.addBreakingChange(BreakingChangeRule.fromNode(entry));
+                }
+            });
 
             TraitDefinition result = builder.build();
             result.setNodeCache(value);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/Severity.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/Severity.java
@@ -17,16 +17,21 @@ package software.amazon.smithy.model.validation;
 
 import java.util.Arrays;
 import java.util.Optional;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ToNode;
 
 /**
  * Severity level of a validation exception.
  */
-public enum Severity {
+public enum Severity implements ToNode {
     SUPPRESSED,
     NOTE,
     WARNING,
     DANGER,
     ERROR;
+
+    private static final String[] NAMES = {"SUPPRESSED", "NOTE", "WARNING", "DANGER", "ERROR"};
 
     /**
      * Check if the severity level of the error can be suppressed.
@@ -46,5 +51,22 @@ public enum Severity {
      */
     public static Optional<Severity> fromString(String text) {
         return Arrays.stream(values()).filter(value -> value.toString().equals(text)).findFirst();
+    }
+
+    /**
+     * Creates a severity value from a node.
+     *
+     * @param node Node to parse.
+     * @return Returns the parsed Severity.
+     * @throws ExpectationNotMetException if the node is invalid.
+     */
+    public static Severity fromNode(Node node) {
+        String value = node.expectStringNode().expectOneOf(NAMES);
+        return Severity.valueOf(value);
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.from(toString());
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitBreakingChangesValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitBreakingChangesValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation.validators;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.NodePointer;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TraitDefinition;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Validates that the JSON pointer paths of the breakingChanges property
+ * of a trait refers to valid parts of the model.
+ */
+public final class TraitBreakingChangesValidator extends AbstractValidator {
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        for (Shape shape : model.getShapesWithTrait(TraitDefinition.class)) {
+            validateTrait(model, shape, events);
+        }
+        return events;
+    }
+
+    private void validateTrait(Model model, Shape shape, List<ValidationEvent> events) {
+        TraitDefinition trait = shape.expectTrait(TraitDefinition.class);
+
+        for (int i = 0; i < trait.getBreakingChanges().size(); i++) {
+            TraitDefinition.BreakingChangeRule diffRule = trait.getBreakingChanges().get(i);
+            // No need to validate empty paths or paths that are "", meaning the entire trait.
+            if (diffRule.getPath().isPresent() && !diffRule.getPath().get().toString().equals("")) {
+                Shape current = shape;
+                NodePointer pointer = diffRule.getPath().get();
+                int segment = 0;
+                for (String part : pointer.getParts()) {
+                    Shape previous = current;
+                    current = current.getMember(part)
+                            .flatMap(member -> model.getShape(member.getTarget()))
+                            .orElse(null);
+                    if (current == null) {
+                        events.add(emit(shape, i, segment, previous));
+                        break;
+                    }
+                    segment++;
+                }
+            }
+        }
+    }
+
+    private ValidationEvent emit(Shape shape, int element, int segment, Shape evaluated) {
+        TraitDefinition definition = shape.expectTrait(TraitDefinition.class);
+        NodePointer path = definition.getBreakingChanges().get(element).getDefaultedPath();
+        return error(shape, definition, String.format(
+                "Invalid trait breakingChanges element %d, '%s', at segment '%s': "
+                + "Evaluated shape `%s`, a %s, has no member named `%s`",
+                element, path, path.getParts().get(segment), evaluated.getId(), evaluated.getType(),
+                path.getParts().get(segment)));
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -39,6 +39,7 @@ software.amazon.smithy.model.validation.validators.SingleOperationBindingValidat
 software.amazon.smithy.model.validation.validators.SingleResourceBindingValidator
 software.amazon.smithy.model.validation.validators.StreamingTraitValidator
 software.amazon.smithy.model.validation.validators.TargetValidator
+software.amazon.smithy.model.validation.validators.TraitBreakingChangesValidator
 software.amazon.smithy.model.validation.validators.TraitConflictValidator
 software.amazon.smithy.model.validation.validators.TraitTargetValidator
 software.amazon.smithy.model.validation.validators.TraitValueValidator

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/allows-empty-paths.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/allows-empty-paths.smithy
@@ -1,0 +1,14 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(
+    breakingChanges: [
+        {
+            path: "",
+            change: "presence",
+            message: "Add or remove this this trait, and it is a backward incompatible change!"
+        }
+    ]
+)
+string someTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-member-of-collection.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-member-of-collection.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#badList: Invalid trait breakingChanges element 0, '/foo', at segment 'foo': Evaluated shape `smithy.example#badList`, a list, has no member named `foo` | TraitBreakingChanges
+[ERROR] smithy.example#badSet: Invalid trait breakingChanges element 0, '/foo', at segment 'foo': Evaluated shape `smithy.example#badSet`, a set, has no member named `foo` | TraitBreakingChanges

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-member-of-collection.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-member-of-collection.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{path: "/foo", change: "any"}])
+list badList {
+    member: String
+}
+
+@trait(breakingChanges: [{path: "/foo", change: "any"}])
+set badSet {
+    member: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-named-members.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-named-members.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#a: Invalid trait breakingChanges element 0, '/foo/bar', at segment 'foo': Evaluated shape `smithy.example#a`, a structure, has no member named `foo` | TraitBreakingChanges
+[ERROR] smithy.example#b: Invalid trait breakingChanges element 0, '/foo/bar', at segment 'foo': Evaluated shape `smithy.example#b`, a union, has no member named `foo` | TraitBreakingChanges

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-named-members.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/invalid-named-members.smithy
@@ -1,0 +1,13 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{path: "/foo/bar", change: "any"}])
+structure a {
+    baz: String
+}
+
+@trait(breakingChanges: [{path: "/foo/bar", change: "any"}])
+union b {
+    bam: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/valid-for-nested.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/trait-breaking-changes/valid-for-nested.smithy
@@ -1,0 +1,21 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@trait(breakingChanges: [{path: "/a/b/member/c", change: "any"}])
+structure a {
+    a: B
+}
+
+@private
+union B {
+    b: CList
+}
+
+list CList {
+    member: C
+}
+
+structure C {
+    c: String
+}

--- a/smithy-mqtt-traits/src/main/resources/META-INF/smithy/smithy.api.mqtt.smithy
+++ b/smithy-mqtt-traits/src/main/resources/META-INF/smithy/smithy.api.mqtt.smithy
@@ -6,16 +6,20 @@ namespace smithy.mqtt
 @protocolDefinition
 structure mqttJson {}
 
-@trait(selector: "operation :not(-[output]-> * > member)",
-       conflicts: ["smithy.mqtt#subscribe"])
-@tags(["diff.error.const"])
+@trait(
+    selector: "operation :not(-[output]-> * > member)",
+    conflicts: ["smithy.mqtt#subscribe"],
+    breakingChanges: [{change: "any"}]
+)
 // Matches one or more characters that are not "#" or "+".
 @pattern("^[^#+]+$")
 string publish
 
-@trait(selector: "operation:test(-[output]-> structure > member > union[trait|streaming])",
-       conflicts: ["smithy.mqtt#publish"])
-@tags(["diff.error.const"])
+@trait(
+    selector: "operation:test(-[output]-> structure > member > union[trait|streaming])",
+    conflicts: ["smithy.mqtt#publish"],
+    breakingChanges: [{change: "any"}]
+)
 // Matches one or more characters that are not "#" or "+".
 @pattern("^[^#+]+$")
 string subscribe


### PR DESCRIPTION
Rather than rely on specialized tags like `diff.error.add`, we can add
`breakingChanges` rules to traits directly.

Other changes to make this easier to implement include:

* Add getMember(String) to Shape simplifies the trait diff validator
  significantly, and can be used to simplify many other code paths in
  Smithy if we go back and refactor them.
* Added toNode and fromNode to various classes like Severity,
  NodePointer, etc.

It is a backward incompatible change to add the following trait to an existing shape:

``` {.smithy}
@trait(breakingChanges: [{change: "add"}])
structure cannotAdd {}
```

Note: The above trait definition is equivalent to the following:

``` {.smithy}
@trait(
    breakingChanges: [
        {
            change: "add",
            path: "",
            severity: "ERROR"
        }
    ]
)
structure cannotAdd {}
```

It is a backward incompatible change to add or remove the following trait from an existing shape:

``` {.smithy}
@trait(breakingChanges: [{change: "presence"}])
structure cannotToAddOrRemove {}
```

It is very likely backward incompatible to change the \"foo\" member of the following trait or to remove the \"baz\" member:

``` {.smithy}
@trait(
    breakingChanges: [
        {
            change: "update",
            path: "/foo",
            severity: "DANGER"
        },
        {
            change: "remove",
            path: "/baz",
            severity: "DANGER"
        }
    ]
)
structure fooBaz {
    foo: String,
    baz: String
}
```

So for example, if the following shape:

``` {.smithy}
@fooBaz(foo: "a", baz: "b")
string Example
```

Is changed to:

``` {.smithy}
@fooBaz(foo: "b")
string Example
```

Then the change to the `foo` member from \"a\" to \"b\" is backward incompatible, as is the removal of the `baz` member.

**Referring to list and set members**

The JSON pointer can path into the members of a list or set using a `member` segment.

In the following example, it is a breaking change to change values of lists or sets in instances of the `names` trait:

``` {.smithy}
@trait(
    breakingChanges: [
        {
            change: "update",
            path: "/names/member"
        }
    ]
)
structure names {
    names: NameList
}

@private
list NameList {
    member: String
}
```

So for example, if the following shape:

``` {.smithy}
@names(names: ["Han", "Luke"])
string Example
```

Is changed to:

``` {.smithy}
@names(names: ["Han", "Chewy"])
string Example
```

Then the change to the second value of the `names` member is backward incompatible because it changed from `Luke` to `Chewy`.

**Referring to map members**

Members of a map shape can be referenced in a JSON pointer using `key`
and `value`.

The following example defines a trait where it is backward incompatible to remove a key value pair from a map:

``` {.smithy}
@trait(
    breakingChanges: [
        {
            change: "remove",
            path: "/key"
        }
    ]
)
map jobs {
    key: String,
    value: String
}
```

So for example, if the following shape:

``` {.smithy}
@jobs(Han: "Smuggler", Luke: "Jedi")
string Example
```

Is changed to:

``` {.smithy}
@jobs(Luke: "Jedi")
string Example
```

Then the removal of the \"Han\" entry of the map is flagged as backward incompatible.

The following example detects when values of a map change.

``` {.smithy}
@trait(
    breakingChanges: [
        {
            change: "update",
            path: "/value"
        }
    ]
)
map jobs {
    key: String,
    value: String
}
```

So for example, if the following shape:

``` {.smithy}
@jobs(Han: "Smuggler", Luke: "Jedi")
string Example
```

Is changed to:

``` {.smithy}
@jobs(Han: "Smuggler", Luke: "Ghost")
string Example
```

Then the change to Luke\'s mapping from \"Jedi\" to \"Ghost\" is backward incompatible.

Note:

-   Using the \"update\" `change` type with a map key has no effect.
-   Using any `change` type other than \"update\" with map values has no
    effect.

**What this does not support**

Note that the current syntax of JSON pointers and validation does not support referring to specific values or a list or set or specific entries in a map. For example, you can't say it's a breaking change to update the first element of a list using `/0`. Nor can you say it's a breaking change to update a specific named entry for a map like `/someKeyName`. This was left out for now, but could be added later if needed. For example, kind of special syntax like `/[0]` and `/[foo]`, or perhaps `/member[0]` and `/key[foo]`.

**Possible future extension**

If we ever _really_ needed it, a conditional change type could be added to add more complex diff detection.

```
@trait(
    breakingChanges: [
        {
            change: "conditinal",
            // these are and-ed together. An "or" and "and" conditional could be added here.
            conditions: [
                // This could add oldValue and newValue to make it even more specific.
                update: {
                    path: "/foo",
                    oldValue: "bye",
                    newValue: "hi"
                },
                remove: {
                    path: "/bar"
                }
            ],
            severity: "ERROR",
            message: "You cannot change /foo from bye to hi and also remove /bar!"
        }
    ]
)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
