### PR TITLE
Add missing comma to EmitEachSelector example

### DIFF
--- a/docs/source/1.0/spec/core/model-validation.rst
+++ b/docs/source/1.0/spec/core/model-validation.rst
@@ -337,7 +337,7 @@ following constraints:
     metadata validators = [{
         name: "EmitEachSelector",
         id: "MissingDocumentation",
-        message: "This shape is missing documentation"
+        message: "This shape is missing documentation",
         configuration: {
             selector: """
                 :not([trait|documentation])


### PR DESCRIPTION
Add missing comma to EmitEachSelector validator example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
