### PR TITLE
Update Smithy IDL ABNF Docs

### DIFF
--- a/docs/source-1.0/spec/aws/aws-ec2-query-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-ec2-query-protocol.rst
@@ -147,9 +147,9 @@ resolved using the following process:
        * - Member location
          - Default value
        * - ``structure`` member
-         - The :token:`member name <smithy:shape_id_member>` capitalized
+         - The :token:`member name <smithy:ShapeIdMember>` capitalized
        * - ``union`` member
-         - The :token:`member name <smithy:shape_id_member>` capitalized
+         - The :token:`member name <smithy:ShapeIdMember>` capitalized
 
 
 ----------------
@@ -351,7 +351,7 @@ of the ``Errors`` tag is an ``Error`` tag which contains the serialized error
 structure members.
 
 Serialized error shapes MUST also contain an additional child element ``Code``
-that contains only the :token:`shape name <smithy:identifier>` of the error's
+that contains only the :token:`shape name <smithy:Identifier>` of the error's
 :ref:`shape-id`. This can be used to distinguish which specific error has been
 serialized in the response.
 
@@ -368,7 +368,7 @@ serialized in the response.
         <RequestId>foo-id</RequestId>
     </Response>
 
-* ``Code``: The :token:`shape name <smithy:identifier>` of the error's
+* ``Code``: The :token:`shape name <smithy:Identifier>` of the error's
   :ref:`shape-id`.
 * ``RequestId``: Contains a unique identifier for the associated request.
 

--- a/docs/source-1.0/spec/aws/aws-json-1_1-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-json-1_1-protocol.rst
@@ -133,7 +133,7 @@ The following example defines a service that requires the use of
 
 .. |quoted shape name| replace:: ``awsJson1_1``
 .. |protocol content type| replace:: ``application/x-amz-json-1.1``
-.. |protocol error type contents| replace:: :token:`shape name <smithy:identifier>`
+.. |protocol error type contents| replace:: :token:`shape name <smithy:Identifier>`
 .. |protocol test link| replace:: https://github.com/awslabs/smithy/tree/main/smithy-aws-protocol-tests/model/awsJson1_1
 .. include:: aws-json.rst.template
 

--- a/docs/source-1.0/spec/aws/aws-json.rst.template
+++ b/docs/source-1.0/spec/aws/aws-json.rst.template
@@ -50,9 +50,9 @@ The |quoted shape name| protocol uses the following headers:
         `RFC 7230 Section 3.3.2`_.
     * - ``X-Amz-Target``
       - true for requests
-      - The value of this header is the :token:`shape name <smithy:identifier>` of the
+      - The value of this header is the :token:`shape name <smithy:Identifier>` of the
         service's :ref:`shape-id` joined to the
-        :token:`shape name <smithy:identifier>` of the operation's :ref:`shape-id`,
+        :token:`shape name <smithy:Identifier>` of the operation's :ref:`shape-id`,
         separated by a single period (``.``) character.
 
         For example, the value for the operation ``ns.example#MyOp`` of the
@@ -188,7 +188,7 @@ There are two difference between :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trai
 Second, error type serialization is different. In ``awsJson1_0``, servers SHOULD
 send the error shape's full :ref:`shape-id` in the ``__type`` field of the body.
 In ``awsJson1_1``, servers SHOULD only send the error's
-:token:`shape name <smithy:identifier>`. However, clients MUST accept either behavior
+:token:`shape name <smithy:Identifier>`. However, clients MUST accept either behavior
 for both protocols. See `Operation error serialization`_ for full details on how to
 deserialize errors for |quoted shape name|.
 

--- a/docs/source-1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-query-protocol.rst
@@ -141,9 +141,9 @@ resolved using the following process:
        * - ``map`` value
          - The string literal "value"
        * - ``structure`` member
-         - The :token:`member name <smithy:shape_id_member>`
+         - The :token:`member name <smithy:ShapeIdMember>`
        * - ``union`` member
-         - The :token:`member name <smithy:shape_id_member>`
+         - The :token:`member name <smithy:ShapeIdMember>`
 
 
 Example requests
@@ -436,7 +436,7 @@ following process:
 
 1. Use the value of the ``code`` member of the :ref:`aws.protocols#awsQueryError-trait`
    applied to the error structure, if present.
-2. The :token:`shape name <smithy:identifier>` of the error's :ref:`shape-id`.
+2. The :token:`shape name <smithy:Identifier>` of the error's :ref:`shape-id`.
 
 
 .. smithy-trait:: aws.protocols#awsQuery

--- a/docs/source-1.0/spec/aws/aws-query-serialization.rst.template
+++ b/docs/source-1.0/spec/aws/aws-query-serialization.rst.template
@@ -18,7 +18,7 @@ Requests MUST include the following key value pairs in the serialized body:
     * - Key
       - Value
     * - ``Action``
-      - The :token:`shape name <smithy:identifier>` of the operation's :ref:`shape-id`.
+      - The :token:`shape name <smithy:Identifier>` of the operation's :ref:`shape-id`.
     * - ``Version``
       - The value of the :ref:`"version" property of the service <service>`.
 

