### PR TITLE
Adds support for [multiple error response objects with same HTTP status code] to Smithy2OpenAPI.

### DIFF
--- a/docs/source/1.0/guides/converting-to-openapi.rst
+++ b/docs/source/1.0/guides/converting-to-openapi.rst
@@ -518,6 +518,56 @@ useIntegerType (``boolean``)
             }
         }
 
+.. _generate-openapi-setting-onErrorStatusConflict:
+
+onErrorStatusConflict (``String``)
+    Specifies how to resolve multiple error responses that share a same HTTP status code.
+    This behavior can be customized using the following values for the ``onErrorStatusConflict`` setting:
+
+    ``oneOf``
+        Use OpenAPI's ``oneOf`` keyword to combine error responses with same HTTP status code.
+
+
+    ``properties``
+        Use ``properties`` field of OpenAPI schema object to combine error responses with same HTTP status code.
+
+    .. note::
+            ``oneOf`` keyword is not supported by Amazon API Gateway.
+
+    Both options generate a single combined response object called "UnionError XXX Response" in the
+    OpenAPI model output, where "XXX" is the status code shared by multiple errors. Both options drop
+    the ``@required`` trait from all members of conflicting error structures, making them optional.
+
+    ``oneOf`` option wraps schemas for contents of conflicting errors responses schemas into a synthetic union schema
+    using OpenAPI's ``oneOf`` keyword.
+
+    ``properties`` option combines the conflicting error structure shapes into one union error shape that contains
+     all members from each and every conflicting error.
+
+    .. warning::
+            When using ``properties`` option, make sure that conflicting error structure shapes do not have member(s)
+            that have same name while having different target shapes. If member shapes with same name
+            (in conflicting error structures) target
+            different shapes, error shapes will not be able to be merged into one union error shape, and
+            an exception will be thrown.
+
+    .. warning::
+            Regardless of the setting, an exception will be thrown if any one of conflicting error structure shape
+            has a member shape with ``@httpPayload`` trait.
+
+    By default, this setting is set to ``oneOf``.
+
+    .. code-block:: json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "smithy.example#Weather",
+                    "onErrorStatusConflict": "properties"
+                }
+            }
+        }
 
 ----------------------------------
 JSON schema configuration settings

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -48,6 +48,28 @@ public class OpenApiConfig extends JsonSchemaConfig {
         WARN
     }
 
+    /** Specifies how to resolve multiple error responses with same error codes. */
+    public enum ErrorStatusConflictHandlingStrategy {
+        /** The default setting that uses OpenAPI's oneOf keyword to combine multiple schemas for same media type. */
+        ONE_OF("oneOf"),
+        /**
+         * The custom setting that combines multiple schemas for same media type using properties field of
+         * OpenAPI Schema object.
+         */
+        PROPERTIES("properties");
+
+        private String stringValue;
+
+        ErrorStatusConflictHandlingStrategy(String stringValue) {
+            this.stringValue = stringValue;
+        }
+
+        @Override
+        public String toString() {
+            return stringValue;
+        }
+    }
+
     /** The JSON pointer to where OpenAPI schema components should be written. */
     private static final String SCHEMA_COMPONENTS_POINTER = "#/components/schemas";
 
@@ -80,6 +102,7 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private boolean forbidGreedyLabels;
     private boolean removeGreedyParameterSuffix;
     private HttpPrefixHeadersStrategy onHttpPrefixHeaders = HttpPrefixHeadersStrategy.FAIL;
+    private ErrorStatusConflictHandlingStrategy onErrorStatusConflict = ErrorStatusConflictHandlingStrategy.ONE_OF;
     private boolean ignoreUnsupportedTraits;
     private Map<String, Node> substitutions = Collections.emptyMap();
     private Map<String, Node> jsonAdd = Collections.emptyMap();
