### PR TITLE
Fix two typos in the specification doc

### DIFF
--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -1256,7 +1256,7 @@ is equivalent to the following JSON AST model:
                 "type": "structure",
                 "traits": {
                     "smithy.api#trait": {},
-                    "smithy.api#documentation": "This is documentation about a trait shapes.\n  More docs here."
+                    "smithy.api#documentation": "This is documentation about a trait shape.\n  More docs here."
                 }
             }
         }
@@ -1877,7 +1877,7 @@ is removed from a text block. The following example uses "." to denote spaces:
 
     """
     ..<div>
-    ....<p>Hi\\n....bar</p>
+    ....<p>Hi\n....bar</p>
     ..</div>
     .."""
 


### PR DESCRIPTION
*Description of changes:*

The first one aligns the contents of the Smithy idl example with the
JSON AST, the second one removes the escape of the new line to align
the example with the output shown below.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
