### PR TITLE
Fix RFC links

### DIFF
--- a/docs/source-2.0/aws/protocols/aws-json.rst.template
+++ b/docs/source-2.0/aws/protocols/aws-json.rst.template
@@ -47,7 +47,7 @@ The |quoted shape name| protocol uses the following headers:
     * - ``Content-Length``
       - true
       - The standard ``Content-Length`` header defined by
-        `RFC 7230 Section 3.3.2`_.
+        :rfc:`7230#section-3.3.2`.
     * - ``X-Amz-Target``
       - true for requests
       - The value of this header is the :token:`shape name <smithy:Identifier>` of the
@@ -254,4 +254,3 @@ the expected serialized HTTP requests and responses for each case.
 
 *TODO: Add event stream handling specifications.*
 
-.. _`RFC 7230 Section 3.3.2`: https://tools.ietf.org/html/rfc7230#section-3.3.2

--- a/docs/source-2.0/aws/protocols/aws-query-serialization.rst.template
+++ b/docs/source-2.0/aws/protocols/aws-query-serialization.rst.template
@@ -102,4 +102,3 @@ to the input's key.
       - A union is serialized identically to a ``structure`` shape, but only a
         single member can be set to a non-null value.
 
-.. _`RFC 7230 Section 3.3.2`: https://tools.ietf.org/html/rfc7230#section-3.3.2

--- a/docs/source-2.0/spec/behavior-traits.rst
+++ b/docs/source-2.0/spec/behavior-traits.rst
@@ -6,7 +6,7 @@ Idempotency
 ===========
 
 Operations marked with the :ref:`readonly-trait` or :ref:`idempotent-trait`
-are considered idempotent as defined in `RFC 7231, section 4.2.2`_. Operations
+are considered idempotent as defined in :rfc:`7231#section-4.2.2`. Operations
 that contain a top-level input member marked with the :ref:`idempotencytoken-trait`
 that are provided a token for the member are also considered idempotent. All
 other operations SHOULD be considered unsafe to retry unless the response to
@@ -36,7 +36,7 @@ Only a single member of the input of an operation can be targeted by the
 ``idempotencyToken`` trait; only top-level structure members of the input of an
 operation are considered.
 
-A unique identifier (typically a UUID_) SHOULD be used by the client when
+A unique identifier (typically a :rfc:`UUID <4122>`) SHOULD be used by the client when
 providing the value for the request token member. When the request token is
 present, the service MUST ensure that the request is not replayed within a
 service-defined period of time. This allows the client to safely retry
@@ -468,5 +468,3 @@ The following changes are considered backward compatible:
 1. Adding the ``paginated`` trait to an existing operation.
 2. Adding the ``pageSize`` member to an existing ``paginated`` trait.
 
-.. _UUID: https://tools.ietf.org/html/rfc4122
-.. _RFC 7231, section 4.2.2: https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.2

--- a/docs/source-2.0/spec/constraint-traits.rst
+++ b/docs/source-2.0/spec/constraint-traits.rst
@@ -439,4 +439,3 @@ An *enum definition* is a structure that supports the following members:
 .. _ECMA 262 regular expression dialect: https://www.ecma-international.org/ecma-262/8.0/index.html#sec-patterns
 .. _CommonMark: https://spec.commonmark.org/
 .. _OWASP Regular expression Denial of Service: https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
-.. _JSON Schema "Instance Equality": https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.4.2.2

--- a/docs/source-2.0/spec/endpoint-traits.rst
+++ b/docs/source-2.0/spec/endpoint-traits.rst
@@ -157,7 +157,8 @@ endpoint host prior to its use. Clients MUST fail when expanding a
 After the ``hostPrefix`` template is expanded, a client MUST prepend the
 expanded value to the client's derived endpoint host. The client MUST NOT add
 any additional characters between the ``hostPrefix`` and client derived
-endpoint host. The resolved host value MUST result in a valid `RFC 3986 Host`_.
+endpoint host. The resolved host value MUST result in a valid
+:rfc:`3986#section-3.2.2` host.
 
 Clients SHOULD provide a way for users to disable the ``hostPrefix`` injection
 behavior. If a user sets this flag, the client MUST NOT perform any
@@ -240,4 +241,3 @@ to an operation marked with the :ref:`endpoint-trait` will be ignored.
         foo: String
     }
 
-.. _RFC 3986 Host: https://tools.ietf.org/html/rfc3986#section-3.2.2

--- a/docs/source-2.0/spec/http-bindings.rst
+++ b/docs/source-2.0/spec/http-bindings.rst
@@ -14,8 +14,8 @@ and error structures are considered when serializing HTTP messages.
 
 .. important::
 
-    Violating `HTTP specifications`_ or relying on poorly-supported HTTP
-    functionality when defining HTTP bindings will limit interoperability
+    Violating :rfc`HTTP specifications <7230>` or relying on poorly-supported
+    HTTP functionality when defining HTTP bindings will limit interoperability
     and likely lead to undefined behavior across Smithy implementations. For
     example, avoid defining GET/DELETE requests with payloads, defining
     response payloads for operations with a 204/205 status, etc.
@@ -685,7 +685,8 @@ structure with the ``httpLabel`` trait MUST have a corresponding
   ``1985-04-12T23%3A20%3A50.52Z``). The :ref:`timestampFormat-trait`
   MAY be used to use a custom serialization format.
 - Reserved characters defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>`
-  and the `%` itself MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
+  and the `%` itself MUST be :rfc:`percent-encoded <3986#section-2.1>` (that is,
+  ``:/?#[]@!$&'()*+,;=%``).
 - However, if the label is greedy, then "/" MUST NOT be percent-encoded
   because greedy labels are meant to span multiple path segments.
 
