### PR TITLE
Ignore valid set->list type change in diff

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedShapeType.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedShapeType.java
@@ -17,7 +17,11 @@ package software.amazon.smithy.diff.evaluators;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
@@ -28,9 +32,23 @@ public final class ChangedShapeType extends AbstractDiffEvaluator {
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.changedShapes()
                 .filter(diff -> diff.getOldShape().getType() != diff.getNewShape().getType())
+                .filter(diff -> !expectedSetToListChange(diff))
                 .map(diff -> error(diff.getNewShape(), String.format(
                         "Shape `%s` type was changed from `%s` to `%s`.",
                         diff.getShapeId(), diff.getOldShape().getType(), diff.getNewShape().getType())))
                 .collect(Collectors.toList());
+    }
+
+    private boolean expectedSetToListChange(ChangedShape<Shape> diff) {
+        ShapeType oldType = diff.getOldShape().getType();
+        ShapeType newType = diff.getNewShape().getType();
+
+        // Smithy diff doesn't raise an issue if a set is changed to a list and the list
+        // has the uniqueItems trait. Set is deprecated and this is a recommended change.
+        if (oldType == ShapeType.SET && newType == ShapeType.LIST) {
+            return diff.getNewShape().hasTrait(UniqueItemsTrait.class);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
It isn't an error to migrate a set to a list with the uniqueItems
trait. This is a recommended change because sets are deprecated and
should not be implemented by any tooling.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
