### PR TITLE
update @examples doc example to avoid type mismatch

### DIFF
--- a/docs/source/1.0/spec/core/documentation-traits.rst
+++ b/docs/source/1.0/spec/core/documentation-traits.rst
@@ -245,12 +245,12 @@ These values use the same semantics and format as
             {
                 title: "Error example for MyOperation",
                 input: {
-                    foo: 1,
+                    foo: "!",
                 },
                 error: {
                     shapeId: MyOperationError,
                     content: {
-                        message: "Invalid 'foo'",
+                        message: "Invalid 'foo'. Special character not allowed.",
                     }
                 }
             },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Smithy validation doesn't allow type mismatch anywhere.
Updated the example in the documentation accordingly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
