### PR TITLE
Update PostUnionWithJsonName protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/unions.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/unions.smithy
@@ -523,7 +523,6 @@ operation PostUnionWithJsonName {
 
 @input
 structure PostUnionWithJsonNameInput {
-    @required
     value: UnionWithJsonName
 }
 


### PR DESCRIPTION
Without this, TypeScript SSDK was failing
PostUnionWithJsonNameResponse*:ServerResponse tests [because the generated tests
use a request with `{}`](https://github.com/awslabs/smithy-typescript/blob/ac8fb3f406807bfd14a8f7be8d938377bde36189/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java#L731-L737) but that fails the validation logic since a member was
marked required. So removing the required trait from the input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
