### PR TITLE
Allow transforms to remove enum members

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTagTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesByTagTest.java
@@ -19,11 +19,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TagsTrait;
 
@@ -50,5 +54,24 @@ public class ExcludeShapesByTagTest {
 
         assertThat(result.getShape(stringA.getId()), is(Optional.empty()));
         assertThat(result.getShape(stringB.getId()), not(Optional.empty()));
+    }
+
+    @Test
+    public void filtersMembers() throws Exception {
+        Model model = Model.assembler()
+                .addImport(Paths.get(getClass().getResource("filter-by-tags.smithy").toURI()))
+                .assemble()
+                .unwrap();
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("tags", Node.fromStrings("filter")))
+                .build();
+        Model result = new ExcludeShapesByTag().transform(context);
+
+        EnumShape foo = result.expectShape(ShapeId.from("smithy.example#Foo"), EnumShape.class);
+        assertThat(foo.members().size(), is(1));
+
+        IntEnumShape bar = result.expectShape(ShapeId.from("smithy.example#Bar"), IntEnumShape.class);
+        assertThat(bar.members().size(), is(1));
     }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filter-by-tags.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filter-by-tags.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+namespace smithy.example
+
+enum Foo {
+    @tags(["filter"])
+    FILTER
+
+    @tags(["keep"])
+    KEEP
+}
+
+intEnum Bar {
+    @tags(["filter"])
+    @enumValue(1)
+    FILTER
+
+    @tags(["keep"])
+    @enumValue(2)
+    KEEP
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/FilterShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/FilterShapes.java
@@ -51,7 +51,10 @@ final class FilterShapes {
 
     private static boolean canFilterShape(Model model, Shape shape) {
         return !shape.isMemberShape() || model.getShape(shape.asMemberShape().get().getContainer())
-                .filter(container -> container.isStructureShape() || container.isUnionShape())
+                .filter(container -> container.isStructureShape()
+                        || container.isUnionShape()
+                        || container.isEnumShape()
+                        || container.isIntEnumShape())
                 .isPresent();
     }
 }


### PR DESCRIPTION
This fixes a bug that was preventing enum members from being removable from transforms, such as removeShapesByTag.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
