### PR TITLE
Set the int32/int64 format only when the type is mapped to integer

### DIFF
--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CorsTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/CorsTest.java
@@ -68,7 +68,7 @@ public class CorsTest {
     /**
      * This test asserts two things: First, it ensures that any existing CORS headers
      * set on an explicitly added API Gateway integration are not overwritten
-     * (i.e., the "Access-Control-Allow-Origin" is "domain.com" intsead of https://foo.com).
+     * (i.e., the "Access-Control-Allow-Origin" is "domain.com" instead of https://foo.com).
      * Next, it asserts that any other headers in the gateway response show up in the
      * injected Access-Control-Expose-Headers header.
      */

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -299,7 +299,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             }
           },

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
@@ -299,7 +299,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             }
           },

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors-wildcards.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors-wildcards.openapi.json
@@ -119,7 +119,6 @@
                         "in": "query",
                         "schema": {
                             "type": "number",
-                            "format": "int32",
                             "nullable": true
                         }
                     },

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/http-api-cors.openapi.json
@@ -119,7 +119,6 @@
                         "in": "query",
                         "schema": {
                             "type": "number",
-                            "format": "int32",
                             "nullable": true
                         }
                     },

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations-without-credentials.openapi.json
@@ -14,7 +14,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true
@@ -24,7 +23,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true
@@ -111,7 +109,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true
@@ -121,7 +118,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/integrations.openapi.json
@@ -14,7 +14,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true
@@ -24,7 +23,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true
@@ -121,7 +119,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true
@@ -131,7 +128,6 @@
             "in": "query",
             "schema": {
               "type": "number",
-              "format": "int32",
               "nullable": true
             },
             "required": true

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
@@ -68,17 +68,21 @@ public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
 
         // Handle OpenAPI's custom "integer" type.
         // https://swagger.io/specification/#data-types
-        if (shape.isByteShape() || shape.isShortShape() || shape.isIntegerShape() || shape.isLongShape()) {
-            if (config instanceof OpenApiConfig && ((OpenApiConfig) config).getUseIntegerType()) {
+        boolean useOpenApiIntegerType = (config instanceof OpenApiConfig && ((OpenApiConfig) config).getUseIntegerType());
+        if (useOpenApiIntegerType) {
+            if (shape.isByteShape() || shape.isShortShape() || shape.isIntegerShape() || shape.isLongShape()) {
                 builder.type("integer");
             }
         }
 
         // Don't overwrite an existing format setting.
         if (!builder.getFormat().isPresent()) {
-            if (shape.isIntegerShape()) {
+            // Only apply the int32/int64 formats if we map the type
+            // to "integer" as those are not valid for "number" type.
+            // See https://swagger.io/specification/#data-types
+            if (useOpenApiIntegerType && shape.isIntegerShape()) {
                 builder.format("int32");
-            } else if (shape.isLongShape()) {
+            } else if (useOpenApiIntegerType && shape.isLongShape()) {
                 builder.format("int64");
             } else if (shape.isFloatShape()) {
                 updateFloatFormat(builder, config, "float");

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
@@ -163,8 +163,11 @@ public class OpenApiJsonSchemaMapperTest {
     public void supportsInt32() {
         IntegerShape shape = IntegerShape.builder().id("a.b#C").build();
         Model model = Model.builder().addShape(shape).build();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setUseIntegerType(true);
         SchemaDocument document = JsonSchemaConverter.builder()
                 .addMapper(new OpenApiJsonSchemaMapper())
+                .config(config)
                 .model(model)
                 .build()
                 .convertShape(shape);
@@ -176,8 +179,11 @@ public class OpenApiJsonSchemaMapperTest {
     public void supportsInt64() {
         LongShape shape = LongShape.builder().id("a.b#C").build();
         Model model = Model.builder().addShape(shape).build();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setUseIntegerType(true);
         SchemaDocument document = JsonSchemaConverter.builder()
                 .addMapper(new OpenApiJsonSchemaMapper())
+                .config(config)
                 .model(model)
                 .build()
                 .convertShape(shape);

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-json-document-bodies.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/adds-json-document-bodies.openapi.json
@@ -44,7 +44,6 @@
           },
           "def": {
             "type": "number",
-            "format": "int32",
             "nullable": true
           }
         }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/aws-rest-json-uses-jsonname.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/aws-rest-json-uses-jsonname.openapi.json
@@ -35,7 +35,6 @@
           },
           "Def": {
             "type": "number",
-            "format": "int32",
             "nullable": true
           }
         }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/non-alphanumeric-content-names.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/non-alphanumeric-content-names.openapi.json
@@ -82,7 +82,6 @@
           },
           "def": {
             "type": "number",
-            "format": "int32",
             "nullable": true
           }
         }
@@ -92,7 +91,6 @@
         "properties": {
           "def": {
             "type": "number",
-            "format": "int32",
             "nullable": true
           }
         }
@@ -105,7 +103,6 @@
           },
           "def": {
             "type": "number",
-            "format": "int32",
             "nullable": true
           }
         }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/synthesizes-contents.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/synthesizes-contents.openapi.json
@@ -82,7 +82,6 @@
                     },
                     "def": {
                         "type": "number",
-                        "format": "int32",
                         "nullable": true
                     }
                 }
@@ -92,7 +91,6 @@
                 "properties": {
                     "def": {
                         "type": "number",
-                        "format": "int32",
                         "nullable": true
                     }
                 }
@@ -105,7 +103,6 @@
                     },
                     "def": {
                         "type": "number",
-                        "format": "int32",
                         "nullable": true
                     }
                 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/test-service.openapi.json
@@ -123,8 +123,7 @@
             "name": "query",
             "in": "query",
             "schema": {
-              "type": "number",
-              "format": "int32"
+              "type": "number"
             }
           },
           {
@@ -197,8 +196,7 @@
             "maxLength": 100
           },
           "def": {
-            "type": "number",
-            "format": "int32"
+            "type": "number"
           },
           "hij": {
             "$ref": "#/components/schemas/Map"


### PR DESCRIPTION
*Issue #, if available:* #1274

*Description of changes:* When we create the JSON schema for open-api we were setting the format int32/int64 if the shape type is integer or long regardless of which type we were mapping to. This is not correct if we do not also map the type to the custom OpenAPI's integer type, as controlled by the `useIntegerType`  configuration setting, which if not set will map the type to "number" instead which cannot use these formats according to the [specification](https://swagger.io/specification/#data-types).  To fix the issue we need to only emit the format when we also map the type to "integer".


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
