### PR TITLE
Fix ABNF grammar for inlined structures.

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -224,7 +224,8 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     OperationInput          :%s"input" *WS (`InlineStructure` / (":" *`WS` `ShapeId`)) `WS`
     OperationOutput         :%s"output" *WS (`InlineStructure` / (":" *`WS` `ShapeId`)) `WS`
     OperationErrors         :%s"errors" *WS ":" *WS "[" *(*`WS` `Identifier`) *`WS` "]" `WS`
-    InlineStructure         :":=" *`WS` `TraitStatements` [`Mixins`] *`WS` `StructureMembers`
+    InlineStructure         :":=" *`WS` `TraitStatements` [`StructureResource`]
+                            :        [`Mixins`] *`WS` `StructureMembers`
 
 .. rubric:: Traits
 


### PR DESCRIPTION
Inlined structures ABNF was missing rule name for structure resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
