### PR TITLE
Do not map required members that are only used for output

### DIFF
--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -1256,7 +1256,7 @@ is equivalent to the following JSON AST model:
                 "type": "structure",
                 "traits": {
                     "smithy.api#trait": {},
-                    "smithy.api#documentation": "This is documentation about a trait shapes.\n  More docs here."
+                    "smithy.api#documentation": "This is documentation about a trait shape.\n  More docs here."
                 }
             }
         }
@@ -1877,7 +1877,7 @@ is removed from a text block. The following example uses "." to denote spaces:
 
     """
     ..<div>
-    ....<p>Hi\\n....bar</p>
+    ....<p>Hi\n....bar</p>
     ..</div>
     .."""
 

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/RequiredMapper.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/RequiredMapper.java
@@ -15,9 +15,13 @@
 
 package software.amazon.smithy.aws.cloudformation.schema.fromsmithy.mappers;
 
+import java.util.Optional;
 import software.amazon.smithy.aws.cloudformation.schema.fromsmithy.CfnMapper;
 import software.amazon.smithy.aws.cloudformation.schema.fromsmithy.Context;
 import software.amazon.smithy.aws.cloudformation.schema.model.ResourceSchema;
+import software.amazon.smithy.aws.cloudformation.traits.CfnResource;
+import software.amazon.smithy.aws.cloudformation.traits.CfnResourceIndex;
+import software.amazon.smithy.aws.cloudformation.traits.CfnResourceProperty;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -38,15 +42,27 @@ public final class RequiredMapper implements CfnMapper {
         if (context.getConfig().getDisableRequiredPropertyGeneration()) {
             return;
         }
-
-        // If any of the pseudo-resource structure's members are required,
-        // then require the CFN property as well.
+        // If any of the pseudo-resource structure's members are
+        // required and are not only used in output structures then
+        // require the CFN property as well.
         Model model = context.getModel();
         StructureShape resourceStructure = context.getResourceStructure();
         for (MemberShape member : resourceStructure.members()) {
             if (member.getMemberTrait(model, RequiredTrait.class).isPresent()) {
-                resourceSchema.addRequired(context.getJsonSchemaConverter().toPropertyName(member));
+                if (hasWriteOrCreateMutability(context, member)) {
+                    resourceSchema.addRequired(context.getJsonSchemaConverter().toPropertyName(member));
+                }
             }
         }
+    }
+
+    private boolean hasWriteOrCreateMutability(Context context, MemberShape member) {
+        CfnResource cfnResource = context.getCfnResource();
+        String memberId = member.getId().toShapeId().getMember().get();
+        Optional<CfnResourceProperty> cfnResourceProperty = cfnResource.getProperty(memberId);
+        return cfnResourceProperty.map(CfnResourceProperty::getMutabilities)
+                .map(mutabilities -> mutabilities.contains(CfnResourceIndex.Mutability.WRITE)
+                        || mutabilities.contains(CfnResourceIndex.Mutability.CREATE))
+                .orElse(false);
     }
 }

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/required-output.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/required-output.cfn.json
@@ -1,0 +1,45 @@
+{
+    "typeName": "Smithy::TestService::RequiredOutput",
+    "description": "Definition of Smithy::TestService::RequiredOutput Resource Type",
+    "properties": {
+        "FooId": {
+            "type": "string"
+        },
+        "LastUpdate": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "Tags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "Tags"
+    ],
+    "readOnlyProperties": [
+        "/properties/FooId",
+        "/properties/LastUpdate"
+    ],
+    "createOnlyProperties": [
+        "/properties/Tags"
+    ],
+    "primaryIdentifier": [
+        "/properties/FooId"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "testservice:CreateFoo"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "testservice:ReadFoo"
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/required-output.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/required-output.smithy
@@ -1,0 +1,64 @@
+namespace smithy.example
+
+use aws.cloudformation#cfnMutability
+use aws.cloudformation#cfnResource
+
+service TestService {
+    version: "2020-07-02",
+    resources: [RequiredOutput]
+}
+
+@cfnResource
+resource RequiredOutput {
+    identifiers: {
+        fooId: String,
+    },
+    create: CreateFoo,
+    read: ReadFoo,
+}
+
+operation CreateFoo {
+    input: CreateFooRequest,
+    output: CreateFooResponse,
+}
+
+structure CreateFooRequest {
+    @required
+    tags: TagList,
+}
+
+structure CreateFooResponse {
+    @required
+    fooId: String,
+}
+
+@readonly
+operation ReadFoo {
+    input: ReadFooRequest,
+    output: ReadFooResponse,
+}
+
+structure ReadFooRequest {
+    @required
+    fooId: String,
+}
+
+@output
+structure ReadFooResponse {
+    @required
+    fooId: String,
+
+    // This property should be included as required since is also part
+    // of the request as @required
+    @required
+    tags: TagList,
+
+    // This property should NOT be included as required since is only
+    // part of an output structure.
+    @required
+    lastUpdate: Timestamp,
+}
+
+list TagList {
+    member: String
+}


### PR DESCRIPTION
*Description of changes:*  This change excludes from the CFN schema `required` element all shape members that even though are marked as `@required` in the model are *only* used in output operations. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
