### PR TITLE
chore(docs): fix allow unknown traits flag

### DIFF
--- a/docs/source/1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source/1.0/guides/building-models/gradle-plugin.rst
@@ -109,7 +109,7 @@ This extension supports the following properties:
       - ``FileCollection``
       - Sets a custom collection of smithy-build.json files to use when
         building the model.
-    * - allowsUnknownTraits
+    * - allowUnknownTraits
       - ``boolean``
       - Sets whether or not unknown traits in the model should be ignored. By
         default, the build will fail if unknown traits are encountered.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Based on the SmithyExtension code [here](https://github.com/awslabs/smithy-gradle-plugin/blob/eebf9c3a964519f6c1890e89e8857c1e47b1a0e6/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java#L34), the right configuration name should be `allowUnknownTraits`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
