### PR TITLE
Add @examples trait conversion to Smithy2OpenAPI converter for REST protocols.

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -873,6 +873,79 @@ Smithy will generate the following OpenAPI model:
         ]
     }
 
+--------------------------------
+``@examples`` trait conversion
+--------------------------------
+
+In Smithy, example values of input structure members and the corresponding
+output or error structure members for an operation are grouped together
+into one set of example values for an operation. Below is an example "unit" of ``FooOperation``
+operation shape, which shows this logical grouping.
+
+.. code-block:: smithy
+
+    apply FooOperation @examples(
+        [
+            {
+                title: "valid example",
+                documentation: "valid example doc",
+                input: {
+                    bar: "1234"
+                },
+                output: {
+                    baz: "5678"
+                },
+            }
+        ]
+    )
+
+However, example values in OpenAPI are scattered throughout the model, with each example value
+contained by the OpenAPI object the example value is for.
+The following is an example OpenAPI model for the above Smithy example value.
+
+.. code-block:: json
+
+        "paths": {
+            "/": {
+                "get": {
+                    "operationId": "FooOperation",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "FooOperation_example1": {
+                                        "summary": "valid example",
+                                        "description": "valid example doc",
+                                        "value": {
+                                            "bar": "1234"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "responses": {
+                        "200": {
+                            "description": "FooOperation response",
+                            "content": {
+                                "application/json": {
+                                    "examples": {
+                                        "FooOperation_example1": {
+                                            "summary": "valid example",
+                                            "description": "valid example doc",
+                                            "value": {
+                                                "baz": "5678"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
 
 -----------------------------
 Amazon API Gateway extensions

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiProtocol.java
@@ -62,6 +62,12 @@ public interface OpenApiProtocol<T extends Trait> {
      * Creates an operation entry, including the method, URI, and operation
      * object builder.
      *
+     * The returned operation object builder should contain protocol-specific fields of an
+     * OpenAPI Operation object, such as: [parameters, requestBody, responses] and [examples for any of the above,
+     * contained by respective objects that the example values are for].
+     * The returned operation object builder should not contain protocol-agnostic fields of an OpenAPI
+     * Operation object, such as: tags, summary, description, externalDocs, deprecated, security.
+     *
      * <p>The operation is returned as an empty Optional if the operation is
      * not supported by the protocol. This method should make calls to
      * {@link #getOperationUri} and {@link #getOperationMethod} when creating

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -17,7 +17,9 @@ package software.amazon.smithy.openapi.fromsmithy.protocols;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,6 +36,9 @@ import software.amazon.smithy.model.knowledge.EventStreamInfo;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -42,6 +47,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.ExamplesTrait;
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
 import software.amazon.smithy.model.traits.HttpPayloadTrait;
 import software.amazon.smithy.model.traits.HttpTrait;
@@ -51,6 +57,7 @@ import software.amazon.smithy.openapi.OpenApiException;
 import software.amazon.smithy.openapi.fromsmithy.Context;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiProtocol;
+import software.amazon.smithy.openapi.model.ExampleObject;
 import software.amazon.smithy.openapi.model.LinkObject;
 import software.amazon.smithy.openapi.model.MediaTypeObject;
 import software.amazon.smithy.openapi.model.OperationObject;
@@ -114,6 +121,25 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             List<HttpBinding> bindings,
             MessageType messageType
     );
+
+
+    /**
+     * Converts Smithy values in Node form to a data exchange format used by a protocol (e.g., XML).
+     * Then returns the converted value as a long string (escaping where necessary).
+     * If data exchange format is JSON (e.g., as in restJson1 protocol),
+     * method should return values without any modification.
+     *
+     * <p> Used for the value property of OpenAPI example objects.
+     * For protocols that do not use JSON as data-exchange format,
+     * converts the Node object to a StringNode object that contains the same data, but represented
+     * in the data representation format used by the protocol.
+     * E.g., for restXML protocol, values would be converted to a large String of XML value / object,
+     * escaping where necessary.
+     *
+     * @param value    value to be converted.
+     * @return  the long string (escaped where necessary) of values in a data exchange format used by a protocol.
+     */
+    abstract Node transformSmithyValueToProtocolValue(Node value);
 
     @Override
     public Set<String> getProtocolRequestHeaders(Context<T> context, OperationShape operationShape) {
@@ -191,10 +217,183 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
                     .name(name)
                     .in("path")
                     .schema(schema)
+                    .examples(createExamplesForMembersWithHttpTraits(
+                            operation, binding, MessageType.REQUEST, null
+                    ))
                     .build());
         }
 
         return result;
+    }
+
+    /*
+     * This method is used for converting the Smithy examples to OpenAPI examples for:
+     * path parameters, query parameters, header parameters, and payload.
+     */
+    private Map<String, Node> createExamplesForMembersWithHttpTraits(
+            Shape operationOrError,
+            HttpBinding binding,
+            MessageType type,
+            OperationShape operation
+    ) {
+        if (operation == null && type == MessageType.ERROR) {
+            return Collections.emptyMap();
+        }
+
+        if (type == MessageType.ERROR) {
+            return createErrorExamplesForMembersWithHttpTraits(operationOrError, binding, operation);
+        } else {
+            Map<String, Node> examples = new TreeMap<>();
+            // unique numbering for unique example names in OpenAPI.
+            int uniqueNum = 1;
+
+            Optional<ExamplesTrait> examplesTrait = operationOrError.getTrait(ExamplesTrait.class);
+            for (ExamplesTrait.Example example
+                    : examplesTrait.map(ExamplesTrait::getExamples).orElse(Collections.emptyList())) {
+                ObjectNode inputOrOutput = type == MessageType.REQUEST ? example.getInput() : example.getOutput();
+                String name = operationOrError.getId().getName() + "_example" + uniqueNum++;
+
+                // this if condition is needed to avoid errors when converting examples of response.
+                if ((!example.getError().isPresent() || type == MessageType.REQUEST)
+                        && inputOrOutput.containsMember(binding.getMemberName())) {
+                    Node values = inputOrOutput.getMember(binding.getMemberName()).get();
+
+                    examples.put(name, ExampleObject.builder()
+                            .summary(example.getTitle())
+                            .description(example.getDocumentation().orElse(""))
+                            .value(transformSmithyValueToProtocolValue(values))
+                            .build()
+                            .toNode());
+                }
+            }
+            return examples;
+        }
+    }
+
+    /*
+     * Helper method for createExamples() method.
+     */
+    private Map<String, Node> createErrorExamplesForMembersWithHttpTraits(
+            Shape error,
+            HttpBinding binding,
+            OperationShape operation
+    ) {
+        Map<String, Node> examples = new TreeMap<>();
+
+        // unique numbering for unique example names in OpenAPI.
+        int uniqueNum = 1;
+        Optional<ExamplesTrait> examplesTrait = operation.getTrait(ExamplesTrait.class);
+        for (ExamplesTrait.Example example
+                : examplesTrait.map(ExamplesTrait::getExamples).orElse(Collections.emptyList())) {
+            String name = operation.getId().getName() + "_example" + uniqueNum++;
+
+            // this has to be checked because an operation can have more than one error linked to it.
+            ExamplesTrait.ErrorExample errorExample = example.getError().orElse(null);
+            if (errorExample != null
+                    && errorExample.getShapeId() == error.toShapeId()
+                    && errorExample.getContent().containsMember(binding.getMemberName())) {
+                Node values = errorExample.getContent()
+                        .getMember(binding.getMemberName()).get();
+
+                examples.put(name, ExampleObject.builder()
+                        .summary(example.getTitle())
+                        .description(example.getDocumentation().orElse(""))
+                        .value(transformSmithyValueToProtocolValue(values))
+                        .build()
+                        .toNode());
+            }
+        }
+        return examples;
+    }
+
+    /*
+     * This method is used for converting the Smithy examples to OpenAPI examples for non-payload HTTP message body.
+     */
+    private Map<String, Node> createBodyExamples(
+            Shape operationOrError,
+            List<HttpBinding> bindings,
+            MessageType type,
+            OperationShape operation
+    ) {
+        if (operation == null && type == MessageType.ERROR)  {
+            return Collections.emptyMap();
+        }
+
+        if (type == MessageType.ERROR) {
+            return createErrorBodyExamples(operationOrError, bindings, operation);
+        } else {
+            Map<String, Node> examples = new TreeMap<>();
+            // unique numbering for unique example names in OpenAPI.
+            int uniqueNum = 1;
+
+            Optional<ExamplesTrait> examplesTrait = operationOrError.getTrait(ExamplesTrait.class);
+            for (ExamplesTrait.Example example
+                    : examplesTrait.map(ExamplesTrait::getExamples).orElse(Collections.emptyList())) {
+                // get members included in bindings
+                ObjectNode values = getMembersWithHttpBindingTrait(bindings,
+                        type == MessageType.REQUEST ? example.getInput() : example.getOutput());
+                String name = operationOrError.getId().getName() + "_example" + uniqueNum++;
+                // this if condition is needed to avoid errors when converting examples of response.
+                if (!example.getError().isPresent() || type == MessageType.REQUEST) {
+                    examples.put(name, ExampleObject.builder()
+                            .summary(example.getTitle())
+                            .description(example.getDocumentation().orElse(""))
+                            .value(transformSmithyValueToProtocolValue(values))
+                            .build()
+                            .toNode());
+                }
+            }
+            return examples;
+        }
+    }
+
+    private Map<String, Node> createErrorBodyExamples(
+            Shape error,
+            List<HttpBinding> bindings,
+            OperationShape operation
+    ) {
+        Map<String, Node> examples = new TreeMap<>();
+        // unique numbering for unique example names in OpenAPI.
+        int uniqueNum = 1;
+        Optional<ExamplesTrait> examplesTrait = operation.getTrait(ExamplesTrait.class);
+        for (ExamplesTrait.Example example
+                : examplesTrait.map(ExamplesTrait::getExamples).orElse(Collections.emptyList())) {
+            String name = operation.getId().getName() + "_example" + uniqueNum++;
+            // this has to be checked because an operation can have more than one error linked to it.
+            if (example.getError().isPresent()
+                    && example.getError().get().getShapeId() == error.toShapeId()) {
+                // get members included in bindings
+                ObjectNode values = getMembersWithHttpBindingTrait(bindings, example.getError().get().getContent());
+                examples.put(name,
+                        ExampleObject.builder()
+                                .summary(example.getTitle())
+                                .description(example.getDocumentation().orElse(""))
+                                .value(transformSmithyValueToProtocolValue(values))
+                                .build()
+                                .toNode());
+            }
+        }
+        return examples;
+    }
+
+    /*
+     * Returns a modified copy of [inputOrOutput] only containing members bound to a HttpBinding trait in [bindings].
+     */
+    private ObjectNode getMembersWithHttpBindingTrait(List<HttpBinding> bindings, ObjectNode inputOrOutput) {
+        ObjectNode.Builder values = ObjectNode.builder();
+
+        Set<String> memberNamesWithHttpBinding = new HashSet<>();
+        for (HttpBinding binding : bindings) {
+            memberNamesWithHttpBinding.add(binding.getMemberName());
+        }
+
+        for (Map.Entry<StringNode, Node> entry : inputOrOutput.getMembers().entrySet()) {
+            if (memberNamesWithHttpBinding.contains(entry.getKey().toString())) {
+                values.withMember(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return values.build();
     }
 
     private Schema createPathParameterSchema(Context<T> context, HttpBinding binding) {
@@ -263,6 +462,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             }
 
             param.schema(createQuerySchema(context, member, target));
+            param.examples(createExamplesForMembersWithHttpTraits(operation, binding, MessageType.REQUEST, null));
             result.add(param.build());
         }
 
@@ -279,13 +479,15 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     private Collection<ParameterObject> createRequestHeaderParameters(Context<T> context, OperationShape operation) {
         List<HttpBinding> bindings = HttpBindingIndex.of(context.getModel())
                 .getRequestBindings(operation, HttpBinding.Location.HEADER);
-        return createHeaderParameters(context, bindings, MessageType.REQUEST).values();
+        return createHeaderParameters(context, bindings, MessageType.REQUEST, operation, null).values();
     }
 
     private Map<String, ParameterObject> createHeaderParameters(
             Context<T> context,
             List<HttpBinding> bindings,
-            MessageType messageType
+            MessageType messageType,
+            Shape operationOrError,
+            OperationShape operation
     ) {
         Map<String, ParameterObject> result = new TreeMap<>();
 
@@ -299,6 +501,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
                 // Response headers don't use "in" or "name".
                 param.in(null).name(null);
             }
+
+            param.examples(createExamplesForMembersWithHttpTraits(operationOrError, binding, messageType, operation));
 
             // Create the appropriate schema based on the shape type.
             Shape target = context.getModel().expectShape(member.getTarget());
@@ -365,7 +569,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         MediaTypeObject mediaTypeObject = getMediaTypeObject(context, schema, operation, shape -> {
             String shapeName = context.getService().getContextualName(shape.getId());
             return shapeName + "InputPayload";
-        });
+        }).toBuilder().examples(createExamplesForMembersWithHttpTraits(
+                operation, binding, MessageType.REQUEST, null)).build();
         RequestBodyObject requestBodyObject = RequestBodyObject.builder()
                 .putContent(Objects.requireNonNull(mediaTypeRange), mediaTypeObject)
                 .required(binding.getMember().isRequired())
@@ -393,6 +598,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
+                .examples(createBodyExamples(operation, bindings, MessageType.REQUEST, null))
                 .build();
 
         // If any of the top level bindings are required, then the body itself must be required.
@@ -454,8 +660,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         Shape operationOrError = shape.hasTrait(ErrorTrait.class) ? shape : operation;
         String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, operationOrError);
         ResponseObject response = createResponse(
-                context, bindingIndex, eventStreamIndex, statusCode, operationOrError, false);
-
+                context, bindingIndex, eventStreamIndex, statusCode, operationOrError, operation, false);
         responses.put(statusCode, response);
     }
 
@@ -485,7 +690,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, shapes.get(0));
         for (StructureShape shape : shapes) {
             errors.add(createResponse(context, bindingIndex, eventStreamIndex, statusCode, shape,
-                    true));
+                    null, true));
         }
 
         // This map contains mapping of mediaType string (e.g., "application/json") to MediaTypeObject objects from
@@ -544,6 +749,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             EventStreamIndex eventStreamIndex,
             String statusCode,
             Shape operationOrError,
+            OperationShape operation,
             boolean dropRequiredTrait
     ) {
         ResponseObject.Builder responseBuilder = ResponseObject.builder();
@@ -551,23 +757,28 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         String responseName = stripNonAlphaNumericCharsIfNecessary(context, contextName);
 
         responseBuilder.description(String.format("%s %s response", responseName, statusCode));
-        Map<String, ParameterObject> headers = createResponseHeaderParameters(context, operationOrError);
+        Map<String, ParameterObject> headers = createResponseHeaderParameters(context, operationOrError, operation);
+
         if (dropRequiredTrait) {
             headers.forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v.toBuilder().required(false).build())));;
         } else {
             headers.forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v)));;
         }
