### PR TITLE
Update gradle plugin guide to direct to quick start guide for example usage

### DIFF
--- a/docs/source-1.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source-1.0/guides/building-models/gradle-plugin.rst
@@ -353,7 +353,8 @@ Complete Examples
 =================
 
 For several complete examples, see the `examples directory`_ of the Smithy
-Gradle plugin repository.
+Gradle plugin repository, or check out the :doc:`Quick start guide </quickstart>` for a tutorial on
+creating a Smithy model and building it with the Smithy Gradle plugin.
 
 .. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples
 .. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin/

--- a/docs/source-2.0/guides/building-models/gradle-plugin.rst
+++ b/docs/source-2.0/guides/building-models/gradle-plugin.rst
@@ -335,7 +335,8 @@ Complete Examples
 =================
 
 For several complete examples, see the `examples directory`_ of the Smithy
-Gradle plugin repository.
+Gradle plugin repository, or check out the :doc:`Quick start guide </quickstart>` for a tutorial on
+creating a Smithy model and building it with the Smithy Gradle plugin.
 
 .. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples
 .. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin/


### PR DESCRIPTION
The quick start guide is a good starter example for basic usage of the gradle plugin.

*Issue #, if available:*
#887 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
