### PR TITLE
Don't serialize empty traits blocks

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -195,7 +195,10 @@ public final class ModelSerializer {
                     traitsToAdd.put(Node.from(trait.toShapeId().toString()), trait.toNode());
                 }
             }
-            builder.withMember("traits", new ObjectNode(traitsToAdd, SourceLocation.none()));
+
+            if (!traitsToAdd.isEmpty()) {
+                builder.withMember("traits", new ObjectNode(traitsToAdd, SourceLocation.none()));
+            }
         }
 
         return builder;

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -219,10 +219,6 @@ public class ModelSerializerTest {
         ModelSerializer serializer = ModelSerializer.builder().build();
         ObjectNode result = serializer.serialize(model);
 
-        assertThat(NodePointer.parse("/shapes/com.foo#Str/traits")
-                           .getValue(result)
-                           .expectObjectNode()
-                           .getStringMap(),
-                   not(hasKey(OriginalShapeIdTrait.ID.toShapeId())));
+        assertTrue(NodePointer.parse("/shapes/com.foo#Str/traits").getValue(result).isNullNode());
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/enums.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/enums.json
@@ -16,8 +16,7 @@
                         "smithy.api#enumValue": "bar"
                     }
                 }
-            },
-            "traits": {}
+            }
         },
         "smithy.example#IntEnum": {
             "type": "intEnum",


### PR DESCRIPTION
This is an idl-2.0 specific patch since this happens much more frequently with `@enum` upgrades. This is present in `main`, but much less impactful without model upgrades -- I'll make a patch there as well if it's believed to be necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