@@ -923,7 +924,8 @@ request:
 * "&" is used to separate query string parameter key-value pairs.
 * "=" is used to separate query string parameter names from values.
 * Reserved characters in keys and values as defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>` and `%`
-  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
+  MUST be :rfc:`percent-encoded <3986#section-2.1>` (that is,
+  ``:/?#[]@!$&'()*+,;=%``).
 * ``boolean`` values are serialized as ``true`` or ``false``.
 * ``timestamp`` values are serialized as an :rfc:`3339`
   ``date-time`` string by default (for example, ``1985-04-12T23:20:50.52Z``,
@@ -961,10 +963,10 @@ the body of the response.
 
 .. rubric:: Do not put too much data in the query string
 
-While there is no limit placed on the length of an `HTTP request line`_,
-many HTTP client and server implementations enforce limits in practice.
-Carefully consider the maximum allowed length of each member that is bound to
-an HTTP query string or path.
+While there is no limit placed on the length of an
+:rfc:`HTTP request line <7230#section-3.1.1>`, many HTTP client and server
+implementations enforce limits in practice. Carefully consider the maximum
+allowed length of each member that is bound to an HTTP query string or path.
 
 
 .. smithy-trait:: smithy.api#httpQueryParams
@@ -1031,7 +1033,7 @@ the body of the response.
 See the :ref:`httpQuery-trait` serialization rules that define how the keys and values of the
 target map will be serialized in the request query string. Key-value pairs in the target map
 are treated like they were explicitly bound using the :ref:`httpQuery-trait`, including the
-requirement that reserved characters MUST be percent-encoded_.
+requirement that reserved characters MUST be :rfc:`percent-encoded <3986#section-2.1>`.
 
 When servers deserialize the query string into a ``map`` of ``string``, they SHOULD take the
 first encountered value for each key. Since this rule applies to all future query string
@@ -1366,7 +1368,3 @@ marked with the ``httpPayload`` trait:
         message: String
     }
 
-
-.. _percent-encoded: https://tools.ietf.org/html/rfc3986#section-2.1
-.. _HTTP request line: https://tools.ietf.org/html/rfc7230.html#section-3.1.1
-.. _HTTP specifications: https://datatracker.ietf.org/doc/html/rfc7230

--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -6,7 +6,8 @@ Smithy IDL
 
 Smithy models are defined using either the Smithy interface definition language
 (IDL) or the :ref:`JSON abstract syntax tree <json-ast>` (AST). This document
-defines the ABNF_ grammar and syntax for defining models with the Smithy IDL.
+defines the :rfc:`ABNF <5234>` grammar and syntax for defining models with the
+Smithy IDL.
 
 
 -------------------
@@ -89,7 +90,7 @@ Smithy IDL ABNF
 ---------------
 
 The Smithy IDL is defined by the following ABNF which uses case-sensitive
-string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
+string support defined in :rfc:`7405`.
 
 .. productionlist:: smithy
     idl:*`WS` `ControlSection` `MetadataSection` `ShapeSection`
@@ -2346,5 +2347,4 @@ example is interpreted as ``Foo\nBaz Bam``:
     Baz \
     Bam"""
 
-.. _ABNF: https://tools.ietf.org/html/rfc5234
 .. _CommonMark: https://spec.commonmark.org/

--- a/docs/source-2.0/spec/protocol-traits.rst
+++ b/docs/source-2.0/spec/protocol-traits.rst
@@ -218,7 +218,7 @@ Smithy defines the following built-in timestamp formats:
       - Description
     * - date-time
       - Date time as defined by the ``date-time`` production in
-        `RFC3339 section 5.6 <https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14>`_
+        :rfc:`3339#section-5.6`
         with no UTC offset and optional fractional precision (for example,
         ``1985-04-12T23:20:50.52Z``).
     * - http-date
@@ -340,7 +340,7 @@ The following table defines how simple types are serialized in XML documents.
     * - Shape
       - Serialization
     * - blob
-      - Serialized as a `base64 encoded`_ string
+      - Serialized as a :rfc:`base64 encoded <4648#section-4>` string
 
         .. code-block:: smithy
 
@@ -381,7 +381,7 @@ The following table defines how simple types are serialized in XML documents.
       - Serialized as the string value of the number using scientific
         notation if an exponent is needed.
     * - timestamp
-      - Serialized as `RFC 3339`_ date-time value.
+      - Serialized as :rfc:`3339` date-time value.
 
         .. code-block:: smithy
 
@@ -1019,7 +1019,6 @@ The XML serialization is:
     </MyStructure>
 
 .. _base64 encoded: https://tools.ietf.org/html/rfc4648#section-4
-.. _RFC 3339: https://tools.ietf.org/html/rfc3339
 .. _XML namespace: https://www.w3.org/TR/REC-xml-names/
 .. _namespace prefix: https://www.w3.org/TR/REC-xml-names/#NT-Prefix
 

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -1604,7 +1604,7 @@ The above selector is equivalent to the following pseudo-code:
 Grammar
 =======
 
-Selectors are defined by the following ABNF_ grammar.
+Selectors are defined by the following :rfc:`ABNF <5234>` grammar.
 
 .. admonition:: Lexical note
    :class: note
@@ -1663,5 +1663,4 @@ Selectors are defined by the following ABNF_ grammar.
     SelectorVariableSet                :"$" `smithy:Identifier` "(" `Selector` ")"
     SelectorVariableGet                :"${" `smithy:Identifier` "}"
 
-.. _ABNF: https://tools.ietf.org/html/rfc5234
 .. _set: https://en.wikipedia.org/wiki/Set_(abstract_data_type)


### PR DESCRIPTION
One of our RFC links was broken because it wasn't using the RFC directive. This updates every RFC link in the 2.0 docs to use the directive.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
