### PR TITLE
Bind PostUnionWithJsonName protocol test operation

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -85,6 +85,7 @@ service RestJson {
         // Unions
         JsonUnions,
         PostPlayerAction,
+        PostUnionWithJsonName,
 
         // @endpoint and @hostLabel trait tests
         EndpointOperation,

--- a/smithy-aws-protocol-tests/model/restJson1/validation/sensitive-validation.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/sensitive-validation.smithy
@@ -48,5 +48,6 @@ apply SensitiveValidation @httpMalformedRequestTests([
 
 structure SensitiveValidationInput {
     @sensitive
+    @suppress(["SensitiveTrait"])
     string: PatternString
 }


### PR DESCRIPTION
Also suppresses a warning that we know is coming in a separate test for `@sensitive`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
