### PR TITLE
Minor semantic correction

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberOrder.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedMemberOrder.java
@@ -43,7 +43,7 @@ public final class ChangedMemberOrder extends AbstractDiffEvaluator {
                 .filter(diff -> isUnordered(diff.getOldShape().members(), diff.getNewShape().members()))
                 .map(diff -> danger(diff.getNewShape(), String.format(
                         "%s shape members were reordered. This can cause ABI compatibility issues in languages "
-                        + "like C, C++, and Rust where the layout and alignment of a data structure matters.",
+                        + "like C and C++ where the layout and alignment of a data structure matters.",
                         diff.getOldShape().getType())))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Remove Rust from the list of languages impacted by the changed member order issue

*Issue #, if available:*

*Description of changes:*
Remove Rust from the list of impacted languages under changed member order

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
