### PR TITLE
Add transformation to exclude shapes based on ShapeType

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByType.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesByType.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Removes shapes from the model if they match a specific type.
+ */
+public final class ExcludeShapesByType extends ConfigurableProjectionTransformer<ExcludeShapesByType.Config> {
+
+    /**
+     * The configuration for this transformation.
+     */
+    public static final class Config {
+        private Set<String> shapeTypes = Collections.emptySet();
+
+        /**
+         * Gets the shape types to filter shapes by.
+         *
+         * @return Returns the shape types.
+         */
+        public Set<String> getShapeTypes() {
+            return shapeTypes;
+        }
+
+        /**
+         * Sets the shape types to filter shapes by.
+         *
+         * @param shapeTypes The shape types such that if a shape matches, it is removed.
+         */
+        public void setShapeTypes(Set<String> shapeTypes) {
+            this.shapeTypes = shapeTypes;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "excludeShapesByType";
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        return context.getTransformer()
+                .removeShapesIf(context.getModel(),
+                        shape -> getShapeTypesFromStrings(
+                                config.getShapeTypes())
+                                        .contains(shape.getType()));
+    }
+
+    private Set<ShapeType> getShapeTypesFromStrings(Set<String> shapeType) {
+        return shapeType.stream()
+                .map(ShapeType::fromString)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTypeTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTypeTest.java
@@ -1,0 +1,65 @@
+package software.amazon.smithy.build.transforms;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+public class ExcludeShapesByTypeTest {
+    @ParameterizedTest
+    @MethodSource("shapeTypeValues")
+    public void removesShapesByType(List<String> shapeTypeValues) {
+        OperationShape operationA = OperationShape.builder()
+                .id(ShapeId.fromParts("ns", "baz"))
+                .build();
+        ServiceShape serviceA = ServiceShape.builder()
+                .id(ShapeId.fromParts("ns", "bar"))
+                .version("1.0")
+                .build();
+        StringShape stringA = StringShape.builder()
+                .id(ShapeId.fromParts("ns", "foo"))
+                .build();
+        Model model = Model.builder()
+                .addShapes(operationA, serviceA, stringA)
+                .build();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode()
+                        .withMember("shapeTypes",
+                                Node.fromStrings(shapeTypeValues)))
+                .build();
+        Model result = new ExcludeShapesByType().transform(context);
+
+        // Aggregate shape removal also removes members.
+        assertThat(result.getShapeIds(),
+                not(hasItem(ShapeId.fromParts("ns", "baz"))));
+        assertThat(result.getShapeIds(),
+                not(hasItem(ShapeId.fromParts("ns", "bar"))));
+        assertThat(result.getShapeIds(),
+                not(hasItem(ShapeId.fromParts("ns", "bar", "world"))));
+
+        // Doesn't remove unmatched shapes.
+        assertThat(result.getShapeIds(),
+                hasItem(ShapeId.fromParts("ns", "foo")));
+    }
+
+    public static List<List<String>> shapeTypeValues() {
+        return Arrays.asList(Arrays.asList(
+                // Relative IDs are assumed to be in "smithy.api".
+                "operation",
+                // Absolute IDs are used as-is.
+                "service"));
+    }
+}


### PR DESCRIPTION
Add a new transformation to support excluding shapes based on their ShapeType.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
