### PR TITLE
Add `x-amz-target` for missing AWS JSON 1.1 tests

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/documents.smithy
@@ -32,7 +32,10 @@ apply PutAndGetInlineDocuments @httpRequestTests([
                   "inlineDocument": {"foo": "bar"}
               }""",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.PutAndGetInlineDocuments",
+        },
         requireHeaders: [
             "Content-Length"
         ],

--- a/smithy-aws-protocol-tests/model/awsJson1_1/empty-operation.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/empty-operation.smithy
@@ -11,6 +11,10 @@ use smithy.test#httpResponseTests
         id: "sends_requests_to_slash",
         protocol: awsJson1_1,
         documentation: "Sends requests to /",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.EmptyOperation",
+        },
         method: "POST",
         uri: "/",
     },
@@ -39,6 +43,7 @@ use smithy.test#httpResponseTests
         bodyMediaType: "application/json",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.EmptyOperation",
         },
         method: "POST",
         uri: "/"
@@ -55,6 +60,7 @@ use smithy.test#httpResponseTests
         body: "",
         headers: {
             "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.EmptyOperation",
         },
         method: "POST",
         uri: "/",

--- a/smithy-aws-protocol-tests/model/awsJson1_1/endpoint-paths.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/endpoint-paths.smithy
@@ -16,6 +16,10 @@ use smithy.test#httpRequestTests
         method: "POST",
         uri: "/custom/",
         body: "{}",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.HostWithPathOperation",
+        },
         host: "example.com/custom",
         appliesTo: "client"
     }

--- a/smithy-aws-protocol-tests/model/awsJson1_1/endpoints.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/endpoints.smithy
@@ -18,6 +18,10 @@ use smithy.test#httpRequestTests
         method: "POST",
         uri: "/",
         body: "{}",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.EndpointOperation",
+        },
         host: "example.com",
         resolvedHost: "foo.example.com",
     }
@@ -38,6 +42,10 @@ operation EndpointOperation {}
         uri: "/",
         body: "{\"label\": \"bar\"}",
         bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.EndpointWithHostLabelOperation",
+        },
         host: "example.com",
         resolvedHost: "foo.bar.example.com",
         params: {

--- a/smithy-aws-protocol-tests/model/awsJson1_1/enums.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/enums.smithy
@@ -42,7 +42,10 @@ apply JsonEnums @httpRequestTests([
                       "zero": "0"
                   }
               }""",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.JsonEnums",
+        },
         bodyMediaType: "application/json",
         params: {
             fooEnum1: "Foo",

--- a/smithy-aws-protocol-tests/model/awsJson1_1/kitchen-sink.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/kitchen-sink.smithy
@@ -12,7 +12,10 @@ use smithy.test#httpResponseTests
         protocol: awsJson1_1,
         documentation: "Serializes string shapes",
         body: "{\"String\":\"abc xyz\"}",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         bodyMediaType: "application/json",
         requireHeaders: [
             "Content-Length"
@@ -29,7 +32,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes string shapes with jsonvalue trait",
         body: "{\"JsonValue\":\"{\\\"string\\\":\\\"value\\\",\\\"number\\\":1234.5,\\\"boolTrue\\\":true,\\\"boolFalse\\\":false,\\\"array\\\":[1,2,3,4],\\\"object\\\":{\\\"key\\\":\\\"value\\\"},\\\"null\\\":null}\"}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -45,7 +51,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes integer shapes",
         body: "{\"Integer\":1234}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -61,7 +70,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes long shapes",
         body: "{\"Long\":999999999999}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -77,7 +89,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes float shapes",
         body: "{\"Float\":1234.5}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -93,7 +108,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes double shapes",
         body: "{\"Double\":1234.5}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -109,7 +127,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes blob shapes",
         body: "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -125,7 +146,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes boolean shapes (true)",
         body: "{\"Boolean\":true}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -141,7 +165,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes boolean shapes (false)",
         body: "{\"Boolean\":false}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -157,7 +184,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes",
         body: "{\"Timestamp\":946845296}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -173,7 +203,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes with iso8601 timestampFormat",
         body: "{\"Iso8601Timestamp\":\"2000-01-02T20:34:56Z\"}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -189,7 +222,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes with httpdate timestampFormat",
         body: "{\"HttpdateTimestamp\":\"Sun, 02 Jan 2000 20:34:56 GMT\"}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -205,7 +241,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes timestamp shapes with unixTimestamp timestampFormat",
         body: "{\"UnixTimestamp\":946845296}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -221,7 +260,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list shapes",
         body: "{\"ListOfStrings\":[\"abc\",\"mno\",\"xyz\"]}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -241,7 +283,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes empty list shapes",
         body: "{\"ListOfStrings\":[]}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -257,7 +302,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list of map shapes",
         body: "{\"ListOfMapsOfStrings\":[{\"foo\":\"bar\"},{\"abc\":\"xyz\"},{\"red\":\"blue\"}]}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -283,7 +331,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list of structure shapes",
         body: "{\"ListOfStructs\":[{\"Value\":\"abc\"},{\"Value\":\"mno\"},{\"Value\":\"xyz\"}]}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -309,7 +360,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes list of recursive structure shapes",
         body: "{\"RecursiveList\":[{\"RecursiveList\":[{\"RecursiveList\":[{\"Integer\":123}]}]}]}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -337,7 +391,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map shapes",
         body: "{\"MapOfStrings\":{\"abc\":\"xyz\",\"mno\":\"hjk\"}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -356,7 +413,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes empty map shapes",
         body: "{\"MapOfStrings\":{}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -372,7 +432,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map of list shapes",
         body: "{\"MapOfListsOfStrings\":{\"abc\":[\"abc\",\"xyz\"],\"mno\":[\"xyz\",\"abc\"]}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -397,7 +460,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map of structure shapes",
         body: "{\"MapOfStructs\":{\"key1\":{\"Value\":\"value-1\"},\"key2\":{\"Value\":\"value-2\"}}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -420,7 +486,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes map of recursive structure shapes",
         body: "{\"RecursiveMap\":{\"key1\":{\"RecursiveMap\":{\"key2\":{\"RecursiveMap\":{\"key3\":{\"Boolean\":false}}}}}}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -448,7 +517,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes structure shapes",
         body: "{\"SimpleStruct\":{\"Value\":\"abc\"}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -466,7 +538,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes structure members with locationName traits",
         body: "{\"StructWithJsonName\":{\"Value\":\"some-value\"}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -484,7 +559,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes empty structure shapes",
         body: "{\"SimpleStruct\":{}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -500,7 +578,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes structure which have no members",
         body: "{\"EmptyStruct\":{}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],
@@ -516,7 +597,10 @@ use smithy.test#httpResponseTests
         documentation: "Serializes recursive structure shapes",
         body: "{\"String\":\"top-value\",\"Boolean\":false,\"RecursiveStruct\":{\"String\":\"nested-value\",\"Boolean\":true,\"RecursiveList\":[{\"String\":\"string-only\"},{\"RecursiveStruct\":{\"MapOfStrings\":{\"color\":\"red\",\"size\":\"large\"}}}]}}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+        },
         requireHeaders: [
             "Content-Length"
         ],

--- a/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
@@ -16,7 +16,10 @@ use smithy.test#httpResponseTests
         protocol: awsJson1_1,
         body: "{}",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.NullOperation",
+        },
         params: {
             string: null
         },

--- a/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
@@ -33,7 +33,10 @@ use smithy.test#httpResponseTests
                 "string": null
             }""",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.NullOperation",
+        },
         params: {},
         method: "POST",
         uri: "/",
@@ -50,7 +53,10 @@ use smithy.test#httpResponseTests
                 }
             }""",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.NullOperation",
+        },
         params: {
             "sparseStringMap": {
                 "foo": null
@@ -70,7 +76,10 @@ use smithy.test#httpResponseTests
                 ]
             }""",
         bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "JsonProtocol.NullOperation",
+        },
         params: {
             "sparseStringList": [
                 null


### PR DESCRIPTION
*Issue #, if available:*
Resolves #1391

*Description of changes:* Add missing `X-Amz-Target` header for AWS JSON 1.1 protocol `@httpRequestTests` listed in #1391


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
