### PR TITLE
Cleanup smithy-build

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionResult.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionResult.java
@@ -74,7 +74,12 @@ public final class ProjectionResult {
      * @return Returns true if the projected model is broken.
      */
     public boolean isBroken() {
-        return events.stream().anyMatch(e -> e.getSeverity() == Severity.ERROR || e.getSeverity() == Severity.DANGER);
+        for (ValidationEvent e : events) {
+            if (e.getSeverity() == Severity.ERROR || e.getSeverity() == Severity.DANGER) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildPlugin.java
@@ -82,9 +82,14 @@ public interface SmithyBuildPlugin {
         // caching a ServiceLoader using a Thread's context ClassLoader VM-wide.
         List<SmithyBuildPlugin> pluginList = new ArrayList<>();
         plugins.forEach(pluginList::add);
-        return name -> pluginList.stream()
-                .filter(plugin -> plugin.getName().equals(name))
-                .findFirst();
+        return name -> {
+            for (SmithyBuildPlugin plugin : pluginList) {
+                if (plugin.getName().equals(name)) {
+                    return Optional.of(plugin);
+                }
+            }
+            return Optional.empty();
+        };
     }
 
     /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildResult.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildResult.java
@@ -18,11 +18,10 @@ package software.amazon.smithy.build;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -52,7 +51,12 @@ public final class SmithyBuildResult {
      * @return Returns true if any are broken.
      */
     public boolean anyBroken() {
-        return results.stream().anyMatch(ProjectionResult::isBroken);
+        for (ProjectionResult result : results) {
+            if (result.isBroken()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -80,7 +84,12 @@ public final class SmithyBuildResult {
      * @return Returns the optionally found result.
      */
     public Optional<ProjectionResult> getProjectionResult(String projectionName) {
-        return results.stream().filter(result -> result.getProjectionName().equals(projectionName)).findFirst();
+        for (ProjectionResult result : results) {
+            if (result.getProjectionName().equals(projectionName)) {
+                return Optional.of(result);
+            }
+        }
+        return Optional.empty();
     }
 
     /**
@@ -99,7 +108,11 @@ public final class SmithyBuildResult {
      * @return Returns the projection results as a map.
      */
     public Map<String, ProjectionResult> getProjectionResultsMap() {
-        return results.stream().collect(Collectors.toMap(ProjectionResult::getProjectionName, Function.identity()));
+        Map<String, ProjectionResult> resultMap = new HashMap<>();
+        for (ProjectionResult result : results) {
+            resultMap.put(result.getProjectionName(), result);
+        }
+        return Collections.unmodifiableMap(resultMap);
     }
 
     /**

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test1ParallelPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test1ParallelPlugin.java
@@ -13,6 +13,6 @@ public class Test1ParallelPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
-        context.getFileManifest().writeFile("hello1Parallel", String.format("%s", System.currentTimeMillis()));
+        context.getFileManifest().writeFile("hello1Parallel", String.format("%s", System.nanoTime()));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test1SerialPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test1SerialPlugin.java
@@ -1,7 +1,5 @@
 package software.amazon.smithy.build;
 
-import java.util.concurrent.TimeUnit;
-
 public class Test1SerialPlugin implements SmithyBuildPlugin {
     @Override
     public String getName() {
@@ -15,12 +13,10 @@ public class Test1SerialPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
-        try {
-            TimeUnit.SECONDS.sleep(1);
-            context.getFileManifest().writeFile("hello1Serial", String.format("%s", System.currentTimeMillis()));
-            TimeUnit.SECONDS.sleep(1);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        int accum = 0;
+        for (int i = 0; i < 100000; i++) {
+            accum++;
         }
+        context.getFileManifest().writeFile("hello1Serial", String.format("%s", System.nanoTime() + accum));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test2ParallelPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test2ParallelPlugin.java
@@ -13,6 +13,6 @@ public class Test2ParallelPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
-        context.getFileManifest().writeFile("hello2Parallel", String.format("%s", System.currentTimeMillis()));
+        context.getFileManifest().writeFile("hello2Parallel", String.format("%s", System.nanoTime()));
     }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/Test2SerialPlugin.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/Test2SerialPlugin.java
@@ -1,7 +1,5 @@
 package software.amazon.smithy.build;
 
-import java.util.concurrent.TimeUnit;
-
 public class Test2SerialPlugin implements SmithyBuildPlugin {
     @Override
     public String getName() {
@@ -15,12 +13,10 @@ public class Test2SerialPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
-        try {
-            TimeUnit.SECONDS.sleep(1);
-            context.getFileManifest().writeFile("hello2Serial", String.format("%s", System.currentTimeMillis()));
-            TimeUnit.SECONDS.sleep(1);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        int accum = 0;
+        for (int i = 0; i < 100000; i++) {
+            accum++;
         }
+        context.getFileManifest().writeFile("hello2Serial", String.format("%s", System.currentTimeMillis() + accum));
     }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/model/loads-from-node.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/model/loads-from-node.json
@@ -1,0 +1,9 @@
+{
+    "version": "1.0",
+    "imports": ["foo.json"],
+    "projections": {
+        "a": {
+            "imports": ["baz.json"]
+        }
+    }
+}


### PR DESCRIPTION
* Removes the need to create intermediate SmithyBuildConfig classes when loading configurations from JSON files.
* Only perform variable expansion if it's used.
* Adds fromNode for smithy-build classes.
* Removes several instances of Stream that are called in hot paths / don't need stream overhead.
* Switch from custom ForkJoinPool to parallel stream. There's no measurable difference here and this approach is simpler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
