### PR TITLE
Improve ChangedNullability diff evaluator

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
@@ -25,11 +25,13 @@ import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ClientOptionalTrait;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.InputTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
@@ -91,37 +93,61 @@ public class ChangedNullability extends AbstractDiffEvaluator {
         StringJoiner joiner = new StringJoiner("; ", message, "");
         boolean oldHasInput = hasInputTrait(differences.getOldModel(), oldMember);
         boolean newHasInput = hasInputTrait(differences.getNewModel(), newMember);
+        Shape newTarget = differences.getNewModel().expectShape(newMember.getTarget());
+        Severity severity = null;
 
         if (oldHasInput && !newHasInput) {
             // If there was an input trait before, but not now, then the nullability must have
             // changed from nullable to non-nullable.
             joiner.add("The @input trait was removed from " + newMember.getContainer());
+            severity = Severity.ERROR;
         } else if (!oldHasInput && newHasInput) {
             // If there was no input trait before, but there is now, then the nullability must have
             // changed from non-nullable to nullable.
             joiner.add("The @input trait was added to " + newMember.getContainer());
+            severity = Severity.DANGER;
         } else if (!newHasInput) {
             // Can't add nullable to a preexisting required member.
             if (change.isTraitAdded(ClientOptionalTrait.ID) && change.isTraitInBoth(RequiredTrait.ID)) {
                 joiner.add("The @nullable trait was added to a @required member.");
+                severity = Severity.ERROR;
             }
             // Can't add required to a member unless the member is marked as nullable.
             if (change.isTraitAdded(RequiredTrait.ID) && !newMember.hasTrait(ClientOptionalTrait.ID)) {
                 joiner.add("The @required trait was added to a member that is not marked as @nullable.");
+                severity = Severity.ERROR;
             }
             // Can't add the default trait to a member unless the member was previously required.
             if (change.isTraitAdded(DefaultTrait.ID) && !change.isTraitRemoved(RequiredTrait.ID)) {
                 joiner.add("The @default trait was added to a member that was not previously @required.");
+                severity = Severity.ERROR;
             }
             // Can only remove the required trait if the member was nullable or replaced by the default trait.
             if (change.isTraitRemoved(RequiredTrait.ID)
                     && !newMember.hasTrait(DefaultTrait.ID)
                     && !oldMember.hasTrait(ClientOptionalTrait.ID)) {
-                joiner.add("The @required trait was removed and not replaced with the @default trait.");
+                if (newTarget.isStructureShape() || newTarget.isUnionShape()) {
+                    severity = severity == null ? Severity.WARNING : severity;
+                    joiner.add("The @required trait was removed from a member that targets a " + newTarget.getType()
+                               + ". This is backward compatible in generators that always treat structures and "
+                               + "unions as optional (e.g., AWS generators)");
+                } else {
+                    joiner.add("The @required trait was removed and not replaced with the @default trait and "
+                               + "@addedDefault trait.");
+                    severity = Severity.ERROR;
+                }
             }
         }
 
-        return error(change.getNewShape(), joiner.toString());
+        // If no explicit severity was detected, then assume an error.
+        severity = severity == null ? Severity.ERROR : severity;
+
+        return ValidationEvent.builder()
+                .id(getEventId())
+                .shapeId(change.getNewShape())
+                .severity(severity)
+                .message(joiner.toString())
+                .build();
     }
 
     private boolean hasInputTrait(Model model, MemberShape member) {


### PR DESCRIPTION
This validator now does not emit trait change warnings when the required trait is changed, and instead relies on ChangedNullability (this matches how the box trait is handled too). When the required trait is removed from a member that targets a structure or union, a warning is emitted instead of an error to indicate that this is often allowed in Smithy generators that treat these members as always nullable regardless of the required trait.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
