### PR TITLE
Generate shapes before generating Service

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -63,7 +63,7 @@ public final class CodegenDirector<
         C extends CodegenContext<S, W, I>,
         S> {
 
-    private static final Logger LOGGER = Logger.getLogger(DirectedCodegen.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(CodegenDirector.class.getName());
 
     private Class<I> integrationClass;
     private ShapeId service;
@@ -278,10 +278,12 @@ public final class CodegenDirector<
 
         registerInterceptors(context, integrations);
 
-        LOGGER.finest(() -> "Generating service " + serviceShape.getId());
-        directedCodegen.generateService(new GenerateServiceDirective<>(context, serviceShape));
+        LOGGER.fine("All setup done. Beginning code generation");
 
         generateShapesInService(context, serviceShape);
+
+        LOGGER.finest(() -> "Generating service " + serviceShape.getId());
+        directedCodegen.generateService(new GenerateServiceDirective<>(context, serviceShape));
 
         CustomizeDirective<C, S> postProcess = new CustomizeDirective<>(context, serviceShape);
 

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -178,7 +178,6 @@ public class CodegenDirectorTest {
         runner.run();
 
         assertThat(testDirected.generatedShapes, contains(
-                ShapeId.from("smithy.example#Foo"),
                 ShapeId.from("smithy.example#D"),
                 ShapeId.from("smithy.example#C"),
                 ShapeId.from("smithy.example#B"),
@@ -186,7 +185,8 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#FooOperationOutput"),
                 ShapeId.from("smithy.example#RecursiveA"),
                 ShapeId.from("smithy.example#RecursiveB"),
-                ShapeId.from("smithy.example#FooOperationInput")
+                ShapeId.from("smithy.example#FooOperationInput"),
+                ShapeId.from("smithy.example#Foo")
         ));
     }
 }


### PR DESCRIPTION
Generating shapes before generating Service level code that references those shapes seems like the better way to go and addresses https://github.com/awslabs/smithy-typescript/pull/548#discussion_r907869868.

Also fixes LOGGER name and adding a log line to indicate beginning of actual code generation logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
