### PR TITLE
Only apply a default to numbers if in range

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-default-out-of-range.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-default-out-of-range.errors
@@ -1,0 +1,11 @@
+[WARNING] -: Smithy IDL 1.0 is deprecated. Please upgrade to Smithy IDL 2.0. | Model
+[WARNING] smithy.example#Integers$noRange: Add the @default trait to this member to make it forward compatible with Smithy IDL 2.0 | UpgradeModel
+[WARNING] smithy.example#Integers$noRange: This member targets smithy.api#PrimitiveInteger which was removed in Smithy IDL 2.0. Target smithy.api#Integer instead  | UpgradeModel
+[WARNING] smithy.example#Integers$valid: Add the @default trait to this member to make it forward compatible with Smithy IDL 2.0 | UpgradeModel
+[WARNING] smithy.example#Integers$valid: This member targets smithy.api#PrimitiveInteger which was removed in Smithy IDL 2.0. Target smithy.api#Integer instead  | UpgradeModel
+[WARNING] smithy.example#Integers$invalidMin: Add the @default trait to this member to make it forward compatible with Smithy IDL 2.0 | UpgradeModel
+[WARNING] smithy.example#Integers$invalidMin: Cannot add the @default trait to this member due to a minimum range constraint. | UpgradeModel
+[WARNING] smithy.example#Integers$invalidMin: This member targets smithy.api#PrimitiveInteger which was removed in Smithy IDL 2.0. Target smithy.api#Integer instead  | UpgradeModel
+[WARNING] smithy.example#Integers$invalidMax: Add the @default trait to this member to make it forward compatible with Smithy IDL 2.0 | UpgradeModel
+[WARNING] smithy.example#Integers$invalidMax: Cannot add the @default trait to this member due to a maximum range constraint. | UpgradeModel
+[WARNING] smithy.example#Integers$invalidMax: This member targets smithy.api#PrimitiveInteger which was removed in Smithy IDL 2.0. Target smithy.api#Integer instead  | UpgradeModel

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-default-out-of-range.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/detects-default-out-of-range.smithy
@@ -1,0 +1,16 @@
+$version: "1.0"
+
+namespace smithy.example
+
+structure Integers {
+    noRange: PrimitiveInteger,
+
+    @range(min: 0, max: 1)
+    valid: PrimitiveInteger,
+
+    @range(min: 1)
+    invalidMin: PrimitiveInteger,
+
+    @range(max: -1)
+    invalidMax: PrimitiveInteger,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/main.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/main.smithy
@@ -25,6 +25,9 @@ structure Integers {
 
     nonNull: PrimitiveInteger,
 
+    @range(min: 0, max: 1)
+    ranged: PrimitiveInteger,
+
     @box
     nullable2: PrimitiveInteger
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/upgraded.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/upgrade/all-1.0/upgraded.smithy
@@ -26,6 +26,10 @@ structure Integers {
     @default(0)
     nonNull: Integer,
 
+    @default(0)
+    @range(min: 0, max: 1)
+    ranged: Integer,
+
     nullable2: Integer
 }
 


### PR DESCRIPTION
Upgrading a model to IDL 2.0 would previously apply a default
trait with a value of 0 when upgrading primitive numbers. This
could fail if the primitive was marked with a range trait that
0 was not a valid value for.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
