### PR TITLE
Lower resource identifier collisions to warning

### DIFF
--- a/docs/source-1.0/spec/core/model.rst
+++ b/docs/source-1.0/spec/core/model.rst
@@ -1950,6 +1950,10 @@ on ``GetHistoricalForecastInput$customHistoricalIdName`` maps that member
 to the "historicalId" identifier.
 
 
+If an operation input supplies both an explicit and an implicit identifier
+binding, the explicit identifier binding is utilized.
+
+
 .. _lifecycle-operations:
 
 Resource lifecycle operations

--- a/docs/source-2.0/spec/service-types.rst
+++ b/docs/source-2.0/spec/service-types.rst
@@ -678,6 +678,10 @@ maps it to the "forecastId" identifier is provided by the
 on ``GetHistoricalForecastInput$customHistoricalIdName`` maps that member
 to the "historicalId" identifier.
 
+If an operation input supplies both an explicit and an implicit identifier
+binding, the explicit identifier binding is utilized.
+
+
 .. _resource-properties:
 
 Resource Properties

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -169,10 +169,12 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
             if (member.hasTrait(ResourceIdentifierTrait.class)) {
                 // Mark as a binding if the member has an explicit @resourceIdentifier trait.
                 String bindingName = member.expectTrait(ResourceIdentifierTrait.class).getValue();
+                // Override any implicit bindings with explicit trait bindings.
                 bindings.put(bindingName, member.getMemberName());
             } else if (isImplicitIdentifierBinding(member, resource)) {
                 // Mark as a binding if the member is an implicit identifier binding.
-                bindings.put(member.getMemberName(), member.getMemberName());
+                // Only utilize implicit bindings when an explicit binding wasn't found.
+                bindings.putIfAbsent(member.getMemberName(), member.getMemberName());
             }
         }
         return bindings;

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.errors
@@ -1,2 +1,4 @@
-[ERROR] smithy.example#GetFooInput: Conflicting resource identifier member bindings found for identifier 'bar' between members bar, bam | ResourceIdentifierBinding
-[ERROR] smithy.example#PutFooInput: Conflicting resource identifier member bindings found for identifier 'bar' between members a, b | ResourceIdentifierBinding
+[WARNING] smithy.example#GetFooInput: Implicit resource identifier for 'bar' is overridden by `resourceIdentifier` trait on members: 'bam' | ResourceIdentifierBinding
+[ERROR] smithy.example#PutFooInput: Conflicting resource identifier member bindings found for identifier 'bar' between members: 'a', 'b' | ResourceIdentifierBinding
+[ERROR] smithy.example#DeleteFooInput: Conflicting resource identifier member bindings found for identifier 'bar' between members: 'a', 'b' | ResourceIdentifierBinding
+[WARNING] smithy.example#DeleteFooInput: Implicit resource identifier for 'bar' is overridden by `resourceIdentifier` trait on members: 'a', 'b' | ResourceIdentifierBinding

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-identifiers/detects-conflicting-bindings.smithy
@@ -8,6 +8,7 @@ resource Foo {
     }
     read: GetFoo
     put: PutFoo
+    delete: DeleteFoo
 }
 
 @readonly
@@ -25,7 +26,22 @@ operation GetFoo {
 @idempotent
 operation PutFoo {
     input:= {
-    @required
+        @resourceIdentifier("bar")
+        @required
+        a: String
+
+        @resourceIdentifier("bar")
+        @required
+        b: String
+    }
+}
+
+@idempotent
+operation DeleteFoo {
+    input:= {
+        @required
+        bar: String
+
         @resourceIdentifier("bar")
         @required
         a: String


### PR DESCRIPTION
This commit updates the validation for resource identifier collisions to warn instead of error. When an explicit and implicit binding for the same resource identifier are found, the explicit binding is preferred.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
