### PR TITLE
Upgrade Sphinx version used for doc generation from 4.2.0 to 4.4.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=4.2.0,<4.3.0
+sphinx>=4.4.0,<4.5.0
 pygments==2.10.0
 sphinx-tabs==3.2.0

--- a/docs/setup.py
+++ b/docs/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-requires = ["sphinx==4.2.0", "pygments==2.10.0", "sphinx-tabs==3.2.0"]
+requires = ["sphinx==4.4.0", "pygments==2.10.0", "sphinx-tabs==3.2.0"]
 
 # Register the custom Smithy loader with Pygments.
 # See: http://pygments.org/docs/plugins/


### PR DESCRIPTION
The main motivation behind this change is to fix the broken rfc links present in the docs.
ietf.org has moved where they host the rfc docs and this has been accounted for in newer
versions of Sphinx (4.4.0+).

https://github.com/awslabs/smithy/issues/1328

I have tested these changes by locally  generating the docs and poking around. The RFC links are fixed. If there are additional testing steps to take, please let me know. 