### PR TITLE
Add set to list doc section

### DIFF
--- a/docs/source-2.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source-2.0/guides/migrating-idl-1-to-2.rst
@@ -241,7 +241,7 @@ needed to model an operation. For example, the following model:
 
 can be updated to:
 
-.. code-block::
+.. code-block:: smithy
 
     $version: "2"
 

--- a/docs/source-2.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source-2.0/guides/migrating-idl-1-to-2.rst
@@ -135,7 +135,7 @@ Needs to be updated to:
 
 .. code-block:: smithy
 
-    $version "2.0"
+    $version "2"
 
     namespace smithy.example
 

--- a/docs/source-2.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source-2.0/guides/migrating-idl-1-to-2.rst
@@ -113,6 +113,38 @@ Needs to be updated to:
     }
 
 
+Convert set shapes to list shapes
+=================================
+
+The set shape was deprecated for IDL 2.0. Each set shape must be replaced by a
+list shape with the :ref:`uniqueItems-trait`.
+
+For example, the following set:
+
+.. code-block:: smithy
+
+    $version "1.0"
+
+    namespace smithy.example
+
+    set StringSet {
+        member: String
+    }
+
+Needs to be updated to:
+
+.. code-block:: smithy
+
+    $version "2.0"
+
+    namespace smithy.example
+
+    @uniqueItems
+    list StringSet {
+        member: String
+    }
+
+
 Add the default trait to streaming blobs
 ========================================
 


### PR DESCRIPTION
Adds converting sets to lists section to idl-1 to idl-2 migration guide.

This PR also fixes a missing `smithy` tag to enable syntax highlighting on a code block in the migration guide.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
