### PR TITLE
Add OpenAPI 3.1 support to Smithy2OpenAPI - nullability & format keyword

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -228,6 +228,25 @@ protocol (``string``)
             }
         }
 
+.. _generate-openapi-setting-version:
+
+version (``string``)
+    Specifies the OpenAPI specification version.
+    Currently supports OpenAPI 3.0.2 and OpenAPI 3.1.0.
+    This option defaults to ``3.0.2``.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "version": "3.1.0"
+                }
+            }
+        }
+
 .. _generate-openapi-setting-tags:
 
 tags (``boolean``)

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -36,9 +36,6 @@ import software.amazon.smithy.utils.StringUtils;
  */
 public class OpenApiConfig extends JsonSchemaConfig {
 
-    /** The supported version of OpenAPI. */
-    public static final String VERSION = "3.0.2";
-
     /** Specifies what to do when the httpPrefixHeaders trait is found in a model. */
     public enum HttpPrefixHeadersStrategy {
         /** The default setting that causes the build to fail. */
@@ -86,6 +83,8 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private List<String> externalDocs = ListUtils.of(
             "Homepage", "API Reference", "User Guide", "Developer Guide", "Reference", "Guide");
     private boolean useIntegerType;
+
+    private OpenApiVersion version = OpenApiVersion.VERSION_3_0_2;
 
     public OpenApiConfig() {
         super();
@@ -328,6 +327,14 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setUseIntegerType(boolean useIntegerType) {
         this.useIntegerType = useIntegerType;
+    }
+
+    public OpenApiVersion getVersion() {
+        return this.version;
+    }
+
+    public void setVersion(OpenApiVersion version) {
+        this.version = Objects.requireNonNull(version);
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiVersion.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiVersion.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.openapi;
+
+public enum OpenApiVersion {
+    /** OpenAPI versions supported by the converter. */
+    VERSION_3_0_2("3.0.2", true, false),
+    VERSION_3_1_0("3.1.0", false, true);
+
+    private final String version;
+    private final boolean supportsNullableKeyword;
+    private final boolean supportsContentEncodingKeyword;
+
+    OpenApiVersion(String version, boolean supportsNullableKeyword, boolean supportsContentEncodingKeyword) {
+        this.version = version;
+        this.supportsNullableKeyword = supportsNullableKeyword;
+        this.supportsContentEncodingKeyword = supportsContentEncodingKeyword;
+    }
+
+    @Override
+    public String toString() {
+        return version;
+    }
+
+    public boolean supportsNullableKeyword() {
+        return supportsNullableKeyword;
+    }
+
+    public boolean supportsContentEncodingKeyword() {
+        return supportsContentEncodingKeyword;
+    }
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -302,7 +302,8 @@ public final class OpenApiConverter {
         Context<T> context = environment.context;
         OpenApiMapper mapper = environment.mapper;
         OpenApiProtocol<T> openApiProtocol = environment.context.getOpenApiProtocol();
-        OpenApi.Builder openapi = OpenApi.builder().openapi(OpenApiConfig.VERSION).info(createInfo(service));
+        String version = context.getConfig().getVersion().toString();
+        OpenApi.Builder openapi = OpenApi.builder().openapi(version).info(createInfo(service));
 
         mapper.before(context, openapi);
 

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -38,6 +38,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.OpenApiException;
+import software.amazon.smithy.openapi.OpenApiVersion;
 import software.amazon.smithy.openapi.model.OpenApi;
 import software.amazon.smithy.openapi.model.PathItem;
 import software.amazon.smithy.utils.IoUtils;
@@ -527,6 +528,39 @@ public class OpenApiConverterTest {
         Node result = OpenApiConverter.create().config(config).convertToNode(model);
         Node expectedNode = Node.parse(IoUtils.toUtf8String(
                 getClass().getResourceAsStream("nonconflicting-unit.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+
+    @Test
+    public void convertsToOpenAPI3_0_2() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("nullability-and-format.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example#Example"));
+        config.setVersion(OpenApiVersion.VERSION_3_0_2);
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("openapi-3-0-2.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+    @Test
+    public void convertsToOpenAPI3_1_0() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("nullability-and-format.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example#Example"));
+        config.setVersion(OpenApiVersion.VERSION_3_1_0);
+        Node result = OpenApiConverter.create().config(config).convertToNode(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("openapi-3-1-0.openapi.json")));
 
         Node.assertEquals(result, expectedNode);
     }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nullability-and-format.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nullability-and-format.smithy
@@ -1,0 +1,38 @@
+namespace example
+use aws.protocols#restJson1
+
+@restJson1
+service Example {
+    version: "2022-07-10",
+    operations: [FooBar]
+}
+
+@idempotent
+@http(method: "PUT", uri: "/test", code: 200)
+operation FooBar {
+    input: FooBarInput,
+    output: FooBarOutput,
+    errors: [FooBarError]
+}
+
+@input
+structure FooBarInput {
+    foo: BoxedInteger,
+    file: FilePayload
+}
+
+@mediaType("video/quicktime")
+blob FilePayload
+
+@output
+structure FooBarOutput {
+    bar: BoxedInteger
+}
+
+@error("client")
+structure FooBarError {
+    message: BoxedInteger
+}
+
+@box
+integer BoxedInteger

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-0-2.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-0-2.openapi.json
@@ -1,0 +1,80 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Example",
+    "version": "2022-07-10"
+  },
+  "paths": {
+    "/test": {
+      "put": {
+        "operationId": "FooBar",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FooBarRequestContent"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "FooBar 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FooBarResponseContent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "FooBarError 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FooBarErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FooBarErrorResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "number",
+            "nullable": true
+          }
+        }
+      },
+      "FooBarRequestContent": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "number",
+            "nullable": true
+          },
+          "file": {
+            "type": "string",
+            "format": "byte"
+          }
+        }
+      },
+      "FooBarResponseContent": {
+        "type": "object",
+        "properties": {
+          "bar": {
+            "type": "number",
+            "nullable": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-1-0.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-1-0.openapi.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Example",
+    "version": "2022-07-10"
+  },
+  "paths": {
+    "/test": {
+      "put": {
+        "operationId": "FooBar",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FooBarRequestContent"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "FooBar 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FooBarResponseContent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "FooBarError 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FooBarErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FooBarErrorResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": [
+              "number",
+              null
+            ]
+          }
+        }
+      },
+      "FooBarRequestContent": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": [
+              "number",
+              null
+            ]
+          },
+          "file": {
+            "type": "string",
+            "contentEncoding": "byte"
+          }
+        }
+      },
+      "FooBarResponseContent": {
+        "type": "object",
+        "properties": {
+          "bar": {
+            "type": [
+              "number",
+              null
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue number:*
#985 

*Description of changes:*

- Adds `version` OpenAPI config setting.
- If `version` is set to `"3.1.0"`, then handles nullability and format keyword differently.
- Nullable keyword does not get added to JSON Schema & adds a `type` extension of array value with `null` value, which overrides existing `String type` property in `Schema.java`. 
- Swap `format` keyword with `contentEncoding` keyword for file payloads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
