### PR TITLE
Add Dependabot for GitHub Action ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds dependabot updates for dependencies in GitHub Action workflows.

> Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer. When you enable Dependabot version updates for GitHub Actions, Dependabot will help ensure that references to actions in a repository's workflow.yml file are kept up to date.
>
> https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

~Here should go an example line of code which is outdated in this repo: ...~
https://github.com/awslabs/smithy/blob/main/.github/workflows/ci.yml#L19 - checkout v3 is available

This branch+commit+pr was generated by IdiosApps, by using [IdiosApp's Dependendabot discovery tool](https://github.com/IdiosApps/dependabot-discovery)
