### PR TITLE
Disable CI on idl-2.0 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [main, idl-2.0]
+    branches: [main]
   pull_request:
-    branches: [main, idl-2.0]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Disables running CI on idl-2.0 branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