--- a/docs/source-1.0/spec/aws/aws-restjson1-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-restjson1-protocol.rst
@@ -316,7 +316,7 @@ is contained. New server-side protocol implementations MUST use a header field
 named ``X-Amzn-Errortype``. Clients MUST accept any one of the following: an
 additional header with the name ``X-Amzn-Errortype``, a body field with the
 name ``__type``, or a body field named ``code``. The value of this component
-SHOULD contain only the :token:`shape name <smithy:identifier>` of the error's
+SHOULD contain only the :token:`shape name <smithy:Identifier>` of the error's
 :ref:`shape-id`.
 
 Legacy server-side protocol implementations sometimes include additional

--- a/docs/source-1.0/spec/aws/aws-restxml-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-restxml-protocol.rst
@@ -261,7 +261,7 @@ contains the serialized error structure members, unless bound to another
 location with HTTP protocol bindings.
 
 Serialized error shapes MUST also contain an additional child element ``Code``
-that contains only the :token:`shape name <smithy:identifier>` of the error's
+that contains only the :token:`shape name <smithy:Identifier>` of the error's
 :ref:`shape-id`. This can be used to distinguish which specific error has been
 serialized in the response.
 
@@ -295,7 +295,7 @@ Error responses contain the following nested elements:
 * ``Error``: A container for the encountered error.
 * ``Type``: One of "Sender" or "Receiver"; whomever is at fault from the
   service perspective.
-* ``Code``: The :token:`shape name <smithy:identifier>` of the error's
+* ``Code``: The :token:`shape name <smithy:Identifier>` of the error's
   :ref:`shape-id`.
 * ``RequestId``: Contains a unique identifier for the associated request.
 

--- a/docs/source-1.0/spec/core/behavior-traits.rst
+++ b/docs/source-1.0/spec/core/behavior-traits.rst
@@ -325,7 +325,7 @@ member in the previously referenced structure. Paths MUST adhere to the
 following ABNF.
 
 .. productionlist:: smithy
-    path    :`identifier` *("." `identifier`)
+    path    :`Identifier` *("." `Identifier`)
 
 The following example defines a paginated operation which uses a result
 wrapper where the output token and items are referenced by paths.

--- a/docs/source-1.0/spec/core/json-ast.rst
+++ b/docs/source-1.0/spec/core/json-ast.rst
@@ -312,7 +312,7 @@ one member, and a structure shape MAY omit the ``members`` property
 entirely if the structure contains no members.
 
 Structure and union member names MUST be case-insensitively unique across the
-entire set of members. Each member name MUST adhere to the :token:`smithy:identifier`
+entire set of members. Each member name MUST adhere to the :token:`smithy:Identifier`
 ABNF grammar.
 
 The following example defines a structure with one required and one optional
@@ -403,7 +403,7 @@ shapes defined in JSON support the same properties as the Smithy IDL.
       - map of :ref:`shape ID <shape-id>` to trait values
       - Traits to apply to the service
     * - rename
-      - map of :ref:`shape ID <shape-id>` to ``string`` :token:`smithy:identifier`
+      - map of :ref:`shape ID <shape-id>` to ``string`` :token:`smithy:Identifier`
       - Disambiguates shape name conflicts in the
         :ref:`service closure <service-closure>`.
 

--- a/docs/source-1.0/spec/core/model-validation.rst
+++ b/docs/source-1.0/spec/core/model-validation.rst
@@ -445,7 +445,7 @@ Message templates
 -----------------
 
 A ``messageTemplate`` is used to create more granular error messages. The
-template consists of literal spans and :token:`selector context value <selectors:selector_context_value>`
+template consists of literal spans and :token:`selector context value <selectors:SelectorContextValue>`
 templates (for example, ``@{id}``). A selector context value MAY be escaped
 by placing a ``@`` before a ``@`` character (for example, ``@@`` expands to
 ``@``). ``@`` characters in the message template that are not escaped MUST

--- a/docs/source-1.0/spec/core/model.rst
+++ b/docs/source-1.0/spec/core/model.rst
@@ -220,14 +220,14 @@ Namespace
     model file, while the JSON AST representation supports zero or more
     namespaces per model file.
 Absolute shape ID
-    An :dfn:`absolute shape ID` starts with a :token:`smithy:namespace` name,
+    An :dfn:`absolute shape ID` starts with a :token:`smithy:Namespace` name,
     followed by "``#``", followed by a *relative shape ID*. All shape
     IDs in the semantic model MUST be absolute.
     For example, ``smithy.example#Foo`` and ``smithy.example#Foo$bar``
     are absolute shape IDs.
 Relative shape ID
-    A :dfn:`relative shape ID` contains a :token:`shape name <smithy:identifier>`
-    and an optional :token:`member name <smithy:identifier>`. The shape name and
+    A :dfn:`relative shape ID` contains a :token:`shape name <smithy:Identifier>`
+    and an optional :token:`member name <smithy:Identifier>`. The shape name and
     member name are separated by the "``$``" symbol if a member name is
     present. For example, ``Foo`` and ``Foo$bar`` are relative shape IDs.
 Root shape ID
