### PR TITLE
Remove pattern from suppress trait entries

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -978,7 +978,6 @@ structure hostLabel {}
 /// Suppresses validation events by ID for a given shape.
 @trait
 list suppress {
-    @pattern("^[_a-zA-Z][A-Za-z0-9]*$")
     @length(min: 1)
     member: String
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/suppression-test.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/suppression-test.errors
@@ -4,4 +4,4 @@
 [SUPPRESSED] smithy.example#List2$member: Members? Yuck! | ListMembersAreBadOkay
 [SUPPRESSED] -: Unable to locate a validator named `UnknownValidator2` (Please ignore this) | UnknownValidator_UnknownValidator2
 [WARNING] -: Unable to locate a validator named `UnknownValidator1` | UnknownValidator_UnknownValidator1
-[SUPPRESSED] smithy.example#MyService: This is suppressed | SuppressedValidator
+[SUPPRESSED] smithy.example#MyService: This is suppressed | SuppressedValidator.Foo

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/suppression-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/suppression-test.smithy
@@ -21,7 +21,7 @@ metadata validators = [
     {
         // This one is suppressed.
         name: "EmitEachSelector",
-        id: "SuppressedValidator",
+        id: "SuppressedValidator.Foo",
         message: "This is suppressed",
         severity: "WARNING",
         configuration: {
@@ -43,11 +43,11 @@ metadata suppressions = [
         reason: "Please ignore this",
     },
     {
-        id: "SuppressedValidator",
+        id: "SuppressedValidator.Foo",
         namespace: "smithy.example.ignore.this.one", // matches nothing
     },
     {
-        id: "SuppressedValidator",
+        id: "SuppressedValidator.Foo",
         namespace: "smithy.example"
     },
 ]
@@ -60,6 +60,7 @@ service MyService {
     operations: [GetFoo],
 }
 
+@suppress(["IgnoreMe.Too"])
 operation GetFoo {
     input: GetFooInput,
     output: GetFooOutput


### PR DESCRIPTION
The suppress trait contained a restrictive pattern trait that was not present in validator ID definitions. This meant that validation events could be suppressed in metadata suppressions (where there was no pattern validation), but not using the `@suppress` trait. Adding the pattern from the `@suppress` trait to validation event IDs at this point has the potential to break existing models, so that is not a desirable alternative.

Closes #987

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
