### PR TITLE
Correct the Resource shape properties Type entry

### DIFF
--- a/docs/source-1.0/spec/core/json-ast.rst
+++ b/docs/source-1.0/spec/core/json-ast.rst
@@ -65,7 +65,7 @@ a ``type`` property to define the shape type or ``apply``.
     }
 
 All entries in the ``shapes`` map can contain a ``traits`` property that
-defines the traits attached to the shape. ``traits`` is a map of where
+defines the traits attached to the shape. ``traits`` is a map where
 each key is the absolute shape ID of a trait shape and each value is
 the value to assign to the trait.
 

--- a/docs/source-2.0/spec/json-ast.rst
+++ b/docs/source-2.0/spec/json-ast.rst
@@ -69,7 +69,7 @@ a ``type`` property to define the shape type or ``apply``.
     }
 
 All entries in the ``shapes`` map can contain a ``traits`` property that
-defines the traits attached to the shape. ``traits`` is a map of where
+defines the traits attached to the shape. ``traits`` is a map where
 each key is the absolute shape ID of a trait shape and each value is
 the value to assign to the trait.
 

--- a/docs/source-2.0/spec/json-ast.rst
+++ b/docs/source-2.0/spec/json-ast.rst
@@ -496,7 +496,7 @@ shapes defined in JSON support the same properties as the Smithy IDL.
       - Map<String, :ref:`AST shape reference <ast-shape-reference>`>
       - Defines identifier names and shape IDs used to identify the resource.
     * - :ref:`properties <resource-properties>`
-      - Map<String, :ref:`shape ID <shape-id>`>
+      - Map<String, :ref:`AST shape reference <ast-shape-reference>`>
       - Defines a map of property string names to shape IDs that
         enumerate the properties of the resource.
     * - :ref:`create <create-lifecycle>`

--- a/docs/source-2.0/spec/json-ast.rst
+++ b/docs/source-2.0/spec/json-ast.rst
@@ -496,7 +496,7 @@ shapes defined in JSON support the same properties as the Smithy IDL.
       - Map<String, :ref:`AST shape reference <ast-shape-reference>`>
       - Defines identifier names and shape IDs used to identify the resource.
     * - :ref:`properties <resource-properties>`
-      - :ref:`AST shape reference <ast-shape-reference>`
+      - Map<String, :ref:`shape ID <shape-id>`>
       - Defines a map of property string names to shape IDs that
         enumerate the properties of the resource.
     * - :ref:`create <create-lifecycle>`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Prior to this change, the docs incorrectly lists the [(JSON AST) Resource shape Type](https://awslabs.github.io/smithy/2.0/spec/json-ast.html#resource-shape) as "AST shape reference", but as per the Description column, and the [Model docs for Resource Properties](https://awslabs.github.io/smithy/2.0/spec/service-types.html#resource-properties), as well as the [Introducing Smithy IDL 2.0 blog post](https://aws.amazon.com/blogs/developer/introducing-smithy-idl-2-0/), this Type should be a map of strings to shape ID.

ie the following blue-highlighted cell is incorrect:

![image](https://user-images.githubusercontent.com/5195222/191139031-5ffd31b8-5143-419d-9d76-937a2af266e1.png)

This PR changes it to `Map<String, shape ID>`, which matches the Model description and AWS blog post examples.

There's also two other very minor grammar corrections including (dropping two instances of `of`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Cheers.