@@ -239,14 +239,14 @@ Root shape ID
 Shape IDs are formally defined by the following ABNF:
 
 .. productionlist:: smithy
-    shape_id               :`root_shape_id` [`shape_id_member`]
-    root_shape_id          :`absolute_root_shape_id` / `identifier`
-    absolute_root_shape_id :`namespace` "#" `identifier`
-    namespace              :`identifier` *("." `identifier`)
-    identifier             :identifier_start *identifier_chars
-    identifier_start       :*"_" ALPHA
-    identifier_chars       :ALPHA / DIGIT / "_"
-    shape_id_member        :"$" `identifier`
+    ShapeId              :`RootShapeId` [`ShapeIdMember`]
+    RootShapeId          :`AbsoluteRootShapeId` / `Identifier`
+    AbsoluteRootShapeId  :`Namespace` "#" `Identifier`
+    Namespace            :`Identifier` *("." `Identifier`)
+    Identifier           :`IdentifierStart` *`IdentifierChars`
+    IdentifierStart      :*"_" ALPHA
+    IdentifierChars      :ALPHA / DIGIT / "_"
+    ShapeIdMember        :"$" `Identifier`
 
 .. rubric:: Best practices for defining shape names
 
@@ -1134,7 +1134,7 @@ The service shape supports the following properties:
         contained in the service, and map values are the disambiguated shape
         names to use in the context of the service. Each given shape ID MUST
         reference a shape contained in the closure of the service. Each given
-        map value MUST match the :token:`smithy:identifier` production used for
+        map value MUST match the :token:`smithy:Identifier` production used for
         shape IDs. Renaming a shape *does not* give the shape a new shape ID.
 
         * No renamed shape name can case-insensitively match any other renamed
@@ -2209,7 +2209,7 @@ An instance of a trait applied to a shape is called an *applied trait*. Only
 a single instance of a trait can be applied to a shape. The way in which a
 trait is applied to a shape depends on the model file representation.
 
-Traits are applied to shapes in the IDL using :token:`smithy:trait_statements` that
+Traits are applied to shapes in the IDL using :token:`smithy:TraitStatements` that
 immediately precede a shape. The following example applies the
 :ref:`length-trait` and :ref:`documentation-trait` to ``MyString``:
 
@@ -2261,7 +2261,7 @@ Applying traits externally
 
 Both the IDL and JSON AST model representations allow traits to be applied
 to shapes outside of a shape's definition. This is done using an
-:token:`apply <smithy:apply_statement>` statement in the IDL, or the
+:token:`apply <smithy:ApplyStatement>` statement in the IDL, or the
 :ref:`apply <ast-apply>` type in the JSON AST. For example, this can be
 useful to allow different teams within the same organization to independently
 own different facets of a model; a service team could own the model that
@@ -2370,7 +2370,7 @@ Trait node values
 The value provided for a trait MUST be compatible with the ``shape`` of the
 trait. The following table defines each shape type that is available to
 target from traits and how their values are defined in
-:token:`node <smithy:node_value>` values.
+:token:`node <smithy:NodeValue>` values.
 
 .. list-table::
     :header-rows: 1

--- a/docs/source-1.0/spec/core/selectors.rst
+++ b/docs/source-1.0/spec/core/selectors.rst
@@ -172,7 +172,7 @@ contains a non-empty ``tags`` list.
 Attribute comparison
 --------------------
 
-An attribute selector with a :token:`comparator <selectors:selector_comparator>`
+An attribute selector with a :token:`comparator <selectors:SelectorComparator>`
 checks for the existence of an attribute and compares the resolved
 attribute value to a comma separated list of possible values. The
 resolved attribute value on the left hand side of the comparator MUST
@@ -191,7 +191,7 @@ There are three kinds of comparators:
 String comparators
 ------------------
 
-:token:`String comparators <selectors:selector_string_comparator>` are used to compare
+:token:`String comparators <selectors:SelectorStringComparator>` are used to compare
 the string representation of values. Attributes that do not have a string
 representation are treated as an empty string when these comparisons are
 performed.
@@ -288,7 +288,7 @@ Numeric comparators
 -------------------
 
 Relative comparators only match if both values being compared contain valid
-:token:`smithy:number` productions when converted to a string.
+:token:`smithy:Number` productions when converted to a string.
 
 .. list-table::
     :header-rows: 1
@@ -396,7 +396,7 @@ The ``id`` attribute can be used as an object, and it supports the
 following properties.
 
 ``namespace``
-    Gets the :token:`smithy:namespace` part of a shape ID.
+    Gets the :token:`smithy:Namespace` part of a shape ID.
 
     The following selector matches shapes in the ``foo.baz`` namespace:
 
@@ -548,7 +548,7 @@ to a shape. The ``trait`` attribute supports the following properties:
 
         [trait|deprecated]
 
