### PR TITLE
Fix a log message for unable to convert string enum to enum shape

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -173,13 +173,13 @@ public final class EnumShape extends StringShape {
         }
 
         EnumTrait trait = shape.expectTrait(EnumTrait.class);
-        if (!synthesizeEnumNames && trait.getValues().iterator().next().getName().isPresent()) {
+        if (!trait.hasNames() && !synthesizeEnumNames) {
             LOGGER.info(String.format(
                     "Unable to convert string shape `%s` to enum shape because it doesn't define names. The "
                             + "`synthesizeNames` option may be able to synthesize the names for you.",
                     shape.getId()
             ));
-            return true;
+            return false;
         }
 
         for (EnumDefinition definition : trait.getValues()) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EnumShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EnumShapeTest.java
@@ -445,4 +445,50 @@ public class EnumShapeTest {
         Map<String, String> expected = MapUtils.of("BAR", "bar");
         assertEquals(expected, shape.getEnumValues());
     }
+
+    @Test
+    public void canConvertToEnumWithNamedEnumTrait() {
+        EnumTrait trait = EnumTrait.builder()
+                .addEnum(EnumDefinition.builder()
+                        .value("foo&bar") // even if this value has invalid characters for a synthesized name
+                        .name("BAR")
+                        .build())
+                .build();
+        StringShape string = StringShape.builder()
+                .id("ns.foo#bar")
+                .addTrait(trait)
+                .build();
+        assertTrue(EnumShape.canConvertToEnum(string, false));
+        assertTrue(EnumShape.canConvertToEnum(string, true));
+    }
+
+    @Test
+    public void canConvertToEnumWithNamelessEnumTrait() {
+        EnumTrait trait = EnumTrait.builder()
+                .addEnum(EnumDefinition.builder()
+                        .value("bar")
+                        .build())
+                .build();
+        StringShape string = StringShape.builder()
+                .id("ns.foo#bar")
+                .addTrait(trait)
+                .build();
+        assertFalse(EnumShape.canConvertToEnum(string, false));
+        assertTrue(EnumShape.canConvertToEnum(string, true));
+    }
+
+    @Test
+    public void canConvertToEnumWithNonConvertableNamelessEnumTrait() {
+        EnumTrait trait = EnumTrait.builder()
+                .addEnum(EnumDefinition.builder()
+                        .value("foo&bar")
+                        .build())
+                .build();
+        StringShape string = StringShape.builder()
+                .id("ns.foo#bar")
+                .addTrait(trait)
+                .build();
+        assertFalse(EnumShape.canConvertToEnum(string, false));
+        assertFalse(EnumShape.canConvertToEnum(string, true));
+    }
 }


### PR DESCRIPTION
For the case where the enum trait does not have names and synthesizeEnumNames
is false.

There is no functional difference with this change, however a more specific and appropriate log message will be used for case where names aren't defined in the enum trait (i.e., they would need to be synthesized) but the synthesizeEnumNames is set to false.

### Testing
Without the EnumShape.java change in this PR, the newly added canConvertToEnumWithNamelessEnumTrait test case for `assertFalse(EnumShape.canConvertToEnum(string, false));` would log
```
INFO: Unable to convert string shape `ns.foo#bar` to enum shape because it has at least one value which cannot be safely synthesized into a name: bar
```

With the change, the test case now logs the more appropriate log for this use case
```
INFO: Unable to convert string shape `ns.foo#bar` to enum shape because it doesn't define names. The `synthesizeNames` option may be able to synthesize the names for you.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
