### PR TITLE
Add localTraits to HttpConfiguration

### DIFF
--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.smithy
@@ -32,7 +32,7 @@ structure awsJson1_1 with [HttpConfiguration] {}
 
 /// Contains HTTP protocol configuration for HTTP-based protocols.
 @private
-@mixin
+@mixin(localTraits: [private])
 structure HttpConfiguration {
     /// The priority ordered list of supported HTTP protocol versions.
     http: StringList


### PR DESCRIPTION
The private trait on HttpConfiguration should be included in localTraits, because we don't want structures mixing in HttpConfiguration to inherit the private trait.

This is part of a gradual re-release of https://github.com/awslabs/smithy/pull/1406


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
