### PR TITLE
Do not use System.exit(0) since 0 is the default

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -43,8 +43,11 @@ public final class SmithyCli {
      */
     public static void main(String... args) {
         try {
-            SmithyCli cli = SmithyCli.create();
-            System.exit(cli.run(args));
+            int exitCode = SmithyCli.create().run(args);
+            // Only exit with a non-zero status on error since 0 is the default exit code.
+            if (exitCode != 0) {
+                System.exit(exitCode);
+            }
         } catch (CliError e) {
             System.exit(e.code);
         } catch (Exception e) {


### PR DESCRIPTION
Exiting on 0 was causing issues in other tools that expected to use the
CLI in a thread.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
