### PR TITLE
Encode space in test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-path.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-path.smithy
@@ -115,7 +115,7 @@ apply MalformedTimestampPathDefault @httpMalformedRequestTests([
                        "1996-12-19T1639",
                        "1996-12-19T16Z",
                        "1996-12-19T16",
-                       "1996-12-19 16%3A39%3A57Z",
+                       "1996-12-19%2016%3A39%3A57Z",
                        "2011-12-03T10%3A15%3A30%2B01%3A00%5BEurope%2FParis%5D"]
         },
         tags : ["timestamp"]

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-query.smithy
@@ -127,7 +127,7 @@ apply MalformedTimestampQueryDefault @httpMalformedRequestTests([
                        "1996-12-19T1639",
                        "1996-12-19T16Z",
                        "1996-12-19T16",
-                       "1996-12-19 16:39:57Z",
+                       "1996-12-19%2016:39:57Z",
                        "2011-12-03T10:15:30+01:00[Europe/Paris]"]
         },
         tags : ["timestamp"]


### PR DESCRIPTION


*Issue #, if available:* #1315

*Description of changes:* Encode a space in the URI of test RestJsonPathTimestampDefaultRejectsDifferent8601Formats (case 13)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
