### PR TITLE
Make streaming blobs required/default

### DIFF
--- a/docs/source/1.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source/1.0/guides/migrating-idl-1-to-2.rst
@@ -119,6 +119,60 @@ Needs to be updated to:
     }
 
 
+Add the default trait to streaming blobs
+========================================
+
+Members that target a blob shape with the :ref:`streaming-trait` have always
+had an implicit default empty value. In IDL 2.0, that will become explicit.
+Any such members that are not already marked with the :ref:`required-trait`
+will now need to be marked with the :ref:`default-trait`.
+
+For example, the following model:
+
+.. code-block:: smithy
+
+    $version: "1.0"
+
+    namespace smithy.example
+
+    structure OptionalStream {
+        // This needs to be updated since it doesn't have the required or
+        // default trait already.
+        payload: StreamingBlob
+    }
+
+    structure RequiredStream {
+        // This doesn't need to be updated because it already has the required
+        // trait.
+        @required
+        payload: StreamingBlob
+    }
+
+    @streaming
+    blob StreamingBlob
+
+Needs to be updated to:
+
+.. code-block:: smithy
+
+    $version: "2.0"
+
+    namespace smithy.example
+
+    structure OptionalStream {
+        @default
+        payload: StreamingBlob
+    }
+
+    structure RequiredStream {
+        @required
+        payload: StreamingBlob
+    }
+
+    @streaming
+    blob StreamingBlob
+
+
 Optional migration steps
 ========================
 

--- a/docs/source/1.0/spec/core/traits/behavior-traits.rst.template
+++ b/docs/source/1.0/spec/core/traits/behavior-traits.rst.template
@@ -538,6 +538,10 @@ Summary
     large and thus should not be stored in memory or that the size is unknown
     at the start of the request.
 
+    .. warning::
+        Members targeting streaming blobs MUST be marked with the
+        :ref:`required-trait` or :ref:`default-trait`.
+
     When applied to a union, it indicates that shape represents an
     :ref:`event stream <event-streams>`.
 Trait selector::

--- a/docs/source/1.0/spec/core/traits/http-traits.rst.template
+++ b/docs/source/1.0/spec/core/traits/http-traits.rst.template
@@ -708,6 +708,7 @@ Trait selector
     The ``httpPayload`` trait can be applied to ``structure`` members that
     target a ``string``, ``blob``, ``structure``, ``union``, ``document``,
     ``set``, ``map``, or ``list``.
+
 Value type
     Annotation trait.
 Conflicts with

--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -206,6 +206,7 @@ structure UploadArchiveInput {
     archiveDescription: string,
     @httpHeader("x-amz-sha256-tree-hash")
     checksum: string,
+    @default
     @httpPayload
     body: Stream,
 }
@@ -224,6 +225,7 @@ structure UploadMultipartPartInput {
     checksum: string,
     @httpHeader("Content-Range")
     range: string,
+    @default
     @httpPayload
     body: Stream,
 }

--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -91,6 +91,7 @@ structure StreamingTraitsInputOutput {
     @httpHeader("X-Foo")
     foo: String,
 
+    @default
     @httpPayload
     blob: StreamingBlob,
 }
@@ -151,6 +152,7 @@ structure StreamingTraitsRequireLengthInput {
     @httpHeader("X-Foo")
     foo: String,
 
+    @default
     @httpPayload
     blob: FiniteStreamingBlob,
 }
