### PR TITLE
Add custom codegen hook before shape generation

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -292,22 +292,26 @@ public final class CodegenDirector<
 
         LOGGER.fine("All setup done. Beginning code generation");
 
+        LOGGER.finest(() -> "Performing custom codegen for "
+                + directedCodegen.getClass().getName() + " before shape codegen");
+        CustomizeDirective<C, S> customizeDirective = new CustomizeDirective<>(context, serviceShape);
+        directedCodegen.customizeBeforeShapeGeneration(customizeDirective);
+
+        LOGGER.finest(() -> "Generating shapes for service " + serviceShape.getId());
         generateShapesInService(context, serviceShape);
 
         LOGGER.finest(() -> "Generating service " + serviceShape.getId());
         directedCodegen.generateService(new GenerateServiceDirective<>(context, serviceShape));
 
-        CustomizeDirective<C, S> postProcess = new CustomizeDirective<>(context, serviceShape);
-
         LOGGER.finest(() -> "Performing custom codegen for "
                             + directedCodegen.getClass().getName() + " before integrations");
-        directedCodegen.customizeBeforeIntegrations(postProcess);
+        directedCodegen.customizeBeforeIntegrations(customizeDirective);
 
         applyIntegrationCustomizations(context, integrations);
 
         LOGGER.finest(() -> "Performing custom codegen for "
                             + directedCodegen.getClass().getName() + " after integrations");
-        directedCodegen.customizeAfterIntegrations(postProcess);
+        directedCodegen.customizeAfterIntegrations(customizeDirective);
 
         LOGGER.finest(() -> "Directed codegen finished for " + directedCodegen.getClass().getName());
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
@@ -107,6 +107,16 @@ public interface DirectedCodegen<C extends CodegenContext<S, ?, I>, S, I extends
     void generateIntEnumShape(GenerateIntEnumDirective<C, S> directive);
 
     /**
+     * Performs any necessary code generation before all shapes are generated,
+     * using the created codegen context object.
+     *
+     * @param directive Directive to perform.
+     */
+    default void customizeBeforeShapeGeneration(CustomizeDirective<C, S> directive) {
+        // Does nothing by default.
+    }
+
+    /**
      * Performs any necessary code generation after all shapes are generated,
      * using the created codegen context object before integrations perform
      * customizations.


### PR DESCRIPTION
Some languages need to generate code before shapes are generated. Previously such languages could have used the service generation hook to perform this, but that was moved to occur after generating the other shapes.

Python particularly needs this because the language has this cool feature where it can't intelligently resolve everything at the top level of a file. For example, you have to define a parent class earlier in the file than any subclasses. Python generates service-specific errors so this is fairly critical.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
