### PR TITLE
Fix apply statement parsing and ABNF

### DIFF
--- a/docs/source-1.0/spec/core/idl.rst
+++ b/docs/source-1.0/spec/core/idl.rst
@@ -235,7 +235,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                             :      *(`Comma` `TraitStructureKvp` *`WS`)
                             :  `TrailingComma`
     TraitStructureKvp       :`NodeObjectKey` *`WS` ":" *`WS` `NodeValue`
-    ApplyStatement          :%s"apply" `WS` `ShapeId` `WS` `Trait` `BR`
+    ApplyStatement          :%s"apply" `SP` `ShapeId` `WS` `Trait` `BR`
 
 .. rubric:: Shape ID
 

--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -237,7 +237,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     TraitStructure          :`TraitStructureKvp` *(*`WS` `TraitStructureKvp`)
     TraitStructureKvp       :`NodeObjectKey` *`WS` ":" *`WS` `NodeValue`
     ApplyStatement          :(`ApplyStatementSingular` / `ApplyStatementBlock`)
-    ApplyStatementSingular  :%s"apply" `WS` `ShapeId` `WS` `Trait` `BR`
+    ApplyStatementSingular  :%s"apply" `SP` `ShapeId` `WS` `Trait` `BR`
     ApplyStatementBlock     :%s"apply" `SP` `ShapeId` `WS` "{" `TraitStatements` "}" `BR`
 
 .. rubric:: Shape ID

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -1126,7 +1126,7 @@ final class IdlModelParser extends SimpleParser {
         expect('p');
         expect('l');
         expect('y');
-        sp();
+        rsp();
 
         String name = ParserUtils.parseShapeId(this);
         rws();


### PR DESCRIPTION
This fixes an issue where `applySomeShape @someTrait` was valid, without any space between the apply and shape name. The fix makes it so spacing is required, not line breaks as was the case in the old ABNF, to be consistent with other shapes grammar (see [SimpleShapeStatement](https://awslabs.github.io/smithy/2.0/spec/idl.html#grammar-token-smithy-SimpleShapeStatement))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