-    Traits are converted to their serialized :token:`node <smithy:node_value>` form
+    Traits are converted to their serialized :token:`node <smithy:NodeValue>` form
     when matching against their values. Only string, boolean, and numeric
     values can be compared using a :ref:`string comparator <string-comparators>`.
     Boolean values are converted to "true" or "false". Numeric values are
@@ -874,7 +874,7 @@ the comparator are projections.
 Scoped attribute selectors
 ==========================
 
-A :token:`scoped attribute selector <selectors:selector_scoped_attr>` is similar to an
+A :token:`scoped attribute selector <selectors:SelectorScopedAttr>` is similar to an
 attribute selector, but it allows multiple complex comparisons to be made
 against a scoped attribute.
 
@@ -884,8 +884,8 @@ Context values
 
 The first part of a scoped attribute selector is the attribute that is scoped
 for the expression, followed by ``:``. The scoped attribute is accessed using
-a :token:`context value <selectors:selector_context_value>` in the form of
-``@{`` :token:`smithy:identifier` ``}``.
+a :token:`context value <selectors:SelectorContextValue>` in the form of
+``@{`` :token:`smithy:Identifier` ``}``.
 
 In the following selector, the ``trait|range`` attribute is used as the scoped
 attribute of the expression, and the selector matches shapes marked with
@@ -997,7 +997,7 @@ a shape.
 Forward undirected neighbor
 ----------------------------
 
-A :token:`forward undirected neighbor <selectors:selector_forward_undirected_neighbor>`
+A :token:`forward undirected neighbor <selectors:SelectorForwardUndirectedNeighbor>`
 (``>``) yields every shape that is connected to the current shape. For
 example, the following selector matches the key and value members of
 every map:
@@ -1026,7 +1026,7 @@ relationships of each operation:
 
     operation > *
 
-A forward directed edge traversal is applied using :token:`selectors:selector_forward_directed_neighbor`
+A forward directed edge traversal is applied using :token:`selectors:SelectorForwardDirectedNeighbor`
 (``-[X, Y, Z]->``). The following selector matches all structure shapes
 referenced as operation ``input`` or ``output``.
 
@@ -1482,7 +1482,7 @@ results that are computed multiples times in a selector or for capturing
 information about the current shape that is referenced later in a selector
 after traversing neighbors.
 
-A variable is set using a :token:`selectors:selector_variable_set` expression.
+A variable is set using a :token:`selectors:SelectorVariableSet` expression.
 Variables can be reassigned without error.
 
 The following selector defines a variable named ``foo`` that sets the
@@ -1492,7 +1492,7 @@ variable to the result of applying the ``*`` selector to the current shape.
 
     $foo(*)
 
-A variable is retrieved by name using a :token:`selectors:selector_variable_get`
+A variable is retrieved by name using a :token:`selectors:SelectorVariableGet`
 expression. Retrieving a variable yields the set of shapes stored in the
 variable. Attempting to get a variable that does not exist yields no shapes.
 
@@ -1596,55 +1596,55 @@ Selectors are defined by the following ABNF_ grammar.
    changing the semantics of a selector.
 
 .. productionlist:: selectors
