### PR TITLE
Fix intEnum example

### DIFF
--- a/docs/source-2.0/spec/simple-types.rst
+++ b/docs/source-2.0/spec/simple-types.rst
@@ -299,16 +299,16 @@ The above example is exactly equivalent to the following:
         JACK
 
         @enumValue(2)
-        QUEEN = 2
+        QUEEN
 
         @enumValue(3)
-        KING = 3
+        KING
 
         @enumValue(4)
-        ACE = 4
+        ACE
 
         @enumValue(5)
-        JOKER = 5
+        JOKER
     }
 
 


### PR DESCRIPTION
Fixes the `@enumValue` example for intEnums.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