@@ -237,6 +260,19 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setOnHttpPrefixHeaders(HttpPrefixHeadersStrategy onHttpPrefixHeaders) {
         this.onHttpPrefixHeaders = Objects.requireNonNull(onHttpPrefixHeaders);
+    }
+
+    public ErrorStatusConflictHandlingStrategy getOnErrorStatusConflict() {
+        return onErrorStatusConflict;
+    }
+
+    /**
+     * Specifies what to do when multiple error responses share the same HTTP status code.
+     *
+     * @param onErrorStatusConflict Strategy to use for multiple errors with same status code.
+     */
+    public void setOnErrorStatusConflict(ErrorStatusConflictHandlingStrategy onErrorStatusConflict) {
+        this.onErrorStatusConflict = Objects.requireNonNull(onErrorStatusConflict);
     }
 
     public boolean getIgnoreUnsupportedTraits() {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.openapi.fromsmithy.protocols;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,12 +43,15 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
 import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.OpenApiException;
 import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiConverter;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiProtocol;
+import software.amazon.smithy.openapi.model.LinkObject;
 import software.amazon.smithy.openapi.model.MediaTypeObject;
 import software.amazon.smithy.openapi.model.OperationObject;
 import software.amazon.smithy.openapi.model.ParameterObject;
@@ -419,9 +423,22 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         updateResponsesMapWithResponseStatusAndObject(
                 context, bindingIndex, eventStreamIndex, operation, output, result);
 
+        Map<String, List<StructureShape>> errors = new HashMap<>();
+
         for (StructureShape error : operationIndex.getErrors(operation)) {
-            updateResponsesMapWithResponseStatusAndObject(
-                    context, bindingIndex, eventStreamIndex, operation, error, result);
+            String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, error);
+            errors.computeIfAbsent(statusCode, (k) -> new ArrayList<>()).add(error);
+        }
+
+        for (Map.Entry<String, List<StructureShape>> error : errors.entrySet()) {
+            List<StructureShape> shapes = error.getValue();
+            if (shapes.size() == 1) {
+                updateResponsesMapWithResponseStatusAndObject(
+                        context, bindingIndex, eventStreamIndex, operation, shapes.get(0), result);
+            } else {
+                updateResponsesMapWithResponseStatusAndMultipleObjectsUsingOneOf(
+                        context, bindingIndex, eventStreamIndex, shapes, result);
+            }
         }
         return result;
     }
@@ -437,8 +454,88 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         Shape operationOrError = shape.hasTrait(ErrorTrait.class) ? shape : operation;
         String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, operationOrError);
         ResponseObject response = createResponse(
-                context, bindingIndex, eventStreamIndex, statusCode, operationOrError);
+                context, bindingIndex, eventStreamIndex, statusCode, operationOrError, false);
+
         responses.put(statusCode, response);
