### PR TITLE
Fix MalformedAcceptWithGenericString

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-accept.smithy
@@ -100,10 +100,10 @@ structure MalformedAcceptWithPayloadOutput {
 @suppress(["UnstableTrait"])
 @http(method: "POST", uri: "/MalformedAcceptWithGenericString")
 operation MalformedAcceptWithGenericString {
-    input: MalformedAcceptWithGenericStringInput
+    output: MalformedAcceptWithGenericStringOutput
 }
 
-structure MalformedAcceptWithGenericStringInput {
+structure MalformedAcceptWithGenericStringOutput {
     @httpPayload
     payload: String
 }


### PR DESCRIPTION
The test had incorrectly specified `input` with `@httpPayload` when it should
have been `output`, similar to MalformedAcceptWithPayload.

The test was last updated in https://github.com/awslabs/smithy/pull/1243 which is causing failure in TS SSDK for this test when upgrading TS codegen to use latest Smithy. With this change, TS SSDK succeeds on this test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
