### PR TITLE
Make string enum to enum shape transform opt-in in CodegenDirector

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -97,7 +97,6 @@ public final class CodegenDirector<
         ServiceShape serviceShape = model.expectShape(service, ServiceShape.class);
         model = transformer.copyServiceErrorsToOperations(model, serviceShape);
         model = transformer.flattenAndRemoveMixins(model);
-        model = transformer.changeStringEnumsToEnumShapes(model, true);
         return model;
     }
 
@@ -235,6 +234,19 @@ public final class CodegenDirector<
         transforms.add((model, transformer) -> {
             LOGGER.finest("Creating dedicated input and output shapes for directed codegen");
             return transformer.createDedicatedInputAndOutput(model, inputSuffix, outputSuffix);
+        });
+    }
+
+    /**
+     * Changes each compatible string shape with the enum trait to an enum shape.
+     *
+     * @param synthesizeEnumNames Whether enums without names should have names synthesized if possible.
+     * @see ModelTransformer#changeStringEnumsToEnumShapes(Model, boolean)
+     */
+    public void changeStringEnumsToEnumShapes(boolean synthesizeEnumNames) {
+        transforms.add((model, transformer) -> {
+            LOGGER.finest("Creating dedicated input and output shapes for directed codegen");
+            return transformer.changeStringEnumsToEnumShapes(model, synthesizeEnumNames);
         });
     }
 


### PR DESCRIPTION
Generators like smithy-typescript are affected by calling this transform. So making it opt-in, similar to createDedicatedInputsAndOutputs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
