### PR TITLE
Fix resource identifier collision and validation

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndexTest.java
@@ -142,4 +142,11 @@ public class IdentifierBindingIndexTest {
                    equalTo(IdentifierBindingIndex.BindingType.INSTANCE));
         assertThat(index.getOperationInputBindings(resource.getId(), operation.getId()), equalTo(expectedBindings));
     }
+
+    @Test
+    public void doesNotFailWhenLoadingModelWithCollidingMemberBindings() {
+        // Ensure that this does not fail to load. This previously failed when using Collectors.toMap due to
+        // a collision in the keys used to map an identifier to multiple members.
+        Model.assembler().addImport(getClass().getResource("colliding-resource-identifiers.smithy")).assemble();
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#GetFooInput: Conflicting resource identifier member bindings found for identifier 'bar' between members bar, bam | ResourceIdentifierBinding
+[ERROR] smithy.example#PutFooInput: Conflicting resource identifier member bindings found for identifier 'bar' between members a, b | ResourceIdentifierBinding

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.smithy
@@ -1,0 +1,37 @@
+$version: "2.0"
+
+namespace smithy.example
+
+resource Foo {
+    identifiers: {
+        bar: String
+    }
+    read: GetFoo
+    put: PutFoo
+}
+
+@readonly
+operation GetFoo {
+    input:= {
+        @required
+        bar: String
+
+        @resourceIdentifier("bar")
+        @required
+        bam: String
+    }
+}
+
+@idempotent
+operation PutFoo {
+    input:= {
+    @required
+        @resourceIdentifier("bar")
+        @required
+        a: String
+
+        @resourceIdentifier("bar")
+        @required
+        b: String
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/colliding-resource-identifiers.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/colliding-resource-identifiers.smithy
@@ -1,0 +1,22 @@
+$version: "2.0"
+
+namespace smithy.example
+
+resource Foo {
+    identifiers: {
+        bar: String
+    }
+    read: GetFoo
+}
+
+@readonly
+operation GetFoo {
+    input:= {
+        @required
+        bar: String
+
+        @resourceIdentifier("bar")
+        @required
+        bam: String
+    }
+}


### PR DESCRIPTION
When loading a model with multiple members bound to the same resource identifier, Smithy failed with an error in IdentifierBindingIndex due to Collectors.toMap:

```
Duplicate key X (attempted merging values y and z)
```

This change updates IdentifierBindingIndex to ignore collisions. However this means that colliding resource identifier bindings would be ignored (which is arguably worse than failing to load the model since it wouldn't ever flag these issues, and retroactively enforcing things is always challenging). To address this, I added validation to detect when members with the resourceIdentifier trait conflict with members of the same binding name or members that have the same resourceIdentifier trait.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
