### PR TITLE
Update smithy-diff for strings with the enum trait to enum shapes

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedShape.java
@@ -16,9 +16,15 @@
 package software.amazon.smithy.diff.evaluators;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
@@ -29,6 +35,7 @@ public final class AddedShape extends AbstractDiffEvaluator {
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.addedShapes()
                 .filter(shape -> !isMemberOfAddedShape(shape, differences))
+                .filter(shape -> !isMemberOfConvertedEnumShape(shape, differences))
                 .map(shape -> note(shape, String.format("Added %s `%s`", shape.getType(), shape.getId())))
                 .collect(Collectors.toList());
     }
@@ -37,5 +44,26 @@ public final class AddedShape extends AbstractDiffEvaluator {
         return shape.asMemberShape()
                 .filter(member -> !differences.getOldModel().getShapeIds().contains(member.getContainer()))
                 .isPresent();
+    }
+
+    private boolean isMemberOfConvertedEnumShape(Shape shape, Differences differences) {
+        if (!shape.asMemberShape().isPresent()) {
+            return false;
+        }
+
+        ShapeId conversionShapeId = shape.asMemberShape().get().getContainer();
+
+        Optional<StringShape> oldStringShapeWithEnumTrait = differences.getOldModel()
+                .getShape(conversionShapeId)
+                .flatMap(Shape::asStringShape)
+                .filter(s -> s.getType() == ShapeType.STRING)
+                .filter(s -> s.hasTrait(EnumTrait.ID));
+
+        Optional<EnumShape> newEnumShape = differences.getNewModel()
+                .getShape(conversionShapeId)
+                .flatMap(Shape::asEnumShape);
+
+        // Changes in enum values are handled in the ChangedEnumTrait evaluator
+        return newEnumShape.isPresent() && oldStringShapeWithEnumTrait.isPresent();
     }
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedShapeType.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedShapeType.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -33,10 +34,17 @@ public final class ChangedShapeType extends AbstractDiffEvaluator {
         return differences.changedShapes()
                 .filter(diff -> diff.getOldShape().getType() != diff.getNewShape().getType())
                 .filter(diff -> !expectedSetToListChange(diff))
+                .filter(diff -> !expectedStringToEnumChange(diff))
                 .map(diff -> error(diff.getNewShape(), String.format(
                         "Shape `%s` type was changed from `%s` to `%s`.",
                         diff.getShapeId(), diff.getOldShape().getType(), diff.getNewShape().getType())))
                 .collect(Collectors.toList());
+    }
+
+    static boolean expectedStringToEnumChange(ChangedShape<Shape> diff) {
+        // Smithy diff doesn't raise an issue if a string with an enum trait is changed
+        // to an enum shape. The enum trait is deprecated and this is a recommended change.
+        return diff.getOldShape().hasTrait(EnumTrait.class) && diff.getNewShape().getType() == ShapeType.ENUM;
     }
 
     private boolean expectedSetToListChange(ChangedShape<Shape> diff) {

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedShapeTest.java
@@ -22,10 +22,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.EnumDefinition;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 public class AddedShapeTest {
@@ -51,5 +54,101 @@ public class AddedShapeTest {
 
         assertThat(TestHelper.findEvents(events, "AddedShape").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, list.getId()).size(), equalTo(1));
+    }
+
+    @Test
+    public void doesNotEmitForMembersOfConvertedEnumShape() {
+        Shape stringWithEnumTrait = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Shape enumShape = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Model modelA = Model.assembler().addShapes(stringWithEnumTrait).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(enumShape).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "AddedShape").size(), equalTo(0));
+    }
+
+    @Test
+    public void doesNotEmitForEnumShapeToEnumTrait() {
+        Shape enumShape = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Shape stringWithEnumTrait = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Model modelA = Model.assembler().addShapes(enumShape).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(stringWithEnumTrait).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "AddedShape").size(), equalTo(0));
+    }
+
+    @Test
+    public void doesNotEmitForEnumTraitToEnumTraitAddedEnum() {
+        Shape stringWithEnumTraitA = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Shape stringWithEnumTraitB = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .name("BAR")
+                                .value("BAR")
+                                .build())
+                        .build())
+                .build();
+        Model modelA = Model.assembler().addShapes(stringWithEnumTraitA).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(stringWithEnumTraitB).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "AddedShape").size(), equalTo(0));
+    }
+
+    @Test
+    public void doesEmitForEnumShapeToEnumShapeAddedMember() {
+        Shape enumShapeA = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Shape enumShapeB = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .addMember("BAR", "BAR")
+                .build();
+        Model modelA = Model.assembler().addShapes(enumShapeA).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(enumShapeB).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "AddedShape").size(), equalTo(1));
+        assertThat(enumShapeB.getMember("BAR").isPresent(), equalTo(true));
+        assertThat(TestHelper.findEvents(events, enumShapeB.getMember("BAR").get().toShapeId()).size(),
+                equalTo(1));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
@@ -54,6 +55,57 @@ public class ChangedEnumTraitTest {
     }
 
     @Test
+    public void detectsAppendedEnumsEnumTraitNoNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .value("foo")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("foo", "foo")
+                .addMember("baz", "baz")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSeverity(),
+                equalTo(Severity.ERROR));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(1).getSeverity(),
+                equalTo(Severity.NOTE));
+    }
+
+    @Test
+    public void detectsAppendedEnumsEnumTraitWithNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("foo")
+                                .value("foo")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("foo", "foo")
+                .addMember("baz", "baz")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
+                .allMatch(e -> e.getSeverity() == Severity.NOTE), equalTo(true));
+    }
+
+    @Test
     public void detectsRemovedEnums() {
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
@@ -74,6 +126,59 @@ public class ChangedEnumTraitTest {
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+    }
+
+    @Test
+    public void detectsRemovedEnumsEnumTraitNoNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .value("foo")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .value("baz")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("foo", "foo")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
+                .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
+    }
+
+    @Test
+    public void detectsRemovedEnumsEnumTraitWithNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("foo")
+                                .value("foo")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .name("baz")
+                                .value("baz")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("foo", "foo")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
+                .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
     }
 
     @Test