-        addResponseContent(context, bindingIndex, eventStreamIndex, responseBuilder, operationOrError);
+
+        addResponseContent(context, bindingIndex, eventStreamIndex, responseBuilder, operationOrError, operation);
+
         return responseBuilder.build();
     }
 
     private Map<String, ParameterObject> createResponseHeaderParameters(
             Context<T> context,
-            Shape operationOrError
+            Shape operationOrError,
+            OperationShape operation
     ) {
         List<HttpBinding> bindings = HttpBindingIndex.of(context.getModel())
                 .getResponseBindings(operationOrError, HttpBinding.Location.HEADER);
-        return createHeaderParameters(context, bindings, MessageType.RESPONSE);
+        MessageType type = !operationOrError.hasTrait(ErrorTrait.class) ? MessageType.RESPONSE : MessageType.ERROR;
+        return createHeaderParameters(context, bindings, type, operationOrError, operation);
     }
 
     private void addResponseContent(
@@ -575,7 +786,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             HttpBindingIndex bindingIndex,
             EventStreamIndex eventStreamIndex,
             ResponseObject.Builder responseBuilder,
-            Shape operationOrError
+            Shape operationOrError,
+            OperationShape operation
     ) {
         List<HttpBinding> payloadBindings = bindingIndex.getResponseBindings(
                 operationOrError, HttpBinding.Location.PAYLOAD);
@@ -593,9 +805,11 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
                 .orElse(null);
 
         if (!payloadBindings.isEmpty()) {
-            createResponsePayload(mediaType, context, payloadBindings.get(0), responseBuilder, operationOrError);
+            createResponsePayload(mediaType, context, payloadBindings.get(0), responseBuilder,
+                    operationOrError, operation);
         } else {
-            createResponseDocumentIfNeeded(mediaType, context, bindingIndex, responseBuilder, operationOrError);
+            createResponseDocumentIfNeeded(mediaType, context, bindingIndex, responseBuilder,
+                    operationOrError, operation);
         }
     }
 
