### PR TITLE
Add missing readonly traits on HTTP GET tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -19,6 +19,7 @@ structure HttpResponseCodeOutput {
     Status: Integer
 }
 
+@readonly
 @http(method: "GET", uri: "/responseCodeRequired", code: 200)
 operation ResponseCodeRequired {
     output: ResponseCodeRequiredOutput,
@@ -31,6 +32,7 @@ structure ResponseCodeRequiredOutput {
     responseCode: Integer,
 }
 
+@readonly
 @http(method: "GET", uri: "/responseCodeHttpFallback", code: 201)
 operation ResponseCodeHttpFallback {
     input: ResponseCodeHttpFallbackInputOutput,


### PR DESCRIPTION
Adds missing @readonly traits on HTTP GET protocol tests, eliminating the following warnings:
```
WARNING: aws.protocoltests.restjson#ResponseCodeRequired (HttpMethodSemantics)
   @ ~/smithy/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
   |
 22 | @http(method: "GET", uri: "/responseCodeRequired", code: 200)
   | ^
   = This operation uses the `GET` method in the `http` trait, but is not marked with the readonly trait
WARNING: aws.protocoltests.restjson#ResponseCodeHttpFallback (HttpMethodSemantics)
   @ ~/smithy/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
   |
 34 | @http(method: "GET", uri: "/responseCodeHttpFallback", code: 201)
   | ^
   = This operation uses the `GET` method in the `http` trait, but is not marked with the readonly trait
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