@@ -99,6 +204,53 @@ public class ChangedEnumTraitTest {
     }
 
     @Test
+    public void detectsRenamedEnumsEnumTraitNoNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .value("foo")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("NEW", "foo")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSeverity(),
+                equalTo(Severity.ERROR));
+    }
+
+    @Test
+    public void detectsRenamedEnumsEnumTraitWithNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("OLD")
+                                .value("foo")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("NEW", "foo")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSeverity(),
+                equalTo(Severity.ERROR));
+    }
+
+    @Test
     public void detectsInsertedEnums() {
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
@@ -119,6 +271,55 @@ public class ChangedEnumTraitTest {
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSeverity(), equalTo(Severity.ERROR));
+    }
+
+    @Test
+    public void detectsInsertedEnumsEnumTraitNoNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .value("foo")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("baz", "baz")
+                .addMember("foo", "foo")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
+                .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
+    }
+
+    @Test
+    public void detectsInsertedEnumsEnumTraitWithNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("foo")
+                                .value("foo")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("baz", "baz")
+                .addMember("foo", "foo")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
+                .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
     }
 
     @Test
@@ -153,5 +354,74 @@ public class ChangedEnumTraitTest {
         ValidationEvent appendedEvent = changeEvents.get(1);
         assertThat(appendedEvent.getSeverity(), equalTo(Severity.NOTE));
         assertThat(appendedEvent.getMessage(), stringContainsInOrder("Enum value `new1` was appended"));
+    }
+
+    @Test
+    public void detectsAppendedEnumsAfterRemovedEnumsEnumTraitNoNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .value("old1")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .value("old2")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .value("old3")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("old1", "old1")
+                .addMember("old3", "old3")
+                .addMember("new1", "new1")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(4));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(0, 3).stream()
+                .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(3, 4).stream()
+                .allMatch(e -> e.getSeverity() == Severity.NOTE), equalTo(true));
+    }
+
+    @Test
+    public void detectsAppendedEnumsAfterRemovedEnumsEnumTraitWithNameToEnumShape() {
+        StringShape s1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("old1")
+                                .value("old1")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .name("old2")
+                                .value("old2")
+                                .build())
+                        .addEnum(EnumDefinition.builder()
+                                .name("old3")
+                                .value("old3")
+                                .build())
+                        .build())
+                .build();
+        EnumShape s2 = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("old1", "old1")
+                .addMember("old3", "old3")
+                .addMember("new1", "new1")
+                .build();
+        Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
+        Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(0, 1).stream()
+                .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(1, 2).stream()
+                .allMatch(e -> e.getSeverity() == Severity.NOTE), equalTo(true));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedShapeTypeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedShapeTypeTest.java
@@ -24,10 +24,13 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.traits.EnumDefinition;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 public class ChangedShapeTypeTest {
@@ -58,5 +61,94 @@ public class ChangedShapeTypeTest {
         List<ValidationEvent> events = ModelDiff.compare(oldModel, newModel);
 
         assertThat(TestHelper.findEvents(events, "ChangedShapeType"), empty());
+    }
+
+    @Test
+    public void ignoresExpectedEnumTraitToEnumMigration() {
+        Shape stringWithEnumTrait = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Shape enumShape = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Model modelA = Model.assembler().addShapes(stringWithEnumTrait).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(enumShape).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedShapeType"), empty());
+    }
+
+    @Test
+    public void ignoresEnumTraitToEnumTraitMigration() {
+        Shape stringWithEnumTraitA = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Shape stringWithEnumTraitB = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Model modelA = Model.assembler().addShapes(stringWithEnumTraitA).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(stringWithEnumTraitB).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedShapeType"), empty());
+    }
+
+    @Test
+    public void ignoresEnumToEnumMigration() {
+        Shape enumShapeA = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Shape enumShapeB = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Model modelA = Model.assembler().addShapes(enumShapeA).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(enumShapeB).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedShapeType"), empty());
+    }
+
+    @Test
+    public void doesNotIgnoreEnumTraitToEnumMigration() {
+        Shape enumShape = EnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", "FOO")
+                .build();
+        Shape stringWithEnumTrait = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder()
+                        .addEnum(EnumDefinition.builder()
+                                .name("FOO")
+                                .value("FOO")
+                                .build())
+                        .build())
+                .build();
+        Model modelA = Model.assembler().addShapes(enumShape).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(stringWithEnumTrait).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedShapeType").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, stringWithEnumTrait.toShapeId()).size(), equalTo(1));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Update smithy-diff for strings with the enum trait to enum shapes
    
Remove the following noise from smithy-diff:
    
- Errors for changing shape type from strings with the `enum` trait to enum shapes since the `enum` trait is deprecated.
- Notes for members added to the converted enum shapes.
    
Updated `ChangedEnumTrait` to not just compare changed `enum` traits, but also changes of an `enum` trait to its converted enum shape.

---

*Testing:*

- Run `./gradlew clean build check :smithy-cli:runtime`
  - Included new unit tests
- Copy 2 example 1.0 -> 2.0 models from aws-sdk-go-v2
- Run smithy cli diff on the 2 models and verify logs

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
