### PR TITLE
Fix issue where we emitted events twice

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -932,4 +932,20 @@ public class ModelAssemblerTest {
                             ShapeId.from("smithy.example#Error5"),
                             ShapeId.from("smithy.example#Error6")));
     }
+
+    @Test
+    public void doesNotEmitWarningsTwice() {
+        List<ValidationEvent> events = new ArrayList<>();
+        Model.assembler()
+                .addUnparsedModel("foo.smithy", "$version: \"1.0\"\n")
+                .validationEventListener(e -> {
+                    if (e.getId().equals(Validator.MODEL_DEPRECATION)) {
+                        events.add(e);
+                    }
+                })
+                .assemble()
+                .unwrap();
+
+        assertThat(events, hasSize(1));
+    }
 }


### PR DESCRIPTION
ModelAssembler event listeners were receiving events twice in some cases,
causing events to appear twice when running the CLI/Gradle/etc.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
