### PR TITLE
Sensitive validator branch

### DIFF
--- a/docs/source-2.0/guides/model-linters.rst
+++ b/docs/source-2.0/guides/model-linters.rst
@@ -129,7 +129,8 @@ This validator scans shape or member names and identifies ones that look like th
 sensitive information but are not marked with the ``@sensitive`` trait. This does not apply to
 shapes where the ``@sensitive`` trait would be invalid. Users may also configure this validator
 with a custom list of terms, and choose to ignore the built-in defaults. The defaults terms include
-categories of personal information such as 'birth day', 'billing address', 'zip code', or 'gender'.
+types of personal information such as 'birth day', 'billing address', 'zip code', or 'gender',
+as well as information that could be maliciously exploited such as  'password', 'secret key', or 'credit card'.
 
 Rationale
     Sensitive information often incurs legal requirements regarding the handling and logging
@@ -169,7 +170,7 @@ Example:
         name: "MissingSensitiveTrait"
         configuration: {
             excludeDefaults: false,
-            terms: ["social security number"]
+            terms: ["home planet"]
         }
     }]
 
@@ -400,7 +401,7 @@ be specified.
 .. _words-boundaries:
 
 Words boundary matching
---------------------------------
+-----------------------
 
 Word boundaries can be used to find terms of interest. Word boundary search
 text consists of one or more alphanumeric words separated by a single

--- a/docs/source-2.0/guides/model-linters.rst
+++ b/docs/source-2.0/guides/model-linters.rst
@@ -128,7 +128,8 @@ MissingSensitiveTrait
 This validator scans shape or member names and identifies ones that look like they could contain
 sensitive information but are not marked with the ``@sensitive`` trait. This does not apply to
 shapes where the ``@sensitive`` trait would be invalid. Users may also configure this validator
-with custom lists of words or phrases, and choose to ignore the built-in defaults.
+with a custom list of terms, and choose to ignore the built-in defaults. The defaults terms include
+categories of personal information such as 'birth day', 'billing address', 'zip code', or 'gender'.
 
 Rationale
     Sensitive information often incurs legal requirements regarding the handling and logging
@@ -146,22 +147,17 @@ Configuration
        * - Property
          - Type
          - Description
-       * - words
+       * - terms
          - [ ``string`` ]
-         - A list of words to either be added to or replace the default
-           words. These are matched to without regards to casing.
-           This property defaults to an empty list.
-       * - phrases
-         - [ ``string`` ]
-         - A list of phrases to either be added to or replace the default
-           phrases. These are matched to without regards to casing or word boundaries.
-           Use this property when trying to match word fragments or multi-words.
-           This property defaults to an empty list.
+         - A list of search terms that match shape or member names
+           case-insensitively based on word boundaries (for example, the term
+           "access key id" matches "AccessKeyId", "access_key_id", and
+           "accesskeyid"). See :ref:`words-boundaries` for details.
        * - excludeDefaults
          - ``boolean``
          - A flag indicating whether or not to disregard the default set
-           of words and phrases. This property is not required and defaults to false.
-           If set to true, either ``words`` or ``phrases`` must be provided.
+           of terms. This property is not required and defaults to false.
+           If set to true, ``terms`` must be provided.
 
 Example:
 
@@ -173,8 +169,7 @@ Example:
         name: "MissingSensitiveTrait"
         configuration: {
             excludeDefaults: false,
-            words: ["confidential"],
-            phrases: ["MyPrivateInfo"]
+            terms: ["social security number"]
         }
     }]
 
@@ -284,7 +279,7 @@ Configuration
           - A list of search terms that match shape or member names
             case-insensitively based on word boundaries (for example, the term
             "access key id" matches "AccessKeyId", "access_key_id", and
-            "accesskeyid"). See :ref:`reserved-words-boundaries` for details.
+            "accesskeyid"). See :ref:`words-boundaries` for details.
         * - selector
           - ``string``
           - Specifies a selector of shapes to validate for this configuration.
