### PR TITLE
Disallow sparse maps with httpPrefixHeaders

### DIFF
--- a/docs/source/1.0/spec/core/http-traits.rst
+++ b/docs/source/1.0/spec/core/http-traits.rst
@@ -794,10 +794,11 @@ Trait selector
     .. code-block:: none
 
         structure > member
-        :test(> map > member[id|member=value] > string)
+        :test(> map :not([trait|sparse]) > member[id|member=value] > string)
 
     The ``httpPrefixHeaders`` trait can be applied to ``structure`` members
-    that target a ``map`` of ``string``.
+    that target a ``map`` of ``string``. The targeted map MUST NOT be marked
+    with the :ref:`sparse-trait`.
 Value type
     ``string`` value that defines the prefix to prepend to each header field
     name stored in the targeted map member. For example, given a prefix value

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -803,7 +803,7 @@ string httpHeader
 @trait(
     selector: """
         structure > member
-        :test(> map > member[id|member=value] > string)""",
+        :test(> map :not([trait|sparse]) > member[id|member=value] > string)""",
     structurallyExclusive: "member",
     conflicts: [httpLabel, httpQuery, httpHeader, httpPayload, httpResponseCode, httpQueryParams],
     breakingChanges: [{change: "any"}]

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpprefixheaders-on-sparse-map.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpprefixheaders-on-sparse-map.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#Foo$headers: Trait `httpPrefixHeaders` cannot be applied to `smithy.example#Foo$headers`. | TraitTarget

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpprefixheaders-on-sparse-map.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/httpprefixheaders-on-sparse-map.smithy
@@ -1,0 +1,14 @@
+$version: "1.0"
+
+namespace smithy.example
+
+structure Foo {
+    @httpPrefixHeaders("")
+    headers: SparseMap
+}
+
+@sparse
+map SparseMap {
+    key: String,
+    value: String
+}


### PR DESCRIPTION
Closes #1228

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
