### PR TITLE
Reverse the logic of the protocol test to be in sync with the current…

### DIFF
--- a/smithy-aws-protocol-tests/model/awsQuery/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/input-lists.smithy
@@ -42,14 +42,14 @@ apply QueryLists @httpRequestTests([
     },
     {
         id: "EmptyQueryLists",
-        documentation: "Does not serialize empty query lists",
+        documentation: "Serializes empty query lists",
         protocol: awsQuery,
         method: "POST",
         uri: "/",
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: "Action=QueryLists&Version=2020-01-08",
+        body: "Action=QueryLists&Version=2020-01-08&ListArg=",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: []

--- a/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
@@ -42,14 +42,14 @@ apply QueryLists @httpRequestTests([
     },
     {
         id: "Ec2EmptyQueryLists",
-        documentation: "Does not serialize empty query lists",
+        documentation: "Serializes empty query lists",
         protocol: ec2Query,
         method: "POST",
         uri: "/",
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: "Action=QueryLists&Version=2020-01-08",
+        body: "Action=QueryLists&Version=2020-01-08&ListArg=",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: []


### PR DESCRIPTION
… behavior

*Issue #, if available:*

*Description of changes:*

This change reverses the logic of the protocol test that asserts that we do not serialize empty lists. We currently do it for other SDK and some services rely on this behavior.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
