### PR TITLE
Fix dead link to RFC3339

### DIFF
--- a/docs/source-1.0/spec/core/protocol-traits.rst
+++ b/docs/source-1.0/spec/core/protocol-traits.rst
@@ -302,7 +302,7 @@ Smithy defines the following built-in timestamp formats:
       - Description
     * - date-time
       - Date time as defined by the ``date-time`` production in
-        `RFC3339 section 5.6 <https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14>`_
+        `RFC3339 section 5.6 <https://www.rfc-editor.org/rfc/rfc3339#section-5.6>`_
         with no UTC offset and optional fractional precision (for example,
         ``1985-04-12T23:20:50.52Z``).
     * - http-date


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The previous link redirects to https://bib.ietf.org/public/rfc/html/rfc3339.html#anchor14, which displays a generic "404 not found" page.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
