### PR TITLE
Duplicate RestJsonStreamingTraitsWithBlob id

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -21,7 +21,7 @@ operation StreamingTraits {
 
 apply StreamingTraits @httpRequestTests([
     {
-        id: "RestJsonStreamingTraitsWithBlob",
+        id: "RestJsonStreamingTraitsWithBlobRequest",
         documentation: "Serializes a blob in the HTTP payload",
         protocol: restJson1,
         method: "POST",
@@ -56,7 +56,7 @@ apply StreamingTraits @httpRequestTests([
 
 apply StreamingTraits @httpResponseTests([
     {
-        id: "RestJsonStreamingTraitsWithBlob",
+        id: "RestJsonStreamingTraitsWithBlobResponse",
         documentation: "Serializes a blob in the HTTP payload",
         protocol: restJson1,
         code: 200,


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:* distinguish two RestJsonStreamingTraitsWithBlob IDs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