@@ -212,6 +214,7 @@ structure StreamingTraitsWithMediaTypeInputOutput {
     @httpHeader("X-Foo")
     foo: String,
 
+    @default
     @httpPayload
     blob: StreamingTextPlainBlob,
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -54,6 +55,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.SmithyIdlModelSerializer;
 import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.AnnotationTrait;
 import software.amazon.smithy.model.traits.BoxTrait;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.EnumTrait;
@@ -313,15 +315,13 @@ public final class Upgrade1to2Command implements Command {
         }
 
         private boolean hasSyntheticDefault(MemberShape shape) {
-            Shape target = completeModel.expectShape(shape.getTarget());
-            if (!(HAD_DEFAULT_VALUE_IN_1_0.contains(target.getType()) && shape.hasTrait(DefaultTrait.class))) {
-                return false;
-            }
+            Optional<SourceLocation> defaultLocation = shape.getTrait(DefaultTrait.class)
+                    .map(AnnotationTrait::getSourceLocation);
             // When Smithy injects the default trait, it sets the source
             // location equal to the shape's source location. This is
             // impossible in any other scenario, so we can use this info
             // to know whether it was injected or not.
-            return shape.getSourceLocation().equals(shape.expectTrait(DefaultTrait.class).getSourceLocation());
+            return defaultLocation.filter(location -> shape.getSourceLocation().equals(location)).isPresent();
         }
 
         @Override

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/Upgrade1to2CommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/Upgrade1to2CommandTest.java
@@ -57,7 +57,7 @@ public class Upgrade1to2CommandTest {
     public static Stream<Arguments> source() throws Exception {
         Path start = Paths.get(Upgrade1to2CommandTest.class.getResource("upgrade/cases").toURI());
         return Files.walk(start)
-                .filter(path -> path.getFileName().toString().endsWith("enum-with-traits.v1.smithy"))
+                .filter(path -> path.getFileName().toString().endsWith(".v1.smithy"))
                 .map(path -> Arguments.of(path, path.getFileName().toString().replace(".v1.smithy", "")));
     }
 

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/http-payload.v1.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/http-payload.v1.smithy
@@ -1,0 +1,20 @@
+$version: "1.0"
+
+namespace smithy.example
+
+structure RequiredPayload {
+    @required
+    payload: StreamingBlob
+}
+
+structure DefaultPayload {
+    @default
+    payload: StreamingBlob
+}
+
+structure NeitherRequiredNorDefaultPayload {
+    payload: StreamingBlob
+}
+
+@streaming
+blob StreamingBlob

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/http-payload.v2.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/http-payload.v2.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure RequiredPayload {
+    @required
+    payload: StreamingBlob
+}
+
+structure DefaultPayload {
+    @default
+    payload: StreamingBlob
+}
+
+structure NeitherRequiredNorDefaultPayload {
+    @default
+    payload: StreamingBlob
+}
+
+@streaming
+blob StreamingBlob

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/HttpBindingIndexTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
@@ -51,10 +51,15 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait;
 
 public class HttpBindingIndexTest {
 
-    private static Model model = Model.assembler()
-            .addImport(HttpBindingIndex.class.getResource("http-index.json"))
-            .assemble()
-            .unwrap();
+    private static Model model;
+
+    @BeforeAll
+    private static void readModel() {
+        model = Model.assembler()
+                .addImport(HttpBindingIndex.class.getResource("http-index.json"))
+                .assemble()
+                .unwrap();
+    }
 
     @Test
     public void providesResponseCode() {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelUpgraderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelUpgraderTest.java
@@ -45,6 +45,8 @@ public class ModelUpgraderTest {
         assertThat(ShapeId.from("smithy.example#Bytes$nonNull"), not(ShapeMatcher.memberIsNullable(result)));
         assertThat(ShapeId.from("smithy.example#Shorts$nonNull"), not(ShapeMatcher.memberIsNullable(result)));
         assertThat(ShapeId.from("smithy.example#Integers$nonNull"), addedDefaultTrait(result));
+
+        assertThat(ShapeId.from("smithy.example#BlobPayload$payload"), addedDefaultTrait(result));
     }
 
     @Test

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/requiresLength-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/requiresLength-validator.json
@@ -17,7 +17,10 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {
@@ -28,7 +31,10 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-blob-without-httppayload.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-blob-without-httppayload.smithy
@@ -29,6 +29,8 @@ structure StreamingOperationInput {}
 structure StreamingOperationOutput {
     @required
     streamId: String,
+
+    @default
     output: StreamingBlob,
 }
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-default-required.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-default-required.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#NeitherRequiredNorDefaultStream$payload: Members that target blobs marked with the `streaming` trait MUST also be marked with the `required` or `default` trait. | StreamingTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-default-required.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-default-required.smithy
@@ -1,0 +1,35 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@http(uri: "/", method: "POST")
+operation RequiredStreamOperation {
+    input: RequiredStream
+}
+
+structure RequiredStream {
+    @required
+    payload: StreamingBlob
+}
+
+@http(uri: "/", method: "POST")
+operation DefaultStreamOperation {
+    input: DefaultStream
+}
+
+structure DefaultStream {
+    @default
+    payload: StreamingBlob
+}
+
+@http(uri: "/", method: "POST")
+operation NeitherRequiredNorDefaultStreamOperation {
+    input: NeitherRequiredNorDefaultStream
+}
+
+structure NeitherRequiredNorDefaultStream {
+    payload: StreamingBlob
+}
+
+@streaming
+blob StreamingBlob

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/streaming-trait.json
@@ -17,7 +17,10 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {
@@ -28,7 +31,10 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {
@@ -63,7 +69,10 @@
             "type": "structure",
             "members": {
                 "Body": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {
@@ -89,10 +98,16 @@
             "type": "structure",
             "members": {
                 "StreamingBlob1": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 },
                 "StreamingBlob2": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {
@@ -127,7 +142,10 @@
             "type": "structure",
             "members": {
                 "nested": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             }
         },
@@ -143,7 +161,10 @@
             "type": "structure",
             "members": {
                 "foo": {
-                    "target": "ns.foo#StreamingBlob"
+                    "target": "ns.foo#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": {}
+                    }
                 }
             },
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/main.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/main.smithy
@@ -28,3 +28,10 @@ structure Integers {
     @box
     nullable2: PrimitiveInteger
 }
+
+structure BlobPayload {
+    payload: StreamingBlob
+}
+
+@streaming
+blob StreamingBlob

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/upgraded.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/upgraded.smithy
@@ -28,3 +28,11 @@ structure Integers {
 
     nullable2: Integer
 }
+
+structure BlobPayload {
+    @default
+    payload: StreamingBlob
+}
+
+@streaming
+blob StreamingBlob

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/streaming-service.smithy
@@ -15,8 +15,9 @@ operation StreamingOperation {
 }
 
 structure Output {
-  @httpPayload
-  body: StreamingPayload,
+    @default
+    @httpPayload
+    body: StreamingPayload,
 }
 
 @streaming


### PR DESCRIPTION
Streaming blobs have always had an implicit default value, and this pr makes that status explicit by requiring that such members have either the required or the default trait.

1.0 models will have the default trait applied automatically, but it must be explicitly added in 2.0 models.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
