### PR TITLE
Copy maven metadata on local publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,17 @@ subprojects {
         }
     }
 
+    task copyMavenMetadataForDevelopment(type: Copy) {
+        from('build/tmp/publishMavenJavaPublicationToMavenLocal') {
+            rename 'module-maven-metadata.xml', 'maven-metadata.xml'
+        }
+
+        def wdir = System.getProperty("user.home") + '/.m2/repository/software/amazon/smithy/' + project.name
+        into(wdir)
+    }
+
+    publishToMavenLocal.finalizedBy(copyMavenMetadataForDevelopment)
+
     // ==== CheckStyle ====
     // https://docs.gradle.org/current/userguide/checkstyle_plugin.html
     apply plugin: "checkstyle"


### PR DESCRIPTION
This PR adds a build task that copies the maven metadata to `maven-metadata.xml` in the `.m2` repository.

Currently, the `publishToMavenLocal` task writes maven metadata to `maven-metadata-local.xml`. Some downstream tools, including Coursier only look for `maven-metadata.xml` when resolving dependencies from the `.m2` repository.

This task will run after `publishToMavenLocal` to make the same metadata available in both `maven-metadata-local.xml` and `maven-metadata.xml`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
