### PR TITLE
Add intEnum DirectedCodegen

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -35,6 +35,7 @@ import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -470,6 +471,13 @@ public final class CodegenDirector<
         public Void enumShape(EnumShape shape) {
             LOGGER.finest(() -> "Generating enum shape" + shape.getId());
             directedCodegen.generateEnumShape(new GenerateEnumDirective<>(context, serviceShape, shape));
+            return null;
+        }
+
+        @Override
+        public Void intEnumShape(IntEnumShape shape) {
+            LOGGER.finest(() -> "Generating intEnum shape" + shape.getId());
+            directedCodegen.generateIntEnumShape(new GenerateIntEnumDirective<>(context, serviceShape, shape));
             return null;
         }
     }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
@@ -100,6 +100,13 @@ public interface DirectedCodegen<C extends CodegenContext<S, ?, I>, S, I extends
     void generateEnumShape(GenerateEnumDirective<C, S> directive);
 
     /**
+     * Generates the code needed for an intEnum shape.
+     *
+     * @param directive Directive to perform.
+     */
+    void generateIntEnumShape(GenerateIntEnumDirective<C, S> directive);
+
+    /**
      * Performs any necessary code generation after all shapes are generated,
      * using the created codegen context object before integrations perform
      * customizations.

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateIntEnumDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateIntEnumDirective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core.directed;
+
+import software.amazon.smithy.codegen.core.CodegenContext;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+
+/**
+ * Directive used to generate an intEnum.
+ *
+ * @param <C> CodegenContext type.
+ * @param <S> Codegen settings type.
+ * @see DirectedCodegen#generateIntEnumShape
+ */
+public final class GenerateIntEnumDirective<C extends CodegenContext<S, ?, ?>, S> extends ShapeDirective<Shape, C, S> {
+
+    GenerateIntEnumDirective(C context, ServiceShape service, Shape shape) {
+        super(context, service, shape);
+    }
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -102,6 +102,11 @@ public class CodegenDirectorTest {
         }
 
         @Override
+        public void generateIntEnumShape(GenerateIntEnumDirective<TestContext, TestSettings> directive) {
+            generatedShapes.add(directive.shape().getId());
+        }
+
+        @Override
         public void customizeBeforeIntegrations(CustomizeDirective<TestContext, TestSettings> directive) {}
 
         @Override
@@ -169,6 +174,7 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#ListFooInput"),
                 ShapeId.from("smithy.example#ListFooOutput"),
                 ShapeId.from("smithy.example#Status"),
+                ShapeId.from("smithy.example#FaceCard"),
                 ShapeId.from("smithy.example#Instruction"),
                 ShapeId.from("smithy.api#Unit")
         ));
@@ -209,6 +215,7 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#ListFooInput"),
                 ShapeId.from("smithy.example#ListFooOutput"),
                 ShapeId.from("smithy.example#Status"),
+                ShapeId.from("smithy.example#FaceCard"),
                 ShapeId.from("smithy.example#Instruction"),
                 ShapeId.from("smithy.api#Unit")
         ));

--- a/smithy-codegen-core/src/test/resources/software/amazon/smithy/codegen/core/directed/directed-model.smithy
+++ b/smithy-codegen-core/src/test/resources/software/amazon/smithy/codegen/core/directed/directed-model.smithy
@@ -23,6 +23,7 @@ operation ListFoo {
         status: Status
         items: StringList
         instruction: Instruction
+        facecard: FaceCard
     }
 }
 
@@ -35,6 +36,12 @@ list StringList {
     {name: "BAD", value: "BAD"}
 ])
 string Status
+
+intEnum FaceCard {
+    JACK = 1
+    QUEEN = 2
+    KING = 3
+}
 
 union Instruction {
     continueIteration: Unit,


### PR DESCRIPTION
Adds `intEnum` support to DirectedCodegen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