+    }
+
+    private void updateResponsesMapWithResponseStatusAndMultipleObjectsUsingOneOf(
+            Context<T> context,
+            HttpBindingIndex bindingIndex,
+            EventStreamIndex eventStreamIndex,
+            List<StructureShape> shapes,
+            Map<String, ResponseObject> responses
+    ) {
+        // Throw an exception if any member in any conflicting error shapes has @httpPayload trait.
+        for (StructureShape error : shapes) {
+            for (Map.Entry<String, MemberShape> member : error.getAllMembers().entrySet()) {
+                if (member.getValue().hasTrait(HttpPayloadTrait.ID)) {
+                    throw new OpenApiException(
+                            OpenApiConverter.createConflictingErrorHttpPayloadExceptionMessage(
+                                    context.getOpenApiProtocol().getOperationResponseStatusCode(context, error),
+                                    error.getId().toString(),
+                                    member.getValue().toShapeId().toString()
+                            )
+                    );
+                }
+            }
+        }
+        // Make response object for each conflicting error response & add to list.
+        List<ResponseObject> errors = new ArrayList<>();
+        String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, shapes.get(0));
+        for (StructureShape shape : shapes) {
+            errors.add(createResponse(context, bindingIndex, eventStreamIndex, statusCode, shape,
+                    true));
+        }
+
+        // This map contains mapping of mediaType string (e.g., "application/json") to MediaTypeObject objects from
+        // conflicting error responses.
+        Map<String, List<MediaTypeObject>> contents = new HashMap<>();
+
+        // Combine conflicting error response objects into one response object.
+        ResponseObject.Builder combinedResponseBuilder = ResponseObject.builder();
+        for (ResponseObject error : errors) {
+            // Combine headers.
+            for (Map.Entry<String, Ref<ParameterObject>> header : error.getHeaders().entrySet()) {
+                combinedResponseBuilder.putHeader(header.getKey(), header.getValue());
+            }
+
+            // Collect contents from conflicting errors.
+            // E.g., if Error1 and Error2 both have application/json MediaTypeObject,
+            //  an entry in contents map will be ("application/json", [Error1/MediaTypeObject, Error2/MediaTypeObject]).
+            for (Map.Entry<String, MediaTypeObject> content : error.getContent().entrySet()) {
+                contents.computeIfAbsent(content.getKey(), (k) -> new ArrayList<>()).add(content.getValue());
+            }
+
+            // Combine links.
+            for (Map.Entry<String, Ref<LinkObject>> link : error.getLinks().entrySet()) {
+                combinedResponseBuilder.putLink(link.getKey(), link.getValue());
+            }
+        }
+
+        // Populate contents into union response.
+        for (Map.Entry<String, List<MediaTypeObject>> mapping : contents.entrySet()) {
+            if (mapping.getValue().size() == 1) {
+                combinedResponseBuilder.putContent(mapping.getKey(), mapping.getValue().get(0));
+            } else {
+                // Combine contents.
+                combinedResponseBuilder.putContent(mapping.getKey(), combineContents(mapping.getValue()));
+            }
+        }
+
+        // Set description, build, and add to responses.
+        combinedResponseBuilder.description("UnionError " + statusCode + " response");
+        responses.put(statusCode, combinedResponseBuilder.build());
+    }
+
+    private MediaTypeObject combineContents(List<MediaTypeObject> contents) {
+        MediaTypeObject.Builder result = MediaTypeObject.builder();
+        Schema.Builder schema = Schema.builder();
+        List<Schema> schemas = new ArrayList<>();
+        for (MediaTypeObject content : contents) {
+            schemas.add(content.getSchema().get());
+        }
+        return result.schema(schema.oneOf(schemas).build()).build();
     }
 
     private ResponseObject createResponse(
@@ -446,14 +543,20 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             HttpBindingIndex bindingIndex,
             EventStreamIndex eventStreamIndex,
             String statusCode,
-            Shape operationOrError
+            Shape operationOrError,
+            boolean dropRequiredTrait
     ) {
         ResponseObject.Builder responseBuilder = ResponseObject.builder();
         String contextName = context.getService().getContextualName(operationOrError);
         String responseName = stripNonAlphaNumericCharsIfNecessary(context, contextName);
+
         responseBuilder.description(String.format("%s %s response", responseName, statusCode));
-        createResponseHeaderParameters(context, operationOrError)
-                .forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v)));
+        Map<String, ParameterObject> headers = createResponseHeaderParameters(context, operationOrError);
+        if (dropRequiredTrait) {
+            headers.forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v.toBuilder().required(false).build())));;
+        } else {
+            headers.forEach((k, v) -> responseBuilder.putHeader(k, Ref.local(v)));;
+        }
         addResponseContent(context, bindingIndex, eventStreamIndex, responseBuilder, operationOrError);
         return responseBuilder.build();
     }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -266,4 +266,53 @@ public class AwsRestJson1ProtocolTest {
             return OpenApiMapper.super.updateOperation(context, shape, operation, httpMethodName, path);
         }
     }
+
+    @Test
+    public void convertsErrorStructuresWithSameErrorCodeWithoutUsingOneOf() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("error-code-collision-test.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example#Example"));
+        config.setOnErrorStatusConflict(OpenApiConfig.ErrorStatusConflictHandlingStrategy.PROPERTIES);
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+        InputStream openApiStream = getClass()
+                .getResourceAsStream("error-code-collision-test-use-properties.openapi.json");
+
+        if (openApiStream == null) {
+            throw new RuntimeException("OpenAPI model not found for test case: "
+                    + "error-code-collision-test-use-properties.openapi.json");
+        } else {
+            Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
+            Node.assertEquals(result, expectedNode);
+        }
+    }
+
+    @Test
+    public void convertsErrorStructuresWithSameErrorCodeUsingOneOf() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("error-code-collision-test.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example#Example"));
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+        InputStream openApiStream = getClass()
+                .getResourceAsStream("error-code-collision-test-use-oneof.openapi.json");
+
+        if (openApiStream == null) {
+            throw new RuntimeException("OpenAPI model not found for test case: "
+                    + "error-code-collision-test-use-oneof.openapi.json");
+        } else {
+            Node expectedNode = Node.parse(IoUtils.toUtf8String(openApiStream));
+            Node.assertEquals(result, expectedNode);
+        }
+    }
 }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test-use-oneof.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test-use-oneof.openapi.json
