### PR TITLE
Fix code block syntax targets

### DIFF
--- a/docs/source-1.0/spec/core/behavior-traits.rst
+++ b/docs/source-1.0/spec/core/behavior-traits.rst
@@ -36,7 +36,7 @@ provided request token to identify and discard duplicate requests.
 Client implementations MAY automatically provide a value for a request token
 member if and only if the member is not explicitly provided.
 
-.. code-block::
+.. code-block:: smithy
 
     operation AllocateWidget {
         input: AllocateWidgetInput

--- a/docs/source-2.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source-2.0/guides/migrating-idl-1-to-2.rst
@@ -421,7 +421,7 @@ can be updated to:
 
 .. code-block:: smithy
 
-    $version: "2.0"
+    $version: "2"
 
     namespace smithy.example
 
@@ -445,7 +445,7 @@ means they can be individually targeted by traits, without having to have
 special handling inside of Smithy itself. Their definitions in the IDL are now
 also much more concise and readable. For example, the following model:
 
-.. code-block::
+.. code-block:: smithy
 
     $version: "1.0"
 

--- a/docs/source-2.0/spec/aggregate-types.rst
+++ b/docs/source-2.0/spec/aggregate-types.rst
@@ -322,7 +322,7 @@ trait does not need to be added in its place.
 The special ":=" syntax for the operation input property automatically applies
 the ``input`` trait:
 
-.. code-block::
+.. code-block:: smithy
 
     operation PutTimeSpan {
         input := {
@@ -334,7 +334,7 @@ the ``input`` trait:
 Because of the ``input`` trait, the operation can be updated to remove the
 ``required`` trait without breaking things like previously generated clients:
 
-.. code-block::
+.. code-block:: smithy
 
     operation PutTimeSpan {
         input := {

--- a/docs/source-2.0/spec/behavior-traits.rst
+++ b/docs/source-2.0/spec/behavior-traits.rst
@@ -47,7 +47,7 @@ provided request token to identify and discard duplicate requests.
 Client implementations MAY automatically provide a value for a request token
 member if and only if the member is not explicitly provided.
 
-.. code-block::
+.. code-block:: smithy
 
     operation AllocateWidget {
         input: AllocateWidgetInput


### PR DESCRIPTION
Fixes missing code-block syntax targets, along with a updating a `$version` statement for consistency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
