### PR TITLE
Restrict `@requiresLength` request tests to clients

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -123,7 +123,8 @@ apply StreamingTraitsRequireLength @httpRequestTests([
         params: {
             foo: "Foo",
             blob: "blobby blob blob"
-        }
+        },
+        appliesTo: "client"
     },
     {
         id: "RestJsonStreamingTraitsRequireLengthWithNoBlobBody",
@@ -137,7 +138,8 @@ apply StreamingTraitsRequireLength @httpRequestTests([
         },
         params: {
             foo: "Foo"
-        }
+        },
+        appliesTo: "client"
     },
 ])
 


### PR DESCRIPTION
*Issue #1086*

*Description of changes:*
As discussed in the linked issue, these tests only apply to clients.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
