### PR TITLE
Remove optionals in shape_section

### DIFF
--- a/docs/source/1.0/spec/core/idl.rst
+++ b/docs/source/1.0/spec/core/idl.rst
@@ -171,7 +171,7 @@ The Smithy IDL is defined by the following ABNF:
 .. rubric:: Shapes
 
 .. productionlist:: smithy
-    shape_section :[`namespace_statement` [`use_section`] [`shape_statements`]]
+    shape_section :[`namespace_statement` `use_section` `shape_statements`]
     namespace_statement :"namespace" `ws` `namespace` `br`
     use_section   :*(`use_statement`)
     use_statement :"use" `ws` `absolute_root_shape_id` `br`


### PR DESCRIPTION
## Motivation

https://github.com/awslabs/smithy/issues/1249

## Changes

Remove optionality of `use_section` and `shape_statements` in `shape_section`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
