### PR TITLE
Http response code

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -21,12 +21,8 @@ structure HttpResponseCodeOutput {
 
 @http(method: "GET", uri: "/responseCodeRequired", code: 200)
 operation ResponseCodeRequired {
-    input: ResponseCodeRequiredInput,
     output: ResponseCodeRequiredOutput,
 }
-
-@input
-structure ResponseCodeRequiredInput {}
 
 @output
 structure ResponseCodeRequiredOutput {
@@ -37,15 +33,13 @@ structure ResponseCodeRequiredOutput {
 
 @http(method: "GET", uri: "/responseCodeHttpFallback", code: 418)
 operation ResponseCodeHttpFallback {
-    input: ResponseCodeHttpFallbackInput,
-    output: ResponseCodeHttpFallbackOutput,
+    input: ResponseCodeHttpFallbackInputOutput,
+    output: ResponseCodeHttpFallbackInputOutput,
 }
 
 @input
-structure ResponseCodeHttpFallbackInput {}
-
 @output
-structure ResponseCodeHttpFallbackOutput {}
+structure ResponseCodeHttpFallbackInputOutput {}
 
 apply HttpResponseCode @httpResponseTests([
     {
@@ -99,7 +93,7 @@ apply HttpResponseCode @httpResponseTests([
             Status: 201,
         },
         appliesTo: "client"
-    }
+    },
 ])
 
 apply ResponseCodeRequired @httpResponseTests([

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -101,7 +101,8 @@ apply ResponseCodeRequired @httpResponseTests([
                 This test ensures that servers handle @httpResponseCode being @required.""",
         protocol: restJson1,
         code: 201,
-        body: "",
+        body: "{}",
+        bodyMediaType: "application/json",
         params: {
             responseCode: 201,
         },
@@ -117,7 +118,8 @@ apply ResponseCodeHttpFallback @httpResponseTests([
                 by @http if @httpResponseCode is not set.""",
         protocol: restJson1,
         code: 201,
-        body: "",
+        body: "{}",
+        bodyMediaType: "application/json",
         appliesTo: "server"
     }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -37,8 +37,6 @@ operation ResponseCodeHttpFallback {
     output: ResponseCodeHttpFallbackInputOutput,
 }
 
-@input
-@output
 structure ResponseCodeHttpFallbackInputOutput {}
 
 apply HttpResponseCode @httpResponseTests([

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -19,6 +19,34 @@ structure HttpResponseCodeOutput {
     Status: Integer
 }
 
+@http(method: "GET", uri: "/responseCodeRequired", code: 200)
+operation ResponseCodeRequired {
+    input: ResponseCodeRequiredInput,
+    output: ResponseCodeRequiredOutput,
+}
+
+@input
+structure ResponseCodeRequiredInput {}
+
+@output
+structure ResponseCodeRequiredOutput {
+    @required
+    @httpResponseCode
+    responseCode: Integer,
+}
+
+@http(method: "GET", uri: "/responseCodeHttpFallback", code: 418)
+operation ResponseCodeHttpFallback {
+    input: ResponseCodeHttpFallbackInput,
+    output: ResponseCodeHttpFallbackOutput,
+}
+
+@input
+structure ResponseCodeHttpFallbackInput {}
+
+@output
+structure ResponseCodeHttpFallbackOutput {}
+
 apply HttpResponseCode @httpResponseTests([
     {
         id: "RestJsonHttpResponseCode",
@@ -71,5 +99,31 @@ apply HttpResponseCode @httpResponseTests([
             Status: 201,
         },
         appliesTo: "client"
-    },
+    }
+])
+
+apply ResponseCodeRequired @httpResponseTests([
+    {
+        id: "RestJsonHttpResponseCodeRequired",
+        documentation: """
+                This test ensures that servers handle @httpResponseCode being @required.""",
+        protocol: restJson1,
+        code: 201,
+        body: "",
+        params: {"responseCode": 201}
+        appliesTo: "server"
+    }
+])
+
+apply ResponseCodeHttpFallback @httpResponseTests([
+    {
+        id: "RestJsonHttpResponseCodeNotSetFallsBackToHttpCode",
+        documentation: """
+                This test ensures that servers fall back to the code set
+                by @http if @httpResponseCode is not set.""",
+        protocol: restJson1,
+        code: 418,
+        body: "",
+        appliesTo: "server"
+    }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -31,7 +31,7 @@ structure ResponseCodeRequiredOutput {
     responseCode: Integer,
 }
 
-@http(method: "GET", uri: "/responseCodeHttpFallback", code: 418)
+@http(method: "GET", uri: "/responseCodeHttpFallback", code: 201)
 operation ResponseCodeHttpFallback {
     input: ResponseCodeHttpFallbackInputOutput,
     output: ResponseCodeHttpFallbackInputOutput,
@@ -116,7 +116,7 @@ apply ResponseCodeHttpFallback @httpResponseTests([
                 This test ensures that servers fall back to the code set
                 by @http if @httpResponseCode is not set.""",
         protocol: restJson1,
-        code: 418,
+        code: 201,
         body: "",
         appliesTo: "server"
     }

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -104,7 +104,9 @@ apply ResponseCodeRequired @httpResponseTests([
         protocol: restJson1,
         code: 201,
         body: "",
-        params: {"responseCode": 201}
+        params: {
+            responseCode: 201,
+        },
         appliesTo: "server"
     }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -101,6 +101,9 @@ apply ResponseCodeRequired @httpResponseTests([
                 This test ensures that servers handle @httpResponseCode being @required.""",
         protocol: restJson1,
         code: 201,
+        headers: {
+            "Content-Type": "application/json"
+        },
         body: "{}",
         bodyMediaType: "application/json",
         params: {
@@ -118,6 +121,9 @@ apply ResponseCodeHttpFallback @httpResponseTests([
                 by @http if @httpResponseCode is not set.""",
         protocol: restJson1,
         code: 201,
+        headers: {
+            "Content-Type": "application/json"
+        },
         body: "{}",
         bodyMediaType: "application/json",
         appliesTo: "server"


### PR DESCRIPTION
*Issue #, if available:* in smithy-rs, https://github.com/awslabs/smithy-rs/issues/1229

*Description of changes:*
Add tests for http response code. These tests ensure that
* `@required` and `@httpResponseCode` are correctly handled
* `@http`'s code is used in place of `@httpResponseCode` when the latter is not used

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
