### PR TITLE
Update doc highlighter for idl 2

### DIFF
--- a/docs/smithy/lexer.py
+++ b/docs/smithy/lexer.py
@@ -6,13 +6,125 @@ Smithy IDL lexer
 Lexers for the Smithy IDL.
 """
 
-from pygments.lexer import inherit
-from pygments.lexers import SmithyLexer as _SmithyLexer
-from pygments.token import String
+import re
+
+from pygments.lexer import RegexLexer, bygroups, words, include
+from pygments.token import (
+    Text,
+    Comment,
+    Keyword,
+    Name,
+    String,
+    Number,
+    Whitespace,
+    Punctuation,
+)
 
 __all__ = ["SmithyLexer"]
 
 
-class SmithyLexer(_SmithyLexer):
-    # The upstream lexer doesn't properly handle text blocks
-    tokens = {"root": [(r'"""(?:.|\n)*?[^\\]"""', String.Single), inherit]}
+class SmithyLexer(RegexLexer):
+    name = "Smithy"
+    url = "https://awslabs.github.io/smithy/"
+    filenames = ["*.smithy"]
+    aliases = ["smithy"]
+
+    flags = re.MULTILINE | re.UNICODE
+    shape_id = r"[A-Za-z0-9_\.#$-]+"
+    identifier = r"[a-zA-Z_]\w*"
+
+    tokens = {
+        "root": [
+            # Regular comment
+            (r"//.*$", Comment),
+            # Triple-slash indicates a documentation comment
+            (r"///.*$", String.Doc),
+            # Traits
+            (r"@[0-9a-zA-Z\.#-]*", Name.Decorator),
+            # Control statements
+            (
+                r"^(\$" + identifier + r")(:)",
+                bygroups(Keyword.Declaration, Name.Decorator),
+            ),
+            # Namespace statement
+            (
+                r"^(namespace)(\s+" + shape_id + r")\b",
+                bygroups(Keyword.Declaration, Name.Class),
+            ),
+            # Metadata statements
+            (
+                r"^(metadata)(\s+.+)(\s*)(=)",
+                bygroups(Keyword.Declaration, Name.Class, Whitespace, Name.Decorator),
+            ),
+            include("keywords"),
+            include("constants"),
+            (r"\$" + identifier, Name.Label),
+            (
+                "(" + identifier + r")(\s*)(:=?)",
+                bygroups(Name.Label, Whitespace, Punctuation),
+            ),
+            (shape_id, Name.Variable.Class),
+            (r"(?:\[|\(|\{)", Text, "#push"),
+            (r"(?:\]|\)|\})", Text, "#pop"),
+            (r'"""', String.Double, "textblock"),
+            (r'"', String.Double, "string"),
+            (r"[:,]+", Punctuation),
+            (r"\s+", Whitespace),
+        ],
+        "textblock": [
+            (r"\\(.|$)", String.Escape),
+            (r'"""', String.Double, "#pop"),
+            (r'[^\\"]+', String.Double),
+            (r'"', String.Double),
+        ],
+        "string": [
+            (r"\\.", String.Escape),
+            (r'"', String.Double, "#pop"),
+            (r'[^\\"]+', String.Double),
+        ],
+        "keywords": [
+            (
+                # These are all keywords that must be followed by an identifier
+                # of some sort. They're mostly, but not entirely, shapes.
+                words(
+                    (
+                        (
+                            "use",
+                            "apply",
+                            "byte",
+                            "short",
+                            "integer",
+                            "intEnum",
+                            "long",
+                            "float",
+                            "document",
+                            "double",
+                            "bigInteger",
+                            "bigDecimal",
+                            "boolean",
+                            "blob",
+                            "string",
+                            "enum",
+                            "timestamp",
+                            "list",
+                            "map",
+                            "set",
+                            "structure",
+                            "union",
+                            "resource",
+                            "operation",
+                            "service",
+                        )
+                    ),
+                    prefix=r"^",
+                    suffix=r"(\s+" + shape_id + r")\b",
+                ),
+                bygroups(Keyword.Declaration, Name.Class),
+            ),
+            (words(("with", "for"), suffix=r"\b"), Keyword),
+        ],
+        "constants": [
+            (words(("true", "false", "null"), suffix=r"\b"), Keyword.Constant),
+            (r"(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)", Number),
+        ],
+    }

--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -2090,7 +2090,7 @@ This example is equivalent to the following:
 
 The following text blocks are ill-formed:
 
-.. code-block:: smithy
+.. code-block::
 
     """foo"""  // missing new line following open delimiter
     """ """    // missing new line following open delimiter


### PR DESCRIPTION
This updates the lexer for the docs to properly handle IDL 2.0. It also does quite a bit of refactoring to it to make it a bit more robust and easier to understand. Once IDL 2 lands we can upstream this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
