### PR TITLE
Add minor perf improvements

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model;
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -89,8 +88,7 @@ public final class Model implements ToSmithyBuilder<Model> {
     private final Map<Class<? extends Shape>, Set<? extends Shape>> cachedTypes = new ConcurrentHashMap<>();
 
     /** Cache of computed {@link KnowledgeIndex} instances. */
-    private final Map<Class<? extends KnowledgeIndex>, KnowledgeIndex> blackboard
-            = new ConcurrentSkipListMap<>(Comparator.comparing(Class::getCanonicalName));
+    private final Map<String, KnowledgeIndex> blackboard = new ConcurrentSkipListMap<>();
 
     /** Lazily computed trait mappings. */
     private volatile TraitCache traitCache;
@@ -882,7 +880,7 @@ public final class Model implements ToSmithyBuilder<Model> {
      */
     @SuppressWarnings("unchecked")
     public <T extends KnowledgeIndex> T getKnowledge(Class<T> type, Function<Model, T> constructor) {
-        return (T) blackboard.computeIfAbsent(type, t -> constructor.apply(this));
+        return (T) blackboard.computeIfAbsent(type.getName(), t -> constructor.apply(this));
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -55,6 +56,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
     private final Map<ShapeId, Shape> mixins;
     private final transient SourceLocation source;
     private transient List<String> memberNames;
+    private int hash;
 
     /**
      * This class is package-private, which means that all subclasses of this
@@ -767,7 +769,14 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
 
     @Override
     public int hashCode() {
-        return getId().hashCode() + 3 * getType().hashCode();
+        int h = hash;
+
+        if (h == 0) {
+            h = Objects.hash(getType(), getId());
+            hash = h;
+        }
+
+        return h;
     }
 
     @Override
@@ -780,6 +789,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
 
         Shape other = (Shape) o;
         return getType() == other.getType()
+               && hashCode() == other.hashCode() // take advantage of hashcode caching
                && getId().equals(other.getId())
                && traits.equals(other.traits)
                && mixins.equals(other.mixins)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AbstractTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AbstractTrait.java
@@ -87,12 +87,16 @@ public abstract class AbstractTrait implements Trait {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof Trait)) {
+        if (other == this) {
+            return true;
+        } else if (!(other instanceof Trait)) {
             return false;
+        } else if (hashCode() != other.hashCode()) { // take advantage of hashcode caching
+            return false;
+        } else {
+            Trait b = (Trait) other;
+            return toShapeId().equals(b.toShapeId()) && toNode().equals(b.toNode());
         }
-
-        Trait b = (Trait) other;
-        return this == other || (toShapeId().equals(b.toShapeId()) && toNode().equals(b.toNode()));
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
@@ -93,7 +93,6 @@ public final class TraitTargetValidator extends AbstractValidator {
             Selector selector,
             List<ShapeId> traits
     ) {
-        selector.shapes(model);
         Set<Shape> matches = selector.select(model);
 
         for (ShapeId traitId : traits) {


### PR DESCRIPTION
I was doing some profiling and saw lots of string
computations caused by recomputing equals and hashcode.
This adds a cache for the hashCode of Shape and takes
advantage of the caching used for Trait and Shape when
performing equals checks.

I also don't think the cost of computing a canonical
class name is needed compared to using Class#getName
for Model's blackboard data structure.

Finally, I saw we were creating a Stream and not using it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