@@ -402,12 +397,12 @@ be specified.
       * - **Codename**
         - Match
 
-.. _reserved-words-boundaries:
+.. _words-boundaries:
 
-Reserved words boundary matching
+Words boundary matching
 --------------------------------
 
-Word boundaries can be used to find reserved words. Word boundary search
+Word boundaries can be used to find terms of interest. Word boundary search
 text consists of one or more alphanumeric words separated by a single
 space. When comparing against another string, the contents of the string
 are separated into words based on word boundaries. Those words are
@@ -436,7 +431,7 @@ demonstrates how comparison text is parsed into words.
     * - access_keyID
       - access key id
 
-The following table shows matches for a reserved term of ``secret id``,
+The following table shows matches for a search term of ``secret id``,
 meaning the word "secret" needs to be followed by the word "id". Word
 boundary searches also match if the search terms concatenated together with
 no spaces is considered a word in the search text (for example,

--- a/docs/source-2.0/guides/model-linters.rst
+++ b/docs/source-2.0/guides/model-linters.rst
@@ -120,6 +120,63 @@ Example:
         {name: "CamelCase"}
     ]
 
+.. _MissingSensitiveTrait:
+
+MissingSensitiveTrait
+=====================
+
+This validator scans shape or member names and identifies ones that look like they could contain
+sensitive information but are not marked with the ``@sensitive`` trait. This does not apply to
+shapes where the ``@sensitive`` trait would be invalid. Users may also configure this validator
+with custom lists of words or phrases, and choose to ignore the built-in defaults.
+
+Rationale
+    Sensitive information often incurs legal requirements regarding the handling and logging
+    of it. Mistakenly not marking sensitive data accordingly carries a large risk, and it is
+    helpful to have an automated validator to catch instances of this rather than rely on best efforts.
+
+Default severity
+    ``WARNING``
+
+Configuration
+    .. list-table::
+       :header-rows: 1
+       :widths: 20 20 60
+
+       * - Property
+         - Type
+         - Description
+       * - words
+         - [ ``string`` ]
+         - A list of words to either be added to or replace the default
+           words. These are matched to without regards to casing.
+           This property defaults to an empty list.
+       * - phrases
+         - [ ``string`` ]
+         - A list of phrases to either be added to or replace the default
+           phrases. These are matched to without regards to casing or word boundaries.
+           Use this property when trying to match word fragments or multi-words.
+           This property defaults to an empty list.
+       * - excludeDefaults
+         - ``boolean``
+         - A flag indicating whether or not to disregard the default set
+           of words and phrases. This property is not required and defaults to false.
+           If set to true, either ``words`` or ``phrases`` must be provided.
+
+Example:
+
+.. code-block:: smithy
+
+    $version: "2"
+
+    metadata validators = [{
+        name: "MissingSensitiveTrait"
+        configuration: {
+            excludeDefaults: false,
+            words: ["confidential"],
+            phrases: ["MyPrivateInfo"]
+        }
+    }]
 
 .. _NoninclusiveTerms:
 

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingSensitiveTraitValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingSensitiveTraitValidator.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.linters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationUtils;
+import software.amazon.smithy.model.validation.ValidatorService;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SetUtils;
+
+/**
+ * <p>Validates that shapes and members that possibly contain sensitive data are marked with the sensitive trait.
+ */
+public final class MissingSensitiveTraitValidator extends AbstractValidator {
+    public static final String SENSITIVE = "sensitive";
+    static final Set<String> DEFAULT_SENSITIVE_WORDS = SetUtils.of(
+            "authorization",
+            "bank",
+            "billing",
+            "birth",
+            "credential",
+            "email",
+            "ethnicity",
+            "insurance",
+            "license",
+            "passphrase",
+            "passport",
+            "password",
+            "phone",
+            "private",
+            "secret",
+            "sensitive",
+            "telephone",
+            "token",
+            "username",
+            "zip"
+    );
+    // "Phrases" will be searched for without regard to word boundaries. (This is so that user configuration )
+    static final Set<String> DEFAULT_SENSITIVE_PHRASES = SetUtils.of(
+            "accesskey",
+            "creditcard",
+            "firstname",
+            "lastname",
+            "plaintext",
+            "taxpayer"
+    );
+
+    public static final class Provider extends ValidatorService.Provider {
+        public Provider() {
+            super(MissingSensitiveTraitValidator.class, node -> {
+                NodeMapper mapper = new NodeMapper();
+                return new MissingSensitiveTraitValidator(
+                        mapper.deserialize(node, MissingSensitiveTraitValidator.Config.class));
+            });
+        }
+    }
+
+    /**
+     * MissingSensitiveTrait configuration.
+     */
+    public static final class Config {
+        private List<String> phrases = ListUtils.of();
+        private boolean excludeDefaults;
+
+        public List<String> getPhrases() {
+            return phrases;
+        }
+
+        public void setPhrases(List<String> phrases) {
+            this.phrases = phrases;
+        }
+
+        public boolean getExcludeDefaults() {
+            return excludeDefaults;
+        }
+
+        public void setExcludeDefaults(boolean excludeDefaults) {
+            this.excludeDefaults = excludeDefaults;
+        }
+    }
+
+    private final Set<String> sensitiveWords;
+    private final Set<String> sensitivePhrases;
+
+    private MissingSensitiveTraitValidator(Config config) {
+        if (!config.getExcludeDefaults()) {
+            Set<String> phrasesInit = new HashSet<>(DEFAULT_SENSITIVE_PHRASES);
+            phrasesInit.addAll(config.getPhrases()
+                    .stream()
+                    .map(phrase -> phrase.toLowerCase(Locale.US))
+                    .collect(Collectors.toSet()));
+            sensitivePhrases = Collections.unmodifiableSet(phrasesInit);
+            sensitiveWords = Collections.unmodifiableSet(DEFAULT_SENSITIVE_WORDS);
+        } else {
+            if (config.getPhrases().isEmpty()) {
+                //This configuration combination makes the validator a no-op.
+                throw new IllegalArgumentException("Cannot set 'excludeDefaults' to true and leave "
+                                                 + "'phrases' empty or unspecified.");
+            }
+            sensitivePhrases = Collections.unmodifiableSet(new HashSet<>(config.getPhrases()));
+            sensitiveWords = Collections.EMPTY_SET;
+        }
+    }
+
+    /**
+     * Finds shapes without the sensitive trait that possibly contain sensitive data,
+     * based on the shape/member name and the list of key words and phrases.
+     * @param model Model to validate.
+     * @return list of violation events
+     */
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> validationEvents = new ArrayList<>();
+        validationEvents.addAll(scanShapeNames(model));
+        validationEvents.addAll(scanMemberNames(model));
+        return validationEvents;
+    }
+
+    private List<ValidationEvent> scanShapeNames(Model model) {
+        List<ValidationEvent> validationEvents = new ArrayList<>();
+        model.shapes()
+                .filter(shape -> !shape.isMemberShape()
+                        && !shape.isOperationShape()
+                        && !shape.isServiceShape()
+                        && !shape.isResourceShape())
+                .filter(shape -> !shape.hasTrait(SENSITIVE))
+                .filter(shape -> containsSensitiveWord(shape.toShapeId().getName())
+                        || containsSensitivePhrase(shape.toShapeId().getName()))
+                .forEach(shape -> validationEvents.add(emit(shape)));
+
+        return validationEvents;
+    }
+
+    private List<ValidationEvent> scanMemberNames(Model model) {
+        return model.shapes()
+                // filter out members with an already sensitive enclosing shape
+                .filter(shape -> !shape.hasTrait(SENSITIVE))
+                .flatMap(shape -> shape.members().stream())
+                // filter out members that target a sensitive shape
+                .filter(memberShape ->
+                        model.getShape(memberShape.getTarget())
+                        .map(shape -> !shape.hasTrait(SENSITIVE))
+                        .orElse(false))
+                .filter(memberShape -> containsSensitiveWord(memberShape.getMemberName())
+                        || containsSensitivePhrase(memberShape.getMemberName()))
+                .map(this::emit)
+                .collect(Collectors.toList());
+    }
+
+    private boolean containsSensitiveWord(String name) {
+        return ValidationUtils.splitCamelCaseWord(name)
+                .stream()
+                .map(word -> word.toLowerCase(Locale.US))
+                .anyMatch(sensitiveWords::contains);
+    }
+
+    private boolean containsSensitivePhrase(String name) {
+        String lowerCasedName = name.toLowerCase(Locale.US);
+        return sensitivePhrases.stream().anyMatch(lowerCasedName::contains);
+    }
+
+    private ValidationEvent emit(Shape shape) {
+        return ValidationEvent.builder()
+                .severity(Severity.WARNING)
+                .id(ValidatorService.determineValidatorName(MissingSensitiveTraitValidator.class))
+                .shape(shape)
+                .message("Detected that this shape possibly contains sensitive data "
+                        + "but is not marked with the 'sensitive' trait")
+                .build();
+    }
+}

