### PR TITLE
Update CodegenDirector to handle mixin and enum shape

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -79,8 +80,8 @@ public final class CodegenDirector<
      *
      * <ul>
      *     <li>Flattens error hierarchies onto every operation.</li>
-     *     <li>Converts enum strings to enum shapes.</li>
      *     <li>Flattens mixins</li>
+     *     <li>Converts enum strings to enum shapes.</li>
      * </ul>
      *
      * <p><em>Note</em>: This transform is applied automatically by a code
@@ -95,9 +96,8 @@ public final class CodegenDirector<
     public static Model simplifyModelForServiceCodegen(Model model, ShapeId service, ModelTransformer transformer) {
         ServiceShape serviceShape = model.expectShape(service, ServiceShape.class);
         model = transformer.copyServiceErrorsToOperations(model, serviceShape);
-        // model = transformer.flattenAndRemoveMixins(model);
-        model = transformer.copyServiceErrorsToOperations(model, serviceShape);
-        // model = transformer.changeStringEnumsToEnumShapes(model, true);
+        model = transformer.flattenAndRemoveMixins(model);
+        model = transformer.changeStringEnumsToEnumShapes(model, true);
         return model;
     }
 
@@ -455,14 +455,11 @@ public final class CodegenDirector<
             return null;
         }
 
-        /*
-        TODO: uncomment in idl-2.0 and remove the stringShape method
         @Override
         public Void enumShape(EnumShape shape) {
-            LOGGER.finest(() -> "Generating string enum " + shape.getId());
+            LOGGER.finest(() -> "Generating enum shape" + shape.getId());
             directedCodegen.generateEnumShape(new GenerateEnumDirective<>(context, serviceShape, shape));
             return null;
         }
-        */
     }
 }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateEnumDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateEnumDirective.java
@@ -16,6 +16,8 @@
 package software.amazon.smithy.codegen.core.directed;
 
 import software.amazon.smithy.codegen.core.CodegenContext;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.EnumTrait;
@@ -34,11 +36,10 @@ public final class GenerateEnumDirective<C extends CodegenContext<S, ?, ?>, S> e
     }
 
     private static Shape validateShape(Shape shape) {
-        if (!shape.isStringShape() || !shape.hasTrait(EnumTrait.class)) {
-            throw new IllegalArgumentException("GenerateEnum requires a string shape with the enum trait");
+        if (shape.isEnumShape() || (shape.isStringShape() && shape.hasTrait(EnumTrait.class))) {
+            return shape;
         }
-
-        return shape;
+        throw new IllegalArgumentException("GenerateEnum requires an enum shape or a string shape with the enum trait");
     }
 
     /**
@@ -48,9 +49,7 @@ public final class GenerateEnumDirective<C extends CodegenContext<S, ?, ?>, S> e
     public enum EnumType {
         /** A string shape marked with the enum trait is being generated. */
         STRING,
-
-        // TODO: idl-2.0
-        // ENUM
+        ENUM
     }
 
     /**
@@ -65,8 +64,7 @@ public final class GenerateEnumDirective<C extends CodegenContext<S, ?, ?>, S> e
      * @see #getEnumTrait()
      */
     public EnumType getEnumType() {
-        // TODO: update when idl-2.0 is released.
-        return EnumType.STRING;
+        return shape().isEnumShape() ? EnumType.ENUM : EnumType.STRING;
     }
 
     /**
@@ -78,11 +76,8 @@ public final class GenerateEnumDirective<C extends CodegenContext<S, ?, ?>, S> e
         return shape().expectTrait(EnumTrait.class);
     }
 
-    /*
-    TODO: Uncomment after IDL-2.0 is shipped.
     public EnumShape expectEnumShape() {
         return shape().asEnumShape().orElseThrow(() -> new ExpectationNotMetException(
                 "Expected an enum shape, but found " + shape(), shape()));
     }
-    */
 }

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.codegen.core.directed;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,11 +86,10 @@ public class CodegenDirectorTest {
         public void generateEnumShape(GenerateEnumDirective<TestContext, TestSettings> directive) {
             generatedShapes.add(directive.shape().getId());
             GenerateEnumDirective.EnumType type = directive.getEnumType();
-            if (type == GenerateEnumDirective.EnumType.STRING) {
-                directive.getEnumTrait();
+            if (type == GenerateEnumDirective.EnumType.ENUM) {
+                directive.expectEnumShape();
             } else {
-                // TODO: update for idl-2.0
-                throw new RuntimeException("Expected enum type to be string");
+                throw new RuntimeException("Expected enum type to be enum shape");
             }
         }
 
@@ -153,6 +153,17 @@ public class CodegenDirectorTest {
         runner.createDedicatedInputsAndOutputs();
         runner.sortMembers();
         runner.run();
+
+        // asserts that mixin smithy.example#Paginated is not generated
+        assertThat(testDirected.generatedShapes, containsInAnyOrder(
+                ShapeId.from("smithy.example#Foo"),
+                ShapeId.from("smithy.example#TheFoo"),
+                ShapeId.from("smithy.example#ListFooInput"),
+                ShapeId.from("smithy.example#ListFooOutput"),
+                ShapeId.from("smithy.example#Status"),
+                ShapeId.from("smithy.example#Instruction"),
+                ShapeId.from("smithy.api#Unit")
+        ));
     }
 
     @Test

--- a/smithy-codegen-core/src/test/resources/software/amazon/smithy/codegen/core/directed/directed-model.smithy
+++ b/smithy-codegen-core/src/test/resources/software/amazon/smithy/codegen/core/directed/directed-model.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 
 namespace smithy.example
 
@@ -15,22 +15,15 @@ resource TheFoo {
 @readonly
 @paginated
 operation ListFoo {
-    input: ListFooInput,
-    output: ListFooOutput
-}
-
-@input
-structure ListFooInput {
-    maxResults: Integer,
-    nextToken: String
-}
-
-@output
-structure ListFooOutput {
-    nextToken: String,
-    status: Status,
-    items: StringList,
-    instruction: Instruction,
+    input:= {
+        maxResults: Integer
+        nextToken: String
+    }
+    output:= with [Paginated] {
+        status: Status
+        items: StringList
+        instruction: Instruction
+    }
 }
 
 list StringList {
@@ -46,4 +39,9 @@ string Status
 union Instruction {
     continueIteration: Unit,
     stopIteration: Unit
+}
+
+@mixin
+structure Paginated {
+    nextToken: String
 }


### PR DESCRIPTION
Use transforms to flatten mixins and change string enums to enum shapes. Added test assertions for these behaviors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