-    selector                             :`selector_expression` *(`selector_expression`)
-    selector_expression                  :`selector_shape_types`
-                                         :/ `selector_attr`
-                                         :/ `selector_scoped_attr`
-                                         :/ `selector_function`
-                                         :/ `selector_forward_undirected_neighbor`
-                                         :/ `selector_reverse_undirected_neighbor`
-                                         :/ `selector_forward_directed_neighbor`
-                                         :/ `selector_reverse_directed_neighbor`
-                                         :/ `selector_forward_recursive_neighbor`
-                                         :/ `selector_variable_set`
-                                         :/ `selector_variable_get`
-    selector_shape_types                 :"*" / `smithy:identifier`
-    selector_forward_undirected_neighbor :">"
-    selector_reverse_undirected_neighbor :"<"
-    selector_forward_directed_neighbor   :"-[" `selector_directed_relationships` "]->"
-    selector_reverse_directed_neighbor   :"<-[" selector_directed_relationships "]-"
-    selector_directed_relationships      :`smithy:identifier` *("," `smithy:identifier`)
-    selector_forward_recursive_neighbor  :"~>"
-    selector_attr                        :"[" `selector_key` [selector_attr_comparison] "]"
-    selector_attr_comparison             :`selector_comparator` `selector_attr_values` ["i"]
-    selector_key                         :`smithy:identifier` ["|" `selector_path`]
-    selector_path                        :`selector_path_segment` *("|" `selector_path_segment`)
-    selector_path_segment                :`selector_value` / `selector_function_property`
-    selector_value                       :`selector_text` / `smithy:number` / `smithy:root_shape_id`
-    selector_function_property           :"(" `smithy:identifier` ")"
-    selector_attr_values                 :`selector_value` *("," `selector_value`)
-    selector_comparator                  :`selector_string_comparator`
-                                         :/ `selector_numeric_comparator`
-                                         :/ `selector_projection_comparator`
-    selector_string_comparator           :"^=" / "$=" / "*=" / "!=" / "=" / "?="
-    selector_numeric_comparator          :">=" / ">" / "<=" / "<"
-    selector_projection_comparator       :"{=}" / "{!=}" / "{<}" / "{<<}"
-    selector_absolute_root_shape_id      :`smithy:namespace` "#" `smithy:identifier`
-    selector_scoped_attr                 :"[@" [`selector_key`] ":" `selector_scoped_assertions` "]"
-    selector_scoped_assertions           :`selector_scoped_assertion` *("&&" `selector_scoped_assertion`)
-    selector_scoped_assertion            :`selector_scoped_value` `selector_comparator` `selector_scoped_values` ["i"]
-    selector_scoped_value                :`selector_value` / `selector_context_value`
-    selector_context_value               :"@{" `selector_path` "}"
-    selector_scoped_values               :`selector_scoped_value` *("," `selector_scoped_value`)
-    selector_function                    :":" `smithy:identifier` "(" `selector_function_args` ")"
-    selector_function_args               :`selector` *("," `selector`)
-    selector_text                        :`selector_single_quoted_text` / `selector_double_quoted_text`
-    selector_single_quoted_text          :"'" 1*`selector_single_quoted_char` "'"
-    selector_double_quoted_text          :DQUOTE 1*`selector_double_quoted_char` DQUOTE
-    selector_single_quoted_char          :%x20-26 / %x28-5B / %x5D-10FFFF ; Excludes (')
-    selector_double_quoted_char          :%x20-21 / %x23-5B / %x5D-10FFFF ; Excludes (")
-    selector_variable_set                :"$" `smithy:identifier` "(" selector ")"
-    selector_variable_get                :"${" `smithy:identifier` "}"
+    Selector                           :`SelectorExpression` *(`SelectorExpression`)
+    SelectorExpression                 :`SelectorShapeTypes`
+                                       :/ `SelectorAttr`
+                                       :/ `SelectorScopedAttr`
+                                       :/ `SelectorFunction`
+                                       :/ `SelectorForwardUndirectedNeighbor`
+                                       :/ `SelectorReverseUndirectedNeighbor`
+                                       :/ `SelectorForwardDirectedNeighbor`
+                                       :/ `SelectorForwardRecursiveNeighbor`
+                                       :/ `SelectorReverseDirectedNeighbor`
+                                       :/ `SelectorVariableSet`
+                                       :/ `SelectorVariableGet`
+    SelectorShapeTypes                 :"*" / `smithy:Identifier`
+    SelectorForwardUndirectedNeighbor  :">"
+    SelectorReverseUndirectedNeighbor  :"<"
+    SelectorForwardDirectedNeighbor    :"-[" `SelectorDirectedRelationships` "]->"
+    SelectorReverseDirectedNeighbor    :"<-[" `SelectorDirectedRelationships` "]-"
+    SelectorDirectedRelationships      :`smithy:Identifier` *("," `smithy:Identifier`)
+    SelectorForwardRecursiveNeighbor   :"~>"
+    SelectorAttr                       :"[" `SelectorKey` [`SelectorAttrComparison`] "]"
+    SelectorAttrComparison             :`SelectorComparator` `SelectorAttrValues` ["i"]
+    SelectorKey                        :`smithy:Identifier` ["|" `SelectorPath`]
+    SelectorPath                       :`SelectorPathSegment` *("|" `SelectorPathSegment`)
+    SelectorPathSegment                :`SelectorValue` / `SelectorFunctionProperty`
+    SelectorValue                      :`SelectorText` / `smithy:Number` / `smithy:RootShapeId`
+    SelectorFunctionProperty           :"(" `smithy:Identifier` ")"
+    SelectorAttrValues                 :`SelectorValue` *("," `SelectorValue`)
+    SelectorComparator                 :`SelectorStringComparator`
+                                       :/ `SelectorNumericComparator`
+                                       :/ `SelectorProjectionComparator`
+    SelectorStringComparator           :"^=" / "$=" / "*=" / "!=" / "=" / "?="
+    SelectorNumericComparator          :">=" / ">" / "<=" / "<"
+    SelectorProjectionComparator       :"{=}" / "{!=}" / "{<}" / "{<<}"
+    SelectorAbsoluteRootShapeId        :`smithy:Namespace` "#" `smithy:Identifier`
+    SelectorScopedAttr                 :"[@" [`SelectorKey`] ":" `SelectorScopedAssertions` "]"
+    SelectorScopedAssertions           :`SelectorScopedAssertion` *("&&" `SelectorScopedAssertion`)
+    SelectorScopedAssertion            :`SelectorScopedValue` `SelectorComparator` `SelectorScopedValues` ["i"]
+    SelectorScopedValue                :`SelectorValue` / `SelectorContextValue`
+    SelectorContextValue               :"@{" `SelectorPath` "}"
+    SelectorScopedValues               :`SelectorScopedValue` *("," `SelectorScopedValue`)
+    SelectorFunction                   :":" `smithy:Identifier` "(" `SelectorFunctionArgs` ")"
+    SelectorFunctionArgs               :`Selector` *("," `Selector`)
+    SelectorText                       :`SelectorSingleQuotedText` / `SelectorDoubleQuotedText`
+    SelectorSingleQuotedText           :"'" 1*`SelectorSingleQuotedChar` "'"
+    SelectorDoubleQuotedText           :DQUOTE 1*`SelectorDoubleQuotedChar` DQUOTE
+    SelectorSingleQuotedChar           :%x20-26 / %x28-5B / %x5D-10FFFF ; Excludes (')
+    SelectorDoubleQuotedChar           :%x20-21 / %x23-5B / %x5D-10FFFF ; Excludes (")
+    SelectorVariableSet                :"$" `smithy:Identifier` "(" `Selector` ")"
+    SelectorVariableGet                :"${" `smithy:Identifier` "}"
 
 .. _ABNF: https://tools.ietf.org/html/rfc5234
 .. _set: https://en.wikipedia.org/wiki/Set_(abstract_data_type)

--- a/docs/source-1.0/spec/core/xml-traits.rst
+++ b/docs/source-1.0/spec/core/xml-traits.rst
@@ -862,11 +862,11 @@ Trait selector
 
     *A structure, union, or member*
 Value type
-    ``string`` value that MUST adhere to the :token:`smithy:xml_name` ABNF production:
+    ``string`` value that MUST adhere to the :token:`smithy:XmlName` ABNF production:
 
     .. productionlist:: smithy
-        xml_name       :xml_identifier / (xml_identifier ":" xml_identifier)
-        xml_identifier :(ALPHA / "_") *(ALPHA / DIGIT / "-" / "_")
+        XmlName       :`XmlIdentifier` / (`XmlIdentifier` ":" `XmlIdentifier`)
+        XmlIdentifier :(ALPHA / "_") *(ALPHA / DIGIT / "-" / "_")
 
 By default, structure properties are serialized in attributes or nested
 elements using the same name as the structure member name. Given the following:
@@ -966,7 +966,7 @@ The ``xmlNamespace`` trait is a structure that contains the following members:
       - ``string`` value
       - The `namespace prefix`_ for elements from this namespace. Values
         provides for ``prefix`` property MUST adhere to the
-        :token:`smithy:xml_identifier` production.
+        :token:`smithy:XmlIdentifier` production.
 
 Given the following:
 

--- a/docs/source-1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source-1.0/spec/http-protocol-compliance-tests.rst
@@ -90,7 +90,7 @@ that support the following members:
       - **Required**. The identifier of the test case. This identifier can
         be used by protocol test implementations to filter out unsupported
         test cases by ID, to generate test case names, etc. The provided
-        ``id`` MUST match Smithy's :token:`smithy:identifier` ABNF. No two
+        ``id`` MUST match Smithy's :token:`smithy:Identifier` ABNF. No two
         ``httpRequestTests`` test cases can share the same ID.
     * - protocol
       - shape ID
@@ -344,7 +344,7 @@ structures that support the following members:
       - **Required**. The identifier of the test case. This identifier can
         be used by protocol test implementations to filter out unsupported
         test cases by ID, to generate test case names, etc. The provided
-        ``id`` MUST match Smithy's :token:`smithy:identifier` ABNF. No two
+        ``id`` MUST match Smithy's :token:`smithy:Identifier` ABNF. No two
         ``httpResponseTests`` test cases can share the same ID.
     * - protocol
       - ``string``
@@ -594,7 +594,7 @@ The ``httpMalformedRequestTests`` trait is a list of
       - **Required**. The identifier of the test case. This identifier can
         be used by protocol test implementations to filter out unsupported
         test cases by ID, to generate test case names, etc. The provided
-        ``id`` MUST match Smithy's :token:`smithy:identifier` ABNF. No two
+        ``id`` MUST match Smithy's :token:`smithy:Identifier` ABNF. No two
         ``httpMalformedRequestTests`` test cases can share the same ID.
     * - protocol
       - shape ID

--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -50,7 +50,7 @@ The following example defines a model file with each section:
     .. code-block:: smithy
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "metadata": {
                 "foo": "bar"
             },
@@ -193,13 +193,13 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     ValueAssignment         :*`SP` "=" *`SP` `NodeValue` `BR`
     ListStatement           :%s"list" `SP` `Identifier` [`Mixins`] *`WS` `ListMembers`
     ListMembers             :"{" *`WS` `ListMember` *`WS` "}"
-    ListMember              :[TraitStatements] (`ElidedListMember` / `ExplicitListMember`)
+    ListMember              :`TraitStatements` (`ElidedListMember` / `ExplicitListMember`)
     ElidedListMember        :%s"$member"
     ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] *`WS` `MapMembers`
     MapMembers              :"{" *`WS` `MapKey` `BR` `MapValue` *`WS` "}"
-    MapKey                  :[TraitStatements] (`ElidedMapKey` / `ExplicitMapKey`)
-    MapValue                :[TraitStatements] (`ElidedMapValue` / `ExplicitMapValue`)
+    MapKey                  :`TraitStatements` (`ElidedMapKey` / `ExplicitMapKey`)
+    MapValue                :`TraitStatements` (`ElidedMapValue` / `ExplicitMapValue`)
     ElidedMapKey            :%s"$key"
     ExplicitMapKey          :%s"key" *`SP` ":" *`SP` `ShapeId`
     ElidedMapValue          :%s"$value"
@@ -282,8 +282,9 @@ The :token:`control section <smithy:ControlSection>` of a model contains
 :token:`control statements <smithy:ControlStatement>` that apply parser directives
 to a *specific IDL file*. Because control statements influence parsing, they
 MUST appear at the beginning of a file before any other statements and have
-no effect on the :ref:`semantic model <semantic-model>` The following control
-statements are currently supported:
+no effect on the :ref:`semantic model <semantic-model>`.
+
+The following control statements are currently supported:
 
 .. list-table::
     :header-rows: 1
@@ -315,7 +316,7 @@ Version statement
 
 The Smithy specification is versioned using a ``major`` . ``minor``
 versioning scheme. A version requirement is specified for a model file using
-the ``$version`` control statement. When no version Number is specified in
+the ``$version`` control statement. When no version number is specified in
 the IDL, an implementation SHOULD assume that the model can be loaded.
 Because this can lead to unexpected parsing errors, models SHOULD always
 include a version.
@@ -345,21 +346,21 @@ support a version greater than or equal to ``2.0`` and less than ``3.0``:
 
 A minor version SHOULD be provided when a model depends on a feature released
 in a minor update of the specification. The following example sets the
-version requirement of a file to ``2.0``, meaning that tooling MUST support a
-version greater than or equal to ``2.0`` and less than ``3.0``:
+version requirement of a file to ``2.1``, meaning that tooling MUST support a
+version greater than or equal to ``2.1`` and less than ``3.0``:
 
 .. tab:: Smithy
 
     .. code-block:: smithy
 
-        $version: "2.0"
+        $version: "2.1"
 
 .. tab:: JSON
 
     .. code-block:: json
 
         {
-            "smithy": "2.0"
+            "smithy": "2.1"
         }
 
 .. rubric:: Version compatibility
@@ -395,7 +396,7 @@ The following example defines metadata in the model:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "metadata": {
                 "greeting": "hello",
                 "stringList": ["a", "b", "c"]
@@ -437,7 +438,7 @@ The following example defines a string shape named ``MyString`` in the
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyString": {
                     "type": "string"
@@ -589,7 +590,7 @@ The above model is equivalent to the following JSON AST model:
 .. code-block:: json
 
     {
-        "smithy": "2.0",
+        "smithy": "2",
         "shapes": {
             "smithy.example#MyList": {
                 "type": "list",
@@ -623,7 +624,7 @@ The above example is equivalent to the following incorrect JSON AST:
 .. code-block:: json
 
     {
-        "smithy": "2.0",
+        "smithy": "2",
         "shapes": {
             "smithy.example#Error": {
                 "type": "structure",
@@ -656,7 +657,7 @@ The above example is equivalent to the following JSON AST:
 .. code-block:: json
 
     {
-        "smithy": "2.0",
+        "smithy": "2",
         "metadata": {
             "String": "smithy.api#String"
         }
@@ -712,7 +713,7 @@ The following example defines a ``string`` shape:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#String": {
                     "type": "string"
@@ -737,7 +738,7 @@ The following example defines an ``integer`` shape with a :ref:`range-trait`:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MaxResults": {
                     "type": "integer",
@@ -889,7 +890,7 @@ The following example defines a list with a string member from the
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyList": {
                     "type": "list",
@@ -920,7 +921,7 @@ Traits can be applied to the list shape and its member:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyList": {
                     "type": "list",
@@ -970,7 +971,7 @@ The following example defines a map of strings to integers:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "type": "map",
                 "smithy.example#IntegerMap": {
@@ -1007,7 +1008,7 @@ Traits can be applied to the map shape and its members:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#IntegerMap": {
                     "type": "map",
@@ -1067,7 +1068,7 @@ The following example defines a structure with two members:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyStructure": {
                     "type": "structure",
@@ -1108,7 +1109,7 @@ Traits can be applied to structure members:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyStructure": {
                     "type": "structure",
@@ -1184,7 +1185,7 @@ The following example defines a union shape with several members:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyUnion": {
                     "type": "union",
@@ -1238,7 +1239,7 @@ a resource named ``Model`` and an operation named ``PingService``:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#ModelRepository": {
                     "type": "service",
@@ -1288,7 +1289,7 @@ can potentially return the ``Unavailable`` or ``BadRequest``
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#PingService": {
                     "type": "operation",
@@ -1445,7 +1446,7 @@ and defines a :ref:`read <read-lifecycle>` operation:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#Sprocket": {
                     "type": "resource",
@@ -1633,7 +1634,7 @@ is equivalent to the following JSON AST model:
 .. code-block:: json
 
     {
-        "smithy": "2.0",
+        "smithy": "2",
         "shapes": {
             "smithy.example#MyString": {
                 "type": "string",
@@ -1714,7 +1715,7 @@ The following example applies the :ref:`length-trait` and
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyString": {
                     "type": "string",
@@ -1803,7 +1804,7 @@ The following applications of the ``foo`` trait are equivalent:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#foo": {
                     "type": "structure",
@@ -1876,7 +1877,7 @@ The following example applies the :ref:`documentation-trait` to the
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyString": {
                     "type": "apply",
@@ -1908,7 +1909,7 @@ and :ref:`length-trait` to the ``smithy.example#MyString`` shape:
     .. code-block:: json
 
         {
-            "smithy": "2.0",
+            "smithy": "2",
             "shapes": {
                 "smithy.example#MyString": {
                     "type": "apply",
@@ -2005,7 +2006,7 @@ The following examples define objects with zero, one, and two key value pairs:
 .. rubric:: Number node
 
 A node :token:`smithy:Number` contains numeric data. It is defined like a JSON
-Number. The following examples define several ``Number`` values:
+number. The following examples define several ``Number`` values:
 
 * ``0``
 * ``0.0``
@@ -2184,7 +2185,7 @@ incidental whitespace using the following algorithm:
        ["    Foo", "        Baz", "", "  ", "    Bar", "    "]
 
 2. Compute the *common whitespace prefix* by iterating over each line,
-   counting the Number of leading spaces (" ") and taking the minimum count.
+   counting the number of leading spaces (" ") and taking the minimum count.
    Except for the last line of content, lines that are empty or consist wholly
    of whitespace are not considered. If the last line of content (that is, the
    line that contains the closing delimiter) appears on its own line, then

--- a/docs/source-2.0/spec/protocol-traits.rst
+++ b/docs/source-2.0/spec/protocol-traits.rst
@@ -897,11 +897,11 @@ Trait selector
 
     *A structure, union, or member*
 Value type
-    ``string`` value that MUST adhere to the :token:`smithy:xml_name` ABNF production:
+    ``string`` value that MUST adhere to the :token:`smithy:XmlName` ABNF production:
 
     .. productionlist:: smithy
-        xml_name       :xml_identifier / (xml_identifier ":" xml_identifier)
-        xml_identifier :(ALPHA / "_") *(ALPHA / DIGIT / "-" / "_")
+        XmlName       :`XmlIdentifier` / (`XmlIdentifier`` ":" `XmlIdentifier``)
+        XmlIdentifier :(ALPHA / "_") *(ALPHA / DIGIT / "-" / "_")
 
 By default, structure properties are serialized in attributes or nested
 elements using the same name as the structure member name. Given the following:
@@ -976,7 +976,7 @@ The ``xmlNamespace`` trait is a structure that contains the following members:
       - ``string`` value
       - The `namespace prefix`_ for elements from this namespace. Values
         provides for ``prefix`` property MUST adhere to the
-        :token:`smithy:xml_identifier` production.
+        :token:`smithy:XmlIdentifier` production.
 
 Given the following:
 

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -1629,10 +1629,10 @@ Selectors are defined by the following ABNF_ grammar.
     SelectorForwardUndirectedNeighbor  :">"
     SelectorReverseUndirectedNeighbor  :"<"
     SelectorForwardDirectedNeighbor    :"-[" `SelectorDirectedRelationships` "]->"
-    SelectorReverseDirectedNeighbor    :"<-[" SelectorDirectedRelationships "]-"
+    SelectorReverseDirectedNeighbor    :"<-[" `SelectorDirectedRelationships` "]-"
     SelectorDirectedRelationships      :`smithy:Identifier` *("," `smithy:Identifier`)
     SelectorForwardRecursiveNeighbor   :"~>"
-    SelectorAttr                       :"[" `SelectorKey` [SelectorAttrComparison] "]"
+    SelectorAttr                       :"[" `SelectorKey` [`SelectorAttrComparison`] "]"
     SelectorAttrComparison             :`SelectorComparator` `SelectorAttrValues` ["i"]
     SelectorKey                        :`smithy:Identifier` ["|" `SelectorPath`]
     SelectorPath                       :`SelectorPathSegment` *("|" `SelectorPathSegment`)
@@ -1660,7 +1660,7 @@ Selectors are defined by the following ABNF_ grammar.
     SelectorDoubleQuotedText           :DQUOTE 1*`SelectorDoubleQuotedChar` DQUOTE
     SelectorSingleQuotedChar           :%x20-26 / %x28-5B / %x5D-10FFFF ; Excludes (')
     SelectorDoubleQuotedChar           :%x20-21 / %x23-5B / %x5D-10FFFF ; Excludes (")
-    SelectorVariableSet                :"$" `smithy:Identifier` "(" selector ")"
+    SelectorVariableSet                :"$" `smithy:Identifier` "(" `Selector` ")"
     SelectorVariableGet                :"${" `smithy:Identifier` "}"
 
 .. _ABNF: https://tools.ietf.org/html/rfc5234


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Update Smithy IDL ABNF Docs:

- Smithy 1.0: Update all ABNF to match ABNF RFC
- Smithy 2.0: Update IDL ABNF, XmlName ABNF, and minor doc fixes

---

*Testing:*

Ran `make clean html`, no warnings / errors.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.