### PR TITLE
Always attempt model interop transforms

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelInteropTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelInteropTransformer.java
@@ -41,7 +41,6 @@ import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.transform.ModelTransformer;
-import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
@@ -74,13 +73,13 @@ final class ModelInteropTransformer {
     private final Function<Shape, Version> fileToVersion;
     private final List<Shape> shapeUpgrades = new ArrayList<>();
 
-    ModelInteropTransformer(Model model, List<ValidationEvent> events, Function<Shape, Version> fileToVersion) {
+    ModelInteropTransformer(Model model, List<ValidationEvent> mutableEvents, Function<Shape, Version> fileToVersion) {
         this.model = model;
-        this.events = events;
+        this.events = mutableEvents;
         this.fileToVersion = fileToVersion;
     }
 
-    ValidatedResult<Model> transform() {
+    Model transform() {
         // TODO: can these transforms be more efficiently moved into the loader?
         for (StructureShape struct : model.getStructureShapes()) {
             if (!Prelude.isPreludeShape(struct)) {
@@ -106,7 +105,7 @@ final class ModelInteropTransformer {
             }
         }
 
-        return new ValidatedResult<>(ModelTransformer.create().replaceShapes(model, shapeUpgrades), events);
+        return ModelTransformer.create().replaceShapes(model, shapeUpgrades);
     }
 
     private void upgradeV1Member(MemberShape member, Shape target) {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid-1.0-model-upgraded.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/invalid-1.0-model-upgraded.smithy
@@ -1,0 +1,20 @@
+$version: "1.0"
+
+namespace smithy.example
+
+integer MyInteger
+
+structure Foo {
+    bar: Integer,
+    baz: MyInteger,
+
+    @box
+    bam: PrimitiveInteger,
+
+    // An invalid trait doesn't break the loading process or prevent upgrades.
+    @thisTraitDoesNotExist
+    boo: String,
+
+    // An invalid target doesn't break the loading process or prevent upgrades.
+    bux: InvalidTarget
+}


### PR DESCRIPTION
We previously did not attempt to perform model interop transforms if a model had errors. For example, if a model referred to an unknown trait, the model wouldn't use the interop transformation. Some use cases might choose to ignore unknown traits and other errors by _not_ unwrapping the assembled model and instead directly accessing the result from ValidatedResult. In these cases, the model would have not gone through the interop transform, resulting in an unexpect model (for example, if performing a diff against a 1.0 and 2.0 model, the upgrade won't run and causes the models to appear to be wildly different).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