--- a/smithy-linters/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.ValidatorService
+++ b/smithy-linters/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.ValidatorService
@@ -9,3 +9,4 @@ software.amazon.smithy.linters.ReservedWordsValidator$Provider
 software.amazon.smithy.linters.ShouldHaveUsedTimestampValidator$Provider
 software.amazon.smithy.linters.StandardOperationVerbValidator$Provider
 software.amazon.smithy.linters.StutteredShapeNameValidator$Provider
+software.amazon.smithy.linters.MissingSensitiveTraitValidator$Provider

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.errors
@@ -1,4 +1,4 @@
-[WARNING] smithy.example#FooOperationRequest: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#FooOperationResponse: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#CabAnkle: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#MyString: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FooOperationRequest: Detected that this shape possibly contains sensitive data (based on presence of 'foo') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FooOperationResponse: Detected that this shape possibly contains sensitive data (based on presence of 'foo') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#CabAnkle: Detected that this shape possibly contains sensitive data (based on presence of 'cabankle') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#MyString: Detected that this shape possibly contains sensitive data (based on presence of 'string') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.errors
@@ -1,0 +1,4 @@
+[WARNING] smithy.example#FooOperationRequest: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FooOperationResponse: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#CabAnkle: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#MyString: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.errors
@@ -1,4 +1,6 @@
-[WARNING] smithy.example#FooOperationRequest: Detected that this shape possibly contains sensitive data (based on presence of 'foo') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#FooOperationResponse: Detected that this shape possibly contains sensitive data (based on presence of 'foo') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#CabAnkle: Detected that this shape possibly contains sensitive data (based on presence of 'cabankle') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#MyString: Detected that this shape possibly contains sensitive data (based on presence of 'string') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FooOperationRequest: This shape possibly contains sensitive data but is not marked with the sensitive trait (based on the presence of 'foo') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FooOperationRequest$secondMember: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'second member') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FooOperationResponse: This shape possibly contains sensitive data but is not marked with the sensitive trait (based on the presence of 'foo') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#MyString: This shape possibly contains sensitive data but is not marked with the sensitive trait (based on the presence of 'string') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo$bank: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'bank') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo$data: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'data') | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
@@ -1,0 +1,71 @@
+$version: "1.0"
+
+metadata validators = [{
+    name: "MissingSensitiveTrait",
+    id: "DefaultMissingSensitiveTrait",
+    configuration: {
+        excludeDefaults: true,
+        phrases: [
+            "foo",
+            "cabankle",
+            "string"
+        ]
+    }
+}]
+
+namespace smithy.example
+
+service FooService {
+    version: "2020-09-21",
+    operations: [FooOperation],
+}
+
+operation FooOperation {
+    input: FooOperationRequest,
+    output: FooOperationResponse,
+    errors: [],
+}
+
+structure FooOperationRequest {
+    firstMember: CabAnkle,
+    secondMember: BillingInfo,
+    thirdMember: SafeBillingInfo
+}
+
+structure FooOperationResponse {
+}
+
+structure CabAnkle {
+    myMember: MyString
+}
+
+// should get flagged
+structure BillingInfo {
+    // should get flagged
+    bank: MyString,
+    data: MyString,
+    safeBank: MySensitiveString,
+    // should get flagged
+    firstName: FirstName,
+    lastName: LastName
+}
+
+@sensitive
+structure SafeBillingInfo {
+    bank: MyString,
+    data: MyString,
+    safeBank: MySensitiveString,
+    firstName: MyString,
+    lastName: MySensitiveString
+}
+
+string MyString
+
+@sensitive
+string MySensitiveString
+
+// should get flagged
+string FirstName
+
+@sensitive
+string LastName

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
@@ -5,13 +5,13 @@ metadata validators = [{
     id: "DefaultMissingSensitiveTrait",
     configuration: {
         excludeDefaults: true,
-        phrases: [
-            "caBANKle",
-        ],
-        words: [
+        terms: [
+            "bank",
             "foo",
             "string",
-            "secondMember"
+            "second member",
+            "bill inginfo",
+            "da ta"
         ]
     }
 }]
@@ -29,12 +29,15 @@ operation FooOperation {
     errors: [],
 }
 
+// should get flagged
 structure FooOperationRequest {
     firstMember: CabAnkle,
+    // should get flagged
     secondMember: BillingInfo,
     thirdMember: SafeBillingInfo
 }
 
+// should get flagged
 structure FooOperationResponse {
 }
 
@@ -42,14 +45,15 @@ structure CabAnkle {
     myMember: MyString
 }
 
-// should get flagged
+//should not get flagged
 structure BillingInfo {
     // should get flagged
     bank: MyString,
     data: MyString,
+    // should not get flagged
     safeBank: MySensitiveString,
-    // should get flagged
     firstName: FirstName,
+    // should not get flagged
     lastName: LastName
 }
 
@@ -67,7 +71,6 @@ string MyString
 @sensitive
 string MySensitiveString
 
-// should get flagged
 string FirstName
 
 @sensitive

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
@@ -6,9 +6,12 @@ metadata validators = [{
     configuration: {
         excludeDefaults: true,
         phrases: [
+            "caBANKle",
+        ],
+        words: [
             "foo",
-            "cabankle",
-            "string"
+            "string",
+            "secondMember"
         ]
     }
 }]

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-custom.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 
 metadata validators = [{
     name: "MissingSensitiveTrait",

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
@@ -1,0 +1,4 @@
+[WARNING] smithy.example#BillingInfo: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo$bank: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo$firstName: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FirstName: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
@@ -1,4 +1,4 @@
-[WARNING] smithy.example#BillingInfo: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#BillingInfo$bank: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#BillingInfo$firstName: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#FirstName: Detected that this shape possibly contains sensitive data but is not marked with the 'sensitive' trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo: Detected that this shape possibly contains sensitive data (based on presence of 'billing') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo$bank: Detected that this shape possibly contains sensitive data (based on presence of 'bank') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingInfo$firstName: Detected that this shape possibly contains sensitive data (based on presence of 'firstname') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FirstName: Detected that this shape possibly contains sensitive data (based on presence of 'firstname') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
@@ -2,3 +2,4 @@
 [WARNING] smithy.example#BillingAddress$bank: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'bank') | DefaultMissingSensitiveTrait
 [WARNING] smithy.example#BillingAddress$firstName: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'first name') | DefaultMissingSensitiveTrait
 [WARNING] smithy.example#FirstName: This shape possibly contains sensitive data but is not marked with the sensitive trait (based on the presence of 'first name') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#CabAnkle$myBirthday: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'birthday') | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.errors
@@ -1,4 +1,4 @@
-[WARNING] smithy.example#BillingInfo: Detected that this shape possibly contains sensitive data (based on presence of 'billing') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#BillingInfo$bank: Detected that this shape possibly contains sensitive data (based on presence of 'bank') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#BillingInfo$firstName: Detected that this shape possibly contains sensitive data (based on presence of 'firstname') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
-[WARNING] smithy.example#FirstName: Detected that this shape possibly contains sensitive data (based on presence of 'firstname') but is not marked with the sensitive trait | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingAddress: This shape possibly contains sensitive data but is not marked with the sensitive trait (based on the presence of 'billing address') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingAddress$bank: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'bank') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#BillingAddress$firstName: This member possibly contains sensitive data but neither the enclosing nor target shape are marked with the sensitive trait (based on the presence of 'first name') | DefaultMissingSensitiveTrait
+[WARNING] smithy.example#FirstName: This shape possibly contains sensitive data but is not marked with the sensitive trait (based on the presence of 'first name') | DefaultMissingSensitiveTrait

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
@@ -1,0 +1,63 @@
+$version: "1.0"
+
+metadata validators = [
+        {name: "MissingSensitiveTrait",
+        id: "DefaultMissingSensitiveTrait"}
+]
+
+namespace smithy.example
+
+service FooService {
+    version: "2020-09-21",
+    operations: [FooOperation],
+}
+
+operation FooOperation {
+    input: FooOperationRequest,
+    output: FooOperationResponse,
+    errors: [],
+}
+
+structure FooOperationRequest {
+    firstMember: CabAnkle,
+    secondMember: BillingInfo,
+    thirdMember: SafeBillingInfo
+}
+
+structure FooOperationResponse {
+}
+
+structure CabAnkle {
+    myMember: MyString
+}
+
+// should get flagged
+structure BillingInfo {
+    // should get flagged
+    bank: MyString,
+    data: MyString,
+    safeBank: MySensitiveString,
+    // should get flagged
+    firstName: FirstName,
+    lastName: LastName
+}
+
+@sensitive
+structure SafeBillingInfo {
+    bank: MyString,
+    data: MyString,
+    safeBank: MySensitiveString,
+    firstName: MyString,
+    lastName: MySensitiveString
+}
+
+string MyString
+
+@sensitive
+string MySensitiveString
+
+// should get flagged
+string FirstName
+
+@sensitive
+string LastName

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 
 metadata validators = [
         {name: "MissingSensitiveTrait",
@@ -28,7 +28,9 @@ structure FooOperationResponse {
 }
 
 structure CabAnkle {
-    myMember: MyString
+    myMember: MyString,
+    // should get flagged
+    myBirthday: MyString
 }
 
 // should get flagged

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
@@ -20,8 +20,8 @@ operation FooOperation {
 
 structure FooOperationRequest {
     firstMember: CabAnkle,
-    secondMember: BillingInfo,
-    thirdMember: SafeBillingInfo
+    secondMember: BillingAddress,
+    thirdMember: SafeBillingAddress
 }
 
 structure FooOperationResponse {
@@ -32,7 +32,7 @@ structure CabAnkle {
 }
 
 // should get flagged
-structure BillingInfo {
+structure BillingAddress {
     // should get flagged
     bank: MyString,
     data: MyString,
@@ -43,7 +43,7 @@ structure BillingInfo {
 }
 
 @sensitive
-structure SafeBillingInfo {
+structure SafeBillingAddress {
     bank: MyString,
     data: MyString,
     safeBank: MySensitiveString,

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-invalid-config.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-invalid-config.errors
@@ -1,0 +1,1 @@
+[ERROR] -: Error creating `MissingSensitiveTrait` validator: Cannot set 'excludeDefaults' to true and leave 'terms' unspecified. | Model

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-invalid-config.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-invalid-config.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+metadata validators = [{
+    name: "MissingSensitiveTrait",
+    id: "DefaultMissingSensitiveTrait",
+    configuration: {
+        excludeDefaults: true,
+        terms: []
+    }
+}]
+
+namespace smithy.example


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Based on various existing services for sensitive data detection and current AWS sensitive trait usage, generated a default list of words and phrases that likely indicate the data stored inside is sensitive. It is configurable the way the non inclusive terms validator is.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
