### PR TITLE
Add protocol tests of timestampFormat on target shapes

### DIFF
--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -271,6 +271,26 @@ apply XmlTimestamps @httpResponseTests([
         }
     },
     {
+        id: "QueryXmlTimestampsWithDateTimeOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
+        protocol: awsQuery,
+        code: 200,
+        body: """
+              <XmlTimestampsResponse xmlns="https://example.com/">
+                  <XmlTimestampsResult>
+                      <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
+                  </XmlTimestampsResult>
+              </XmlTimestampsResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml"
+        },
+        params: {
+            dateTimeOnTarget: 1398796238
+        }
+    },
+    {
         id: "QueryXmlTimestampsWithEpochSecondsFormat",
         documentation: "Ensures that the timestampFormat of epoch-seconds works",
         protocol: awsQuery,
@@ -288,6 +308,26 @@ apply XmlTimestamps @httpResponseTests([
         },
         params: {
             epochSeconds: 1398796238
+        }
+    },
+    {
+        id: "QueryXmlTimestampsWithEpochSecondsOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of epoch-seconds on the target shape works",
+        protocol: awsQuery,
+        code: 200,
+        body: """
+              <XmlTimestampsResponse xmlns="https://example.com/">
+                  <XmlTimestampsResult>
+                      <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
+                  </XmlTimestampsResult>
+              </XmlTimestampsResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml"
+        },
+        params: {
+            epochSecondsOnTarget: 1398796238
         }
     },
     {
@@ -310,7 +350,36 @@ apply XmlTimestamps @httpResponseTests([
             httpDate: 1398796238
         }
     },
+    {
+        id: "QueryXmlTimestampsWithHttpDateOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of http-date on the target shape works",
+        protocol: awsQuery,
+        code: 200,
+        body: """
+              <XmlTimestampsResponse xmlns="https://example.com/">
+                  <XmlTimestampsResult>
+                      <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
+                  </XmlTimestampsResult>
+              </XmlTimestampsResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml"
+        },
+        params: {
+            httpDateOnTarget: 1398796238
+        }
+    },
 ])
+
+@timestampFormat("date-time")
+timestamp DateTimeTimestamp
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSecondsTimestamp
+
+@timestampFormat("http-date")
+timestamp HttpDateTimestamp
 
 structure XmlTimestampsOutput {
     normal: Timestamp,
@@ -318,11 +387,17 @@ structure XmlTimestampsOutput {
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
+    dateTimeOnTarget: DateTimeTimestamp,
+
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
+    epochSecondsOnTarget: EpochSecondsTimestamp,
+
     @timestampFormat("http-date")
     httpDate: Timestamp,
+
+    httpDateOnTarget: HttpDateTimestamp,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -5,10 +5,13 @@ $version: "2.0"
 namespace aws.protocoltests.query
 
 use aws.protocols#awsQuery
+use aws.protocoltests.shared#DateTime
+use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
 use aws.protocoltests.shared#FooEnumSet
 use aws.protocoltests.shared#FooEnumMap
+use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
 // This example serializes simple scalar types in the top level XML document.
@@ -372,32 +375,23 @@ apply XmlTimestamps @httpResponseTests([
     },
 ])
 
-@timestampFormat("date-time")
-timestamp DateTimeTimestamp
-
-@timestampFormat("epoch-seconds")
-timestamp EpochSecondsTimestamp
-
-@timestampFormat("http-date")
-timestamp HttpDateTimestamp
-
 structure XmlTimestampsOutput {
     normal: Timestamp,
 
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
-    dateTimeOnTarget: DateTimeTimestamp,
+    dateTimeOnTarget: DateTime,
 
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
-    epochSecondsOnTarget: EpochSecondsTimestamp,
+    epochSecondsOnTarget: EpochSeconds,
 
     @timestampFormat("http-date")
     httpDate: Timestamp,
 
-    httpDateOnTarget: HttpDateTimestamp,
+    httpDateOnTarget: HttpDate,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -6,10 +6,13 @@ namespace aws.protocoltests.ec2
 
 use aws.protocols#ec2QueryName
 use aws.protocols#ec2Query
+use aws.protocoltests.shared#DateTime
+use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
 use aws.protocoltests.shared#FooEnumSet
 use aws.protocoltests.shared#FooEnumMap
+use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
 // This example serializes simple scalar types in the top level XML document.
@@ -359,32 +362,23 @@ apply XmlTimestamps @httpResponseTests([
     },
 ])
 
-@timestampFormat("date-time")
-timestamp DateTimeTimestamp
-
-@timestampFormat("epoch-seconds")
-timestamp EpochSecondsTimestamp
-
-@timestampFormat("http-date")
-timestamp HttpDateTimestamp
-
 structure XmlTimestampsOutput {
     normal: Timestamp,
 
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
-    dateTimeOnTarget: DateTimeTimestamp,
+    dateTimeOnTarget: DateTime,
 
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
-    epochSecondsOnTarget: EpochSecondsTimestamp,
+    epochSecondsOnTarget: EpochSeconds,
 
     @timestampFormat("http-date")
     httpDate: Timestamp,
 
-    httpDateOnTarget: HttpDateTimestamp,
+    httpDateOnTarget: HttpDate,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -263,6 +263,25 @@ apply XmlTimestamps @httpResponseTests([
         }
     },
     {
+        id: "Ec2XmlTimestampsWithDateTimeOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
+        protocol: ec2Query,
+        code: 200,
+        body: """
+              <XmlTimestampsResponse xmlns="https://example.com/">
+                  <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
+                  <RequestId>requestid</RequestId>
+              </XmlTimestampsResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml;charset=UTF-8"
+        },
+        params: {
+            dateTimeOnTarget: 1398796238
+        }
+    },
+    {
         id: "Ec2XmlTimestampsWithEpochSecondsFormat",
         documentation: "Ensures that the timestampFormat of epoch-seconds works",
         protocol: ec2Query,
@@ -279,6 +298,25 @@ apply XmlTimestamps @httpResponseTests([
         },
         params: {
             epochSeconds: 1398796238
+        }
+    },
+    {
+        id: "Ec2XmlTimestampsWithEpochSecondsOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of epoch-seconds on the target shape works",
+        protocol: ec2Query,
+        code: 200,
+        body: """
+              <XmlTimestampsResponse xmlns="https://example.com/">
+                  <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
+                  <RequestId>requestid</RequestId>
+              </XmlTimestampsResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml;charset=UTF-8"
+        },
+        params: {
+            epochSecondsOnTarget: 1398796238
         }
     },
     {
@@ -300,7 +338,35 @@ apply XmlTimestamps @httpResponseTests([
             httpDate: 1398796238
         }
     },
+    {
+        id: "Ec2XmlTimestampsWithHttpDateOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of http-date on the target shape works",
+        protocol: ec2Query,
+        code: 200,
+        body: """
+              <XmlTimestampsResponse xmlns="https://example.com/">
+                  <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
+                  <RequestId>requestid</RequestId>
+              </XmlTimestampsResponse>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "text/xml;charset=UTF-8"
+        },
+        params: {
+            httpDateOnTarget: 1398796238
+        }
+    },
 ])
