### PR TITLE
Add test for synthetic box traits on mixins

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/AstModelLoader.java
@@ -194,7 +194,7 @@ final class AstModelLoader {
                 return loadOperation(id, value);
             case "apply":
                 LoaderUtils.checkForAdditionalProperties(value, id, APPLY_PROPERTIES).ifPresent(this::emit);
-                applyTraits(id, value.expectObjectMember(TRAITS));
+                value.getObjectMember(TRAITS).ifPresent(traits -> applyTraits(id, traits));
                 return null;
             default:
                 throw new SourceException("Invalid shape `type`: " + type, value);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/AstModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/AstModelLoaderTest.java
@@ -15,14 +15,13 @@
 
 package software.amazon.smithy.model.loader;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AstModelLoaderTest {
     @Test
@@ -33,5 +32,15 @@ public class AstModelLoaderTest {
         assertEquals(1, model.getValidationEvents(Severity.ERROR).size());
         assertTrue(model.getValidationEvents(Severity.ERROR).get(0).getMessage()
                 .contains("Resource properties can only be used with Smithy version 2 or later."));
+    }
+
+    @Test
+    public void doesNotFailOnEmptyApply() {
+        // Empty apply statements are pointless but shouldn't break the loader.
+        Model.assembler()
+                .addImport(getClass().getResource("ast-empty-apply-1.json"))
+                .addImport(getClass().getResource("ast-empty-apply-2.json"))
+                .assemble()
+                .unwrap();
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/ast-empty-apply-1.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/ast-empty-apply-1.json
@@ -1,0 +1,8 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "smithy.example#Foo": {
+            "type": "string"
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/ast-empty-apply-2.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/ast-empty-apply-2.json
@@ -1,0 +1,8 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "smithy.example#Foo": {
+            "type": "apply"
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/synthetic-boxing-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/synthetic-boxing-mixins.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+namespace smithy.example
+
+@mixin
+integer MixinInteger
+
+integer MixedInteger with [MixinInteger]
+
+@mixin
+structure MixinStruct {
+    bar: MixedInteger = null
+}
+
+structure MixedStruct with [MixinStruct] {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/no-empty-apply-types.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/no-empty-apply-types.json
@@ -1,0 +1,28 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "smithy.example#MixedStruct": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "smithy.example#MixinStruct"
+                }
+            ],
+            "members": {}
+        },
+        "smithy.example#MixinStruct": {
+            "type": "structure",
+            "members": {
+                "bar": {
+                    "target": "smithy.api#PrimitiveInteger",
+                    "traits": {
+                        "smithy.api#default": null
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/no-empty-apply-types.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/no-empty-apply-types.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+namespace smithy.example
+
+@mixin
+structure MixinStruct {
+    bar: PrimitiveInteger = null
+}
+
+structure MixedStruct with [MixinStruct] {}


### PR DESCRIPTION
This commit also fixes an issue where we would sometimes add empty apply statements to the JSON AST because a mixin introduces no traits. The AST parser now handles this without failing, and the model serializer no longer writes out empty apply blocks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
