### PR TITLE
Fix `@httpMalformedRequestTests` being applied to the wrong operation

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-map.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-map.smithy
@@ -11,7 +11,7 @@ operation MalformedMap {
     input: MalformedMapInput
 }
 
-apply MalformedList @httpMalformedRequestTests([
+apply MalformedMap @httpMalformedRequestTests([
     {
         id: "RestJsonBodyMalformedMapNullKey",
         documentation: """


### PR DESCRIPTION
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
