### PR TITLE
Fix constraint trait docs error

### DIFF
--- a/docs/source/1.0/spec/core/constraint-traits.rst
+++ b/docs/source/1.0/spec/core/constraint-traits.rst
@@ -650,9 +650,9 @@ Value type
 Trait precedence
 ----------------
 
-Some constraints can be applied to shapes as well as structure members. If a
-constraint of the same type is applied to a structure member and the shape
-that the member targets, the trait applied to the member takes precedence.
+Some constraint traits can be applied to shapes as well as members.
+Constraint traits applied to members take precedence over constraint
+traits applied to the shape targeted by members.
 
 In the below example, the ``range`` trait applied to ``numberOfItems``
 takes precedence over the one applied to ``PositiveInteger``. The resolved


### PR DESCRIPTION
Constraint traits cascade for non-structure members too.

Closes #1181

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
