### PR TITLE
Handle unknown model versions for built-shapes

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/FullyResolvedModelFile.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/FullyResolvedModelFile.java
@@ -52,9 +52,8 @@ final class FullyResolvedModelFile extends AbstractMutableModelFile {
      * @return Returns the create {@code FullyResolvedModelFile} containing the shapes.
      */
     static FullyResolvedModelFile fromShapes(TraitFactory traitFactory, Collection<Shape> shapes) {
-        return fromShapes(traitFactory, shapes, null);
+        return fromShapes(traitFactory, shapes, Version.UNKNOWN);
     }
-
 
     /**
      * Create a {@code FullyResolvedModelFile} from already built shapes.
@@ -67,9 +66,7 @@ final class FullyResolvedModelFile extends AbstractMutableModelFile {
         FullyResolvedModelFile modelFile = new FullyResolvedModelFile(
                 SourceLocation.none().getFilename(), traitFactory);
 
-        if (version != null) {
-            modelFile.setVersion(version);
-        }
+        modelFile.setVersion(version);
 
         for (Shape shape : shapes) {
             // Convert the shape to a builder and remove all the traits.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -105,7 +105,6 @@ public final class ModelAssembler {
     private final Map<String, Object> properties = new HashMap<>();
     private boolean disablePrelude;
     private Consumer<ValidationEvent> validationEventListener = DEFAULT_EVENT_LISTENER;
-    private Version parsedShapesVersion;
 
     // Lazy initialization holder class idiom to hold a default trait factory.
     static final class LazyTraitFactoryHolder {
@@ -369,20 +368,6 @@ public final class ModelAssembler {
     }
 
     /**
-     * Sets the Smithy version to use for parsed shapes added directly to the
-     * assembler.
-     *
-     * If unset, the default version of 1.0 will be assumed.
-     *
-     * @param version A Smithy IDL version.
-     * @return Returns the assembler.
-     */
-    public ModelAssembler setParsedShapesVersion(String version) {
-        this.parsedShapesVersion = Version.fromString(version);
-        return this;
-    }
-
-    /**
      * Explicitly adds a trait to a shape in the assembled model.
      *
      * @param target Shape to add the trait to.
@@ -632,8 +617,7 @@ public final class ModelAssembler {
         }
 
         // A modelFile is created for the assembler to capture anything that was manually added.
-        FullyResolvedModelFile assemblerModelFile = FullyResolvedModelFile.fromShapes(
-                traitFactory, shapes, parsedShapesVersion);
+        FullyResolvedModelFile assemblerModelFile = FullyResolvedModelFile.fromShapes(traitFactory, shapes);
 
         modelFiles.add(assemblerModelFile);
         metadata.forEach(assemblerModelFile::putMetadata);
@@ -648,11 +632,7 @@ public final class ModelAssembler {
             List<Shape> nonPrelude = model.shapes()
                     .filter(FunctionalUtils.not(Prelude::isPreludeShape))
                     .collect(Collectors.toList());
-            // Since we're pulling from a loaded model, we know that it has been converted to the latest
-            // supported version. We include that here to ensure we don't hit any validation issues from
-            // using new features.
-            FullyResolvedModelFile resolvedFile = FullyResolvedModelFile.fromShapes(
-                    traitFactory, nonPrelude, Version.fromString(Model.MODEL_VERSION));
+            FullyResolvedModelFile resolvedFile = FullyResolvedModelFile.fromShapes(traitFactory, nonPrelude);
             model.getMetadata().forEach(resolvedFile::putMetadata);
             modelFiles.add(resolvedFile);
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelUpgrader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelUpgrader.java
@@ -91,13 +91,16 @@ final class ModelUpgrader {
             // We must assume v2 for manually created shapes.
             Version version = fileToVersion.getOrDefault(member.getSourceLocation().getFilename(),
                                                          Version.VERSION_2_0);
-            if (version == Version.VERSION_1_0) {
+
+            if (version == Version.VERSION_2_0) {
+                validateV2Member(member);
+            } else {
+                // Also attempt to upgrade unknown versions since they could be 1.0 and
+                // trying to upgrade 2.0 shapes has no effect.
                 // For v1 shape checks, we need to know the containing shape type to apply the appropriate transform.
                 model.getShape(member.getContainer()).ifPresent(container -> {
                     upgradeV1Member(container.getType(), member);
                 });
-            } else if (version == Version.VERSION_2_0) {
-                validateV2Member(member);
             }
         }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -54,6 +54,8 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.SetShapeTest;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -748,5 +750,19 @@ public class ModelAssemblerTest {
         });
 
         assertThat(e.getMessage(), containsString("Conflicting shape definition for `smithy.example#A`"));
+    }
+
+    @Test
+    public void canLoadSetsUsingBuiltModel() {
+        SetShape set = SetShape.builder()
+                .id("smithy.example#Set")
+                .member(ShapeId.from("smithy.api#String"))
+                .build();
+        Model model = Model.assembler()
+                .addShape(set)
+                .assemble()
+                .unwrap();
+
+        Model.assembler().addModel(model).assemble().unwrap();
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
@@ -330,7 +330,6 @@ public class ChangeShapeTypeTest {
                 .build();
 
         Model model = Model.assembler()
-                .setParsedShapesVersion("2.0")
                 .addShape(startShape)
                 .assemble()
                 .unwrap();
@@ -431,7 +430,6 @@ public class ChangeShapeTypeTest {
         IntEnumShape intEnum = intEnumBuilder.addMember("FOO", 1).build();
 
         Model model = Model.assembler()
-                .setParsedShapesVersion("2.0")
                 .addShapes(stringEnum, intEnum)
                 .assemble().unwrap();
         Model result = ModelTransformer.create().downgradeEnums(model);


### PR DESCRIPTION
The handling of unknown model versions for built shapes needs
to make no assumptions about the version of provided shapes.
Instead, it should use the UNKNOWN version which allows for any
kind of 1.0 or 2.0 trait/shape, but still attempts to convert
1.0 -> 2.0 compatible models when loading shapes. This was a
little haphazard before and we exposed controls to set the
assumed parsed version that have now been removed. I don't think
there's a reasonable use case where automated tooling will set
that right now.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
