### PR TITLE
Make SmithyIntegrations available from CodegenContext

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/CodegenContext.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/CodegenContext.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.codegen.core;
 
+import java.util.List;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.model.Model;
 
@@ -24,8 +25,9 @@ import software.amazon.smithy.model.Model;
  *
  * @param <S> The settings object used to configure the generator.
  * @param <W> The type of {@link SymbolWriter} used by the generator.
+ * @param <I> The type of {@link SmithyIntegration}s used by the generator.
  */
-public interface CodegenContext<S, W extends SymbolWriter<W, ?>> {
+public interface CodegenContext<S, W extends SymbolWriter<W, ?>, I extends SmithyIntegration<S, W, ?>> {
     /**
      * @return Gets the model being code generated.
      */
@@ -57,4 +59,9 @@ public interface CodegenContext<S, W extends SymbolWriter<W, ?>> {
      * @return Returns the writer delegator used by the generator.
      */
     WriterDelegator<W> writerDelegator();
+
+    /**
+     * @return Gets the SmithyIntegrations used for code generation.
+     */
+    List<I> integrations();
 }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
@@ -42,7 +42,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * @param <C> The CodegenContext value used by the generator.
  */
 @SmithyUnstableApi
-public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends CodegenContext<S, W>> {
+public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends CodegenContext<S, W, ?>> {
     /**
      * Gets the name of the integration.
      *

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -71,7 +71,7 @@ public final class CodegenDirector<
     private S settings;
     private FileManifest fileManifest;
     private Supplier<Iterable<I>> integrationFinder;
-    private DirectedCodegen<C, S> directedCodegen;
+    private DirectedCodegen<C, S, I> directedCodegen;
     private final List<BiFunction<Model, ModelTransformer, Model>> transforms = new ArrayList<>();
 
     /**
@@ -124,7 +124,7 @@ public final class CodegenDirector<
      *
      * @param directedCodegen Directed code generator to run.
      */
-    public void directedCodegen(DirectedCodegen<C, S> directedCodegen) {
+    public void directedCodegen(DirectedCodegen<C, S, I> directedCodegen) {
         this.directedCodegen = directedCodegen;
     }
 
@@ -269,7 +269,7 @@ public final class CodegenDirector<
 
         SymbolProvider provider = createSymbolProvider(integrations, serviceShape);
 
-        C context = createContext(serviceShape, provider);
+        C context = createContext(serviceShape, provider, integrations);
 
         // After the context is created, it holds the model that should be used for rest of codegen. So `model` should
         // not really be used directly after this point in the flow. Setting the `model` to `context.model()` to avoid
@@ -356,10 +356,10 @@ public final class CodegenDirector<
         return SymbolProvider.cache(provider);
     }
 
-    private C createContext(ServiceShape serviceShape, SymbolProvider provider) {
+    private C createContext(ServiceShape serviceShape, SymbolProvider provider, List<I> integrations) {
         LOGGER.fine(() -> "Creating a codegen context for " + directedCodegen.getClass().getName());
         return directedCodegen.createContext(new CreateContextDirective<>(
-                model, settings, serviceShape, provider, fileManifest));
+                model, settings, serviceShape, provider, fileManifest, integrations));
     }
 
     private void registerInterceptors(C context, List<I> integrations) {
@@ -404,9 +404,9 @@ public final class CodegenDirector<
 
         private final C context;
         private final ServiceShape serviceShape;
-        private final DirectedCodegen<C, S> directedCodegen;
+        private final DirectedCodegen<C, S, ?> directedCodegen;
 
-        ShapeGenerator(C context, ServiceShape serviceShape, DirectedCodegen<C, S> directedCodegen) {
+        ShapeGenerator(C context, ServiceShape serviceShape, DirectedCodegen<C, S, ?> directedCodegen) {
             this.context = context;
             this.serviceShape = serviceShape;
             this.directedCodegen = directedCodegen;

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -60,7 +60,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 public final class CodegenDirector<
         W extends SymbolWriter<W, ? extends ImportContainer>,
         I extends SmithyIntegration<S, W, C>,
-        C extends CodegenContext<S, W>,
+        C extends CodegenContext<S, W, I>,
         S> {
 
     private static final Logger LOGGER = Logger.getLogger(DirectedCodegen.class.getName());
@@ -399,7 +399,7 @@ public final class CodegenDirector<
 
     private static class ShapeGenerator<
             W extends SymbolWriter<W, ? extends ImportContainer>,
-            C extends CodegenContext<S, W>,
+            C extends CodegenContext<S, W, ?>,
             S> extends ShapeVisitor.Default<Void> {
 
         private final C context;

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/ContextualDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/ContextualDirective.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
  * @param <C> CodegenContext type.
  * @param <S> Codegen settings type.
  */
-public abstract class ContextualDirective<C extends CodegenContext<S, ?>, S> extends Directive<S> {
+public abstract class ContextualDirective<C extends CodegenContext<S, ?, ?>, S> extends Directive<S> {
 
     private final C context;
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CreateContextDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CreateContextDirective.java
@@ -15,9 +15,12 @@
 
 package software.amazon.smithy.codegen.core.directed;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.CodegenContext;
+import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
@@ -29,23 +32,28 @@ import software.amazon.smithy.model.traits.Trait;
  * Directive used to create a {@link CodegenContext}.
  *
  * @param <S> Codegen settings type.
+ * @param <I> {@link SmithyIntegration} type.
+
  * @see DirectedCodegen#createContext
  */
-public final class CreateContextDirective<S> extends Directive<S> {
+public final class CreateContextDirective<S, I extends SmithyIntegration<S, ?, ?>> extends Directive<S> {
 
     private final SymbolProvider symbolProvider;
     private final FileManifest fileManifest;
+    private final List<I> integrations;
 
     CreateContextDirective(
             Model model,
             S settings,
             ServiceShape service,
             SymbolProvider symbolProvider,
-            FileManifest fileManifest
+            FileManifest fileManifest,
+            List<I> integrations
     ) {
         super(model, settings, service);
         this.symbolProvider = symbolProvider;
         this.fileManifest = fileManifest;
+        this.integrations = Collections.unmodifiableList(integrations);
     }
 
     /**
@@ -60,6 +68,14 @@ public final class CreateContextDirective<S> extends Directive<S> {
      */
     public FileManifest fileManifest() {
         return fileManifest;
+    }
+
+
+    /**
+     * @return Returns the list of Integrations used during codegen.
+     */
+    public List<I> integrations() {
+        return integrations;
     }
 
     /**

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CustomizeDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CustomizeDirective.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
  * @see DirectedCodegen#customizeBeforeIntegrations
  * @see DirectedCodegen#customizeAfterIntegrations
  */
-public final class CustomizeDirective<C extends CodegenContext<S, ?>, S> extends ContextualDirective<C, S> {
+public final class CustomizeDirective<C extends CodegenContext<S, ?, ?>, S> extends ContextualDirective<C, S> {
     CustomizeDirective(C context, ServiceShape service) {
         super(context, service);
     }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
@@ -30,8 +30,9 @@ import software.amazon.smithy.codegen.core.WriterDelegator;
  *
  * @param <C> Smithy {@link CodegenContext} to use in directed methods.
  * @param <S> Settings object passed to directed methods as part of the context.
+ * @param <I> {@link SmithyIntegration} type to use in directed methods.
  */
-public interface DirectedCodegen<C extends CodegenContext<S, ?>, S> {
+public interface DirectedCodegen<C extends CodegenContext<S, ?>, S, I extends SmithyIntegration<S, ?, ?>> {
 
     /**
      * Create the {@link SymbolProvider} used to map shapes to code symbols.
@@ -47,7 +48,7 @@ public interface DirectedCodegen<C extends CodegenContext<S, ?>, S> {
      * @param directive Directive context data.
      * @return Returns the created context object used by the rest of the directed generation.
      */
-    C createContext(CreateContextDirective<S> directive);
+    C createContext(CreateContextDirective<S, I> directive);
 
     /**
      * Generates the code needed for a service shape.

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
@@ -32,7 +32,7 @@ import software.amazon.smithy.codegen.core.WriterDelegator;
  * @param <S> Settings object passed to directed methods as part of the context.
  * @param <I> {@link SmithyIntegration} type to use in directed methods.
  */
-public interface DirectedCodegen<C extends CodegenContext<S, ?>, S, I extends SmithyIntegration<S, ?, ?>> {
+public interface DirectedCodegen<C extends CodegenContext<S, ?, I>, S, I extends SmithyIntegration<S, ?, C>> {
 
     /**
      * Create the {@link SymbolProvider} used to map shapes to code symbols.

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateEnumDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateEnumDirective.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.traits.EnumTrait;
  * @param <S> Codegen settings type.
  * @see DirectedCodegen#generateEnumShape
  */
-public final class GenerateEnumDirective<C extends CodegenContext<S, ?>, S> extends ShapeDirective<Shape, C, S> {
+public final class GenerateEnumDirective<C extends CodegenContext<S, ?, ?>, S> extends ShapeDirective<Shape, C, S> {
 
     GenerateEnumDirective(C context, ServiceShape service, Shape shape) {
         super(context, service, validateShape(shape));

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateErrorDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateErrorDirective.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.traits.ErrorTrait;
  * @param <S> Codegen settings type.
  * @see DirectedCodegen#generateError
  */
-public final class GenerateErrorDirective<C extends CodegenContext<S, ?>, S>
+public final class GenerateErrorDirective<C extends CodegenContext<S, ?, ?>, S>
         extends ShapeDirective<StructureShape, C, S> {
 
     GenerateErrorDirective(C context, ServiceShape service, StructureShape shape) {

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateResourceDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateResourceDirective.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
  * @param <S> Codegen settings type.
  * @see DirectedCodegen#generateResource
  */
-public final class GenerateResourceDirective<C extends CodegenContext<S, ?>, S>
+public final class GenerateResourceDirective<C extends CodegenContext<S, ?, ?>, S>
         extends ShapeDirective<ResourceShape, C, S> {
     GenerateResourceDirective(C context, ServiceShape service, ResourceShape shape) {
         super(context, service, shape);

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateServiceDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateServiceDirective.java
@@ -35,7 +35,7 @@ import software.amazon.smithy.model.traits.TitleTrait;
  * @param <S> Codegen settings type.
  * @see DirectedCodegen#generateService
  */
-public final class GenerateServiceDirective<C extends CodegenContext<S, ?>, S>
+public final class GenerateServiceDirective<C extends CodegenContext<S, ?, ?>, S>
         extends ShapeDirective<ServiceShape, C, S> {
 
     GenerateServiceDirective(C context, ServiceShape service) {

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateStructureDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateStructureDirective.java
@@ -29,7 +29,7 @@ import software.amazon.smithy.model.transform.ModelTransformer;
  * @param <S> Codegen settings type.
  * @see DirectedCodegen#generateStructure
  */
-public final class GenerateStructureDirective<C extends CodegenContext<S, ?>, S>
+public final class GenerateStructureDirective<C extends CodegenContext<S, ?, ?>, S>
         extends ShapeDirective<StructureShape, C, S> {
 
     GenerateStructureDirective(C context, ServiceShape service, StructureShape shape) {

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateUnionDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateUnionDirective.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.traits.StreamingTrait;
  * @param <S> Codegen settings type.
  * @see DirectedCodegen#generateUnion
  */
-public final class GenerateUnionDirective<C extends CodegenContext<S, ?>, S>
+public final class GenerateUnionDirective<C extends CodegenContext<S, ?, ?>, S>
         extends ShapeDirective<UnionShape, C, S> {
 
     GenerateUnionDirective(C context, ServiceShape service, UnionShape shape) {

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/ShapeDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/ShapeDirective.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.shapes.Shape;
  * @param <C> CodegenContext type.
  * @param <S> Codegen settings type.
  */
-public abstract class ShapeDirective<T extends Shape, C extends CodegenContext<S, ?>, S>
+public abstract class ShapeDirective<T extends Shape, C extends CodegenContext<S, ?, ?>, S>
         extends ContextualDirective<C, S> {
 
     private final T shape;

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/IntegrationTopologicalSortTest.java
@@ -34,7 +34,7 @@ public class IntegrationTopologicalSortTest {
     private static final class MyIntegration implements SmithyIntegration<
             MySettings,
             MySimpleWriter,
-            CodegenContext<MySettings, MySimpleWriter>
+            CodegenContext<MySettings, MySimpleWriter, MyIntegration>
     > {
         private final String name;
         private final byte priority;

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SmithyIntegrationTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SmithyIntegrationTest.java
@@ -29,7 +29,7 @@ public class SmithyIntegrationTest {
 
     private static final class MySettings {}
 
-    private static final class MyContext implements CodegenContext<MySettings, MySimpleWriter> {
+    private static final class MyContext implements CodegenContext<MySettings, MySimpleWriter, MyIntegration> {
         @Override
         public Model model() {
             return null;
@@ -54,6 +54,9 @@ public class SmithyIntegrationTest {
         public WriterDelegator<MySimpleWriter> writerDelegator() {
             return null;
         }
+
+        @Override
+        public List<MyIntegration> integrations() { return null; }
     }
 
     private static final class MyIntegration implements SmithyIntegration<MySettings, MySimpleWriter, MyContext> {

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.MockManifest;
-import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
@@ -34,8 +33,6 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class CodegenDirectorTest {
-
-    interface TestIntegration extends SmithyIntegration<TestSettings, TestWriter, TestContext> {}
 
     private static final class TestDirected implements DirectedCodegen<TestContext, TestSettings, TestIntegration> {
         public final List<ShapeId> generatedShapes = new ArrayList<>();

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -31,14 +31,13 @@ import software.amazon.smithy.codegen.core.WriterDelegator;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class CodegenDirectorTest {
 
     interface TestIntegration extends SmithyIntegration<TestSettings, TestWriter, TestContext> {}
 
-    private static final class TestDirected implements DirectedCodegen<TestContext, TestSettings> {
+    private static final class TestDirected implements DirectedCodegen<TestContext, TestSettings, TestIntegration> {
         public final List<ShapeId> generatedShapes = new ArrayList<>();
 
         @Override
@@ -50,7 +49,7 @@ public class CodegenDirectorTest {
         }
 
         @Override
-        public TestContext createContext(CreateContextDirective<TestSettings> directive) {
+        public TestContext createContext(CreateContextDirective<TestSettings, TestIntegration> directive) {
             WriterDelegator<TestWriter> delegator = new WriterDelegator<>(
                     directive.fileManifest(),
                     directive.symbolProvider(),

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/TestContext.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/TestContext.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.codegen.core.directed;
 
+import java.util.ArrayList;
+import java.util.List;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.codegen.core.CodegenContext;
@@ -25,7 +27,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
-final class TestContext implements CodegenContext<TestSettings, TestWriter> {
+final class TestContext implements CodegenContext<TestSettings, TestWriter, TestIntegration> {
 
     private final Model model;
     private final TestSettings settings;
@@ -84,6 +86,11 @@ final class TestContext implements CodegenContext<TestSettings, TestWriter> {
     @Override
     public WriterDelegator<TestWriter> writerDelegator() {
         return delegator;
+    }
+
+    @Override
+    public List<TestIntegration> integrations() {
+        return new ArrayList<>();
     }
 
     public ServiceShape service() {

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/TestIntegration.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/TestIntegration.java
@@ -1,2 +1,8 @@
-package software.amazon.smithy.codegen.core.directed;public class TestIntegration {
+package software.amazon.smithy.codegen.core.directed;
+
+import software.amazon.smithy.codegen.core.SmithyIntegration;
+
+interface TestIntegration extends SmithyIntegration<TestSettings, TestWriter, TestContext> {
+
 }
+

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/TestIntegration.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/TestIntegration.java
@@ -1,0 +1,2 @@
+package software.amazon.smithy.codegen.core.directed;public class TestIntegration {
+}


### PR DESCRIPTION
This PR has 2 commits.

The 1st commit, only made `SmithyIntegration`s available from CreateContextDirective, so subclasses
of CodegenContext can access it. But it likely can be made part of parent CodegenContext interface.

The 2nd commit, made it part of CodegenContext interface. ~~This requires another generic parameter to be added in multiple places.~~ Avoided adding generic parameter to CodegenContext by defining the method as `List<? extends SmithyIntegration<S, W, ?>> integrations();` where subclasses can return more specific `List<MyIntegration> integrations();`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
