### PR TITLE
Add API helper for deserializing object nodes

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ConfigLoader.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelSyntaxException;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.node.NodeVisitor;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
@@ -60,8 +59,7 @@ final class ConfigLoader {
     }
 
     private static SmithyBuildConfig load(Path baseImportPath, ObjectNode node) {
-        NodeMapper mapper = new NodeMapper();
-        return resolveImports(baseImportPath, mapper.deserialize(node, SmithyBuildConfig.class));
+        return resolveImports(baseImportPath, SmithyBuildConfig.fromNode(node));
     }
 
     private static SmithyBuildConfig resolveImports(Path baseImportPath, SmithyBuildConfig config) {

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/ProjectionConfig.java
@@ -19,7 +19,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.build.SmithyBuildException;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -55,6 +57,20 @@ public final class ProjectionConfig implements ToSmithyBuilder<ProjectionConfig>
                 .plugins(plugins)
                 .transforms(transforms)
                 .setAbstract(isAbstract);
+    }
+
+    public static ProjectionConfig fromNode(Node node) {
+        Builder builder = ProjectionConfig.builder();
+        node.expectObjectNode()
+                .getBooleanMember("abstract", builder::setAbstract)
+                .getArrayMember("imports", StringNode::getValue, builder::imports)
+                .getArrayMember("transforms", TransformConfig::fromNode, builder::transforms)
+                .getObjectMember("plugins", plugins -> {
+                    for (Map.Entry<String, Node> entry : plugins.getStringMap().entrySet()) {
+                        builder.plugins.get().put(entry.getKey(), entry.getValue().expectObjectNode());
+                    }
+                });
+        return builder.build();
     }
 
     /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/TransformConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/TransformConfig.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.build.model;
 
+import java.util.function.Function;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -29,6 +30,14 @@ public final class TransformConfig {
     private TransformConfig(Builder builder) {
         name = SmithyBuilder.requiredState("name", builder.name);
         args = builder.args;
+    }
+
+    public static TransformConfig fromNode(Node node) {
+        TransformConfig.Builder builder = builder();
+        node.expectObjectNode()
+                .expectStringMember("name", builder::name)
+                .getMember("args", Function.identity(), builder::args);
+        return builder.build();
     }
 
     public static Builder builder() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -205,17 +206,21 @@ public final class ArrayNode extends Node implements Iterable<Node>, ToSmithyBui
                 String message = e.getMessage();
                 Matcher matcher = CAST_PATTERN_TYPE.matcher(message);
                 String formatted = matcher.matches()
-                        ? String.format(
-                                "Expected ArrayNode element %d to be a `%s` but found a `%s`.",
-                                i, matcher.group(1), elements.get(i).getClass().getSimpleName())
-                        : String.format(
-                                "ArrayNode element at position %d is an invalid type `%s`: %s",
-                                i, elements.get(i).getClass().getSimpleName(), e.getMessage());
+                        ? String.format("Expected array element %d to be a %s but found %s.", i,
+                                        nodeClassToSimpleTypeName(matcher.group(1)),
+                                        nodeClassToSimpleTypeName(elements.get(i).getClass().getSimpleName()))
+                        : String.format("Array element at position %d is an invalid type `%s`: %s", i,
+                                        nodeClassToSimpleTypeName(elements.get(i).getClass().getSimpleName()),
+                                        e.getMessage());
                 throw new ExpectationNotMetException(formatted, elements.get(i));
             }
         }
 
         return result;
