### PR TITLE
Fix javadoc for CodegenDirector.simplifyModelForServiceCodegen

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -81,7 +81,6 @@ public final class CodegenDirector<
      * <ul>
      *     <li>Flattens error hierarchies onto every operation.</li>
      *     <li>Flattens mixins</li>
-     *     <li>Converts enum strings to enum shapes.</li>
      * </ul>
      *
      * <p><em>Note</em>: This transform is applied automatically by a code


### PR DESCRIPTION
This was missed in https://github.com/awslabs/smithy/pull/1370

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
