### PR TITLE
Add doc comment to each of the PayloadFormatVersion members

### DIFF
--- a/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.smithy
+++ b/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.smithy
@@ -349,6 +349,8 @@ enum PassThroughBehavior {
 /// Defines the payloadFormatVersion used by authorizers
 @private
 enum PayloadFormatVersion {
+    /// Specifies 1.0 version of the format used by the authorizer
     V1_0 = "1.0"
+    /// Specifies 2.0 version of the format used by the authorizer
     V2_0 = "2.0"
 }


### PR DESCRIPTION
*Description of changes:*

Added missing doc comments to each of the `PayloadFormatVersion` enum members. This is needed to avoid errors when validating that all enum members have documentation.