### PR TITLE
Fix MalformedAcceptWithGenericString

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
@@ -64,7 +64,7 @@ apply MalformedAcceptWithGenericString @httpMalformedRequestTests([
         protocol: restJson1,
         request: {
             method: "POST",
-            uri: "/MalformedAcceptWithPayload",
+            uri: "/MalformedAcceptWithGenericString",
             headers: {
                 // this should be text/plain
                 "accept": "application/json"
@@ -105,5 +105,5 @@ operation MalformedAcceptWithGenericString {
 
 structure MalformedAcceptWithGenericStringInput {
     @httpPayload
-    payload: Blob
+    payload: String
 }


### PR DESCRIPTION




*Issue #, if available:*

*Description of changes:*

MalformedAcceptWithGenericString targets a Blob, while it should test the behavior with a String payload

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
