### PR TITLE
Simplify getting required mixin members

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/CollectionShape.java
@@ -33,13 +33,7 @@ public abstract class CollectionShape extends Shape {
 
     CollectionShape(Builder<?, ?> builder) {
         super(builder, false);
-
-        // Get the member from the builder or from any mixins.
-        if (builder.member != null) {
-            member = builder.member;
-        } else {
-            member = getRequiredMixinMember(builder, "member");
-        }
+        member = getRequiredMixinMember(builder, builder.member, "member");
 
         ShapeId expected = getId().withMember("member");
         if (!member.getId().equals(expected)) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MapShape.java
@@ -42,8 +42,8 @@ public final class MapShape extends Shape implements ToSmithyBuilder<MapShape> {
 
     private MapShape(Builder builder) {
         super(builder, false);
-        key = builder.key != null ? builder.key : getRequiredMixinMember(builder, "key");
-        value = builder.value != null ? builder.value : getRequiredMixinMember(builder, "value");
+        key = getRequiredMixinMember(builder, builder.key, "key");
+        value = getRequiredMixinMember(builder, builder.value, "value");
         validateMemberShapeIds();
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -108,7 +108,15 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
         }
     }
 
-    protected MemberShape getRequiredMixinMember(AbstractShapeBuilder<?, ?> builder, String name) {
+    protected MemberShape getRequiredMixinMember(
+            AbstractShapeBuilder<?, ?> builder,
+            MemberShape onBuilder,
+            String name
+    ) {
+        if (onBuilder != null) {
+            return onBuilder;
+        }
+
         // Get the most recently introduced mixin member with the given name.
         MemberShape mostRecentMember = null;
 


### PR DESCRIPTION
No logic changes, just centralizes the checks for getting a required
member from a builder or from mixins.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