+    }
+
+    private static String nodeClassToSimpleTypeName(String className) {
+        return className.replace("Node", "").toLowerCase(Locale.ENGLISH);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -306,12 +306,8 @@ public abstract class Node implements FromSourceLocation, ToNode {
      * @throws SourceException on error.
      */
     public static List<String> loadArrayOfString(String descriptor, Node node) {
-        return node.expectArrayNode("Expected `" + descriptor + "` to be an array of strings. Found {type}.")
-                .getElements().stream()
-                .map(element -> element.expectStringNode(
-                        "Each element of `" + descriptor + "` must be a string. Found {type}."))
-                .map(StringNode::getValue)
-                .collect(Collectors.toList());
+        return node.expectArrayNode(() -> "Expected `" + descriptor + "` to be an array of strings. Found {type}.")
+                .getElementsAs(StringNode::getValue);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import software.amazon.smithy.model.loader.ParserUtils;
 import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.node.Node;
 
 /**
  * Immutable identifier for each shape in a model.
@@ -76,6 +77,10 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
      */
     public static ShapeId from(String id) {
         return FACTORY.create(id);
+    }
+
+    public static ShapeId fromNode(Node node) {
+        return node.expectStringNode().expectShapeId();
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
@@ -77,12 +77,7 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
         @Override
         public AuthDefinitionTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value);
-            ObjectNode objectNode = value.expectObjectNode();
-            objectNode.getArrayMember("traits").ifPresent(traits -> {
-                for (String string : Node.loadArrayOfString("traits", traits)) {
-                    builder.addTrait(ShapeId.from(string));
-                }
-            });
+            value.expectObjectNode().getArrayMember("traits", ShapeId::fromNode, builder::traits);
             AuthDefinitionTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthTrait.java
@@ -15,14 +15,12 @@
 
 package software.amazon.smithy.model.traits;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
@@ -78,10 +76,8 @@ public final class AuthTrait extends AbstractTrait {
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            Set<ShapeId> values = new LinkedHashSet<>();
-            for (StringNode node : value.expectArrayNode().getElementsAs(StringNode.class)) {
-                values.add(node.expectShapeId());
-            }
+            ArrayNode arrayNode = value.expectArrayNode();
+            List<ShapeId> values = arrayNode.getElementsAs(ShapeId::fromNode);
             AuthTrait trait = new AuthTrait(values, value.getSourceLocation());
             trait.setNodeCache(value);
             return trait;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -45,12 +45,9 @@ public final class DeprecatedTrait extends AbstractTrait implements ToSmithyBuil
         @Override
         public Trait createTrait(ShapeId target, Node value) {
             DeprecatedTrait.Builder builder = builder().sourceLocation(value);
-            ObjectNode objectNode = value.expectObjectNode();
-            String sinceValue = objectNode.getMember("since")
-                    .map(v -> v.expectStringNode().getValue()).orElse(null);
-            String messageValue = objectNode.getMember("message")
-                    .map(v -> v.expectStringNode().getValue()).orElse(null);
-            builder.since(sinceValue).message(messageValue);
+            value.expectObjectNode()
+                    .getStringMember("since", builder::since)
+                    .getStringMember("message", builder::message);
             DeprecatedTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EndpointTrait.java
@@ -82,8 +82,7 @@ public final class EndpointTrait extends AbstractTrait implements ToSmithyBuilde
         @Override
         public Trait createTrait(ShapeId target, Node value) {
             EndpointTrait.Builder builder = builder().sourceLocation(value);
-            ObjectNode objectNode = value.expectObjectNode();
-            builder.hostPrefix(objectNode.expectStringMember("hostPrefix").getValue());
+            value.expectObjectNode().expectStringMember("hostPrefix", builder::hostPrefix);
             EndpointTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumDefinition.java
@@ -33,12 +33,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  */
 public final class EnumDefinition implements ToNode, ToSmithyBuilder<EnumDefinition>, Tagged {
 
-    public static final String VALUE = "value";
-    public static final String NAME = "name";
-    public static final String DOCUMENTATION = "documentation";
-    public static final String TAGS = "tags";
-    public static final String DEPRECATED = "deprecated";
-
     private final String value;
     private final String documentation;
     private final List<String> tags;
@@ -76,35 +70,29 @@ public final class EnumDefinition implements ToNode, ToSmithyBuilder<EnumDefinit
     @Override
     public Node toNode() {
         ObjectNode.Builder builder = Node.objectNodeBuilder();
-        builder.withMember(EnumDefinition.VALUE, getValue())
-                .withOptionalMember(EnumDefinition.NAME, getName().map(Node::from))
-                .withOptionalMember(EnumDefinition.DOCUMENTATION, getDocumentation().map(Node::from));
+        builder.withMember("value", getValue())
+                .withOptionalMember("name", getName().map(Node::from))
+                .withOptionalMember("documentation", getDocumentation().map(Node::from));
 
         if (!tags.isEmpty()) {
-            builder.withMember(EnumDefinition.TAGS, Node.fromStrings(getTags()));
+            builder.withMember("tags", Node.fromStrings(getTags()));
         }
 
         if (isDeprecated()) {
-            builder.withMember(EnumDefinition.DEPRECATED, true);
+            builder.withMember("deprecated", true);
         }
 
         return builder.build();
     }
 
     public static EnumDefinition fromNode(Node node) {
-        ObjectNode value = node.expectObjectNode();
-        EnumDefinition.Builder builder = EnumDefinition.builder()
-                .value(value.expectStringMember(EnumDefinition.VALUE).getValue())
-                .name(value.getStringMember(EnumDefinition.NAME).map(StringNode::getValue).orElse(null))
-                .documentation(value.getStringMember(EnumDefinition.DOCUMENTATION)
-                        .map(StringNode::getValue)
-                        .orElse(null))
-                .deprecated(value.getBooleanMemberOrDefault(EnumDefinition.DEPRECATED));
-
-        value.getMember(EnumDefinition.TAGS).ifPresent(tags -> {
-            builder.tags(Node.loadArrayOfString(EnumDefinition.TAGS, tags));
-        });
-
+        EnumDefinition.Builder builder = EnumDefinition.builder();
+        node.expectObjectNode()
+                .expectStringMember("value", builder::value)
+                .getStringMember("name", builder::name)
+                .getStringMember("documentation", builder::documentation)
+                .getBooleanMember("deprecated", builder::deprecated)
+                .getArrayMember("tags", StringNode::getValue, builder::tags);
         return builder.build();
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java
@@ -108,11 +108,11 @@ public final class HttpApiKeyAuthTrait extends AbstractTrait implements ToSmithy
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            ObjectNode objectNode = value.expectObjectNode();
             Builder builder = builder().sourceLocation(value.getSourceLocation());
-            builder.scheme(objectNode.getStringMemberOrDefault("scheme", null));
-            builder.name(objectNode.expectStringMember("name").getValue());
-            builder.in(Location.from(objectNode.expectStringMember("in").expectOneOf("header", "query")));
+            value.expectObjectNode()
+                    .getStringMember("scheme", builder::scheme)
+                    .expectStringMember("name", builder::name)
+                    .getStringMember("in", s -> builder.in(Location.from(s)));
             HttpApiKeyAuthTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdRefTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/IdRefTrait.java
@@ -16,10 +16,8 @@
 package software.amazon.smithy.model.traits;
 
 import java.util.Optional;
-import software.amazon.smithy.model.node.BooleanNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -40,10 +38,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  */
 public final class IdRefTrait extends AbstractTrait implements ToSmithyBuilder<IdRefTrait> {
     public static final ShapeId ID = ShapeId.from("smithy.api#idRef");
-
-    private static final String SELECTOR_MEMBER_ID = "selector";
-    private static final String FAIL_WHEN_MISSING_MEMBER = "failWhenMissing";
-    private static final String ERROR_MESSAGE = "errorMessage";
 
     private final Selector selector;
     private final boolean failWhenMissing;
@@ -81,11 +75,11 @@ public final class IdRefTrait extends AbstractTrait implements ToSmithyBuilder<I
         ObjectNode.Builder builder = Node.objectNodeBuilder()
                 .sourceLocation(getSourceLocation())
                 .withOptionalMember(
-                        SELECTOR_MEMBER_ID,
+                        "selector",
                         Optional.ofNullable(selector).map(Selector::toString).map(Node::from))
-                .withOptionalMember(ERROR_MESSAGE, getErrorMessage().map(Node::from));
+                .withOptionalMember("errorMessage", getErrorMessage().map(Node::from));
         if (failWhenMissing) {
-            builder = builder.withMember(FAIL_WHEN_MISSING_MEMBER, Node.from(true));
+            builder = builder.withMember("failWhenMissing", Node.from(true));
         }
         return builder.build();
     }
@@ -131,16 +125,10 @@ public final class IdRefTrait extends AbstractTrait implements ToSmithyBuilder<I
         @Override
         public IdRefTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value);
-            ObjectNode objectNode = value.expectObjectNode();
-            objectNode.getStringMember(SELECTOR_MEMBER_ID)
-                    .map(Selector::fromNode)
-                    .ifPresent(builder::selector);
-            objectNode.getBooleanMember(FAIL_WHEN_MISSING_MEMBER)
-                    .map(BooleanNode::getValue)
-                    .ifPresent(builder::failWhenMissing);
-            objectNode.getStringMember(ERROR_MESSAGE)
-                    .map(StringNode::getValue)
-                    .ifPresent(builder::errorMessage);
+            value.expectObjectNode()
+                    .getMember("selector", Selector::fromNode, builder::selector)
+                    .getBooleanMember("failWhenMissing", builder::failWhenMissing)
+                    .getStringMember("errorMessage", builder::errorMessage);
             IdRefTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/LengthTrait.java
@@ -109,12 +109,11 @@ public final class LengthTrait extends AbstractTrait implements ToSmithyBuilder<
 
         @Override
         public LengthTrait createTrait(ShapeId target, Node value) {
-            ObjectNode objectNode = value.expectObjectNode();
-            Long minValue = objectNode.getMember("min")
-                    .map(v -> v.expectNumberNode().getValue().longValue()).orElse(null);
-            Long maxValue = objectNode.getMember("max")
-                    .map(v -> v.expectNumberNode().getValue().longValue()).orElse(null);
-            LengthTrait result = builder().sourceLocation(value).min(minValue).max(maxValue).build();
+            LengthTrait.Builder builder = builder().sourceLocation(value.getSourceLocation());
+            value.expectObjectNode()
+                    .getNumberMember("min", n -> builder.min(n.longValue()))
+                    .getNumberMember("max", n -> builder.max(n.longValue()));
+            LengthTrait result = builder.build();
             result.setNodeCache(value);
             return result;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/MixinTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/MixinTrait.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -146,12 +144,7 @@ public final class MixinTrait extends AbstractTrait implements ToSmithyBuilder<M
         @Override
         public MixinTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value);
-            ObjectNode objectNode = value.expectObjectNode();
-            objectNode.getArrayMember("localTraits").ifPresent(values -> {
-                for (StringNode entry : values.getElementsAs(StringNode.class)) {
-                    builder.addLocalTrait(entry.expectShapeId());
-                }
-            });
+            value.expectObjectNode().getArrayMember("localTraits", ShapeId::fromNode, builder::localTraits);
             return builder.build();
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/PaginatedTrait.java
@@ -239,11 +239,11 @@ public final class PaginatedTrait extends AbstractTrait implements ToSmithyBuild
         @Override
         public PaginatedTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value);
-            ObjectNode members = value.expectObjectNode();
-            builder.pageSize(members.getStringMemberOrDefault("pageSize", null));
-            builder.items(members.getStringMemberOrDefault("items", null));
-            builder.inputToken(members.getStringMemberOrDefault("inputToken", null));
-            builder.outputToken(members.getStringMemberOrDefault("outputToken", null));
+            value.expectObjectNode()
+                    .getStringMember("pageSize", builder::pageSize)
+                    .getStringMember("items", builder::items)
+                    .getStringMember("inputToken", builder::inputToken)
+                    .getStringMember("outputToken", builder::outputToken);
             PaginatedTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/PropertyTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/PropertyTrait.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.model.traits;
 
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -76,9 +75,9 @@ public final class PropertyTrait extends AbstractTrait implements ToSmithyBuilde
 
         @Override
         public PropertyTrait createTrait(ShapeId target, Node value) {
-            ObjectNode objectNode = value.expectObjectNode();
-            String name = objectNode.getStringMemberOrDefault("name", null);
-            PropertyTrait result = builder().sourceLocation(value).name(name).build();
+            Builder builder = builder().sourceLocation(value.getSourceLocation());
+            value.expectObjectNode().getStringMember("name", builder::name);
+            PropertyTrait result = builder.build();
             result.setNodeCache(value);
             return result;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
@@ -29,8 +29,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSmithyBuilder<ProtocolDefinitionTrait> {
 
     public static final ShapeId ID = ShapeId.from("smithy.api#protocolDefinition");
-    private static final String NO_INLINE_DOCUMENT_SUPPORT = "noInlineDocumentSupport";
-    private static final String TRAITS = "traits";
 
     private final List<ShapeId> traits;
     private final boolean noInlineDocumentSupport;
@@ -73,10 +71,10 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
                     .map(ShapeId::toString)
                     .map(Node::from)
                     .collect(ArrayNode.collect());
-            builder.withMember(TRAITS, ids);
+            builder.withMember("traits", ids);
 
             if (noInlineDocumentSupport) {
-                builder.withMember(NO_INLINE_DOCUMENT_SUPPORT, true);
+                builder.withMember("noInlineDocumentSupport", true);
             }
         }
         return builder.build();
@@ -98,13 +96,9 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
         @Override
         public ProtocolDefinitionTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value);
-            ObjectNode objectNode = value.expectObjectNode();
-            objectNode.getArrayMember(TRAITS).ifPresent(traits -> {
-                for (String string : Node.loadArrayOfString(TRAITS, traits)) {
-                    builder.addTrait(ShapeId.from(string));
-                }
-            });
-            builder.noInlineDocumentSupport(objectNode.getBooleanMemberOrDefault(NO_INLINE_DOCUMENT_SUPPORT));
+            value.expectObjectNode()
+                    .getArrayMember("traits", ShapeId::fromNode, builder::traits)
+                    .getBooleanMember("noInlineDocumentSupport", builder::noInlineDocumentSupport);
             ProtocolDefinitionTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RangeTrait.java
@@ -110,14 +110,18 @@ public final class RangeTrait extends AbstractTrait implements ToSmithyBuilder<R
 
         @Override
         public RangeTrait createTrait(ShapeId target, Node value) {
-            ObjectNode objectNode = value.expectObjectNode();
-            BigDecimal minValue = objectNode.getMember("min")
-                    .map(node -> new BigDecimal(node.expectNumberNode().getValue().toString())).orElse(null);
-            BigDecimal maxValue = objectNode.getMember("max")
-                    .map(node -> new BigDecimal(node.expectNumberNode().getValue().toString())).orElse(null);
-            RangeTrait result = builder().sourceLocation(value).min(minValue).max(maxValue).build();
+            Builder builder = builder().sourceLocation(value.getSourceLocation());
+            value.expectObjectNode()
+                    .getMember("min", Provider::convertToBigDecimal, builder::min)
+                    .getMember("max", Provider::convertToBigDecimal, builder::max);
+            RangeTrait result = builder.build();
             result.setNodeCache(value);
             return result;
+        }
+
+        private static BigDecimal convertToBigDecimal(Node number) {
+            Number value = number.expectNumberNode().getValue();
+            return value instanceof BigDecimal ? (BigDecimal) value : new BigDecimal(value.toString());
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.traits;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -85,11 +84,9 @@ public final class RecommendedTrait extends AbstractTrait implements ToSmithyBui
 
         @Override
         public RecommendedTrait createTrait(ShapeId target, Node value) {
-            ObjectNode objectNode = value.expectObjectNode();
-            String reason = objectNode.getStringMember("reason")
-                    .map(StringNode::getValue)
-                    .orElse(null);
-            RecommendedTrait result = builder().sourceLocation(value).reason(reason).build();
+            Builder builder = builder().sourceLocation(value.getSourceLocation());
+            value.expectObjectNode().getStringMember("reason", builder::reason);
+            RecommendedTrait result = builder().build();
             result.setNodeCache(value);
             return result;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReferencesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ReferencesTrait.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.traits;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -26,13 +27,11 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.validation.validators.ReferencesTraitValidator;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
-import software.amazon.smithy.utils.Pair;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -114,7 +113,7 @@ public final class ReferencesTrait extends AbstractTrait implements ToSmithyBuil
      * Builder use to create the references trait.
      */
     public static final class Builder extends AbstractTraitBuilder<ReferencesTrait, Builder> {
-        private List<Reference> references = new ArrayList<>();
+        private final List<Reference> references = new ArrayList<>();
 
         public Builder addReference(Reference reference) {
             references.add(Objects.requireNonNull(reference));
@@ -142,10 +141,10 @@ public final class ReferencesTrait extends AbstractTrait implements ToSmithyBuil
      * Reference to a resource.
      */
     public static final class Reference implements ToSmithyBuilder<Reference>, ToNode {
-        private ShapeId resource;
-        private Map<String, String> ids;
-        private ShapeId service;
-        private String rel;
+        private final ShapeId resource;
+        private final Map<String, String> ids;
+        private final ShapeId service;
+        private final String rel;
 
         private Reference(Builder builder) {
             resource = SmithyBuilder.requiredState("resource", builder.resource);
@@ -289,23 +288,19 @@ public final class ReferencesTrait extends AbstractTrait implements ToSmithyBuil
         }
 
         private static Reference referenceFromNode(ObjectNode referenceProperties) {
-            return Reference.builder()
-                    .resource(referenceProperties.expectStringMember("resource").expectShapeId())
-                    .ids(referenceProperties.getObjectMember("ids")
-                                 .map(obj -> obj.getMembers().entrySet().stream()
-                                         .map(entry -> Pair.of(
-                                                 entry.getKey().getValue(),
-                                                 entry.getValue().expectStringNode().getValue()))
-                                         .collect(Collectors.toMap(Pair::getLeft, Pair::getRight)))
-                                 .orElseGet(Collections::emptyMap))
-                    .service(referenceProperties
-                                     .getStringMember("service")
-                                     .map(StringNode::expectShapeId)
-                                     .orElse(null))
-                    .rel(referenceProperties.getStringMember("rel")
-                                 .map(StringNode::getValue)
-                                 .orElse(null))
-                    .build();
+            Reference.Builder builder = Reference.builder();
+            referenceProperties.expectObjectNode()
+                    .expectMember("resource", ShapeId::fromNode, builder::resource)
+                    .getObjectMember("ids", object -> {
+                        Map<String, String> result = new LinkedHashMap<>(object.size());
+                        object.getStringMap().forEach((k, v) -> {
+                            result.put(k, v.expectStringNode().getValue());
+                        });
+                        builder.ids(result);
+                    })
+                    .getMember("service", ShapeId::fromNode, builder::service)
+                    .getStringMember("rel", builder::rel);
+            return builder.build();
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RetryableTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RetryableTrait.java
@@ -26,7 +26,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  */
 public final class RetryableTrait extends AbstractTrait implements ToSmithyBuilder<RetryableTrait> {
     public static final ShapeId ID = ShapeId.from("smithy.api#retryable");
-    private static final String THROTTLING = "throttling";
 
     private final boolean throttling;
 
@@ -60,7 +59,7 @@ public final class RetryableTrait extends AbstractTrait implements ToSmithyBuild
     protected Node createNode() {
         ObjectNode.Builder nodeBuilder = Node.objectNodeBuilder().sourceLocation(getSourceLocation());
         if (throttling) {
-            nodeBuilder.withMember(THROTTLING, true);
+            nodeBuilder.withMember("throttling", true);
         }
         return nodeBuilder.build();
     }
@@ -91,9 +90,9 @@ public final class RetryableTrait extends AbstractTrait implements ToSmithyBuild
 
         @Override
         public RetryableTrait createTrait(ShapeId target, Node value) {
-            ObjectNode node = value.expectObjectNode();
             Builder builder = builder().sourceLocation(value.getSourceLocation());
-            RetryableTrait result = builder.throttling(node.getBooleanMemberOrDefault(THROTTLING)).build();
+            value.expectObjectNode().getBooleanMember("throttling", builder::throttling);
+            RetryableTrait result = builder.build();
             result.setNodeCache(value);
             return result;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlNamespaceTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/XmlNamespaceTrait.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -30,9 +29,6 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 */
 public final class XmlNamespaceTrait extends AbstractTrait implements ToSmithyBuilder<XmlNamespaceTrait> {
     public static final ShapeId ID = ShapeId.from("smithy.api#xmlNamespace");
-
-    private static final String PREFIX = "prefix";
-    private static final String URI = "uri";
 
     private final String prefix;
     private final String uri;
@@ -54,8 +50,8 @@ public final class XmlNamespaceTrait extends AbstractTrait implements ToSmithyBu
     @Override
     protected Node createNode() {
         return new ObjectNode(MapUtils.of(), getSourceLocation())
-                .withMember(URI, Node.from(uri))
-                .withOptionalMember(PREFIX, getPrefix().map(Node::from));
+                .withMember("uri", Node.from(uri))
+                .withOptionalMember("prefix", getPrefix().map(Node::from));
     }
 
     /**
@@ -107,9 +103,9 @@ public final class XmlNamespaceTrait extends AbstractTrait implements ToSmithyBu
         @Override
         public XmlNamespaceTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value);
-            ObjectNode node = value.expectObjectNode();
-            builder.uri(node.expectStringMember(URI).getValue());
-            node.getStringMember(PREFIX).map(StringNode::getValue).ifPresent(builder::prefix);
+            value.expectObjectNode()
+                    .expectStringMember("uri", builder::uri)
+                    .getStringMember("prefix", builder::prefix);
             XmlNamespaceTrait result = builder.build();
             result.setNodeCache(value);
             return result;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -200,22 +199,12 @@ public final class ValidationEvent implements Comparable<ValidationEvent>, ToNod
                 objectNode.expectStringMember("filename").getValue(),
                 objectNode.getNumberMemberOrDefault("line", 0).intValue(),
                 objectNode.getNumberMemberOrDefault("column", 0).intValue());
-
-        // Set required properties.
-        Builder builder = builder()
-                .id(objectNode.expectStringMember("id").getValue())
-                .severity(Severity.valueOf(objectNode.expectStringMember("severity").getValue()))
-                .message(objectNode.expectStringMember("message").getValue())
-                .sourceLocation(location);
-
-        // Set optional properties.
-        objectNode.getStringMember("suppressionReason").map(StringNode::getValue)
-                .ifPresent(builder::suppressionReason);
-        objectNode.getStringMember("shapeId")
-                .map(StringNode::getValue)
-                .map(ShapeId::from)
-                .ifPresent(builder::shapeId);
-
+        Builder builder = builder().sourceLocation(location);
+        objectNode.expectStringMember("id", builder::id)
+                .expectMember("severity", Severity::fromNode, builder::severity)
+                .expectStringMember("message", builder::message)
+                .getStringMember("suppressionReason", builder::suppressionReason)
+                .getMember("shapeId", ShapeId::fromNode, builder::shapeId);
         return builder.build();
     }
 


### PR DESCRIPTION
This new API helper makes it easier to deserialize object nodes using a fluent API.
Does a few other cleanup tasks for node handling and trait loading.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
