### PR TITLE
Correct precedence in NullableIndex and fix diffs

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
@@ -135,15 +135,11 @@ public class NullableIndex implements KnowledgeIndex {
         SERVER {
             @Override
             boolean isStructureMemberOptional(StructureShape container, MemberShape member, Shape target) {
-                // Defaults set to null on a member make the member optional.
-                if (member.hasNullDefault()) {
-                    return true;
-                } else if (member.hasNonNullDefault()) {
-                    return false;
-                } else {
-                    // A 2.0 member with the required trait is never nullable.
-                    return !member.hasTrait(RequiredTrait.class);
-                }
+                // Evaluated in this order.
+                // 1. Does the member have the required trait? Stop further checks, it's non-optional.
+                // 2. Does the member have a default trait set to null? Stop further checks, it's optional.
+                // 3. Does the member have a default trait not set to null? Stop further checks, it's non-optional.
+                return !member.hasTrait(RequiredTrait.class) && !member.hasNonNullDefault();
             }
         };
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/NullableIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/NullableIndexTest.java
@@ -523,4 +523,29 @@ public class NullableIndexTest {
         assertThat(index.isMemberNullable(model.expectShape(ShapeId.from("smithy.example#Foo$baz"), MemberShape.class)),
                    is(false));
     }
+
+    // The required trait makes this non-nullable. The default(null) trait just means that there's no default value,
+    // it doesn't make the member nullable. A value is still required to be present. Therefore, it's non-nullable
+    // in code generated types. "default(null)" just means the framework does not provide a default value.
+    @Test
+    public void requiredMembersAreNonNullableEvenIfDefaultNullTraitIsPresent() {
+        String modelText =
+                "$version: \"2.0\"\n"
+                + "namespace smithy.example\n"
+                + "structure Foo {\n"
+                + "    @required\n"
+                + "    baz: Integer = null\n"
+                + "}\n";
+        Model model = Model.assembler()
+                .addUnparsedModel("foo.smithy", modelText)
+                .assemble()
+                .unwrap();
+
+        NullableIndex index = NullableIndex.of(model);
+
+        assertThat(
+            index.isMemberNullable(model.expectShape(ShapeId.from("smithy.example#Foo$baz"), MemberShape.class)),
+            is(false)
+        );
+    }
 }


### PR DESCRIPTION
Smithy-Diff was flagging acceptable changes of removing `@default(null)` from member when the trait had no effect because the target shape was already nullable. NullableIndex was also giving the `@default(null)` trait precedence over the `@required` trait which is incorrect. Required members are non-nullable, and the `@default(null)` trait doesn't override this. It simply means that there is no default value for the member (so coupled with the required trait, the member is still always present).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
