### PR TITLE
docs: Fix operationOutputSuffix in example code snippet

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -1398,7 +1398,7 @@ The suffixes for the generated names can be customized using the
 
     $version: "2"
     $operationInputSuffix: "Request"
-    $operationInputSuffix: "Response"
+    $operationOutputSuffix: "Response"
 
     namespace smithy.example
 


### PR DESCRIPTION
Simple doc update. The code example used operationInputSuffix twice. 