### PR TITLE
Add validation to validator and suppression ids

### DIFF
--- a/docs/source-1.0/spec/core/model-validation.rst
+++ b/docs/source-1.0/spec/core/model-validation.rst
@@ -50,6 +50,8 @@ objects that are used to constrain a model. Each object in the
         implementations to find and configure the appropriate validator
         implementation. Validators only take effect if a Smithy processor
         implements the validator.
+
+        ``name`` follows the :ref:`validation-event-id-abnf`.
     * - id
       - ``string``
       - Defines a custom identifier for the validator.
@@ -60,6 +62,8 @@ objects that are used to constrain a model. Each object in the
 
         If ``id`` is not specified, it will default to the ``name`` property of
         the validator definition.
+
+        ``id`` follows the :ref:`validation-event-id-abnf`.
     * - message
       - ``string``
       - Provides a custom message to use when emitting validation events. The
@@ -189,7 +193,7 @@ Summary
 Trait selector
     ``*``
 Value type
-    ``[string]``
+    ``[string]``, where each ``string`` follows the :ref:`validation-event-id-abnf`
 
 The following example suppresses the ``Foo`` and ``Bar`` validation events
 for the ``smithy.example#MyString`` shape:
@@ -228,6 +232,8 @@ following properties:
     * - id
       - ``string``
       - **Required**. The validation event ID to suppress.
+
+        ``id`` follows the :ref:`validation-event-id-abnf`.
     * - namespace
       - ``string``
       - **Required**. The validation event is only suppressed if it matches the
@@ -644,3 +650,18 @@ traits.
             selector: ":is([trait|enum], [trait|pattern], [trait|length], [trait|range])",
         }
     }]
