### PR TITLE
Fix typo in quickstart

### DIFF
--- a/docs/source-2.0/quickstart.rst
+++ b/docs/source-2.0/quickstart.rst
@@ -183,7 +183,7 @@ were added to the identifiers property that isn't present on the ``City``
 resource.
 
 The state of a resource is represented through its
-:ref:-properties <resource-properties>`. ``City`` contains coordinates, and
+:ref:`properties <resource-properties>`. ``City`` contains coordinates, and
 ``Forecast`` has a chance of rain represented as a float. Input and output
 members of resource operations map to resource properties or identifiers to
 perform updates on or examine the state of a resource.


### PR DESCRIPTION
*Issue*

`properties` reference in quickstart not rendering properly due to typo.

*Description of changes:*

Replace the erroneous `-` with a back tick.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
