### PR TITLE
Implement `--silent` for `smithy build`

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -30,6 +30,7 @@ public final class SmithyCli {
     public static final String DISCOVER_CLASSPATH = "--discover-classpath";
     public static final String ALLOW_UNKNOWN_TRAITS = "--allow-unknown-traits";
     public static final String SEVERITY = "--severity";
+    public static final String SILENT = "--silent";
 
     private ClassLoader classLoader = getClass().getClassLoader();
     private boolean configureLogging;

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.cli.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -95,6 +96,36 @@ public class BuildCommandTest {
         assertThat(output, containsString("ResourceLifecycle"));
         assertThat(e.getMessage(),
                    containsString("The following 1 Smithy build projection(s) failed: [exampleProjection]"));
+    }
+
+    @Test
+    public void validationEventsAreOutputByDefault() throws Exception {
+        String model = Paths.get(getClass().getResource("build-events.smithy").toURI()).toString();
+
+        PrintStream out = System.out;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+        System.setOut(printStream);
+        SmithyCli.create().run("build", model);
+        System.setOut(out);
+        String output = outputStream.toString("UTF-8");
+
+        assertThat(output, containsString("Validation result: 0 ERROR(s), 0 DANGER(s), 1 WARNING(s), 1 NOTE(s)"));
+    }
+
+    @Test
+    public void nothingIsOutputWhenSilentAndSuccessful() throws Exception {
+        String model = Paths.get(getClass().getResource("build-events.smithy").toURI()).toString();
+
+        PrintStream out = System.out;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+        System.setOut(printStream);
+        SmithyCli.create().run("build", "--silent", model);
+        System.setOut(out);
+        String output = outputStream.toString("UTF-8");
+
+        assertThat(output, isEmptyString());
     }
 
     @Test

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/build-events.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/build-events.smithy
@@ -1,0 +1,26 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "EmitNotes",
+        severity: "NOTE",
+        configuration: {
+            selector: "[id = smithy.example#Note]"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "EmitWarnings",
+        severity: "WARNING",
+        configuration: {
+            selector: "[id = smithy.example#Warning]"
+        }
+    }
+]
+
+namespace smithy.example
+
+string Note
+
+string Warning


### PR DESCRIPTION
*Issue #, if available:* #1062

*Description of changes:*

This commit adds the `--silent` flag to `smithy build`, which suppresses all non-error output during build. This includes validation statistics and information about plugins and projections. In the event that an error is encountered, output is printed and execution halted as normal.

For now, this PR only extends the `build` command. Validation is used in several places, such as `validate` and `ast`, but in these instances it is already passed a feature set containing `QUIET`. The code is a little hacky but I've started by making the changes as minimally invasive as possible. Additionally some test cases have been added to try and guard the functionality of the need case. Feedback welcome!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
