### PR TITLE
Filter out synthetic traits from build info

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/plugins/BuildInfoPluginTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/plugins/BuildInfoPluginTest.java
@@ -1,0 +1,42 @@
+package software.amazon.smithy.build.plugins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.model.ProjectionConfig;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.ListUtils;
+
+public class BuildInfoPluginTest {
+
+    @Test
+    public void testFiltersSyntheticEnumTrait() throws URISyntaxException {
+
+        String testPath = "build-info/example.smithy";
+
+        Model model = Model.assembler()
+                .addImport(getClass().getResource(testPath))
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .fileManifest(manifest)
+                .model(model)
+                .originalModel(model)
+                .projection("TEST", ProjectionConfig.builder().build())
+                .sources(ListUtils.of(Paths.get(getClass().getResource(testPath).toURI()).getParent()))
+                .build();
+        new BuildInfoPlugin().execute(context);
+
+        String buildInfo = manifest.getFileString(BuildInfoPlugin.BUILD_INFO_PATH).get();
+
+        assertThat(buildInfo, not(containsString("smithy.synthetic#enum")));
+    }
+
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/build-info/example.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/build-info/example.smithy
@@ -1,0 +1,26 @@
+$version: "2.0"
+
+namespace smithy.example
+
+service Example {
+    version: "1.0.0"
+    operations: [
+        ChangeCard
+    ]
+}
+
+operation ChangeCard {
+    input: Card
+    output: Card
+}
+
+structure Card {
+    suit: Suit
+}
+
+enum Suit {
+    DIAMOND
+    CLUB
+    HEART
+    SPADE
+}


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Filter out synthetic traits from build info `traitNames`, as synthetic traits should not be serialized and should only be in-memory.

---

*Testing:*

- Ran `./gradlew clean build check`.
- Added unit test `BuildInfoPluginTest > testFiltersSyntheticEnumTrait()` that tests `smithy.synthetic#enum` is not present in `smithy-build-info.json`(synthetic enum trait generated from enum shape).
  ```diff
  <             "smithy.api#unstable",
  <             "smithy.synthetic#enum"
  ---
  >             "smithy.api#unstable"
  ```
  <details>
  <summary>
  Complete Output Before / After
  </summary>

  - Before
  ```json
    {
        "metadata": {},
        "operationShapeIds": [
            "smithy.example#ChangeCard"
        ],
        "projection": {
            "abstract": false,
            "imports": [],
            "plugins": {},
            "transforms": []
        },
        "projectionName": "TEST",
        "resourceShapeIds": [],
        "serviceShapeIds": [
            "smithy.example#Example"
        ],
        "traitDefNames": [
            "smithy.api#auth",
            "smithy.api#authDefinition",
            "smithy.api#box",
            "smithy.api#clientOptional",
            "smithy.api#cors",
            "smithy.api#default",
            "smithy.api#deprecated",
            "smithy.api#documentation",
            "smithy.api#endpoint",
            "smithy.api#enum",
            "smithy.api#enumValue",
            "smithy.api#error",
            "smithy.api#eventHeader",
            "smithy.api#eventPayload",
            "smithy.api#examples",
            "smithy.api#externalDocumentation",
            "smithy.api#hostLabel",
            "smithy.api#http",
            "smithy.api#httpApiKeyAuth",
            "smithy.api#httpBasicAuth",
            "smithy.api#httpBearerAuth",
            "smithy.api#httpChecksumRequired",
            "smithy.api#httpDigestAuth",
            "smithy.api#httpError",
            "smithy.api#httpHeader",
            "smithy.api#httpLabel",
            "smithy.api#httpPayload",
            "smithy.api#httpPrefixHeaders",
            "smithy.api#httpQuery",
            "smithy.api#httpQueryParams",
            "smithy.api#httpResponseCode",
            "smithy.api#idempotencyToken",
            "smithy.api#idempotent",
            "smithy.api#idRef",
            "smithy.api#input",
            "smithy.api#internal",
            "smithy.api#jsonName",
            "smithy.api#length",
            "smithy.api#mediaType",
            "smithy.api#mixin",
            "smithy.api#nestedProperties",
            "smithy.api#noReplace",
            "smithy.api#notProperty",
            "smithy.api#optionalAuth",
            "smithy.api#output",
            "smithy.api#paginated",
            "smithy.api#pattern",
            "smithy.api#private",
            "smithy.api#property",
            "smithy.api#protocolDefinition",
            "smithy.api#range",
            "smithy.api#readonly",
            "smithy.api#recommended",
            "smithy.api#references",
            "smithy.api#required",
            "smithy.api#requiresLength",
            "smithy.api#resourceIdentifier",
            "smithy.api#retryable",
            "smithy.api#sensitive",
            "smithy.api#since",
            "smithy.api#sparse",
            "smithy.api#streaming",
            "smithy.api#suppress",
            "smithy.api#tags",
            "smithy.api#timestampFormat",
            "smithy.api#title",
            "smithy.api#trait",
            "smithy.api#uniqueItems",
            "smithy.api#unitType",
            "smithy.api#unstable",
            "smithy.api#xmlAttribute",
            "smithy.api#xmlFlattened",
            "smithy.api#xmlName",
            "smithy.api#xmlNamespace"
        ],
        "traitNames": [
            "smithy.api#authDefinition",
            "smithy.api#box",
            "smithy.api#default",
            "smithy.api#deprecated",
            "smithy.api#documentation",
            "smithy.api#enumValue",
            "smithy.api#externalDocumentation",
            "smithy.api#idRef",
            "smithy.api#length",
            "smithy.api#notProperty",
            "smithy.api#pattern",
            "smithy.api#private",
            "smithy.api#range",
            "smithy.api#required",
            "smithy.api#tags",
            "smithy.api#trait",
            "smithy.api#uniqueItems",
            "smithy.api#unitType",
            "smithy.api#unstable",
            "smithy.synthetic#enum"
        ],
        "validationEvents": [],
        "version": "1.0"
    }
  ```
  - After
  ```json
    {
        "metadata": {},
        "operationShapeIds": [
            "smithy.example#ChangeCard"
        ],
        "projection": {
            "abstract": false,
            "imports": [],
            "plugins": {},
            "transforms": []
        },
        "projectionName": "TEST",
        "resourceShapeIds": [],
        "serviceShapeIds": [
            "smithy.example#Example"
        ],
        "traitDefNames": [
            "smithy.api#auth",
            "smithy.api#authDefinition",
            "smithy.api#box",
            "smithy.api#clientOptional",
            "smithy.api#cors",
            "smithy.api#default",
            "smithy.api#deprecated",
            "smithy.api#documentation",
            "smithy.api#endpoint",
            "smithy.api#enum",
            "smithy.api#enumValue",
            "smithy.api#error",
            "smithy.api#eventHeader",
            "smithy.api#eventPayload",
            "smithy.api#examples",
            "smithy.api#externalDocumentation",
            "smithy.api#hostLabel",
            "smithy.api#http",
            "smithy.api#httpApiKeyAuth",
            "smithy.api#httpBasicAuth",
            "smithy.api#httpBearerAuth",
            "smithy.api#httpChecksumRequired",
            "smithy.api#httpDigestAuth",
            "smithy.api#httpError",
            "smithy.api#httpHeader",
            "smithy.api#httpLabel",
            "smithy.api#httpPayload",
            "smithy.api#httpPrefixHeaders",
            "smithy.api#httpQuery",
            "smithy.api#httpQueryParams",
            "smithy.api#httpResponseCode",
            "smithy.api#idempotencyToken",
            "smithy.api#idempotent",
            "smithy.api#idRef",
            "smithy.api#input",
            "smithy.api#internal",
            "smithy.api#jsonName",
            "smithy.api#length",
            "smithy.api#mediaType",
            "smithy.api#mixin",
            "smithy.api#nestedProperties",
            "smithy.api#noReplace",
            "smithy.api#notProperty",
            "smithy.api#optionalAuth",
            "smithy.api#output",
            "smithy.api#paginated",
            "smithy.api#pattern",
            "smithy.api#private",
            "smithy.api#property",
            "smithy.api#protocolDefinition",
            "smithy.api#range",
            "smithy.api#readonly",
            "smithy.api#recommended",
            "smithy.api#references",
            "smithy.api#required",
            "smithy.api#requiresLength",
            "smithy.api#resourceIdentifier",
            "smithy.api#retryable",
            "smithy.api#sensitive",
            "smithy.api#since",
            "smithy.api#sparse",
            "smithy.api#streaming",
            "smithy.api#suppress",
            "smithy.api#tags",
            "smithy.api#timestampFormat",
            "smithy.api#title",
            "smithy.api#trait",
            "smithy.api#uniqueItems",
            "smithy.api#unitType",
            "smithy.api#unstable",
            "smithy.api#xmlAttribute",
            "smithy.api#xmlFlattened",
            "smithy.api#xmlName",
            "smithy.api#xmlNamespace"
        ],
        "traitNames": [
            "smithy.api#authDefinition",
            "smithy.api#box",
            "smithy.api#default",
            "smithy.api#deprecated",
            "smithy.api#documentation",
            "smithy.api#enumValue",
            "smithy.api#externalDocumentation",
            "smithy.api#idRef",
            "smithy.api#length",
            "smithy.api#notProperty",
            "smithy.api#pattern",
            "smithy.api#private",
            "smithy.api#range",
            "smithy.api#required",
            "smithy.api#tags",
            "smithy.api#trait",
            "smithy.api#uniqueItems",
            "smithy.api#unitType",
            "smithy.api#unstable"
        ],
        "validationEvents": [],
        "version": "1.0"
    }
  ```
  </details>
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
