### PR TITLE
Fix dedicated io transform leaving unused shapes

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-heuristic-for-shared-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-heuristic-for-shared-after.smithy
@@ -1,0 +1,18 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// `@output` is added to `GetFooOutput`
+// and a dedicated input shape is added
+operation GetFoo {
+    input: GetFooInput
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {
+}
+
+@output
+structure GetFooOutput {
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-heuristic-for-shared-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/creates-dedicated-heuristic-for-shared-before.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// `GetFooOutput` is shared by input and output
+// and has the right naming for an output shape
+operation GetFoo {
+    input: GetFooOutput
+    output: GetFooOutput
+}
+
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shared-shape-after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shared-shape-after.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Dedicated input and output are created
+// and the old shared shape removed
+operation GetFoo {
+    input: GetFooInput
+    output: GetFooOutput
+}
+
+@input
+structure GetFooInput {}
+
+@output
+structure GetFooOutput {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shared-shape-before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/dedicated-input-output/removes-disconnected-shared-shape-before.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// A shape is shared by both input and output
+// but is not named properly for an output
+operation GetFoo {
+    input: MyGetFooOutput
+    output: MyGetFooOutput
+}
+
+structure MyGetFooOutput {}


### PR DESCRIPTION
This commit changes the way `CreateDedicatedInputOutput` transform checks for singular references to a shape being used as input or output in an operation. It now checks to make sure the shape is only referenced by the specified operation. This fixes an edge case where a shape was being used as both the input and output for an operation, and would be left unused in the model after the transformation was applied.  Two new test cases were added to verify the behavior when a shape is used as both input and output.

*Issue #, if available:* #1373

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
