### PR TITLE
Filter out synthetic traits before turning those into LoadOperations

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderShapeMap.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderShapeMap.java
@@ -138,15 +138,22 @@ final class LoaderShapeMap {
                 operation.addModifier(new ApplyMixin(mixin));
             }
             builder.clearMixins();
-            // Remove traits from the shape and members and send them through the merging logic of loader.
-            shape.getIntroducedTraits().values()
-                    .forEach(trait -> processor.accept(LoadOperation.ApplyTrait.from(shape.getId(), trait)));
+            // Remove traits from the shape and members and send them through the merging logic of loader
+            // filtering out the synthetic ones to avoid attempting to reparse them.
+            for (Trait trait : shape.getIntroducedTraits().values()) {
+                if (!trait.isSynthetic()) {
+                    processor.accept(LoadOperation.ApplyTrait.from(shape.getId(), trait));
+                }
+            }
             builder.clearTraits();
             // Clear out member mixins and traits, and register the newly created builders.
             for (MemberShape member : shape.members()) {
                 MemberShape.Builder memberBuilder = member.toBuilder();
-                member.getIntroducedTraits().values()
-                        .forEach(trait -> processor.accept(LoadOperation.ApplyTrait.from(member.getId(), trait)));
+                for (Trait trait : member.getIntroducedTraits().values()) {
+                    if (!trait.isSynthetic()) {
+                        processor.accept(LoadOperation.ApplyTrait.from(member.getId(), trait));
+                    }
+                }
                 memberBuilder.clearTraits().clearMixins();
                 operation.addMember(memberBuilder);
             }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -694,6 +694,24 @@ public class ModelAssemblerTest {
                    equalTo(originalId));
     }
 
+    // Synthetic traits should not be parsed again. That will cause a
+    // failure, for instance, if we import a 1.0 model that has @enum
+    // traits. If we try to reparse them this will fail with an error
+    // Unable to resolve trait `smithy.synthetic#enum`
+    @Test
+    public void doesNotReParsesSyntheticTraits() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("does-not-reparses-synthetic-traits.smithy"))
+                .assemble()
+                .unwrap();
+
+        Model.assembler()
+                .addModel(model)
+                .addUnparsedModel("foo.smithy", "namespace smithy.example\napply Foo @sensitive\n")
+                .assemble()
+                .unwrap();
+    }
+
     @Test
     public void resetDoesNotBarf() {
         ModelAssembler assembler = new ModelAssembler();

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/does-not-reparses-synthetic-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/does-not-reparses-synthetic-traits.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace smithy.example
+
+enum Foo {
+    HI
+}


### PR DESCRIPTION
*Description of changes:*

Synthetic traits should not be parsed again. That will cause a failure, for instance, if we import a 1.0 model that has @enum traits. If we try to reparse them this will fail with an error

```
Unable to resolve trait `smithy.synthetic#enum`
```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