@@ -1,0 +1,155 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Example",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/time": {
+      "get": {
+        "operationId": "GetCurrentTime",
+        "responses": {
+          "200": {
+            "description": "GetCurrentTime 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCurrentTimeResponseContent"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "UnionError 429 response",
+            "headers": {
+              "error1-header": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "error2-header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Error1ResponseContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Error2ResponseContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Error3ResponseContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Error4ResponseContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Error5ResponseContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Error6ResponseContent"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error1ResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "Error2ResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "message2": {
+            "type": "string"
+          },
+          "message3": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "Error3ResponseContent": {
+        "type": "object",
+        "properties": {
+          "message24": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message24"
+        ]
+      },
+      "Error4ResponseContent": {
+        "type": "object",
+        "properties": {
+          "message365": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message365"
+        ]
+      },
+      "Error5ResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "Error6ResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "GetCurrentTimeResponseContent": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "time"
+        ]
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test-use-properties.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test-use-properties.openapi.json
@@ -1,0 +1,84 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Example",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/time": {
+      "get": {
+        "operationId": "GetCurrentTime",
+        "responses": {
+          "200": {
+            "description": "GetCurrentTime 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCurrentTimeResponseContent"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Union429Error 429 response",
+            "headers": {
+              "error1-header": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "error2-header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Union429ErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetCurrentTimeResponseContent": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "time"
+        ]
+      },
+      "Union429ErrorResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "message2": {
+            "type": "string"
+          },
+          "message3": {
+            "type": "string"
+          },
+          "message24": {
+            "type": "string"
+          },
+          "message365": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test.smithy
@@ -1,0 +1,94 @@
+namespace example
+
+use aws.protocols#restJson1
+use smithy.framework#ValidationException
+
+@restJson1
+service Example {
+    version: "2006-03-01",
+    operations: [GetCurrentTime],
+    errors: [
+        Error1,
+        Error2,
+        Error3,
+        Error4,
+        Error5,
+        Error6
+    ]
+}
+
+@error("client")
+@retryable(throttling: true)
+@httpError(429) // Too many requests
+structure Error1 {
+    @httpHeader("error1-header")
+    @required
+    header: String,
+
+    @required
+    message: String,
+}
+
+@error("client")
+@retryable(throttling: true)
+@httpError(429) // Too many requests
+structure Error2 {
+    @httpHeader("error2-header")
+    @required
+    header: String,
+
+    @required
+    message: String,
+
+    message2: String,
+
+    message3: String
+}
+
+@error("client")
+@retryable(throttling: true)
+@httpError(429) // Too many requests
+structure Error3 {
+    @required
+    message24 : String,
+}
+
+@error("client")
+@retryable(throttling: true)
+@httpError(429) // Too many requests
+structure Error4 {
+    @required
+    message365: String,
+}
+
+@error("client")
+@retryable(throttling: true)
+@httpError(429) // Too many requests
+structure Error5 {
+    @required
+    message: String,
+}
+
+@error("client")
+@retryable(throttling: true)
+@httpError(429) // Too many requests
+structure Error6 {
+    @required
+    message: String,
+}
+
+@readonly
+@http(uri: "/time", method: "GET")
+operation GetCurrentTime {
+    input: GetCurrentTimeInput,
+    output: GetCurrentTimeOutput
+}
+
+@input
+structure GetCurrentTimeInput {}
+
+@output
+structure GetCurrentTimeOutput {
+    @required
+    time: Timestamp
+}


### PR DESCRIPTION
*Issue #, if available:*
#1265 

*Description of changes:*
- Add new OpenAPI config setting ``disableOneOf``.
- Combines response objects that share same HTTP status code before adding them to ``Map<String, ResponseObject> responses`` of ``OperationObject`` to prevent overwrites from happening.
- Test case + input / output files.
- Add documentation to existing OpenAPI converter guide regarding new config setting ``disableOneOf``.

_Internal:_
[Design doc](https://quip-amazon.com/BOTiANUdbNNu/Smithy2OpenAPI-Improvement-Project#temp:C:aMfab7e781fe5474397ab83a5d64)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