+
+
+.. _validation-event-id-abnf:
+
+------------------------
+Validation Event ID ABNF
+------------------------
+
+The Validation Event ID is defined by the following ABNF:
+
+.. productionlist:: smithy
+    validation_event_id    :`identifier` *("." `identifier`)
+    identifier             :`identifier_start` *`identifier_chars`
+    identifier_start       :*"_" ALPHA
+    identifier_chars       :ALPHA / DIGIT / "_"

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidationLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidationLoader.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationEventId;
 import software.amazon.smithy.utils.ListUtils;
 
 final class ValidationLoader {
@@ -67,7 +68,9 @@ final class ValidationLoader {
     private static ValidatorDefinition loadSingleValidator(ObjectNode node) {
         node.warnIfAdditionalProperties(VALIDATOR_PROPERTIES);
         String name = node.expectStringMember("name").getValue();
+        ValidationEventId.validateValidationEventId(name, node);
         String id = node.getStringMemberOrDefault("id", name);
+        ValidationEventId.validateValidationEventId(id, node);
         ValidatorDefinition def = new ValidatorDefinition(name, id);
         def.sourceLocation = node.getSourceLocation();
         def.message = node.getStringMemberOrDefault("message", null);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorLoadException.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorLoadException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader;
+
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.SourceException;
+
+/**
+ * Exception thrown when a validator fails to be loaded.
+ */
+public class ValidatorLoadException extends SourceException {
+
+    public ValidatorLoadException(String message, FromSourceLocation sourceLocation) {
+        super(message, sourceLocation);
+    }
+
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
@@ -130,10 +130,13 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
         // Parse the required identifier_start production.
         char startingChar = identifier.charAt(offset);
         if (startingChar == '_') {
-            while (identifier.charAt(offset) == '_') {
+            while (offset < identifier.length() && identifier.charAt(offset) == '_') {
                 offset++;
             }
-            if (!ParserUtils.isValidIdentifierCharacter(identifier.charAt(offset))) {
+            if (offset >= identifier.length()) {
+                return -1;
+            }
+            if (!ParserUtils.isAlphabetic(identifier.charAt(offset))) {
                 return -1;
             }
             offset++;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEventId.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEventId.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation;
+
+import java.util.Optional;
+import software.amazon.smithy.model.loader.ParserUtils;
+import software.amazon.smithy.model.loader.ValidatorLoadException;
+import software.amazon.smithy.model.node.ObjectNode;
+
+/**
+ * Custom Identifier for Validators.
+ *
+ * <p>A validation event ID is used to identify specific instances of a
+ * validator so that suppressions can be applied to those instances.
+ */
+public final class ValidationEventId {
+
+    private static final String VALIDATION_EVENT_ID_REGEX_PATTERN =
+            "^_*[A-Za-z][A-Za-z0-9_]*(\\._*[A-Za-z][A-Za-z0-9_]*)*$";
+
+    private ValidationEventId() {}
+
+    /**
+     * Checks if the given string is a valid validation event ID.
+     *
+     * @param validationEventId Validation Event ID value to check.
+     * @return Returns true if this is a valid validationEventId.
+     */
+    public static boolean isValidValidationEventId(CharSequence validationEventId) {
+        if (validationEventId == null) {
+            return false;
+        }
+
+        int length = validationEventId.length();
+        if (length == 0) {
+            return false;
+        }
+
+        int position = 0;
+        while (true) {
+            position = parseIdentifier(validationEventId, position);
+            if (position == -1) { // Bad: did not parse a valid identifier.
+                return false;
+            } else if (position == length) { // Good: parsed and reached the end.
+                return true;
+            } else if (validationEventId.charAt(position) != '.') { // Bad: invalid character.
+                return false;
+            } else if (++position >= length) { // Bad: trailing '.'
+                return false;
+            } // continue parsing after '.', expecting an identifier.
+        }
+    }
+
+    private static int parseIdentifier(CharSequence identifier, int offset) {
+        if (identifier == null || identifier.length() <= offset) {
+            return -1;
+        }
+
+        // Parse the required identifier_start production.
+        char startingChar = identifier.charAt(offset);
+        if (startingChar == '_') {
+            while (offset < identifier.length() && identifier.charAt(offset) == '_') {
+                offset++;
+            }
+            if (offset >= identifier.length()) {
+                return -1;
+            }
+            if (!ParserUtils.isAlphabetic(identifier.charAt(offset))) {
+                return -1;
+            }
+            offset++;
+        } else if (!ParserUtils.isAlphabetic(startingChar)) {
+            return -1;
+        }
+
+        // Parse the optional identifier_chars production.
+        while (offset < identifier.length()) {
+            if (!ParserUtils.isValidIdentifierCharacter(identifier.charAt(offset))) {
+                // Return the position of the character that stops the identifier.
+                // The marker is needed for isValidValidationEventId to find '.'.
+                return offset;
+            }
+            offset++;
+        }
+
+        return offset;
+    }
+
+    public static void validateValidationEventId(String validationEventId, ObjectNode node)
+            throws ValidatorLoadException {
+        Optional.ofNullable(validationEventId)
+                .filter(ValidationEventId::isValidValidationEventId)
+                .orElseThrow(() -> new ValidatorLoadException(String.format(
+                        "Validation Event ID `%s` must match regular expression: %s",
+                        validationEventId, VALIDATION_EVENT_ID_REGEX_PATTERN), node.getSourceLocation()));
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/MetadataSuppression.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/MetadataSuppression.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationEventId;
 import software.amazon.smithy.utils.ListUtils;
 
 /**
@@ -48,6 +49,7 @@ final class MetadataSuppression implements Suppression {
         ObjectNode rule = node.expectObjectNode();
         rule.warnIfAdditionalProperties(SUPPRESSION_KEYS);
         String id = rule.expectStringMember(ID).getValue();
+        ValidationEventId.validateValidationEventId(id, rule);
         String namespace = rule.expectStringMember(NAMESPACE).getValue();
         String reason = rule.getStringMemberOrDefault(REASON, null);
         return new MetadataSuppression(id, namespace, reason);

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -985,7 +985,7 @@ structure hostLabel {}
 /// Suppresses validation events by ID for a given shape.
 @trait
 list suppress {
-    @pattern("^[_a-zA-Z][A-Za-z0-9]*$")
+    @pattern("^_*[A-Za-z][A-Za-z0-9_]*(\\._*[A-Za-z][A-Za-z0-9_]*)*$")
     @length(min: 1)
     member: String
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeIdTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeIdTest.java
@@ -122,6 +122,12 @@ public class ShapeIdTest {
         assertFalse(ShapeId.isValidNamespace("foo.bar.*"));
         assertFalse(ShapeId.isValidNamespace("foo.bar.."));
         assertFalse(ShapeId.isValidNamespace(""));
+        assertFalse(ShapeId.isValidNamespace("___"));
+        assertFalse(ShapeId.isValidNamespace("a.___"));
+        assertFalse(ShapeId.isValidNamespace("___1"));
+        assertFalse(ShapeId.isValidNamespace("1"));
+        assertFalse(ShapeId.isValidNamespace("a.___.b"));
+        assertFalse(ShapeId.isValidNamespace("_._._"));
 
         assertTrue(ShapeId.isValidNamespace("foo"));
         assertTrue(ShapeId.isValidNamespace("Foo.bar"));
@@ -134,6 +140,7 @@ public class ShapeIdTest {
         assertTrue(ShapeId.isValidNamespace("f.b1.c_d_.e"));
         assertTrue(ShapeId.isValidNamespace("f.b1.c_d_.e"));
         assertTrue(ShapeId.isValidNamespace("f.b1.c_d_1234.e"));
+        assertTrue(ShapeId.isValidNamespace("____f"));
     }
 
     @ParameterizedTest

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/ValidationEventIdTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/ValidationEventIdTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.validation;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.loader.ValidatorLoadException;
+import software.amazon.smithy.model.node.ObjectNode;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ValidationEventIdTest {
+
+    private static final ObjectNode TEST_OBJECT_NODE =
+            new ObjectNode(Collections.emptyMap(), SourceLocation.none());
+
+    @Test
+    public void checksIfValidValidatorId() {
+        assertFalse(ValidationEventId.isValidValidationEventId("foo.bar."));
+        assertFalse(ValidationEventId.isValidValidationEventId(".foo.bar"));
+        assertFalse(ValidationEventId.isValidValidationEventId("foo.bar#baz"));
+        assertFalse(ValidationEventId.isValidValidationEventId("1foo.bar"));
+        assertFalse(ValidationEventId.isValidValidationEventId("foo.1bar"));
+        assertFalse(ValidationEventId.isValidValidationEventId("foo.bar.1"));
+        assertFalse(ValidationEventId.isValidValidationEventId("foo.bar.*"));
+        assertFalse(ValidationEventId.isValidValidationEventId("foo.bar.."));
+        assertFalse(ValidationEventId.isValidValidationEventId(""));
+        assertFalse(ValidationEventId.isValidValidationEventId("___"));
+        assertFalse(ValidationEventId.isValidValidationEventId("a.___"));
+        assertFalse(ValidationEventId.isValidValidationEventId("___1"));
+        assertFalse(ValidationEventId.isValidValidationEventId("1"));
+        assertFalse(ValidationEventId.isValidValidationEventId("a.___.b"));
+        assertFalse(ValidationEventId.isValidValidationEventId("_._._"));
+
+        assertTrue(ValidationEventId.isValidValidationEventId("foo"));
+        assertTrue(ValidationEventId.isValidValidationEventId("Foo.bar"));
+        assertTrue(ValidationEventId.isValidValidationEventId("foo._bar"));
+        assertTrue(ValidationEventId.isValidValidationEventId("foo.bar"));
+        assertTrue(ValidationEventId.isValidValidationEventId("foo.bar1"));
+        assertTrue(ValidationEventId.isValidValidationEventId("_foo.bar"));
+        assertTrue(ValidationEventId.isValidValidationEventId("f.b"));
+        assertTrue(ValidationEventId.isValidValidationEventId("f.b1.c_d"));
+        assertTrue(ValidationEventId.isValidValidationEventId("f.b1.c_d_.e"));
+        assertTrue(ValidationEventId.isValidValidationEventId("f.b1.c_d_.e"));
+        assertTrue(ValidationEventId.isValidValidationEventId("f.b1.c_d_1234.e"));
+        assertTrue(ValidationEventId.isValidValidationEventId("____f"));
+    }
+
+    @Test
+    public void test_validateValidationEventId_idValid() {
+        ValidationEventId.validateValidationEventId(
+                "valid.id",
+                TEST_OBJECT_NODE);
+    }
+
+    @Test
+    public void test_validateValidationEventId_idInvalid_ValidatorLoadException() {
+        assertThrows(ValidatorLoadException.class, () -> {
+            ValidationEventId.validateValidationEventId(
+                    "invalid.id.",
+                    TEST_OBJECT_NODE);
+        });
+    }
+
+    @Test
+    public void test_validateValidationEventId_idNull_ValidatorLoadException() {
+        assertThrows(ValidatorLoadException.class, () -> {
+            ValidationEventId.validateValidationEventId(
+                    null,
+                    TEST_OBJECT_NODE);
+        });
+    }
+
+    @Test
+    public void test_validateValidationEventId_idValid_nodeNull() {
+        ValidationEventId.validateValidationEventId(
+                "valid.id",
+                null);
+    }
+
+    @Test
+    public void test_validateValidationEventId_idInvalid_nodeNull_NullPointerException() {
+        assertThrows(NullPointerException.class, () -> {
+            ValidationEventId.validateValidationEventId(
+                    "invalid.id.",
+                    null);
+        });
+    }
+
+    @Test
+    public void test_validateValidationEventId_idNull_nodeNull_NullPointerException() {
+        assertThrows(NullPointerException.class, () -> {
+            ValidationEventId.validateValidationEventId(
+                    null,
+                    null);
+        });
+    }
+
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/validator-id-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/validator-id-test.errors
@@ -1,0 +1,7 @@
+[DANGER] smithy.example#List1: This list must not exist! | _no.LiSt_s.__ple.ase__
+[WARNING] smithy.example#List1$member: Members? Yuck! | _list_members_.are_bad_okay
+[SUPPRESSED] smithy.example#List2: This list must not exist! | _no.LiSt_s.__ple.ase__
+[SUPPRESSED] smithy.example#List2$member: Members? Yuck! | _list_members_.are_bad_okay
+[SUPPRESSED] -: Unable to locate a validator named `_Unknown.Validato._r2._b` (Please ignore this) | UnknownValidator__Unknown.Validato._r2._b
+[WARNING] -: Unable to locate a validator named `_Unknown.Validato._r1._a` | UnknownValidator__Unknown.Validato._r1._a
+[SUPPRESSED] smithy.example#MyService: This is suppressed | Suppressed_Validator._test

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/validator-id-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/validator-id-test.smithy
@@ -1,0 +1,85 @@
+$version: "1.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "_no.LiSt_s.__ple.ase__",
+        message: "This list must not exist!",
+        configuration: {
+            selector: "list"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "_list_members_.are_bad_okay",
+        message: "Members? Yuck!",
+        severity: "WARNING",
+        configuration: {
+            selector: "list > member"
+        }
+    },
+    {
+        // This one is suppressed.
+        name: "EmitEachSelector",
+        id: "Suppressed_Validator._test",
+        message: "This is suppressed",
+        severity: "WARNING",
+        configuration: {
+            selector: "service"
+        }
+    },
+    {
+        name: "_Unknown.Validato._r1._a"
+    },
+    {
+        name: "_Unknown.Validato._r2._b"
+    }
+]
+
+metadata suppressions = [
+    {
+        id: "UnknownValidator__Unknown.Validato._r2._b", // Matches any event not bound to a shape.
+        namespace: "*",
+        reason: "Please ignore this",
+    },
+    {
+        id: "Suppressed_Validator._test",
+        namespace: "smithy.example.ignore.this.one", // matches nothing
+    },
+    {
+        id: "Suppressed_Validator._test",
+        namespace: "smithy.example"
+    },
+]
+
+namespace smithy.example
+
+@suppress(["_Ingore_Me.today"])
+service MyService {
+    version: "XYZ",
+    operations: [GetFoo],
+}
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {
+    list1: List1,
+    list2: List2,
+}
+
+@output
+structure GetFooOutput {}
+
+list List1 {
+    member: String,
+}
+
+@suppress(["_no.LiSt_s.__ple.ase__"])
+list List2 {
+    @suppress(["_list_members_.are_bad_okay"])
+    member: String,
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/linters/emit-each-selector-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/linters/emit-each-selector-validator.errors
@@ -1,10 +1,10 @@
-[DANGER] ns.foo#String: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#String: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#String: Selector capture matched selector: [id='ns.foo#String'] | shapeId
 [DANGER] ns.foo#String: Selector capture matched selector: [id=ns.foo#String] | shapeId
 [DANGER] ns.foo#String: Selector capture matched selector: [id|name="String"] | shapeName
 [DANGER] ns.foo#String: Selector capture matched selector: [id|name='String'] | shapeName
 [DANGER] ns.foo#String: Selector capture matched selector: simpleType | simpleType
-[DANGER] ns.foo#Integer: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#Integer: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#Integer: Selector capture matched selector: integer | integer
 [DANGER] ns.foo#Integer: Selector capture matched selector: number | number
 [DANGER] ns.foo#Integer: Selector capture matched selector: simpleType | simpleType
@@ -39,56 +39,56 @@
 [NOTE] ns.foo#List: The list shape is not connected to from any service shape. | UnreferencedShape
 [DANGER] ns.foo#List$member: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
 [DANGER] ns.foo#List$member: Selector capture matched selector: :test(member > [id='ns.foo#String']) | memberTargetsString
-[DANGER] ns.foo#List$member: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#List$member: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#List$member: Selector capture matched selector: member | member
 [DANGER] ns.foo#Map: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#Map: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#Map: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#Map: Selector capture matched selector: map | map
 [DANGER] ns.foo#Map$key: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
 [DANGER] ns.foo#Map$key: Selector capture matched selector: :test(member > [id='ns.foo#String']) | memberTargetsString
-[DANGER] ns.foo#Map$key: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#Map$key: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#Map$key: Selector capture matched selector: member | member
 [DANGER] ns.foo#Map$value: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
 [DANGER] ns.foo#Map$value: Selector capture matched selector: :test(member > [id='ns.foo#String']) | memberTargetsString
-[DANGER] ns.foo#Map$value: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#Map$value: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#Map$value: Selector capture matched selector: member | member
 [DANGER] ns.foo#MyService: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#MyService: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#MyService: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#MyService: Selector capture matched selector: [service|version^=2017] | serviceVersion
 [DANGER] ns.foo#MyResource: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#MyResource: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#MyResource: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#MyResource: Selector capture matched selector: resource | resource
 [DANGER] ns.foo#MyResource: Selector capture matched selector: service -[resource]-> resource | serviceChild
-[DANGER] ns.foo#MyResourceIdentifier: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#MyResourceIdentifier: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#MyResourceIdentifier: Selector capture matched selector: resource -[identifier]-> string | identifier
 [DANGER] ns.foo#MyResourceIdentifier: Selector capture matched selector: simpleType | simpleType
 [DANGER] ns.foo#OperationA: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationA: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationA: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationA: Selector capture matched selector: operation | operation
 [DANGER] ns.foo#OperationAInput: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationAInput: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationAInput: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationAInput$memberName: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
 [DANGER] ns.foo#OperationAInput$memberName: Selector capture matched selector: :test(member > [id='ns.foo#String']) | memberTargetsString
-[DANGER] ns.foo#OperationAInput$memberName: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationAInput$memberName: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationAInput$memberName: Selector capture matched selector: [id|member=memberName] | shapeMember
 [DANGER] ns.foo#OperationAInput$memberName: Selector capture matched selector: member | member
 [DANGER] ns.foo#OperationAInput$otherMemberName: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationAInput$otherMemberName: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationAInput$otherMemberName: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationAInput$otherMemberName: Selector capture matched selector: member | member
 [DANGER] ns.foo#OperationAOutput: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationAOutput: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationAOutput: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationAOutput$b: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationAOutput$b: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationAOutput$b: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationAOutput$b: Selector capture matched selector: member | member
-[DANGER] ns.foo#OperationErrorA: Selector capture matched selector: > | valid-neighbor-only
-[DANGER] ns.foo#OperationErrorB: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationErrorA: Selector capture matched selector: > | valid.neighbor.only
+[DANGER] ns.foo#OperationErrorB: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationB: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationB: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationB: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationB: Selector capture matched selector: operation | operation
 [DANGER] ns.foo#OperationBInput: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationBInput: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationBInput: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationBInput$id: Selector capture matched selector: :not(:is([trait|error], simpleType)) | not
-[DANGER] ns.foo#OperationBInput$id: Selector capture matched selector: > | valid-neighbor-only
+[DANGER] ns.foo#OperationBInput$id: Selector capture matched selector: > | valid.neighbor.only
 [DANGER] ns.foo#OperationBInput$id: Selector capture matched selector: member | member
 [DANGER] ns.foo#UtcTimestamp: Selector capture matched selector: simpleType | simpleType
 [NOTE] ns.foo#UtcTimestamp: The timestamp shape is not connected to from any service shape. | UnreferencedShape

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/linters/emit-each-selector-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/linters/emit-each-selector-validator.json
@@ -357,7 +357,7 @@
                 }
             },
             {
-                "id": "valid-neighbor-only",
+                "id": "valid.neighbor.only",
                 "name": "EmitEachSelector",
                 "configuration": {
                     "selector": ">"


### PR DESCRIPTION
**Note: Created this pull request to target the `idl-2.0` branch compared to #1325.**

*Issue #, if available:*

#987

*Description of changes:*

Prior, validator ids / names and the suppressions from metadata
were not constrained by any language, while the suppression trait
pattern was overly constrained.

This commit ensures validators and suppressions share the same ABNF
in the following places:

- `validators` metadata

- `suppressions` metadata

- `@suppress` trait

Also, fixed bugs in the ShapeId namespace code:

- StringIndexOutOfBoundsException thrown for the case "___".

- Mismatch in `identifier_start` parsing compared to ABNF

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