+
+@timestampFormat("date-time")
+timestamp DateTimeTimestamp
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSecondsTimestamp
+
+@timestampFormat("http-date")
+timestamp HttpDateTimestamp
 
 structure XmlTimestampsOutput {
     normal: Timestamp,
@@ -308,11 +374,17 @@ structure XmlTimestampsOutput {
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
+    dateTimeOnTarget: DateTimeTimestamp,
+
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
+    epochSecondsOnTarget: EpochSecondsTimestamp,
+
     @timestampFormat("http-date")
     httpDate: Timestamp,
+
+    httpDateOnTarget: HttpDateTimestamp,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -396,6 +396,24 @@ apply JsonTimestamps @httpRequestTests([
         }
     },
     {
+        id: "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonTimestamps",
+        body: """
+              {
+                  "dateTimeOnTarget": "2014-04-29T18:30:38Z"
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            dateTimeOnTarget: 1398796238
+        }
+    },
+    {
         id: "RestJsonJsonTimestampsWithEpochSecondsFormat",
         documentation: "Ensures that the timestampFormat of epoch-seconds works",
         protocol: restJson1,
@@ -414,6 +432,24 @@ apply JsonTimestamps @httpRequestTests([
         }
     },
     {
+        id: "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of epoch-seconds on the target shape works",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonTimestamps",
+        body: """
+              {
+                  "epochSecondsOnTarget": 1398796238
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            epochSecondsOnTarget: 1398796238
+        }
+    },
+    {
         id: "RestJsonJsonTimestampsWithHttpDateFormat",
         documentation: "Ensures that the timestampFormat of http-date works",
         protocol: restJson1,
@@ -429,6 +465,24 @@ apply JsonTimestamps @httpRequestTests([
         },
         params: {
             httpDate: 1398796238
+        }
+    },
+    {
+        id: "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of http-date on the target shape works",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonTimestamps",
+        body: """
+              {
+                  "httpDateOnTarget": "Tue, 29 Apr 2014 18:30:38 GMT"
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            httpDateOnTarget: 1398796238
         }
     },
 ])
@@ -469,6 +523,23 @@ apply JsonTimestamps @httpResponseTests([
         }
     },
     {
+        id: "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
+        protocol: restJson1,
+        code: 200,
+        body: """
+              {
+                  "dateTimeOnTarget": "2014-04-29T18:30:38Z"
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            dateTimeOnTarget: 1398796238
+        }
+    },
+    {
         id: "RestJsonJsonTimestampsWithEpochSecondsFormat",
         documentation: "Ensures that the timestampFormat of epoch-seconds works",
         protocol: restJson1,
@@ -483,6 +554,23 @@ apply JsonTimestamps @httpResponseTests([
         },
         params: {
             epochSeconds: 1398796238
+        }
+    },
+    {
+        id: "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of epoch-seconds on the target shape works",
+        protocol: restJson1,
+        code: 200,
+        body: """
+              {
+                  "epochSecondsOnTarget": 1398796238
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            epochSecondsOnTarget: 1398796238
         }
     },
     {
@@ -502,7 +590,33 @@ apply JsonTimestamps @httpResponseTests([
             httpDate: 1398796238
         }
     },
+    {
+        id: "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of http-date on the target shape works",
+        protocol: restJson1,
+        code: 200,
+        body: """
+              {
+                  "httpDateOnTarget": "Tue, 29 Apr 2014 18:30:38 GMT"
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            httpDateOnTarget: 1398796238
+        }
+    },
 ])
+
+@timestampFormat("date-time")
+timestamp DateTimeTimestamp
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSecondsTimestamp
+
+@timestampFormat("http-date")
+timestamp HttpDateTimestamp
 
 structure JsonTimestampsInputOutput {
     normal: Timestamp,
@@ -510,11 +624,17 @@ structure JsonTimestampsInputOutput {
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
+    dateTimeOnTarget: DateTimeTimestamp,
+
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
+    epochSecondsOnTarget: EpochSecondsTimestamp,
+
     @timestampFormat("http-date")
     httpDate: Timestamp,
+
+    httpDateOnTarget: HttpDateTimestamp,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -6,10 +6,13 @@ $version: "2.0"
 namespace aws.protocoltests.restjson
 
 use aws.protocols#restJson1
+use aws.protocoltests.shared#DateTime
+use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
 use aws.protocoltests.shared#FooEnumSet
 use aws.protocoltests.shared#FooEnumMap
+use aws.protocoltests.shared#HttpDate
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
@@ -609,32 +612,23 @@ apply JsonTimestamps @httpResponseTests([
     },
 ])
 
-@timestampFormat("date-time")
-timestamp DateTimeTimestamp
-
-@timestampFormat("epoch-seconds")
-timestamp EpochSecondsTimestamp
-
-@timestampFormat("http-date")
-timestamp HttpDateTimestamp
-
 structure JsonTimestampsInputOutput {
     normal: Timestamp,
 
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
-    dateTimeOnTarget: DateTimeTimestamp,
+    dateTimeOnTarget: DateTime,
 
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
-    epochSecondsOnTarget: EpochSecondsTimestamp,
+    epochSecondsOnTarget: EpochSeconds,
 
     @timestampFormat("http-date")
     httpDate: Timestamp,
 
-    httpDateOnTarget: HttpDateTimestamp,
+    httpDateOnTarget: HttpDate,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -6,10 +6,13 @@ $version: "2.0"
 namespace aws.protocoltests.restxml
 
 use aws.protocols#restXml
+use aws.protocoltests.shared#DateTime
+use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
 use aws.protocoltests.shared#FooEnumSet
 use aws.protocoltests.shared#FooEnumMap
+use aws.protocoltests.shared#HttpDate
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
@@ -871,32 +874,23 @@ apply XmlTimestamps @httpResponseTests([
     },
 ])
 
-@timestampFormat("date-time")
-timestamp DateTimeTimestamp
-
-@timestampFormat("epoch-seconds")
-timestamp EpochSecondsTimestamp
-
-@timestampFormat("http-date")
-timestamp HttpDateTimestamp
-
 structure XmlTimestampsInputOutput {
     normal: Timestamp,
 
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
-    dateTimeOnTarget: DateTimeTimestamp,
+    dateTimeOnTarget: DateTime,
 
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
-    epochSecondsOnTarget: EpochSecondsTimestamp,
+    epochSecondsOnTarget: EpochSeconds,
 
     @timestampFormat("http-date")
     httpDate: Timestamp,
 
-    httpDateOnTarget: HttpDateTimestamp,
+    httpDateOnTarget: HttpDate,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -646,6 +646,25 @@ apply XmlTimestamps @httpRequestTests([
         }
     },
     {
+        id: "XmlTimestampsWithDateTimeOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
+        protocol: restXml,
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            dateTimeOnTarget: 1398796238
+        }
+    },
+    {
         id: "XmlTimestampsWithEpochSecondsFormat",
         documentation: "Ensures that the timestampFormat of epoch-seconds works",
         protocol: restXml,
@@ -665,6 +684,25 @@ apply XmlTimestamps @httpRequestTests([
         }
     },
     {
+        id: "XmlTimestampsWithEpochSecondsOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of epoch-seconds on the target shape works",
+        protocol: restXml,
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            epochSecondsOnTarget: 1398796238
+        }
+    },
+    {
         id: "XmlTimestampsWithHttpDateFormat",
         documentation: "Ensures that the timestampFormat of http-date works",
         protocol: restXml,
@@ -681,6 +719,25 @@ apply XmlTimestamps @httpRequestTests([
         },
         params: {
             httpDate: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithHttpDateOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of http-date on the target shape works",
+        protocol: restXml,
+        method: "POST",
+        uri: "/XmlTimestamps",
+        body: """
+              <XmlTimestampsInputOutput>
+                  <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            httpDateOnTarget: 1398796238
         }
     },
 ])
@@ -723,6 +780,24 @@ apply XmlTimestamps @httpResponseTests([
         }
     },
     {
+        id: "XmlTimestampsWithDateTimeOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            dateTimeOnTarget: 1398796238
+        }
+    },
+    {
         id: "XmlTimestampsWithEpochSecondsFormat",
         documentation: "Ensures that the timestampFormat of epoch-seconds works",
         protocol: restXml,
@@ -738,6 +813,24 @@ apply XmlTimestamps @httpResponseTests([
         },
         params: {
             epochSeconds: 1398796238
+        }
+    },
+    {
+        id: "XmlTimestampsWithEpochSecondsOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of epoch-seconds on the target shape works",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            epochSecondsOnTarget: 1398796238
         }
     },
     {
@@ -758,7 +851,34 @@ apply XmlTimestamps @httpResponseTests([
             httpDate: 1398796238
         }
     },
+    {
+        id: "XmlTimestampsWithHttpDateOnTargetFormat",
+        documentation: "Ensures that the timestampFormat of http-date on the target shape works",
+        protocol: restXml,
+        code: 200,
+        body: """
+              <XmlTimestampsInputOutput>
+                  <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
+              </XmlTimestampsInputOutput>
+              """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        },
+        params: {
+            httpDateOnTarget: 1398796238
+        }
+    },
 ])
+
+@timestampFormat("date-time")
+timestamp DateTimeTimestamp
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSecondsTimestamp
+
+@timestampFormat("http-date")
+timestamp HttpDateTimestamp
 
 structure XmlTimestampsInputOutput {
     normal: Timestamp,
@@ -766,11 +886,17 @@ structure XmlTimestampsInputOutput {
     @timestampFormat("date-time")
     dateTime: Timestamp,
 
+    dateTimeOnTarget: DateTimeTimestamp,
+
     @timestampFormat("epoch-seconds")
     epochSeconds: Timestamp,
 
+    epochSecondsOnTarget: EpochSecondsTimestamp,
+
     @timestampFormat("http-date")
     httpDate: Timestamp,
+
+    httpDateOnTarget: HttpDateTimestamp,
 }
 
 /// This example serializes enums as top level properties, in lists, sets, and maps.


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:* Adds additional protocol tests of correct timestamp de/serialization of members which target shapes which have the `timestampFormat` trait applied. The need for these additional tests was discovered when [a bug identified incorrect de/serialization behavior in the Kotlin SDK](https://github.com/awslabs/smithy-kotlin/issues/714).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
