### PR TITLE
Add missing mixin relationships

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
@@ -102,6 +102,7 @@ public final class TargetValidator extends AbstractValidator {
                     return Optional.of(error(shape, format(
                             "Members cannot target %s shapes, but found %s", target.getType(), target)));
                 }
+                return Optional.empty();
             case MAP_KEY:
                 return target.asMemberShape().flatMap(m -> validateMapKey(shape, m.getTarget(), model));
             case RESOURCE:


### PR DESCRIPTION
Mixin relationships can exist on any shape but we only created
a relationship for structure and union. This also attempts to
ensure that the list of relationships is created with sufficient
capacity to avoiding needing to resize the array as rels are
computed and added.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
