### PR TITLE
Fix dropping doc comments after default values

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelParser.java
@@ -802,13 +802,10 @@ final class IdlModelParser extends SimpleParser {
 
             parseMember(op, definedMembers, memberParsing);
 
-            // Clears out any previously captured documentation
-            // comments that may have been found when parsing the member.
-            clearPendingDocs();
-
             ws();
         }
 
+        clearPendingDocs();
         expect('}');
     }
 
@@ -861,6 +858,12 @@ final class IdlModelParser extends SimpleParser {
             sp();
             memberBuilder.addTrait(memberParsing.createAssignmentTrait(memberId, IdlNodeParser.parseNode(this)));
             br();
+        } else {
+            // Clears out any previously captured documentation
+            // comments that may have been found when parsing the member.
+            // Default value parsing may safely load comments for the next
+            // member, so leave those intact.
+            clearPendingDocs();
         }
 
         // Only add the member once fully parsed.

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/default-subsequent-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/default-subsequent-trait.smithy
@@ -1,0 +1,20 @@
+$version: "2.0"
+
+ namespace smithy.example
+
+ structure TestShape {
+     /// foo
+     @required
+     foo: Boolean = false
+     /// bar
+     @required
+     bar: MyString = "bar"
+
+     /// baz
+     @required
+     baz: Integer
+
+     /// This doc comment will be dropped
+ }
+
+string MyString


### PR DESCRIPTION
This commit fixes an issue where documentation comments were dropped for members that follow a member with a default value. Pending docs are only cleared when a default isn't encountered or the container is complete.

*Issue #, if available:*
Fixes #1457 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
