### PR TITLE
Add support for 1.0 downgrades and serialization

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntEnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/IntEnumShape.java
@@ -116,6 +116,11 @@ public final class IntEnumShape extends IntegerShape {
             return this;
         }
 
+        @Override
+        public Builder id(String shapeId) {
+            return id(ShapeId.from(shapeId));
+        }
+
         /**
          * Replaces the members of the builder.
          *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/DowngradeToV1.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/DowngradeToV1.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.transform;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NullableIndex;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.AddedDefaultTrait;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
+import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.model.traits.NotPropertyTrait;
+import software.amazon.smithy.model.traits.PropertyTrait;
+
+final class DowngradeToV1 {
+
+    Model transform(ModelTransformer transformer, Model model) {
+        // Flatten and remove mixins since they aren't part of IDL 1.0
+        model = transformer.flattenAndRemoveMixins(model);
+
+        // Change enums to string shapes and intEnums to integers.
+        model = downgradeEnums(transformer, model);
+
+        // Remove resource properties
+        model = removeResourceProperties(transformer, model);
+
+        // Remove default traits that do not correlate to box traits from v1.
+        model = removeUnnecessaryDefaults(transformer, model);
+
+        return removeOtherV2Traits(transformer, model);
+    }
+
+    private Model downgradeEnums(ModelTransformer transformer, Model model) {
+        Map<ShapeId, ShapeType> typeChanges = new HashMap<>();
+
+        for (Shape shape : model.getEnumShapes()) {
+            typeChanges.put(shape.getId(), ShapeType.STRING);
+        }
+
+        for (Shape shape : model.getIntEnumShapes()) {
+            typeChanges.put(shape.getId(), ShapeType.INTEGER);
+        }
+
+        return transformer.changeShapeType(model, typeChanges);
+    }
+
+    private Model removeResourceProperties(ModelTransformer transformer, Model model) {
+        List<Shape> updates = new ArrayList<>();
+
+        // Remove the "properties" key from resources.
+        for (ResourceShape shape : model.getResourceShapes()) {
+            if (shape.hasProperties()) {
+                updates.add(shape.toBuilder().properties(Collections.emptyMap()).build());
+            }
+        }
+
+        // Remove @notProperty.
+        for (Shape shape : model.getShapesWithTrait(NotPropertyTrait.class)) {
+            updates.add(Shape.shapeToBuilder(shape).removeTrait(NotPropertyTrait.ID).build());
+        }
+
+        // Remove @property.
+        for (Shape shape : model.getShapesWithTrait(PropertyTrait.class)) {
+            updates.add(Shape.shapeToBuilder(shape).removeTrait(PropertyTrait.ID).build());
+        }
+
+        return transformer.replaceShapes(model, updates);
+    }
+
+    private Model removeUnnecessaryDefaults(ModelTransformer transformer, Model model) {
+        Set<Shape> updates = new HashSet<>();
+
+        // Remove addedDefault traits, and any found default trait if present.
+        for (MemberShape shape : model.getMemberShapesWithTrait(AddedDefaultTrait.class)) {
+            updates.add(shape.toBuilder().removeTrait(DefaultTrait.ID).removeTrait(AddedDefaultTrait.ID).build());
+        }
+
+        for (Shape shape : model.getShapesWithTrait(DefaultTrait.class)) {
+            DefaultTrait trait = shape.expectTrait(DefaultTrait.class);
+            // Members with a null default are considered boxed. Keep the trait to retain consistency with other
+            // indexes and checks.
+            if (!trait.toNode().isNullNode()) {
+                if (!NullableIndex.isDefaultZeroValueOfTypeInV1(trait.toNode(), shape.getType())) {
+                    updates.add(Shape.shapeToBuilder(shape)
+                                        .removeTrait(DefaultTrait.ID)
+                                        .removeTrait(AddedDefaultTrait.ID)
+                                        .build());
+                }
+            }
+        }
+
+        return transformer.replaceShapes(model, updates);
+    }
+
+    private Model removeOtherV2Traits(ModelTransformer transformer, Model model) {
+        Set<Shape> updates = new HashSet<>();
+
+        for (StructureShape structure : model.getStructureShapes()) {
+            for (MemberShape member : structure.getAllMembers().values()) {
+                if (member.hasTrait(ClientOptionalTrait.class)) {
+                    updates.add(member.toBuilder().removeTrait(ClientOptionalTrait.ID).build());
+                }
+            }
+        }
+
+        return transformer.replaceShapes(model, updates);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -636,4 +636,20 @@ public final class ModelTransformer {
     public Model addClientOptional(Model model, boolean applyWhenNoDefaultValue) {
         return new AddClientOptional(applyWhenNoDefaultValue).transform(this, model);
     }
+
+    /**
+     * Removes Smithy IDL 2.0 features from a model that are not strictly necessary to keep for consistency with the
+     * rest of Smithy.
+     *
+     * <p>This transformer converts enum shapes to string shapes with the enum trait, intEnum shapes to integer shapes,
+     * flattens and removes mixins, removes properties from resources, and removes default traits that have no impact
+     * on IDL 1.0 semantics (i.e., default traits on structure members set to something other than null, or default
+     * traits on any other shape that are not the zero value of the shape of a 1.0 model).
+     *
+     * @param model Model to downgrade.
+     * @return Returns the downgraded model.
+     */
+    public Model downgradeToV1(Model model) {
+        return new DowngradeToV1().transform(this, model);
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/DowngradeToV1Test.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/DowngradeToV1Test.java
@@ -1,0 +1,160 @@
+package software.amazon.smithy.model.transform;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.AddedDefaultTrait;
+import software.amazon.smithy.model.traits.BoxTrait;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
+import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
+import software.amazon.smithy.model.traits.NotPropertyTrait;
+import software.amazon.smithy.model.traits.PropertyTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+
+public class DowngradeToV1Test {
+    @Test
+    public void convertsIntEnums() {
+        IntEnumShape intEnumShape = IntEnumShape.builder()
+                .id("smithy.example#IntEnum")
+                .addMember("foo", 1)
+                .build();
+        Model model = Model.assembler()
+                .addShape(intEnumShape)
+                .assemble()
+                .unwrap();
+
+        Model downgraded = ModelTransformer.create().downgradeToV1(model);
+
+        assertThat(downgraded.expectShape(intEnumShape.getId()).isIntEnumShape(), Matchers.is(false));
+        assertThat(downgraded.expectShape(intEnumShape.getId()).isIntegerShape(), Matchers.is(true));
+        assertThat(downgraded.expectShape(intEnumShape.getId()).getAllTraits().entrySet(), Matchers.empty());
+    }
+
+    @Test
+    public void convertsEnumShapes() {
+        EnumShape enumShape = EnumShape.builder()
+                .id("smithy.example#Enum")
+                .addMember("foo", "hello")
+                .build();
+        Model model = Model.assembler()
+                .addShape(enumShape)
+                .assemble()
+                .unwrap();
+
+        Model downgraded = ModelTransformer.create().downgradeToV1(model);
+
+        assertThat(downgraded.expectShape(enumShape.getId()).isEnumShape(), Matchers.is(false));
+        assertThat(downgraded.expectShape(enumShape.getId()).isStringShape(), Matchers.is(true));
+        assertThat(downgraded.expectShape(enumShape.getId()).getAllTraits(), Matchers.hasKey(EnumTrait.ID));
+    }
+
+    @Test
+    public void flattensMixins() {
+        StringShape mixin = StringShape.builder()
+                .id("smithy.example#Mixin")
+                .addTrait(MixinTrait.builder().build())
+                .addTrait(new SensitiveTrait())
+                .build();
+        StringShape concrete = StringShape.builder()
+                .id("smithy.example#Concrete")
+                .addMixin(mixin)
+                .build();
+        Model model = Model.assembler()
+                .addShapes(mixin, concrete)
+                .assemble()
+                .unwrap();
+
+        Model downgraded = ModelTransformer.create().downgradeToV1(model);
+
+        assertThat(downgraded.expectShape(concrete.getId()).getMixins(), Matchers.empty());
+        assertThat(downgraded.expectShape(concrete.getId()).getAllTraits(), Matchers.hasKey(SensitiveTrait.ID));
+        assertThat(downgraded.getShape(mixin.getId()).isPresent(), Matchers.is(false));
+    }
+
+    @Test
+    public void removesResourceProperties() {
+        StructureShape input = StructureShape.builder()
+                .id("smithy.example#Input")
+                .addMember("foo", ShapeId.from("smithy.api#String"), b -> b.addTrait(PropertyTrait.builder().build()))
+                .addMember("baz", ShapeId.from("smithy.api#String"), b -> b.addTrait(new NotPropertyTrait()))
+                .build();
+        OperationShape operation = OperationShape.builder()
+                .id(ShapeId.from("smithy.example#Op"))
+                .input(input)
+                .build();
+        ResourceShape resource = ResourceShape.builder()
+                .id(ShapeId.from("smithy.example#Foo"))
+                .addProperty("foo", "smithy.api#String")
+                .addOperation(operation)
+                .build();
+
+        Model model = Model.assembler()
+                .addShapes(input, operation, resource)
+                .assemble()
+                .unwrap();
+
+        Model downgraded = ModelTransformer.create().downgradeToV1(model);
+
+        assertThat(downgraded.expectShape(resource.getId(), ResourceShape.class).getProperties(),
+                   Matchers.anEmptyMap());
+
+        assertThat(downgraded.expectShape(input.getMember("foo").get().getId()).hasTrait(PropertyTrait.class),
+                   Matchers.is(false));
+        assertThat(downgraded.expectShape(input.getMember("baz").get().getId()).hasTrait(NotPropertyTrait.class),
+                   Matchers.is(false));
+    }
+
+    @Test
+    public void removesUnnecessaryDefaults() {
+        String stringModel = "$version: \"2.0\"\n"
+                + "namespace smithy.example\n"
+                + "@default(10)\n"
+                + "integer MyInteger\n"
+                + "structure Struct {\n"
+                + "  @default(10)\n"
+                + "  foo: MyInteger\n"
+                + "  baz: PrimitiveInteger = null\n"
+                + "  @default(\"hi\")\n"
+                + "  @addedDefault\n"
+                + "  bar: String\n"
+                + "  @required\n"
+                + "  @clientOptional\n"
+                + "  bam: String\n"
+                + "}";
+
+        Model model = Model.assembler()
+                .addUnparsedModel("example.smithy", stringModel)
+                .assemble()
+                .unwrap();
+
+        Model downgraded = ModelTransformer.create().downgradeToV1(model);
+
+        ShapeId integerShape = ShapeId.from("smithy.example#MyInteger");
+        assertThat(downgraded.expectShape(integerShape).hasTrait(DefaultTrait.class), Matchers.is(false));
+        assertThat(downgraded.expectShape(integerShape).hasTrait(BoxTrait.class), Matchers.is(true));
+
+        StructureShape dStruct = downgraded.expectShape(ShapeId.from("smithy.example#Struct"), StructureShape.class);
+        assertThat(dStruct.getAllMembers().get("foo").hasTrait(DefaultTrait.class), Matchers.is(false));
+
+        assertThat(dStruct.getAllMembers().get("baz").hasTrait(DefaultTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("baz").hasTrait(BoxTrait.class), Matchers.is(true));
+
+        assertThat(dStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.class), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("bar").hasTrait(AddedDefaultTrait.class), Matchers.is(false));
+
+        assertThat(dStruct.getAllMembers().get("bam").hasTrait(RequiredTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("bam").hasTrait(ClientOptionalTrait.class), Matchers.is(false));
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/data-mixins.1.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/data-mixins.1.0.json
@@ -1,0 +1,120 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#B": {
+            "type": "structure",
+            "members": {}
+        },
+        "smithy.example#F": {
+            "type": "structure",
+            "members": {}
+        },
+        "smithy.example#MixedBigDecimal": {
+            "type": "bigDecimal"
+        },
+        "smithy.example#MixedBigInt": {
+            "type": "bigInteger"
+        },
+        "smithy.example#MixedBlob": {
+            "type": "blob"
+        },
+        "smithy.example#MixedBoolean": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedByte": {
+            "type": "byte",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedDocument": {
+            "type": "document"
+        },
+        "smithy.example#MixedDouble": {
+            "type": "double",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedFloat": {
+            "type": "float",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedList": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String"
+            }
+        },
+        "smithy.example#MixedLong": {
+            "type": "long",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
+            }
+        },
+        "smithy.example#MixedSet": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String"
+            },
+            "traits": {
+                "smithy.api#uniqueItems": {}
+            }
+        },
+        "smithy.example#MixedShort": {
+            "type": "short",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "smithy.example#MixedString": {
+            "type": "string"
+        },
+        "smithy.example#MixedTimestamp": {
+            "type": "timestamp"
+        },
+        "smithy.example#PrimitiveInteger": {
+            "type": "integer"
+        },
+        "smithy.example#Struct": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "smithy.example#PrimitiveInteger"
+                },
+                "bar": {
+                    "target": "smithy.example#PrimitiveInteger",
+                    "traits": {
+                        "smithy.api#box": {}
+                    }
+                },
+                "baz": {
+                    "target": "smithy.example#MixedInteger"
+                },
+                "bam": {
+                    "target": "smithy.example#MixedInteger"
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/data-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/data-mixins.json
@@ -254,6 +254,38 @@
             "mixins": [{
                 "target": "smithy.example#MixinMap"
             }]
+        },
+        "smithy.example#PrimitiveInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "smithy.example#Struct": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "smithy.example#PrimitiveInteger",
+                    "traits": {
+                        "smithy.api#default": 0
+                    }
+                },
+                "bar": {
+                    "target": "smithy.example#PrimitiveInteger",
+                    "traits": {
+                        "smithy.api#default": null
+                    }
+                },
+                "baz": {
+                    "target": "smithy.example#MixedInteger"
+                },
+                "bam": {
+                    "target": "smithy.example#MixedInteger",
+                    "traits": {
+                        "smithy.api#default": 1
+                    }
+                }
+            }
         }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/enums.1.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/enums.1.0.json