@@ -604,7 +818,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             Context<T> context,
             HttpBinding binding,
             ResponseObject.Builder responseBuilder,
-            Shape operationOrError
+            Shape operationOrError,
+            OperationShape operation
     ) {
         Objects.requireNonNull(mediaType, "Unable to determine response media type for " + operationOrError);
 
@@ -612,12 +827,15 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         // or arrays. These schemas are synthesized as references so that
         // any schemas with string types will pass validation.
         Schema schema = context.inlineOrReferenceSchema(binding.getMember());
+        MessageType type = !operationOrError.hasTrait(ErrorTrait.class) ? MessageType.RESPONSE : MessageType.ERROR;
         MediaTypeObject mediaTypeObject = getMediaTypeObject(context, schema, operationOrError, shape -> {
             String shapeName = context.getService().getContextualName(shape.getId());
             return shape instanceof OperationShape
                     ? shapeName + "OutputPayload"
                     : shapeName + "ErrorPayload";
-        });
+        }).toBuilder().examples(createExamplesForMembersWithHttpTraits(
+                operationOrError, binding, type, operation
+        )).build();
 
         responseBuilder.putContent(mediaType, mediaTypeObject);
     }
@@ -649,7 +867,8 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             Context<T> context,
             HttpBindingIndex bindingIndex,
             ResponseObject.Builder responseBuilder,
