### PR TITLE
Simplify ShapeId caching

### DIFF
--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -142,4 +142,10 @@
         <Class name="software.amazon.smithy.rulesengine.traits.ContextIndex"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>
+
+    <!-- We don't care about the return value of putIfAbsent in this cache -->
+    <Match>
+        <Class name="software.amazon.smithy.model.shapes.ShapeId$ShapeIdFactory"/>
+        <Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
The previous implementation could cause a recursive update error when a shape ID is purged from the cache because it attempted to remove an element from the ConcurrentHashMap inside of a computeIfAbsent call. This updated approach is simpler and instead separates prelude shape IDs into a ConcurrentHashMap that just stops caching after 500 entries are in the cache (which does more than cover the shapes currently in the prelude), and uses a synchronized LinkedHashMap to function as an LRU cache for all other shape IDs. The performance of this approach vs what we had previously is essentially the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