@@ -1,0 +1,23 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#IntEnum": {
+            "type": "integer"
+        },
+        "smithy.example#StringEnum": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "foo",
+                        "name": "FOO"
+                    },
+                    {
+                        "value": "bar",
+                        "name": "BAR"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/operation-mixins.1.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/operation-mixins.1.0.json
@@ -1,0 +1,29 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#ConcreteError": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#error": "client"
+            }
+        },
+        "smithy.example#MixedOperation": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "smithy.example#ConcreteError"
+                }
+            ],
+            "traits": {
+                "smithy.api#internal": {}
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/operation-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/operation-mixins.json
@@ -5,7 +5,8 @@
             "type": "structure",
             "members": {},
             "traits": {
-                "smithy.api#error": "server"
+                "smithy.api#error": "server",
+                "smithy.api#mixin": {}
             }
         },
         "smithy.example#MixinOperation": {
@@ -17,7 +18,7 @@
                 "target": "smithy.api#Unit"
             },
             "errors": [{
-                "target": "smithy.example#MixinError"
+                "target": "smithy.example#ConcreteError"
             }],
             "traits": {
                 "smithy.api#mixin": {},
@@ -27,6 +28,11 @@
         "smithy.example#ConcreteError": {
             "type": "structure",
             "members": {},
+            "mixins": [
+                {
+                    "target": "smithy.example#MixinError"
+                }
+            ],
             "traits": {
                 "smithy.api#error": "client"
             }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/resource-mixins.1.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/resource-mixins.1.0.json
@@ -1,0 +1,11 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#MixedResource": {
+            "type": "resource",
+            "traits": {
+                "smithy.api#internal": {}
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/service-mixins-with-overrides.1.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/service-mixins-with-overrides.1.0.json
@@ -1,0 +1,99 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#MixedError": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.example#MixedRename"
+                }
+            },
+            "traits": {
+                "smithy.api#error": "server"
+            }
+        },
+        "smithy.example#MixedOperation": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            }
+        },
+        "smithy.example#MixedRename": {
+            "type": "string"
+        },
+        "smithy.example#MixedResource": {
+            "type": "resource"
+        },
+        "smithy.example#MixedService": {
+            "type": "service",
+            "version": "2022-01-01",
+            "operations": [
+                {
+                    "target": "smithy.example#MixedOperation"
+                },
+                {
+                    "target": "smithy.example#MixinOperation"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "smithy.example#MixedResource"
+                },
+                {
+                    "target": "smithy.example#MixinResource"
+                }
+            ],
+            "errors": [
+                {
+                    "target": "smithy.example#MixedError"
+                },
+                {
+                    "target": "smithy.example#MixinError"
+                }
+            ],
+            "rename": {
+                "smithy.example#MixinRename": "ThisWillBeInherited",
+                "smithy.example#OverriddenRename": "Override",
+                "smithy.example#MixedRename": "LocalRename"
+            },
+            "traits": {
+                "smithy.api#internal": {}
+            }
+        },
+        "smithy.example#MixinError": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.example#MixinRename"
+                },
+                "state": {
+                    "target": "smithy.example#OverriddenRename"
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client"
+            }
+        },
+        "smithy.example#MixinOperation": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            }
+        },
+        "smithy.example#MixinRename": {
+            "type": "string"
+        },
+        "smithy.example#MixinResource": {
+            "type": "resource"
+        },
+        "smithy.example#OverriddenRename": {
+            "type": "string"
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/service-mixins.1.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/service-mixins.1.0.json
@@ -1,0 +1,56 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "smithy.example#MixedService": {
+            "type": "service",
+            "version": "2021-12-31",
+            "operations": [
+                {
+                    "target": "smithy.example#MixinOperation"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "smithy.example#MixinResource"
+                }
+            ],
+            "errors": [
+                {
+                    "target": "smithy.example#MixinError"
+                }
+            ],
+            "rename": {
+                "smithy.example#ShapeToRename": "RenamedShape"
+            },
+            "traits": {
+                "smithy.api#internal": {}
+            }
+        },
+        "smithy.example#MixinError": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.example#ShapeToRename"
+                }
+            },
+            "traits": {
+                "smithy.api#error": "client"
+            }
+        },
+        "smithy.example#MixinOperation": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            }
+        },
+        "smithy.example#MixinResource": {
+            "type": "resource"
+        },
+        "smithy.example#ShapeToRename": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the ability to downgrade the in-memory semantic model to 1.0 models, and adds support for serializing 1.0 JSON AST models to ModelSerializer.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