-            Shape operationOrError
+            Shape operationOrError,
+            OperationShape operation
     ) {
         List<HttpBinding> bindings = bindingIndex.getResponseBindings(
                 operationOrError, HttpBinding.Location.DOCUMENT);
@@ -694,6 +913,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
+                .examples(createBodyExamples(operationOrError, bindings, messageType, operation))
                 .build();
 
         responseBuilder.putContent(mediaType, mediaTypeObject);

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.aws.traits.protocols.RestJson1Trait;
 import software.amazon.smithy.jsonschema.Schema;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -129,5 +130,10 @@ public final class AwsRestJson1Protocol extends AbstractRestProtocol<RestJson1Tr
 
         StructureShape cleanedShape = containerShapeBuilder.build();
         return context.getJsonSchemaConverter().convertShape(cleanedShape).getRootSchema();
+    }
+
+    @Override
+    Node transformSmithyValueToProtocolValue(Node value) {
+        return value;
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ExampleObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ExampleObject.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.openapi.model;
+
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class ExampleObject extends Component implements ToSmithyBuilder<ExampleObject> {
+    private final String summary;
+    private final String description;
+    private final Node value;
+    private final String externalValue;
+
+    private ExampleObject(Builder builder) {
+        super(builder);
+        this.summary = builder.summary;
+        this.description = builder.description;
+        this.value = builder.value;
+        this.externalValue = builder.externalValue;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // getters
+    public Optional<String> getSummary() {
+        return Optional.ofNullable(summary);
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    public Optional<Node> getValue() {
+        return Optional.ofNullable(value);
+    }
+
+    public Optional<String> getExternalValue() {
+        return Optional.ofNullable(externalValue);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder()
+                .extensions(getExtensions())
+                .summary(summary)
+                .description(description)
+                .value(value)
+                .externalValue(externalValue);
+    }
+
+    @Override
+    protected ObjectNode.Builder createNodeBuilder() {
+        return Node.objectNodeBuilder()
+                .withOptionalMember("summary", getSummary().map(Node::from))
+                .withOptionalMember("description", getDescription().map(Node::from))
+                .withOptionalMember("value", getValue().map(Node::from))
+                .withOptionalMember("externalValue", getExternalValue().map(Node::from));
+    }
+
+    public static ExampleObject fromNode(Node exampleObject) {
+        if (exampleObject == null) {
+            return null;
+        }
+        NodeMapper mapper = new NodeMapper();
+        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
+        ObjectNode node = exampleObject.expectObjectNode();
+        ExampleObject.Builder result = new ExampleObject.Builder();
+        mapper.deserializeInto(node, result);
+        return result.build();
+    }
+
+
+    public static final class Builder extends Component.Builder<Builder, ExampleObject> {
+        private String summary;
+        private String description;
+        private Node value;
+        private String externalValue;
+
+        private Builder() {}
+
+        @Override
+        public ExampleObject build() {
+            return new ExampleObject(this);
+        }
+
+        public Builder summary(String summary) {
+            this.summary = summary;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder value(Node value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder externalValue(String externalValue) {
+            this.externalValue = externalValue;
+            return this;
+        }
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/MediaTypeObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/MediaTypeObject.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.openapi.model;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -25,8 +26,8 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 
 public final class MediaTypeObject extends Component implements ToSmithyBuilder<MediaTypeObject> {
     private final Schema schema;
-    private final Node example;
-    private final Map<String, Node> examples = new TreeMap<>();
+    private final ExampleObject example;
+    private final Map<String, ExampleObject> examples = new TreeMap<>();
     private final Map<String, EncodingObject> encoding = new TreeMap<>();
 
     private MediaTypeObject(Builder builder) {
@@ -45,11 +46,11 @@ public final class MediaTypeObject extends Component implements ToSmithyBuilder<
         return Optional.ofNullable(schema);
     }
 
-    public Optional<Node> getExample() {
+    public Optional<ExampleObject> getExample() {
         return Optional.ofNullable(example);
     }
 
-    public Map<String, Node> getExamples() {
+    public Map<String, ExampleObject> getExamples() {
         return examples;
     }
 
@@ -78,18 +79,22 @@ public final class MediaTypeObject extends Component implements ToSmithyBuilder<
 
     @Override
     public Builder toBuilder() {
+        Map<String, Node> nodeExamples = new HashMap<>();
+        for (Map.Entry<String, ExampleObject> ex : examples.entrySet()) {
+            nodeExamples.put(ex.getKey(), ex.getValue().toNode());
+        }
         return builder()
                 .extensions(getExtensions())
                 .schema(schema)
-                .example(example)
-                .examples(examples)
+                .example(example == null ? null : example.toNode())
+                .examples(nodeExamples)
                 .encoding(encoding);
     }
 
     public static final class Builder extends Component.Builder<Builder, MediaTypeObject> {
         private Schema schema;
-        private Node example;
-        private final Map<String, Node> examples = new TreeMap<>();
+        private ExampleObject example;
+        private final Map<String, ExampleObject> examples = new TreeMap<>();
         private final Map<String, EncodingObject> encoding = new TreeMap<>();
 
         private Builder() {}
@@ -105,17 +110,19 @@ public final class MediaTypeObject extends Component implements ToSmithyBuilder<
         }
 
         public Builder example(Node example) {
-            this.example = example;
+            this.example = ExampleObject.fromNode(example);
             return this;
         }
 
         public Builder examples(Map<String, Node> examples) {
             this.examples.clear();
-            this.examples.putAll(examples);
+            for (Map.Entry<String, Node> example : examples.entrySet()) {
+                this.examples.put(example.getKey(), ExampleObject.fromNode(example.getValue()));
+            }
             return this;
         }
 
-        public Builder putExample(String name, Node example) {
+        public Builder putExample(String name, ExampleObject example) {
             examples.put(name, example);
             return this;
         }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ParameterObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ParameterObject.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.openapi.model;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -35,8 +36,8 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
     private final boolean explode;
     private final boolean allowReserved;
     private final Schema schema;
-    private final Node example;
-    private final Map<String, Node> examples;
+    private final ExampleObject example;
+    private final Map<String, ExampleObject> examples;
     private final Map<String, MediaTypeObject> content;
 
     private ParameterObject(Builder builder) {
@@ -68,7 +69,7 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
         return Optional.ofNullable(in);
     }
 
-    public Map<String, Node> getExamples() {
+    public Map<String, ExampleObject> getExamples() {
         return examples;
     }
 
@@ -108,7 +109,7 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
         return Optional.ofNullable(schema);
     }
 
-    public Optional<Node> getExample() {
+    public Optional<ExampleObject> getExample() {
         return Optional.ofNullable(example);
     }
 
@@ -157,6 +158,10 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
 
     @Override
     public Builder toBuilder() {
+        Map<String, Node> nodeExamples = new HashMap<>();
+        for (Map.Entry<String, ExampleObject> ex : examples.entrySet()) {
+            nodeExamples.put(ex.getKey(), ex.getValue().toNode());
+        }
         return builder()
                 .extensions(getExtensions())
                 .name(name)
@@ -169,8 +174,8 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
                 .explode(explode)
                 .allowReserved(allowReserved)
                 .schema(schema)
-                .example(example)
-                .examples(examples)
+                .example(example == null ? null : example.toNode())
+                .examples(nodeExamples)
                 .content(content);
     }
 
@@ -185,8 +190,8 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
         private boolean explode;
         private boolean allowReserved;
         private Schema schema;
-        private Node example;
-        private final Map<String, Node> examples = new TreeMap<>();
+        private ExampleObject example;
+        private final Map<String, ExampleObject> examples = new TreeMap<>();
         private final Map<String, MediaTypeObject> content = new TreeMap<>();
 
         private Builder() {}
@@ -247,18 +252,20 @@ public final class ParameterObject extends Component implements ToSmithyBuilder<
         }
 
         public Builder example(Node example) {
-            this.example = example;
+            this.example = ExampleObject.fromNode(example);
             return this;
         }
 
         public Builder examples(Map<String, Node> examples) {
             this.examples.clear();
-            this.examples.putAll(examples);
+            for (Map.Entry<String, Node> example : examples.entrySet()) {
+                this.examples.put(example.getKey(), ExampleObject.fromNode(example.getValue()));
+            }
             return this;
         }
 
         public Builder putExample(String name, Node example) {
-            this.examples.put(name, example);
+            this.examples.put(name, ExampleObject.fromNode(example));
             return this;
         }
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -266,7 +266,29 @@ public class AwsRestJson1ProtocolTest {
             return OpenApiMapper.super.updateOperation(context, shape, operation, httpMethodName, path);
         }
     }
+    
+    @Test
+    public void convertsExamples() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("examples-test.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.examplestrait#Banking"));
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+        InputStream openApiStream = getClass().getResourceAsStream("examples-test.openapi.json");
 
+        if (openApiStream == null) {
+            throw new RuntimeException("OpenAPI model not found for test case: examples-test.openapi.json");
+        } else {
+            Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
+            Node.assertEquals(result, expectedNode);
+        }
+    }
+    
     @Test
     public void convertsErrorStructuresWithSameErrorCodeWithoutUsingOneOf() {
         Model model = Model.assembler()

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.openapi.json
@@ -1,0 +1,490 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Banking",
+    "version": "2022-06-26"
+  },
+  "paths": {
+    "/account/withdraw": {
+      "patch": {
+        "operationId": "Withdraw",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WithdrawRequestContent"
+              },
+              "examples": {
+                "Withdraw_example1": {
+                  "summary": "Withdraw valid example",
+                  "description": "withdrawTestDoc",
+                  "value": {
+                    "time": "Tue, 29 Apr 2014 18:30:38 GMT",
+                    "withdrawAmount": "-35",
+                    "withdrawOption": "ATM"
+                  }
+                },
+                "Withdraw_example2": {
+                  "summary": "Withdraw invalid username example",
+                  "description": "withdrawTestDoc2",
+                  "value": {
+                    "withdrawAmount": "-450",
+                    "withdrawOption": "Venmo"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "withdrawParams",
+            "in": "query",
+            "style": "form",
+            "schema": {
+              "$ref": "#/components/schemas/ExampleMap"
+            },
+            "examples": {
+              "Withdraw_example1": {
+                "summary": "Withdraw valid example",
+                "description": "withdrawTestDoc",
+                "value": {
+                  "location": "Denver",
+                  "bankName": "Chase"
+                }
+              },
+              "Withdraw_example2": {
+                "summary": "Withdraw invalid username example",
+                "description": "withdrawTestDoc2",
+                "value": {
+                  "location": "Seoul",
+                  "bankName": "Chase"
+                }
+              }
+            }
+          },
+          {
+            "name": "accountNumber",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Withdraw_example1": {
+                "summary": "Withdraw valid example",
+                "description": "withdrawTestDoc",
+                "value": "124634"
+              },
+              "Withdraw_example2": {
+                "summary": "Withdraw invalid username example",
+                "description": "withdrawTestDoc2",
+                "value": "231565"
+              }
+            }
+          },
+          {
+            "name": "username",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Withdraw_example1": {
+                "summary": "Withdraw valid example",
+                "description": "withdrawTestDoc",
+                "value": "amazon"
+              },
+              "Withdraw_example2": {
+                "summary": "Withdraw invalid username example",
+                "description": "withdrawTestDoc2",
+                "value": "peccy"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Withdraw 200 response",
+            "headers": {
+              "branch": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "Withdraw_example1": {
+                    "summary": "Withdraw valid example",
+                    "description": "withdrawTestDoc",
+                    "value": "Denver-203"
+                  }
+                }
+              },
+              "result": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "examples": {
+                  "Withdraw_example1": {
+                    "summary": "Withdraw valid example",
+                    "description": "withdrawTestDoc",
+                    "value": [
+                      "34",
+                      "5",
+                      "-250"
+                    ]
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WithdrawResponseContent"
+                },
+                "examples": {
+                  "Withdraw_example1": {
+                    "summary": "Withdraw valid example",
+                    "description": "withdrawTestDoc",
+                    "value": {
+                      "location": "Denver",
+                      "bankName": "Chase",
+                      "atmRecording": "dGVzdHZpZGVv"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidUsername 400 response",
+            "headers": {
+              "internalErrorCode": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "Withdraw_example2": {
+                    "summary": "Withdraw invalid username example",
+                    "description": "withdrawTestDoc2",
+                    "value": "8dfws-21"
+                  }
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidUsernameErrorPayload"
+                },
+                "examples": {
+                  "Withdraw_example2": {
+                    "summary": "Withdraw invalid username example",
+                    "description": "withdrawTestDoc2",
+                    "value": "ERROR: Invalid username."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/account/{username}": {
+      "put": {
+        "operationId": "Deposit",
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/DepositInputPayload"
+              },
+              "examples": {
+                "Deposit_example1": {
+                  "summary": "Deposit valid example",
+                  "description": "depositTestDoc",
+                  "value": "200"
+                },
+                "Deposit_example2": {
+                  "summary": "Deposit invalid username example",
+                  "description": "depositTestDoc2",
+                  "value": "-200"
+                },
+                "Deposit_example3": {
+                  "summary": "Deposit invalid amount example",
+                  "description": "depositTestDoc3",
+                  "value": "-100"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "examples": {
+              "Deposit_example1": {
+                "summary": "Deposit valid example",
+                "description": "depositTestDoc",
+                "value": "sichanyoo"
+              },
+              "Deposit_example2": {
+                "summary": "Deposit invalid username example",
+                "description": "depositTestDoc2",
+                "value": "sichanyoo"
+              },
+              "Deposit_example3": {
+                "summary": "Deposit invalid amount example",
+                "description": "depositTestDoc3",
+                "value": "obidos"
+              }
+            }
+          },
+          {
+            "name": "accountHistory",
+            "in": "query",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": true,
+            "examples": {
+              "Deposit_example1": {
+                "summary": "Deposit valid example",
+                "description": "depositTestDoc",
+                "value": [
+                  "10",
+                  "-25",
+                  "50"
+                ]
+              },
+              "Deposit_example2": {
+                "summary": "Deposit invalid username example",
+                "description": "depositTestDoc2",
+                "value": [
+                  "-200",
+                  "200",
+                  "10"
+                ]
+              },
+              "Deposit_example3": {
+                "summary": "Deposit invalid amount example",
+                "description": "depositTestDoc3",
+                "value": [
+                  "2000",
+                  "50000",
+                  "100"
+                ]
+              }
+            }
+          },
+          {
+            "name": "accountNumber",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Deposit_example1": {
+                "summary": "Deposit valid example",
+                "description": "depositTestDoc",
+                "value": "102935"
+              },
+              "Deposit_example3": {
+                "summary": "Deposit invalid amount example",
+                "description": "depositTestDoc3",
+                "value": "203952"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deposit 200 response",
+            "headers": {
+              "authenticationResult": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "examples": {
+                  "Deposit_example1": {
+                    "summary": "Deposit valid example",
+                    "description": "depositTestDoc",
+                    "value": [
+                      "pass1",
+                      "pass2",
+                      "pass3"
+                    ]
+                  }
+                }
+              },
+              "username": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "Deposit_example1": {
+                    "summary": "Deposit valid example",
+                    "description": "depositTestDoc",
+                    "value": "sichanyoo"
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepositResponseContent"
+                },
+                "examples": {
+                  "Deposit_example1": {
+                    "summary": "Deposit valid example",
+                    "description": "depositTestDoc",
+                    "value": {
+                      "textMessage": "You deposited 200-text",
+                      "emailMessage": "You deposited 200-email"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidUsername 400 response",
+            "headers": {
+              "internalErrorCode": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "Deposit_example2": {
+                    "summary": "Deposit invalid username example",
+                    "description": "depositTestDoc2",
+                    "value": "4gsw2-34"
+                  }
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidUsernameErrorPayload"
+                },
+                "examples": {
+                  "Deposit_example2": {
+                    "summary": "Deposit invalid username example",
+                    "description": "depositTestDoc2",
+                    "value": "ERROR: Invalid username."
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InvalidAmount 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAmountResponseContent"
+                },
+                "examples": {
+                  "Deposit_example3": {
+                    "summary": "Deposit invalid amount example",
+                    "description": "depositTestDoc3",
+                    "value": {
+                      "errorMessage1": "ERROR: Invalid amount.",
+                      "errorMessage2": "2gdx4-34",
+                      "errorMessage3": "2gcbe-98"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DepositInputPayload": {
+        "type": "string"
+      },
+      "DepositResponseContent": {
+        "type": "object",
+        "properties": {
+          "textMessage": {
+            "type": "string"
+          },
+          "emailMessage": {
+            "type": "string"
+          }
+        }
+      },
+      "InvalidAmountResponseContent": {
+        "type": "object",
+        "properties": {
+          "errorMessage1": {
+            "type": "string"
+          },
+          "errorMessage2": {
+            "type": "string"
+          },
+          "errorMessage3": {
+            "type": "string"
+          }
+        }
+      },
+      "InvalidUsernameErrorPayload": {
+        "type": "string"
+      },
+      "WithdrawRequestContent": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "string"
+          },
+          "withdrawAmount": {
+            "type": "string"
+          },
+          "withdrawOption": {
+            "type": "string"
+          }
+        }
+      },
+      "WithdrawResponseContent": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          },
+          "bankName": {
+            "type": "string"
+          },
+          "atmRecording": {
+            "type": "string",
+            "format": "byte"
+          }
+        }
+      },
+      "ExampleMap": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.smithy
@@ -1,0 +1,213 @@
+namespace smithy.examplestrait
+
+use aws.protocols#restJson1
+
+@restJson1
+service Banking {
+    version: "2022-06-26",
+    operations: [Deposit, Withdraw]
+}
+
+@idempotent
+@http(method: "PUT", uri: "/account/{username}", code: 200)
+operation Deposit {
+    input: DepositInput,
+    output: DepositOutput,
+    errors: [InvalidUsername, InvalidAmount]
+}
+
+@idempotent
+@http(method: "PATCH", uri: "/account/withdraw", code: 200)
+operation Withdraw {
+    input: WithdrawInput,
+    output: WithdrawOutput,
+    errors: [InvalidUsername]
+}
+
+@input
+structure DepositInput {
+    @httpHeader("accountNumber")
+    accountNumber: String,
+
+    @required
+    @httpLabel
+    username: String,
+
+    @httpQuery("accountHistory")
+    accountHistory: ExampleList,
+
+    @httpPayload
+    depositAmount: String
+}
+
+@input
+structure WithdrawInput {
+    @httpHeader("accountNumber")
+    accountNumber: String,
+
+    @httpHeader("username")
+    username: String,
+
+    @httpQueryParams()
+    withdrawParams: ExampleMap,
+
+    time: date,
+    withdrawAmount: String,
+    withdrawOption: String
+}
+
+list ExampleList {
+    member: String
+}
+
+map ExampleMap {
+    key: String,
+    value: String
+}
+
+@mediaType("video/quicktime")
+blob exampleVideo
+
+@timestampFormat("http-date")
+timestamp date
+
+@output
+structure DepositOutput {
+    @httpHeader("username")
+    username: String,
+
+    @httpHeader("authenticationResult")
+    authenticationResult: ExampleList,
+
+    textMessage: String,
+    emailMessage: String
+}
+
+@output
+structure WithdrawOutput {
+    @httpHeader("branch")
+    branch: String,
+
+    @httpHeader("result")
+    accountHistory: ExampleList,
+
+    location: String,
+    bankName: String,
+    atmRecording: exampleVideo
+}
+
+@error("client")
+structure InvalidUsername {
+    @httpHeader("internalErrorCode")
+    internalErrorCode: String,
+
+    @httpPayload
+    errorMessage: String
+}
+
+@error("server")
+structure InvalidAmount {
+    errorMessage1: String,
+    errorMessage2: String,
+    errorMessage3: String
+}
+
+apply Deposit @examples(
+    [
+        {
+            title: "Deposit valid example",
+            documentation: "depositTestDoc",
+            input: {
+                accountNumber: "102935",
+                username: "sichanyoo",
+                accountHistory: ["10", "-25", "50"],
+                depositAmount: "200"
+            },
+            output: {
+                username: "sichanyoo",
+                authenticationResult: ["pass1", "pass2", "pass3"],
+                textMessage: "You deposited 200-text",
+                emailMessage: "You deposited 200-email"
+            },
+        },
+
+        {
+            title: "Deposit invalid username example",
+            documentation: "depositTestDoc2",
+            input: {
+                username: "sichanyoo",
+                accountHistory: ["-200", "200", "10"],
+                depositAmount: "-200"
+            },
+            error: {
+                shapeId: InvalidUsername,
+                content: {
+                    internalErrorCode: "4gsw2-34",
+                    errorMessage: "ERROR: Invalid username."
+                }
+            },
+        },
+
+        {
+            title: "Deposit invalid amount example",
+            documentation: "depositTestDoc3",
+            input: {
+                accountNumber: "203952",
+                username: "obidos",
+                accountHistory: ["2000", "50000", "100"],
+                depositAmount: "-100"
+            },
+            error: {
+                shapeId: InvalidAmount,
+                content: {
+                    errorMessage1: "ERROR: Invalid amount.",
+                    errorMessage2: "2gdx4-34",
+                    errorMessage3: "2gcbe-98"
+                }
+            },
+        }
+    ]
+)
+
+apply Withdraw @examples(
+    [
+        {
+            title: "Withdraw valid example",
+            documentation: "withdrawTestDoc",
+            input: {
+                accountNumber: "124634",
+                username: "amazon",
+                withdrawParams: {"location" : "Denver", "bankName" : "Chase"},
+                time: "Tue, 29 Apr 2014 18:30:38 GMT",
+                withdrawAmount: "-35",
+                withdrawOption: "ATM"
+            },
+            output: {
+                branch: "Denver-203",
+                accountHistory: ["34", "5", "-250"],
+                location: "Denver",
+                bankName: "Chase",
+                atmRecording: "dGVzdHZpZGVv"
+            },
+        },
+
+        {
+            title: "Withdraw invalid username example",
+            documentation: "withdrawTestDoc2",
+            input: {
+                accountNumber: "231565",
+                username: "peccy",
+                withdrawParams: {"location" : "Seoul", "bankName" : "Chase"},
+                withdrawAmount: "-450",
+                withdrawOption: "Venmo"
+            },
+            error: {
+                shapeId: InvalidUsername,
+                content: {
+                    internalErrorCode: "8dfws-21",
+                    errorMessage: "ERROR: Invalid username."
+                }
+            },
+        }
+    ]
+)


### PR DESCRIPTION
Issue Number:
#921 

***Files changed:***

**OpenApiProtocol.java**
Just the contract of `createOperation()` method to include examples conversion, so implementers know that logic for examples conversion belongs in protocol specific implementation.

**AbstractRestProtocol.java**
Where all of conversion logic is located. Five methods created: `createExamples(), createErrorExamples()  createBodyExamples(), createErrorBodyExamples()` with a helper method `filter()`. Comments describe what they do.

**ExampleObject.java**
Smithy Example object's fields are populated into an instance of ExampleObject, thereby "converting" from Smithy to OpenAPI. I.e., ExampleObject.java is the OpenAPI model object equivalent of Smithy's Example.

**MediaTypeObject.java + ParameterObject.java**
Added these two OpenAPI model objects to have ExampleObject. How they relate to final OpenAPI model output is explained [here.](https://quip-amazon.com/BOTiANUdbNNu/Smithy2OpenAPI-Improvement-Project#temp:C:aMf05dc45fbc5c346d7b7e722ce7)

**AwsRestJson1ProtocolTest.java + examples-test.openapi.json + examples-test.smithy**
Test case code, test output, test input for examples trait conversion.

[**As additional source of help, the Problem 1 section of this design document has more information regarding this PR.**](https://quip-amazon.com/BOTiANUdbNNu/Smithy2OpenAPI-Improvement-Project)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
