### PR TITLE
Add Maven dependency resolution to the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
           distribution: 'zulu'
 
       - name: Clean and build
-        run: ./gradlew clean build -Plog-tests
+        run: ./gradlew clean build -Plog-tests --stacktrace
+
+      - name: CLI integration tests
+        if: matrix.java >= 17
+        run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -148,4 +148,15 @@
         <Class name="software.amazon.smithy.model.shapes.ShapeId$ShapeIdFactory"/>
         <Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/>
     </Match>
+
+    <!-- The FileWriter API that specifies a Charset is not available in Java 8 -->
+    <Match>
+        <Class name="software.amazon.smithy.cli.commands.WarmupCommand"/>
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
+    </Match>
+
+    <!-- SecurityManager is deprecated and scheduled for removal, so this isn't a good check. -->
+    <Match>
+        <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
+    </Match>
 </FindBugsFilter>

--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -33,14 +33,22 @@ The configuration file accepts the following properties:
         projection will create a subdirectory named after the projection, and
         the artifacts from the projection, including a ``model.json`` file,
         will be placed in the directory.
+    * - sources
+      - ``[string]``
+      - Provides a list of relative files or directories that contain the
+        models that are considered the source models of the build. When a
+        directory is encountered, all files in the entire directory tree are
+        added as sources. Sources are relative to the configuration file.
     * - imports
-      - ``string[]``
+      - ``[string]``
       - Provides a list of relative imports to combine into a single model.
-        When a directory is encountered, all files and all files within all
-        subdirectories are imported. Note that build systems MAY choose to rely
-        on other mechanisms for importing models and forming a composite model.
-        These imports are used in every projection. Note: imports are relative
-        to the configuration file.
+        Imports are a kind of local dependency: they aren't considered part of
+        model being built, but are required to build the model. When a
+        directory is encountered, all files in the entire directory tree are
+        imported. Note that build systems MAY choose to rely on other
+        mechanisms for importing models and forming a composite model.
+        Imports defined at the top-level are used in every projection. Imports
+        are relative to the configuration file.
     * - projections
       - ``map<string, object>``
       - A map of projection names to projection configurations.
@@ -54,6 +62,11 @@ The configuration file accepts the following properties:
       - If a plugin can't be found, Smithy will by default fail the build. This
         setting can be set to ``true`` to allow the build to progress even if
         a plugin can't be found on the classpath.
+    * - maven
+      - :ref:`maven-configuration` structure
+      - Defines Java Maven dependencies needed to build the model.
+        Dependencies are used to bring in model imports, build plugins,
+        validators, transforms, and other extensions.
 
 The following is an example ``smithy-build.json`` configuration:
 
@@ -62,7 +75,13 @@ The following is an example ``smithy-build.json`` configuration:
     {
         "version": "1.0",
         "outputDirectory": "build/output",
+        "sources": ["model"],
         "imports": ["foo.json", "some/directory"],
+        "maven": {
+            "dependencies": [
+                "software.amazon.smithy:smithy-aws-traits:__smithy_version__"
+            ]
+        },
         "projections": {
             "my-abstract-projection": {
                 "abstract": true
@@ -100,6 +119,166 @@ The following is an example ``smithy-build.json`` configuration:
     }
 
 
+.. _maven-configuration:
+
+Maven configuration
+===================
+
+Maven dependencies and repositories can be defined in smithy-build.json files,
+and the Smithy CLI will automatically resolve these dependencies using the
+`Apache Maven`_ dependency resolver.
+
+The ``maven`` property accepts the following configuration:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - dependencies
+      - ``[string]``
+      - A list of Maven dependency coordinates in the form of
+        ``groupId:artifactId:version``. The Smithy CLI will search each
+        registered Maven repository for the dependency.
+    * - repositories
+      - ``[`` :ref:`maven-repositories` ``]``
+      - A list of Maven repositories to search for dependencies. If no
+        repositories are defined and the :ref:`SMITHY_MAVEN_REPOS environment variable <SMITHY_MAVEN_REPOS>`
+        is not defined, then this value defaults to `Maven Central`_.
+
+
+Dependency versions
+-------------------
+
+Maven dependencies are defined using GAV coordinates
+(``groupId:artifactId:version``). The version of a dependency can specify
+*version requirements* that are used to control how versions are resolved.
+Requirements can be given as *soft requirements*, meaning the version can be
+replaced by other versions found in the dependency graph. Hard requirements
+can be used to mandate a particular version and override soft requirements.
+Maven picks the highest version of each project that satisfies all the hard
+requirements of the dependencies on that project. If no version satisfies
+all the hard requirements, dependency resolution fails.
+
+The following table defines version requirement syntax as defined in
+the `official Maven documentation`_:
+
+.. list-table:: Dependency version syntax
+    :header-rows: 1
+    :widths: 20 80
+
+    * - Version
+      - Description
+    * - ``1.0``
+      - Soft requirement for 1.0. Use 1.0 if no other version appears earlier
+        in the dependency tree.
+    * - ``[1.0]``
+      - Hard requirement for 1.0. Use 1.0 and only 1.0.
+    * - ``(,1.0]``
+      - Hard requirement for any version <= 1.0.
+    * - ``[1.2,1.3]``
+      - Hard requirement for any version between 1.2 and 1.3 inclusive.
+    * - ``[1.0,2.0)``
+      - 1.0 <= x < 2.0; Hard requirement for any version between 1.0 inclusive
+        and 2.0 exclusive.
+    * - ``[1.5,)``
+      - Hard requirement for any version greater than or equal to 1.5.
+    * - ``(,1.0],[1.2,)``
+      - Multiple requirements are separated by commas. This requirement
+        forbids version 1.1 by adding a hard requirement for any version less
+        than or equal to 1.0 or greater than or equal to 1.2.
+    * - ``(,1.1),(1.1,)``
+      - Hard requirement for any version except 1.1 (for example, if 1.1
+        has a critical vulnerability).
+
+
+Unsupported version requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* LATEST, SNAPSHOT, RELEASE, latest-status, and latest.* versions are not
+  supported.
+* Gradle style ``+`` versions are not supported.
+
+
+.. _maven-repositories:
+
+Maven Repositories
+------------------
+
+The ``repositories`` property accepts a list of structures that each accept
+the following configuration:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - url
+      - ``string``
+      - The URL of the repository (for example, ``https://repo.maven.apache.org/maven2``).
+    * - httpCredentials
+      - ``string``
+      - HTTP basic or digest credentials to use with the repository.
+        Credentials are provided in the form of "username:password".
+
+        .. warning::
+
+            Credentials SHOULD NOT be defined statically in a smithy-build.json
+            file. Instead, use :ref:`environment variables <build_envars>` to
+            keep credentials out of source control.
+
+.. code-block::
+
+    {
+        "version": "1.0",
+        "maven": {
+            "repositories": [
+                {
+                    "url": "https://my_domain-111122223333.d.codeartifact.region.amazonaws.com/maven/my_repo/",
+                    "httpCredentials": "aws:${CODEARTIFACT_AUTH_TOKEN}"
+                }
+            ],
+            "dependencies": [
+                "software.amazon.smithy:smithy-aws-traits:__smithy_version__"
+            ]
+        }
+    }
+
+
+.. _SMITHY_MAVEN_REPOS:
+
+SMITHY_MAVEN_REPOS environment variable
+---------------------------------------
+
+When using the Smithy CLI, the ``SMITHY_MAVEN_REPOS`` environment variable can
+be used to configure Maven repositories automatically. The
+``SMITHY_MAVEN_REPOS`` environment variable is a pipe-delimited value ("|")
+that contains the URL of each repository to use.
+
+.. code-block::
+
+    SMITHY_MAVEN_REPOS="https://repo.maven.apache.org/maven2|https://example.repo.com/maven"
+
+Credentials can be provided in the URL. For example:
+
+.. code-block::
+
+    SMITHY_MAVEN_REPOS='https://user:password@example.repo.com/maven'
+
+When repositories are provided through the ``SMITHY_MAVEN_REPOS`` environment
+variable, no default repositories are assumed when resolving the
+``maven.repositories`` setting.
+
+.. important::
+
+    Repositories defined in ``SMITHY_MAVEN_REPOS`` take precedence over
+    repositories defined through smithy-build.json configuration.
+
+
 .. _projections:
 
 Projections
@@ -129,11 +308,12 @@ A projection accepts the following configuration:
         Smithy will not build artifacts for abstract projections. Abstract
         projections must not define ``imports`` or ``plugins``.
     * - imports
-      - ``string[]``
+      - ``[string]``
       - Provides a list of relative imports to include when building this
-        specific projection. When a directory is encountered, all files and
-        all files within all subdirectories are imported. Note: imports are
-        relative to the configuration file.
+        specific projection (in addition to any imports defined at the
+        top-level). When a directory is encountered, all files in the
+        directory tree are imported. Note: imports are relative to the
+        configuration file.
     * - transforms
       - ``list<Transforms>``
       - Defines the transformations to apply to the projection.
@@ -1401,3 +1581,6 @@ ignored. A Smithy manifest file is stored in a JAR as ``META-INF/smithy/manifest
 All model files referenced by the manifest are relative to ``META-INF/smithy/``.
 
 .. _Java SPI: https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html
+.. _Apache Maven: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
+.. _Maven Central: https://search.maven.org
+.. _official Maven documentation: https://maven.apache.org/pom.html#dependency-version-requirement-specification

--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -25,7 +25,7 @@ ext {
 }
 
 dependencies {
-    implementation project(":smithy-cli")
+    implementation project(path: ":smithy-cli", configuration: "shadow")
     implementation project(":smithy-protocol-test-traits")
     implementation project(":smithy-aws-traits")
     api project(":smithy-validation-model")

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -93,6 +93,15 @@ public final class SmithyBuild {
     }
 
     /**
+     * Gets the default directory where smithy-build artifacts are written.
+     *
+     * @return Returns the build output path.
+     */
+    public static Path getDefaultOutputDirectory() {
+        return DefaultPathHolder.DEFAULT_PATH;
+    }
+
+    /**
      * Builds the model and applies all projections.
      *
      * <p>This method loads all projections, projected models, and their
@@ -169,6 +178,9 @@ public final class SmithyBuild {
      */
     public SmithyBuild config(SmithyBuildConfig config) {
         this.config = config;
+        for (String source : config.getSources()) {
+            sources.add(Paths.get(source));
+        }
         return this;
     }
 
@@ -391,5 +403,14 @@ public final class SmithyBuild {
     public SmithyBuild pluginFilter(Predicate<String> pluginFilter) {
         this.pluginFilter = Objects.requireNonNull(pluginFilter);
         return this;
+    }
+
+    // Lazy initialization holder class idiom.
+    private static final class DefaultPathHolder {
+        private static final Path DEFAULT_PATH = resolveDefaultPath();
+
+        private static Path resolveDefaultPath() {
+            return Paths.get(".").toAbsolutePath().normalize().resolve("build").resolve("smithy");
+        }
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -179,9 +179,16 @@ public final class SmithyBuild {
     public SmithyBuild config(SmithyBuildConfig config) {
         this.config = config;
         for (String source : config.getSources()) {
-            sources.add(Paths.get(source));
+            addSource(Paths.get(source));
         }
         return this;
+    }
+
+    // Add a source path using absolute paths to better de-conflict source files. ModelAssembler also
+    // de-conflicts imports with absolute paths, but this ensures the same file doesn't appear twice in
+    // the build plugin output (though it does not use realpath to de-conflict based on symlinks).
+    private void addSource(Path path) {
+        sources.add(path.toAbsolutePath());
     }
 
     /**
@@ -377,7 +384,9 @@ public final class SmithyBuild {
      * @return Returns the builder.
      */
     public SmithyBuild registerSources(Path... pathToSources) {
-        Collections.addAll(sources, pathToSources);
+        for (Path path : pathToSources) {
+            addSource(path);
+        }
         return this;
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -92,7 +92,7 @@ final class SmithyBuildImpl {
             outputDirectory = Paths.get(config.getOutputDirectory().get());
         } else {
             // Default the output directory to the current working directory + "./build/smithy"
-            outputDirectory = Paths.get(".").toAbsolutePath().normalize().resolve("build").resolve("smithy");
+            outputDirectory = SmithyBuild.getDefaultOutputDirectory();
         }
 
         // Create the transformers for each projection.

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenConfig.java
@@ -23,10 +23,8 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
-@SmithyUnstableApi
 public final class MavenConfig implements ToSmithyBuilder<MavenConfig> {
 
     private final Set<String> dependencies;

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.model;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.utils.BuilderRef;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+@SmithyUnstableApi
+public final class MavenConfig implements ToSmithyBuilder<MavenConfig> {
+
+    private final Set<String> dependencies;
+    private final Set<MavenRepository> repositories;
+
+    private MavenConfig(Builder builder) {
+        this.dependencies = builder.dependencies.copy();
+        this.repositories =  builder.repositories.copy();
+    }
+
+    public static MavenConfig fromNode(Node node) {
+        MavenConfig.Builder builder = builder();
+        node.expectObjectNode()
+                .warnIfAdditionalProperties(ListUtils.of("dependencies", "repositories"))
+                .getArrayMember("dependencies", StringNode::getValue, builder::dependencies)
+                .getArrayMember("repositories", MavenRepository::fromNode, builder::repositories);
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Gets the repositories.
+     *
+     * @return Returns the repositories in an insertion ordered set.
+     */
+    public Set<MavenRepository> getRepositories() {
+        return repositories;
+    }
+
+    /**
+     * Gets the dependencies.
+     *
+     * @return Returns the dependencies in an insertion ordered set.
+     */
+    public Set<String> getDependencies() {
+        return dependencies;
+    }
+
+    public MavenConfig merge(MavenConfig other) {
+        MavenConfig.Builder builder = toBuilder();
+        builder.dependencies.get().addAll(other.getDependencies());
+
+        if (other.repositories != null) {
+            builder.repositories.get().addAll(other.repositories);
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().repositories(repositories).dependencies(dependencies);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dependencies, repositories);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (!(obj instanceof MavenConfig)) {
+            return false;
+        }
+
+        MavenConfig other = (MavenConfig) obj;
+        return dependencies.equals(other.dependencies) && Objects.equals(repositories, other.repositories);
+    }
+
+    public static final class Builder implements SmithyBuilder<MavenConfig> {
+        private final BuilderRef<Set<String>> dependencies = BuilderRef.forOrderedSet();
+        private final BuilderRef<Set<MavenRepository>> repositories = BuilderRef.forOrderedSet();
+
+        private Builder() {}
+
+        @Override
+        public MavenConfig build() {
+            return new MavenConfig(this);
+        }
+
+        public Builder dependencies(Collection<String> dependencies) {
+            this.dependencies.clear();
+            this.dependencies.get().addAll(dependencies);
+            return this;
+        }
+
+        public Builder repositories(Collection<MavenRepository> repositories) {
+            this.repositories.clear();
+            if (repositories != null) {
+                this.repositories.get().addAll(repositories);
+            }
+            return this;
+        }
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenRepository.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenRepository.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
+
+    private final String url;
+    private final String httpCredentials;
+
+    public MavenRepository(Builder builder) {
+        this.url = SmithyBuilder.requiredState("url", builder.url);
+        this.httpCredentials = builder.httpCredentials;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static MavenRepository fromNode(Node node) {
+        Builder builder = builder();
+        node.expectObjectNode()
+                .warnIfAdditionalProperties(Arrays.asList("url", "httpCredentials"))
+                .expectStringMember("url", builder::url)
+                .getStringMember("httpCredentials", builder::httpCredentials);
+        return builder.build();
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public Optional<String> getHttpCredentials() {
+        return Optional.ofNullable(httpCredentials);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().url(url).httpCredentials(httpCredentials);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(url, httpCredentials);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof MavenRepository)) {
+            return false;
+        }
+        MavenRepository mavenRepo = (MavenRepository) o;
+        return Objects.equals(url, mavenRepo.url) && Objects.equals(httpCredentials, mavenRepo.httpCredentials);
+    }
+
+    public static final class Builder implements SmithyBuilder<MavenRepository> {
+        private String url;
+        private String httpCredentials;
+
+        private Builder() {}
+
+        @Override
+        public MavenRepository build() {
+            return new MavenRepository(this);
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder httpCredentials(String httpCredentials) {
+            this.httpCredentials = httpCredentials;
+            if (httpCredentials != null) {
+                int position = httpCredentials.indexOf(':');
+                if (position < 1 || position == httpCredentials.length() - 1) {
+                    throw new IllegalArgumentException("Invalid httpCredentials: expected in the format of user:pass");
+                }
+            }
+            return this;
+        }
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -41,20 +41,30 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     private static final Set<String> BUILTIN_PLUGINS = SetUtils.of("build-info", "model", "sources");
 
     private final String version;
+    private final List<String> sources;
     private final List<String> imports;
     private final String outputDirectory;
     private final Map<String, ProjectionConfig> projections;
     private final Map<String, ObjectNode> plugins;
     private final boolean ignoreMissingPlugins;
+    private final MavenConfig maven;
+    private final long lastModifiedInMillis;
 
     private SmithyBuildConfig(Builder builder) {
         SmithyBuilder.requiredState("version", builder.version);
         version = builder.version;
         outputDirectory = builder.outputDirectory;
+        sources = builder.sources.copy();
         imports = builder.imports.copy();
         projections = builder.projections.copy();
         plugins = builder.plugins.copy();
         ignoreMissingPlugins = builder.ignoreMissingPlugins;
+        maven = builder.maven;
+        lastModifiedInMillis = builder.lastModifiedInMillis;
+
+        if (outputDirectory != null && outputDirectory.isEmpty()) {
+            throw new IllegalArgumentException("outputDirectory must be set to a valid directory");
+        }
     }
 
     public static SmithyBuildConfig fromNode(Node node) {
@@ -78,8 +88,18 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
      * <code>
      * {
      *     "version": "1.0",
+     *     "sources": ["model"],
      *     "imports": ["foo.json", "baz.json"],
      *     "outputDirectory": "build/output",
+     *     "maven" {
+     *          "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.26.1"],
+     *          "repositories": [
+     *              {
+     *                  "url": "https://example.com/maven",
+     *                  "httpCredentials": "${MAVEN_USER}:${MAVEN_PASSWORD}"
+     *              }
+     *          ]
+     *     }
      *     "projections": {
      *         "projection-name": {
      *             "transforms": [
@@ -116,10 +136,12 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         return builder()
                 .version(version)
                 .outputDirectory(outputDirectory)
+                .sources(sources)
                 .imports(imports)
                 .projections(projections)
                 .plugins(plugins)
-                .ignoreMissingPlugins(ignoreMissingPlugins);
+                .ignoreMissingPlugins(ignoreMissingPlugins)
+                .maven(maven);
     }
 
     /**
@@ -132,7 +154,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
-     * Gets the paths to all of the models to import.
+     * Gets the paths to all the models to import.
      *
      * <p>Paths can point to individual model files or directories.
      * All models stored in all recursive directories will be imported.
@@ -144,6 +166,19 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
+     * Gets the paths to all model sources.
+     *
+     * <p>Paths can point to individual model files or directories.
+     * All models stored in all recursive directories will be imported.
+     * Each found Smithy model will be considered a source model.
+     *
+     * @return Gets the list of models to import.
+     */
+    public List<String> getSources() {
+        return sources;
+    }
+
+    /**
      * @return Gets the optional output directory to store artifacts.
      */
     public Optional<String> getOutputDirectory() {
@@ -151,7 +186,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
-     * Gets all of the configured projections.
+     * Gets all the configured projections.
      *
      * @return Gets the available projections as a map of name to config.
      */
@@ -181,15 +216,41 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
+     * Gets Maven dependency configuration.
+     *
+     * <p>Note that smithy-build does not directly resolve or use dependencies.
+     * It's up to other packages like the Smithy CLI to use a dependency resolver
+     * based on smithy-build.json configuration and call smithy-build with
+     * the appropriate classpath.
+     *
+     * @return Returns Maven dependency information.
+     */
+    public Optional<MavenConfig> getMaven() {
+        return Optional.ofNullable(maven);
+    }
+
+    /**
+     * Get the last modified time of the configuration file.
+     *
+     * @return Returns the last modified time in milliseconds since the epoch.
+     */
+    public long getLastModifiedInMillis() {
+        return lastModifiedInMillis;
+    }
+
+    /**
      * Builder used to create a {@link SmithyBuildConfig}.
      */
     public static final class Builder implements SmithyBuilder<SmithyBuildConfig> {
         private final BuilderRef<List<String>> imports = BuilderRef.forList();
+        private final BuilderRef<List<String>> sources = BuilderRef.forList();
         private final BuilderRef<Map<String, ProjectionConfig>> projections = BuilderRef.forOrderedMap();
         private final BuilderRef<Map<String, ObjectNode>> plugins = BuilderRef.forOrderedMap();
         private String version;
         private String outputDirectory;
         private boolean ignoreMissingPlugins;
+        private MavenConfig maven;
+        private long lastModifiedInMillis = 0;
 
         Builder() {}
 
@@ -238,6 +299,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
             node.expectObjectNode()
                     .expectStringMember("version", this::version)
                     .getStringMember("outputDirectory", this::outputDirectory)
+                    .getArrayMember("sources", s -> SmithyBuildUtils.resolveImportPath(basePath, s),
+                                    values -> sources.get().addAll(values))
                     .getArrayMember("imports", s -> SmithyBuildUtils.resolveImportPath(basePath, s),
                                     values -> imports.get().addAll(values))
                     .getObjectMember("projections", v -> {
@@ -251,7 +314,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
                             plugins.get().put(entry.getKey(), entry.getValue().expectObjectNode());
                         }
                     })
-                    .getBooleanMember("ignoreMissingPlugins", this::ignoreMissingPlugins);
+                    .getBooleanMember("ignoreMissingPlugins", this::ignoreMissingPlugins)
+                    .getMember("maven", MavenConfig::fromNode, this::maven);
             return this;
         }
 
@@ -264,9 +328,18 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         public Builder merge(SmithyBuildConfig config) {
             config.getOutputDirectory().ifPresent(this::outputDirectory);
             version(config.getVersion());
+            sources.get().addAll(config.getSources());
             imports.get().addAll(config.getImports());
             projections.get().putAll(config.getProjections());
             plugins.get().putAll(config.getPlugins());
+
+            if (config.getMaven().isPresent()) {
+                if (maven == null) {
+                    maven = config.maven;
+                } else {
+                    maven = maven.merge(config.maven);
+                }
+            }
 
             // If either one wants to ignore missing plugins, then ignore them.
             if (config.isIgnoreMissingPlugins()) {
@@ -296,6 +369,18 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         public Builder imports(Collection<String> imports) {
             this.imports.clear();
             this.imports.get().addAll(imports);
+            return this;
+        }
+
+        /**
+         * Replaces sources on the config.
+         *
+         * @param sources Sources to set.
+         * @return Returns the builder.
+         */
+        public Builder sources(Collection<String> sources) {
+            this.sources.clear();
+            this.sources.get().addAll(sources);
             return this;
         }
 
@@ -331,6 +416,16 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
          */
         public Builder ignoreMissingPlugins(boolean ignoreMissingPlugins) {
             this.ignoreMissingPlugins = ignoreMissingPlugins;
+            return this;
+        }
+
+        public Builder maven(MavenConfig maven) {
+            this.maven = maven;
+            return this;
+        }
+
+        public Builder lastModifiedInMillis(long lastModifiedInMillis) {
+            this.lastModifiedInMillis = lastModifiedInMillis;
             return this;
         }
     }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenConfigTest.java
@@ -1,0 +1,82 @@
+package software.amazon.smithy.build.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+
+public class MavenConfigTest {
+    @Test
+    public void hasNoDefaultsBuiltInToThePojo() {
+        MavenConfig config = MavenConfig.builder().build();
+
+        assertThat(config.getRepositories(), empty());
+    }
+
+    @Test
+    public void loadsEmptyConfig() {
+        MavenConfig config = MavenConfig.fromNode(Node.objectNode());
+
+        assertThat(config.getDependencies(), empty());
+        assertThat(config.getRepositories(), empty());
+    }
+
+    @Test
+    public void loadsFromNodeAndOverridesMavenCentral() {
+        MavenConfig config = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v"))
+                .withMember("repositories", Node.fromNodes(Node.objectNode().withMember("url", "https://example.com")))
+                .build());
+
+        assertThat(config.getDependencies(), contains("g:a:v"));
+        assertThat(config.getRepositories(), hasSize(1));
+        assertThat(config.getRepositories().iterator().next().getUrl(), equalTo("https://example.com"));
+    }
+
+    @Test
+    public void convertToBuilder() {
+        MavenConfig config1 = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v"))
+                .withMember("repositories", Node.fromNodes(Node.objectNode().withMember("url", "https://example.com")))
+                .build());
+        MavenConfig config2 = config1.toBuilder().build();
+
+        assertThat(config1, equalTo(config1));
+        assertThat(config1, equalTo(config2));
+    }
+
+    @Test
+    public void mergesConfigs() {
+        MavenConfig config1 = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v"))
+                .withMember("repositories", Node.fromNodes(Node.objectNode().withMember("url", "https://example.com")))
+                .build());
+        MavenConfig config2 = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v", "a:a:a"))
+                .withMember("repositories", Node.fromNodes(
+                        Node.objectNode().withMember("url", "https://example.com"),
+                        Node.objectNode().withMember("url", "https://m2.example.com")))
+                .build());
+        MavenConfig merged = config1.merge(config2);
+
+        List<MavenRepository> repos = new ArrayList<>(config1.getRepositories());
+        repos.add(MavenRepository.builder().url("https://m2.example.com").build());
+
+        List<String> dependencies = new ArrayList<>();
+        dependencies.add("g:a:v");
+        dependencies.add("a:a:a");
+
+        MavenConfig expectedMerge = MavenConfig.builder()
+            .repositories(repos)
+            .dependencies(dependencies)
+            .build();
+
+        assertThat(merged, equalTo(expectedMerge));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenRepositoryTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenRepositoryTest.java
@@ -1,0 +1,59 @@
+package software.amazon.smithy.build.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+
+public class MavenRepositoryTest {
+    @Test
+    public void validatesHttpCredentialsValidColon() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MavenRepository.builder().url("https://example.com").httpCredentials(":").build();
+        });
+    }
+
+    @Test
+    public void validatesHttpCredentialsHasColon() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MavenRepository.builder().url("https://example.com").httpCredentials("foo").build();
+        });
+    }
+
+    @Test
+    public void validatesHttpCredentialsColonNotAtBeginning() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MavenRepository.builder().url("https://example.com").httpCredentials(":foo").build();
+        });
+    }
+
+    @Test
+    public void hasUrlAndAuth() {
+        MavenRepository repo1 = MavenRepository.builder()
+                .url("https://example.com")
+                .httpCredentials("user:pass")
+                .build();
+        MavenRepository repo2 = repo1.toBuilder().build();
+
+        assertThat(repo1.getUrl(), equalTo("https://example.com"));
+        assertThat(repo1.getHttpCredentials(), equalTo(Optional.of("user:pass")));
+        assertThat(repo2.getUrl(), equalTo("https://example.com"));
+        assertThat(repo2.getHttpCredentials(), equalTo(Optional.of("user:pass")));
+        assertThat(repo1, equalTo(repo1));
+        assertThat(repo1, equalTo(repo2));
+    }
+
+    @Test
+    public void loadsFromNode() {
+        MavenRepository repo = MavenRepository.fromNode(Node.objectNodeBuilder()
+                .withMember("url", "https://example.com")
+                .withMember("httpCredentials", "user:pass")
+                .build());
+
+        assertThat(repo.getUrl(), equalTo("https://example.com"));
+        assertThat(repo.getHttpCredentials(), equalTo(Optional.of("user:pass")));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
@@ -210,4 +210,47 @@ public class SmithyBuildConfigTest {
         assertThat(config.getImports(), contains(cwd.resolve("foo.json").toString()));
         assertThat(config.getProjections().get("a").getImports(), contains(cwd.resolve("baz.json").toString()));
     }
+
+    @Test
+    public void outputDirCannotBeEmpty() throws IOException {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            SmithyBuildConfig.builder()
+                    .version("1.0")
+                    .outputDirectory("")
+                    .build();
+        });
+    }
+
+    @Test
+    public void mergingTakesOtherMavenConfigWhenHasNone() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder().version("1").build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("a:b:1.0.0")).build())
+                .build();
+
+        assertThat(a.toBuilder().merge(b).build().getMaven(), equalTo(b.getMaven()));
+    }
+
+    @Test
+    public void mergingTakesSelfMavenConfigWhenOtherHasNone() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("a:b:1.0.0")).build())
+                .build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1").build();
+
+        assertThat(a.toBuilder().merge(b).build().getMaven(), equalTo(a.getMaven()));
+    }
+
+    @Test
+    public void mergingCombinesMavenConfigsWhenBothPresent() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("c:d:1.0.0")).build())
+                .build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("a:b:1.0.0", "c:d:1.0.0")).build())
+                .build();
+
+        assertThat(a.toBuilder().merge(b).build().getMaven().get().getDependencies(),
+                   contains("c:d:1.0.0", "a:b:1.0.0"));
+    }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/plugins/SourcesPluginTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/plugins/SourcesPluginTest.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.build.plugins;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.net.URISyntaxException;
@@ -11,8 +12,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.SmithyBuildResult;
 import software.amazon.smithy.build.SourcesConflictException;
 import software.amazon.smithy.build.model.ProjectionConfig;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.utils.ListUtils;
@@ -181,5 +185,27 @@ public class SourcesPluginTest {
                 .build();
 
         Assertions.assertThrows(SourcesConflictException.class, () -> new SourcesPlugin().execute(context));
+    }
+
+    @Test
+    public void copiesModelsDefinedInConfigAsSources() throws URISyntaxException {
+        SmithyBuildConfig config = SmithyBuildConfig.builder()
+                .load(Paths.get(getClass().getResource("sources/copiesModelsDefinedInConfigAsSources.json").toURI()))
+                .build();
+        SmithyBuild b = new SmithyBuild();
+        b.fileManifestFactory(p -> new MockManifest());
+        b.config(config);
+        SmithyBuildResult result = b.build();
+
+        MockManifest manifest = (MockManifest) result
+                .getProjectionResult("source")
+                .get()
+                .getPluginManifest("sources")
+                .get();
+
+        assertThat(manifest.getFileString("manifest").get(), containsString("a.smithy"));
+        assertThat(manifest.getFileString("manifest").get(), not(containsString("d.smithy")));
+        assertThat(manifest.hasFile("a.smithy"), is(true));
+        assertThat(manifest.hasFile("d.smithy"), is(false));
     }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources/copiesModelsDefinedInConfigAsSources.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources/copiesModelsDefinedInConfigAsSources.json
@@ -1,0 +1,5 @@
+{
+    "version": "1.0",
+    "sources": ["a.smithy"],
+    "imports": ["../notsources/d.smithy"]
+}

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -15,9 +15,12 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+import java.nio.file.Paths
+
 plugins {
     id "application"
     id "org.beryx.runtime" version "1.12.7"
+    id 'com.github.johnrengelman.shadow' version "7.1.2"
 }
 
 description = "This module implements the Smithy command line interface."
@@ -27,25 +30,111 @@ ext {
     moduleName = "software.amazon.smithy.cli"
     imageJreVersion = "17"
     correttoRoot = "https://corretto.aws/downloads/latest/amazon-corretto-${imageJreVersion}"
+    generatedResourcesDir = file("$buildDir/generated-resources")
+}
+
+dependencies {
+    // Keeps these as exported transitive dependencies.
+    implementation project(":smithy-model")
+    implementation project(":smithy-build")
+    implementation project(":smithy-diff")
+
+    // This is needed to ensure the above dependencies are added to the runtime image.
+    shadow project(":smithy-model")
+    shadow project(":smithy-build")
+    shadow project(":smithy-diff")
+
+    // These maven resolver dependencies are shaded into the smithy-cli JAR.
+    implementation 'org.apache.maven:maven-resolver-provider:3.8.6'
+    implementation "org.apache.maven.resolver:maven-resolver-api:1.8.2"
+    implementation "org.apache.maven.resolver:maven-resolver-spi:1.8.2"
+    implementation "org.apache.maven.resolver:maven-resolver-util:1.8.2"
+    implementation "org.apache.maven.resolver:maven-resolver-impl:1.8.2"
+    implementation "org.apache.maven.resolver:maven-resolver-connector-basic:1.8.2"
+    implementation "org.apache.maven.resolver:maven-resolver-transport-file:1.8.2"
+    implementation "org.apache.maven.resolver:maven-resolver-transport-http:1.8.2"
+    implementation 'org.slf4j:slf4j-jdk14:1.7.36' // Route slf4j used by Maven through JUL like the rest of Smithy.
+}
+
+// ------ Shade Maven dependency resolvers into the JAR. -------
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+    }
+}
+
+shadowJar {
+    // Replace the normal JAR with the shaded JAR.
+    archiveClassifier.set('')
+
+    mergeServiceFiles()
+
+    // Shade dependencies to prevent conflicts with other dependencies.
+    relocate('org.slf4j', 'software.amazon.smithy.cli.shaded.slf4j')
+    relocate('org.eclipse', 'software.amazon.smithy.cli.shaded.eclipse')
+    relocate('org.apache', 'software.amazon.smithy.cli.shaded.apache')
+    relocate('org.sonatype', 'software.amazon.smithy.cli.shaded.sonatype')
+    relocate('org.codehaus', 'software.amazon.smithy.cli.shaded.codehaus')
+
+    // If other javax packages are ever pulled in, we'll need to update this list. This is more deliberate about
+    // what's shaded to ensure that things like javax.net.ssl.SSLSocketFactory are not inadvertently shaded.
+    relocate('javax.annotation', 'software.amazon.smithy.cli.shaded.javax.annotation')
+    relocate('javax.inject', 'software.amazon.smithy.cli.shaded.javax.inject')
+
+    // Don't shade Smithy dependencies into the CLI. These are normal dependencies that we want our consumers
+    // to resolve.
+    dependencies {
+        exclude(project(':smithy-utils'))
+        exclude(project(':smithy-model'))
+        exclude(project(':smithy-build'))
+        exclude(project(':smithy-diff'))
+    }
+}
+
+tasks['jar'].finalizedBy(tasks['shadowJar'])
+
+// ------ Generate a file that contains the Smithy CLI version number. -------
+
+task generateVersionFile {
+    ext.versionFile = file("$generatedResourcesDir/software/amazon/smithy/cli/cli-version")
+    outputs.file(versionFile)
+    doLast {
+        versionFile.text = "${project.version}"
+    }
+}
+
+sourceSets.main.output.dir generatedResourcesDir, builtBy: generateVersionFile
+
+// ------ Setup CLI binary -------
+
+// This setting is needed by the Shadow plugin for some reason to define a main application class.
+mainClassName = "software.amazon.smithy.cli.SmithyCli"
+
+application {
+    mainClass = "${mainClassName}"
+    applicationName = "smithy"
 }
 
 // Detect which OS and arch is running to create an application class data sharing
-// archive for the current platform.
+// archive for the current platform. This is not how we'll ultimately build and release images.
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-    ext.set("imageOs", "win64")
+    ext.set("imageOs", "windows-x64")
 } else if (Os.isFamily(Os.FAMILY_MAC)) {
     if (Os.isArch("aarch64")) {
-        ext.set("imageOs", "osx-aarch_64")
-    } else if (Os.isArch("x86_64")) {
-        ext.set("imageOs", "osx-x86_64")
+        ext.set("imageOs", "darwin-aarch64")
+    } else if (Os.isArch("x86_64") || Os.isArch("amd64")) {
+        ext.set("imageOs", "darwin-x86_64")
     } else {
         println("No JDK for ${System.getProperty("os.arch")}")
         ext.set("imageOs", "")
     }
 } else if (Os.isFamily(Os.FAMILY_UNIX)) {
     if (Os.isArch("aarch")) {
-        ext.set("imageOs", "linux-aarch_64")
-    } else if (Os.isArch("x86_64")) {
+        ext.set("imageOs", "linux-aarch64")
+    } else if (Os.isArch("x86_64") || Os.isArch("amd64")) {
         ext.set("imageOs", "linux-x86_64")
     } else {
         println("No JDK for ${System.getProperty("os.arch")}")
@@ -56,24 +145,31 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     ext.set("imageOs", "")
 }
 
-dependencies {
-    implementation project(":smithy-model")
-    implementation project(":smithy-build")
-    implementation project(":smithy-linters")
-    implementation project(":smithy-diff")
+// This is needed in order for integration tests to find the build jlink CLI.
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    ext.set("smithyBinary", Paths.get(
+            "${project.buildDir}", "image", "smithy-cli-${imageOs}", "bin", "smithy.bat").toString())
+} else {
+    ext.set("smithyBinary", Paths.get(
+            "${project.buildDir}", "image", "smithy-cli-${imageOs}", "bin", "smithy").toString())
 }
-
-application {
-    mainClass = "software.amazon.smithy.cli.SmithyCli"
-    applicationName = "smithy"
-}
+System.setProperty("SMITHY_BINARY", "${smithyBinary}")
 
 runtime {
-    addOptions("--compress", "0", "--strip-debug", "--no-header-files", "--no-man-pages")
-    addModules("java.logging", "java.xml")
+    addOptions("--compress", "2", "--strip-debug", "--no-header-files", "--no-man-pages")
+    addModules("java.logging", "java.xml", "java.naming")
 
     launcher {
+        // This script is a combination of the default startup script used by the badass runtime
+        // plugin, and the upstream source it's based on:
+        // https://raw.githubusercontent.com/gradle/gradle/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+        // Using the Gradle wrapper script as-is results in a huge startup penalty, so I instead updated parts of the
+        // script that didn't affect performance, and kept others that did. Namely, the set and eval code of the Gradle
+        // startup script is significantly slower than what was used by the plugin.
+        unixScriptTemplate = file('config/unixStartScript.txt')
         jvmArgs = [
+            // Disable this when attempting to profile the CLI. In 99% of use cases this isn't not necessary.
+            '-XX:-UsePerfData',
             '-Xshare:auto',
             '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
         ]
@@ -83,38 +179,70 @@ runtime {
         jdkHome = jdkDownload("${correttoRoot}-x64-linux-jdk.tar.gz")
     }
 
-    targetPlatform("linux-aarch_64") {
+    targetPlatform("linux-aarch64") {
         jdkHome = jdkDownload("${correttoRoot}-aarch64-linux-jdk.tar.gz")
     }
 
-    targetPlatform("osx-x86_64") {
+    targetPlatform("darwin-x86_64") {
         jdkHome = jdkDownload("${correttoRoot}-x64-macos-jdk.tar.gz")
     }
 
-    targetPlatform("osx-aarch_64") {
+    targetPlatform("darwin-aarch64") {
         jdkHome = jdkDownload("${correttoRoot}-aarch64-macos-jdk.tar.gz")
     }
 
-    targetPlatform("win64") {
+    targetPlatform("windows-x64") {
         jdkHome = jdkDownload("${correttoRoot}-x64-windows-jdk.zip")
     }
 }
 
 // First, call validate with no args and create a class list to use application class data sharing.
-tasks.register("createClassList", Exec) {
+tasks.register("_createClassList", Exec) {
     environment("SMITHY_OPTS", "-XX:DumpLoadedClassList=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.lst")
-    commandLine("${project.buildDir}/image/smithy-cli-${imageOs}/bin/smithy", "validate")
+    environment("SMITHY_WARMUP_INTERNAL_ONLY", "true")
+    commandLine("$smithyBinary", "warmup", "--discover")
 }
 
 // Next, actually dump out the archive of the collected classes. This is platform specific,
 // so it can only be done for the current OS+architecture.
-tasks.register("dumpArchive", Exec) {
+tasks.register("_dumpArchive", Exec) {
     environment("SMITHY_OPTS", "-Xshare:dump -XX:SharedArchiveFile=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.jsa -XX:SharedClassListFile=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.lst")
-    commandLine("${project.buildDir}/image/smithy-cli-${imageOs}/bin/smithy", "validate")
+    environment("SMITHY_WARMUP_INTERNAL_ONLY", "true")
+    commandLine("$smithyBinary", "warmup", "--discover")
 }
 
 // Can't do CDS if the OS and architecture is not one of our targets.
 if (!imageOs.isEmpty()) {
-    tasks["dumpArchive"].dependsOn("createClassList")
-    tasks["runtime"].finalizedBy("dumpArchive")
+    tasks["_dumpArchive"].dependsOn("_createClassList")
+    tasks["runtime"].finalizedBy("_dumpArchive")
 }
+
+// Always shadow the JAR and replace the JAR by the shadowed JAR.
+tasks['jar'].finalizedBy("shadowJar")
+
+// Prevent https://docs.gradle.org/7.3.3/userguide/validation_problems.html#implicit_dependency issues between
+// the runtime image and shadowJar tasks.
+tasks['distZip'].dependsOn("shadowJar")
+tasks['distTar'].dependsOn("shadowJar")
+tasks['startScripts'].dependsOn("shadowJar")
+tasks["runtime"].dependsOn("shadowJar")
+
+// ------ Setup integration testing -------
+
+sourceSets {
+    create("it") {
+        compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
+        runtimeClasspath += output + compileClasspath + sourceSets["test"].runtimeClasspath
+    }
+}
+
+task integ(type: Test) {
+    useJUnitPlatform()
+    systemProperty "SMITHY_BINARY", "${smithyBinary}"
+    testClassesDirs = sourceSets["it"].output.classesDirs
+    classpath = sourceSets["it"].runtimeClasspath
+    maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+}
+
+// Runtime images need to be created before integration tests can run.
+tasks["integ"].dependsOn("runtime")

--- a/smithy-cli/config/unixStartScript.txt
+++ b/smithy-cli/config/unixStartScript.txt
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+
+# Resolve links: \$0 may be a link
+app_path=\$0
+
+# Need this for daisy-chained symlinks.
+while
+    APP_HOME=\${app_path%"\${app_path##*/}"}  # leaves a trailing /; empty if no leading path
+    [ -h "\$app_path" ]
+do
+    ls=\$( ls -ld "\$app_path" )
+    link=\${ls#*' -> '}
+    case \$link in             #(
+      /*)   app_path=\$link ;; #(
+      *)    app_path=\$APP_HOME\$link ;;
+    esac
+done
+
+# This is normally unused
+# shellcheck disable=SC2034
+APP_BASE_NAME=\${0##*/}
+APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "\$( uname )" in               #(
+  CYGWIN* )         cygwin=true  ;; #(
+  Darwin* )         darwin=true  ;; #(
+  MSYS* | MINGW* )  msys=true    ;; #(
+  NONSTOP* )        nonstop=true ;;
+esac
+
+CLASSPATH="\$APP_HOME/lib/*"
+JAVA_HOME="\$APP_HOME"
+JAVACMD="\$JAVA_HOME/bin/java"
+
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if "\$cygwin" || "\$msys" ; then
+    APP_HOME=\$( cygpath --path --mixed "\$APP_HOME" )
+    CLASSPATH=\$( cygpath --path --mixed "\$CLASSPATH" )
+    JAVACMD=\$( cygpath --unix "\$JAVACMD" )
+
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    for arg do
+        if
+            case \$arg in                                #(
+              -*)   false ;;                            # don't mess with options #(
+              /?*)  t=\${arg#/} t=/\${t%%/*}              # looks like a POSIX filepath
+                    [ -e "\$t" ] ;;                      #(
+              *)    false ;;
+            esac
+        then
+            arg=\$( cygpath --path --ignore --mixed "\$arg" )
+        fi
+        # Roll the args list around exactly as many times as the number of
+        # args, so each arg winds up back in the position where it started, but
+        # possibly modified.
+        #
+        # NB: a `for` loop captures its iteration list before it begins, so
+        # changing the positional parameters here affects neither the number of
+        # iterations, nor the values presented in `arg`.
+        shift                   # remove old arg
+        set -- "\$@" "\$arg"      # push replacement arg
+    done
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\\\n "\$i" | sed "s/'/'\\\\\\\\''/g;1s/^/'/;\\\$s/\\\$/' \\\\\\\\/" ; done
+    echo " "
+}
+APP_ARGS=\$(save "\$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- \$JAVA_TOOL_OPTIONS \$DEFAULT_JVM_OPTS \$CDS_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
+
+# Unset this environment variable before calling Java to prevent it from appearing in stderr.
+# Instead, the value stored in this variable is passed in to the command in the previous line manually.
+unset JAVA_TOOL_OPTIONS
+
+<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %>cd "\$APP_HOME/bin" && <% } %>exec "\$JAVACMD" "\$@"

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
@@ -1,0 +1,38 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class CleanCommandTest {
+    @Test
+    public void exitNormallyIfBuildDirMissing() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("clean"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), hasLength(0));
+        });
+    }
+
+    @Test
+    public void deletesContentsOfBuildDir() {
+        IntegUtils.withProject("simple-config-sources", root -> {
+            try {
+                Path created = Files.createDirectories(root.resolve("build").resolve("smithy").resolve("foo"));
+                assertThat(Files.exists(created), is(true));
+                RunResult result = IntegUtils.run(root, ListUtils.of("clean"));
+                assertThat(Files.exists(created), is(false));
+                assertThat(result.getExitCode(), is(0));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 public final class IntegUtils {
 
@@ -47,7 +48,7 @@ public final class IntegUtils {
     }
 
     public static void run(String projectName, List<String> args, Consumer<RunResult> consumer) {
-        run(projectName, args, Collections.emptyMap(), consumer);
+        run(projectName, args, MapUtils.of(EnvironmentVariable.NO_COLOR.toString(), "true"), consumer);
     }
 
     public static void run(String projectName, List<String> args, Map<String, String> env,
@@ -60,7 +61,7 @@ public final class IntegUtils {
         try {
             String cacheDir = Files.createTempDirectory("foo").toString();
             Map<String, String> actualEnv = new HashMap<>(env);
-            actualEnv.put("SMITHY_MAVEN_CACHE", cacheDir);
+            actualEnv.put(EnvironmentVariable.SMITHY_MAVEN_CACHE.toString(), cacheDir);
             withProject(projectName, path -> consumer.accept(run(path, args, actualEnv)));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.utils.IoUtils;
+
+public final class IntegUtils {
+
+    private IntegUtils() {}
+
+    public static void withProject(String projectName, Consumer<Path> consumer) {
+        withTempDir(projectName, path -> {
+            copyProject(projectName, path);
+            consumer.accept(path);
+        });
+    }
+
+    public static void run(String projectName, List<String> args, Consumer<RunResult> consumer) {
+        run(projectName, args, Collections.emptyMap(), consumer);
+    }
+
+    public static void run(String projectName, List<String> args, Map<String, String> env,
+            Consumer<RunResult> consumer) {
+        withProject(projectName, path -> consumer.accept(run(path, args, env)));
+    }
+
+    public static void runWithEmptyCache(String projectName, List<String> args, Map<String, String> env,
+            Consumer<RunResult> consumer) {
+        try {
+            String cacheDir = Files.createTempDirectory("foo").toString();
+            Map<String, String> actualEnv = new HashMap<>(env);
+            actualEnv.put("SMITHY_MAVEN_CACHE", cacheDir);
+            withProject(projectName, path -> consumer.accept(run(path, args, actualEnv)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static RunResult run(Path root, List<String> args) {
+        return run(root, args, Collections.emptyMap());
+    }
+
+    public static RunResult run(Path root, List<String> args, Map<String, String> env) {
+        List<String> smithyCommand = createSmithyCommand(args);
+        StringBuilder output = new StringBuilder();
+        int exitCode = IoUtils.runCommand(smithyCommand, root, output, env);
+        return new RunResult(smithyCommand, exitCode, output.toString(), root);
+    }
+
+    private static List<String> createSmithyCommand(List<String> args) {
+        String smithyBinary = System.getProperty("SMITHY_BINARY");
+        if (smithyBinary != null) {
+            List<String> result = new ArrayList<>(args.size() + 1);
+            result.add(smithyBinary);
+            result.addAll(args);
+            return result;
+        }
+
+        throw new RuntimeException("No SMITHY_BINARY location was set. Did you build the Smithy jlink CLI?");
+    }
+
+    private static void withTempDir(String name, Consumer<Path> consumer) {
+        try {
+            Path path = Files.createTempDirectory(name.replace("/", "_"));
+            try {
+                consumer.accept(path);
+            } finally {
+                IoUtils.rmdir(path);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void copyProject(String name, Path dest) {
+        try {
+            URL url = IntegUtils.class.getResource("projects/" + name);
+            if (url == null) {
+                throw new IllegalArgumentException("Invalid project name: " + name);
+            }
+            Path source = Paths.get(url.toURI());
+            copyDirectory(source, dest);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void copyDirectory(Path from, Path to) throws IOException {
+        Files.walkFileTree(from, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                // Create parent directories if they don't exist.
+                Path targetDir = to.resolve(from.relativize(dir));
+                try {
+                    Files.copy(dir, targetDir);
+                } catch (FileAlreadyExistsException e) {
+                    // do nothing
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.copy(file, to.resolve(from.relativize(file)), StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -132,25 +132,31 @@ public class MavenResolverTest {
 
     @Test
     public void canIgnoreDependencyResolution() {
-        IntegUtils.run("aws-model", ListUtils.of("validate", "--dependency-mode", "ignore", "model"), result -> {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "model"),
+                       MapUtils.of(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.toString(), "ignore"),
+                       result -> {
             assertThat(result.getExitCode(), equalTo(1));
-            assertThat(result.getOutput(), containsString("--dependency-mode is set to 'ignore'"));
         });
     }
 
     @Test
     public void canForbidDependencyResolution() {
-        IntegUtils.run("aws-model", ListUtils.of("validate", "--dependency-mode", "forbid", "model"), result -> {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "model"),
+                       MapUtils.of(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.toString(), "forbid"),
+                       result -> {
             assertThat(result.getExitCode(), equalTo(1));
-            assertThat(result.getOutput(), containsString("--dependency-mode is set to 'forbid'"));
+            assertThat(result.getOutput(), containsString("set to 'forbid'"));
         });
     }
 
     @Test
     public void validatesDependencyResolution() {
-        IntegUtils.run("aws-model", ListUtils.of("validate", "--dependency-mode", "Beeblebrox", "model"), result -> {
+        IntegUtils.run("aws-model",
+                       ListUtils.of("validate", "model"),
+                       MapUtils.of(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.toString(), "Beeblebrox"),
+                       result -> {
             assertThat(result.getExitCode(), equalTo(1));
-            assertThat(result.getOutput(), containsString("Invalid --dependency-mode parameter: 'Beeblebrox'"));
+            assertThat(result.getOutput(), containsString("Beeblebrox"));
         });
     }
 

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -1,0 +1,191 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+
+public class MavenResolverTest {
+    @Test
+    public void resolvesDependenciesFromMavenCentralDefault() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
+
+    @Test
+    public void resolveDependenciesWithDebugInfo() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "--debug", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("Resolving Maven dependencies for Smithy CLI"));
+            assertThat(result.getOutput(), containsString("Dependency resolution time in ms"));
+        });
+    }
+
+    @Test
+    public void lowerSmithyVersionsAreUpgradedToNewerVersions() {
+        IntegUtils.run("lower-smithy-version", ListUtils.of("validate", "--logging", "FINE"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("Replaced software.amazon.smithy:smithy-model:1.25.2"));
+        });
+    }
+
+    @Test
+    public void lowerSmithyVersionsAreUpgradedToNewerVersionsQuiet() {
+        IntegUtils.run("lower-smithy-version", ListUtils.of("validate", "--quiet"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), not(containsString("Replacing software.amazon.smithy:smithy-model:jar:1.0.0 with software.amazon.smithy:smithy-model:" + SmithyCli.getVersion())));
+        });
+    }
+
+    @Test
+    public void failsWhenBadVersionRequested() {
+        IntegUtils.run("bad-smithy-version", ListUtils.of("validate"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("software.amazon.smithy:smithy-model:jar:[999.999.999]"));
+        });
+    }
+
+    // TODO: This test could be better and actually test that auth works somehow.
+    @Test
+    public void usesCustomRepoWithAuth() {
+        IntegUtils.runWithEmptyCache("maven-auth", ListUtils.of("validate", "--debug"),
+                                     Collections.emptyMap(), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("with xxx=****"));
+        });
+    }
+
+    @Test
+    public void ignoresEmptyCacheFiles() {
+        IntegUtils.withProject("aws-model", path -> {
+            try {
+                Files.createDirectories(path.resolve("build").resolve("smithy"));
+                Files.write(path.resolve("build").resolve("smithy").resolve("classpath.json"),
+                            "".getBytes(StandardCharsets.UTF_8));
+                RunResult result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+
+                assertThat(result.getExitCode(), is(0));
+                assertThat(result.getOutput(), containsString("Invalidating dependency cache"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void deletesStaleCacheFiles() {
+        IntegUtils.withProject("aws-model", path -> {
+            // Do the first run and expect it to resolve, cache, and work.
+            RunResult result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            assertThat(result.hasFile("build", "smithy", "classpath.json"), is(true));
+
+            // Update the config file lastModified time to force the cache to be invalidated.
+            assertThat(result.resolve(result.getRoot(), "smithy-build.json").toFile()
+                               .setLastModified(System.currentTimeMillis()), is(true));
+
+            // Do the next run and expect it to resolve, invalidate the cache, and work.
+            result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            assertThat(result.hasFile("build", "smithy", "classpath.json"), is(true));
+            assertThat(result.getOutput(), containsString("Invalidating dependency cache"));
+        });
+    }
+
+    // If a dependency changes, its POM could have changed too, so invalidate the cache.
+    @Test
+    public void invalidatesCacheWhenDependencyChanges() {
+        IntegUtils.withProject("aws-model", path -> {
+            // Do the first run and expect it to resolve, cache, and work.
+            RunResult result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            String cacheContents = result.getFile("build", "smithy", "classpath.json");
+
+            ObjectNode node = Node.parse(cacheContents).expectObjectNode();
+            String location = node.expectStringMember("software.amazon.smithy:smithy-aws-traits:"
+                                                      + SmithyCli.getVersion()).getValue();
+
+            // Set the lastModified of the JAR to the current time, which is > than the time of the config file,
+            // so the cache is invalided.
+            assertThat(new File(location).setLastModified(System.currentTimeMillis()), is(true));
+
+            // Do the next run and expect it to resolve, invalidate the cache, and work.
+            result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            assertThat(result.hasFile("build", "smithy", "classpath.json"), is(true));
+            assertThat(result.getOutput(), containsString("Invalidating dependency cache"));
+        });
+    }
+
+    @Test
+    public void canIgnoreDependencyResolution() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "--dependency-mode", "ignore", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("--dependency-mode is set to 'ignore'"));
+        });
+    }
+
+    @Test
+    public void canForbidDependencyResolution() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "--dependency-mode", "forbid", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("--dependency-mode is set to 'forbid'"));
+        });
+    }
+
+    @Test
+    public void validatesDependencyResolution() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "--dependency-mode", "Beeblebrox", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Invalid --dependency-mode parameter: 'Beeblebrox'"));
+        });
+    }
+
+    @Test
+    public void canDisableMavenLocalDefaultWithEnvSetting() {
+        // Note that running with an empty cache means it can't find the packages at all. Running with a cache
+        // means it could potentially find the packages.
+        IntegUtils.runWithEmptyCache("aws-model",
+                                     ListUtils.of("validate", "--debug", "model"),
+                                     MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(), ""),
+                                     result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+
+    @Test
+    public void canSetMavenReposUsingEnvironmentVariable() {
+        IntegUtils.runWithEmptyCache("aws-model",
+                                     ListUtils.of("validate", "--debug", "model"),
+                                     MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(),
+                                                 "https://repo.maven.apache.org/maven2"),
+                                     result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
+
+    @Test
+    public void setSetMavenRepoWithEnvUsingAuth() {
+        String repo = "https://xxx:yyy@localhost:1234/maven/not/there";
+        IntegUtils.runWithEmptyCache("aws-model",
+                                     ListUtils.of("validate", "--debug", "model"),
+                                     MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(), repo),
+                                     result -> {
+            assertThat(result.getOutput(), containsString("with xxx=****"));
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
@@ -18,9 +18,11 @@ package software.amazon.smithy.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 public class RootCommandTest {
     @Test
@@ -36,6 +38,9 @@ public class RootCommandTest {
         IntegUtils.run("simple-config-sources", ListUtils.of("-h"), result -> {
             assertThat(result.getExitCode(), equalTo(0));
             ensureHelpOutput(result);
+
+            // We force NO_COLOR by default in the run method. Test that's honored here.
+            assertThat(result.getOutput(), not(containsString("[0m")));
         });
     }
 
@@ -68,6 +73,17 @@ public class RootCommandTest {
         IntegUtils.run("simple-config-sources", ListUtils.of("--foo"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
             assertThat(result.getOutput(), containsString("Unknown argument or command: --foo"));
+        });
+    }
+
+    @Test
+    public void runsWithColors() {
+        IntegUtils.run("simple-config-sources",
+                       ListUtils.of("--help"),
+                       MapUtils.of(EnvironmentVariable.FORCE_COLOR.toString(), "true"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("[0m"));
         });
     }
 

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class RootCommandTest {
+    @Test
+    public void providingNoInputPrintsHelp() {
+        IntegUtils.run("simple-config-sources", ListUtils.of(), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            ensureHelpOutput(result);
+        });
+    }
+
+    @Test
+    public void passing_h_printsHelp() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("-h"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            ensureHelpOutput(result);
+        });
+    }
+
+    @Test
+    public void passingHelpPrintsHelp() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--help"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            ensureHelpOutput(result);
+        });
+    }
+
+    @Test
+    public void supportsVersionPseudoCommand() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--version"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), equalTo(SmithyCli.getVersion()));
+        });
+    }
+
+    @Test
+    public void errorsOnInvalidCommand() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("doesNotExist"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Unknown argument or command: doesNotExist"));
+        });
+    }
+
+    @Test
+    public void errorsOnInvalidArgument() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--foo"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Unknown argument or command: --foo"));
+        });
+    }
+
+    private void ensureHelpOutput(RunResult result) {
+        // Make sure it's the help output.
+        assertThat(result.getOutput(),
+                   containsString("Usage: smithy [-h | --help] [--version] <command> [<args>]"));
+        // Make sure commands are listed.
+        assertThat(result.getOutput(), containsString("Available commands:"));
+        // Check on one of the command's help summary.
+        assertThat(result.getOutput(), containsString("Validates Smithy models"));
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RunResult.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RunResult.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.smithy.utils.IoUtils;
+
+final class RunResult {
+    private final List<String> args;
+    private final int exitCode;
+    private final String output;
+    private final Path root;
+    private Path buildDir;
+
+    RunResult(List<String> args, int exitCode, String output, Path root) {
+        this.args = args;
+        this.exitCode = exitCode;
+        this.output = output;
+        this.root = root;
+    }
+
+    List<String> getArgs() {
+        return args;
+    }
+
+    int getExitCode() {
+        return exitCode;
+    }
+
+    String getOutput() {
+        return output;
+    }
+
+    Path getRoot() {
+        return root;
+    }
+
+    Path withBuildDir(String... paths) {
+        Path result = resolve(root, paths);
+        if (!Files.isDirectory(result)) {
+            throw new RuntimeException("Smithy build directory does not exist: " + result);
+        }
+        this.buildDir = result;
+        return result;
+    }
+
+    Path getBuildDir() {
+        if (buildDir == null) {
+            buildDir = resolve(root, "build", "smithy");
+        }
+        return buildDir;
+    }
+
+    boolean hasFile(String... paths) {
+        return Files.exists(resolve(root, paths));
+    }
+
+    String getFile(String... paths) {
+        Path resolved = resolve(root, paths);
+        if (!Files.isRegularFile(resolved)) {
+            throw new IllegalArgumentException("File not found: " + resolved);
+        }
+        return IoUtils.readUtf8File(resolved);
+    }
+
+    boolean hasProjection(String projection) {
+        return Files.isDirectory(getBuildDir().resolve(projection));
+    }
+
+    boolean hasPlugin(String projection, String plugin) {
+        return Files.isDirectory(getArtifactPath(projection, plugin));
+    }
+
+    boolean hasArtifact(String projection, String plugin, String... paths) {
+        return Files.exists(getArtifactPath(projection, plugin, paths));
+    }
+
+    Path getArtifactPath(String projection, String plugin, String... paths) {
+        return resolve(getBuildDir().resolve(projection).resolve(plugin), paths);
+    }
+
+    String getArtifact(String projection, String plugin, String... paths) {
+        return IoUtils.readUtf8File(getArtifactPath(projection, plugin, paths));
+    }
+
+    Path resolve(Path result, String... paths) {
+        for (String path : paths) {
+            result = result.resolve(path);
+        }
+        return result;
+    }
+
+    Set<Path> getFiles() {
+        return getFiles(root);
+    }
+
+    Set<Path> getFiles(Path inDir) {
+        try (Stream<Path> files  = Files.find(inDir, 999, (p, a) -> Files.isRegularFile(p))) {
+            return files.collect(Collectors.toCollection(TreeSet::new));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    Set<Path> getDirectories() {
+        try (Stream<Path> files  = Files.find(root, 999, (p, a) -> Files.isDirectory(p))) {
+            return files.collect(Collectors.toCollection(TreeSet::new));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RunResult{"
+               + "args='" + args + '\''
+               + ", exitCode=" + exitCode
+               + ", output='" + output + '\''
+               +  ", root=" + root + '}';
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
@@ -1,0 +1,33 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+
+public class SelectTest {
+    @Test
+    public void selectsShapeIds() {
+        List<String> args = Arrays.asList("select", "--selector", "string [id|namespace=smithy.example]");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), equalTo("smithy.example#MyString"));
+        });
+    }
+
+    @Test
+    public void selectsVariables() {
+        List<String> args = Arrays.asList("select", "--vars", "--selector", "list $list(*) > member > string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"shape\": \"smithy.api#String\""));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
@@ -69,4 +69,14 @@ public class SmithyBuildTest {
             assertThat(result.getOutput(), containsString("Caused by"));
         });
     }
+
+    @Test
+    public void successfullyDeDupesConfigAndCliArguments() {
+        // The config adds model as a source and so does the CLI. Without de-duping, this would fail due to the
+        // enum being defined twice with the same members. Without de-conflicting in SmithyBuild, the sources plugin
+        // would fail due to finding two files named main.smithy.
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
@@ -1,0 +1,72 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class SmithyBuildTest {
+    @Test
+    public void buildsModelsWithSourcesAndDefaultPlugins() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("build"), this::doSimpleBuildAssertions);
+    }
+
+    @Test
+    public void canSetSpecificConfigFile() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "-c", "smithy-build.json"),
+                       this::doSimpleBuildAssertions);
+    }
+
+    @Test
+    public void registersSourcesFromArguments() {
+        IntegUtils.run("simple-no-config", ListUtils.of("build", "model"), this::doSimpleBuildAssertions);
+    }
+
+    private void doSimpleBuildAssertions(RunResult result) {
+        assertThat(result.getExitCode(), equalTo(0));
+        assertThat(result.getOutput(), containsString("SUCCESS"));
+        assertThat(result.hasProjection("source"), is(true));
+        assertThat(result.hasPlugin("source", "model"), is(true));
+        assertThat(result.hasPlugin("source", "sources"), is(true));
+        assertThat(result.hasPlugin("source", "build-info"), is(true));
+        assertThat(result.hasArtifact("source", "model", "model.json"), is(true));
+        assertThat(result.hasArtifact("source", "sources", "manifest"), is(true));
+        assertThat(result.hasArtifact("source", "sources", "main.smithy"), is(true));
+        assertThat(result.getArtifact("source", "sources", "main.smithy"), containsString("string MyString"));
+    }
+
+    @Test
+    public void canUseQuietOutput() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "--quiet"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), emptyString());
+        });
+    }
+
+    @Test
+    public void showsErrorMessageWhenConfigIsMissing() {
+        String path = Paths.get("does", "not", "exist1234.json").toString();
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "-c", path), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString(path));
+            assertThat(result.getOutput(), not(containsString("java.io.UncheckedIOException")));
+        });
+    }
+
+    @Test
+    public void showsErrorMessageWithStacktraceWhenConfigIsMissing() {
+        String path = Paths.get("does", "not", "exist1234.json").toString();
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "-c", path, "--stacktrace"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString(path));
+            assertThat(result.getOutput(), containsString("java.io.UncheckedIOException"));
+            assertThat(result.getOutput(), containsString("Caused by"));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
@@ -1,0 +1,41 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class SmithyValidateTest {
+    @Test
+    public void validatesModelSuccess() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("validate"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("SUCCESS: Validated "));
+            assertThat(result.hasProjection("source"), is(false));
+        });
+    }
+
+    @Test
+    public void validatesModelSuccessQuiet() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("validate", "--quiet"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), emptyString());
+        });
+    }
+
+    @Test
+    public void validatesModelFailure() {
+        IntegUtils.run("invalid-model", ListUtils.of("validate", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("ERROR: smithy.example#MyString (TraitTarget)"));
+            // Normalize windows paths.
+            assertThat(result.getOutput().replace("\\", "/"), containsString("@ model/invalid.smithy"));
+            assertThat(result.getOutput(), containsString("@range(min: 10, max: 100) // not valid for strings!"));
+            assertThat(result.getOutput(), containsString("ERROR: 1"));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
@@ -32,8 +32,7 @@ public class SmithyValidateTest {
         IntegUtils.run("invalid-model", ListUtils.of("validate", "model"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
             assertThat(result.getOutput(), containsString("ERROR: smithy.example#MyString (TraitTarget)"));
-            // Normalize windows paths.
-            assertThat(result.getOutput().replace("\\", "/"), containsString("@ model/invalid.smithy"));
+            assertThat(result.getOutput(), containsString("invalid.smithy"));
             assertThat(result.getOutput(), containsString("@range(min: 10, max: 100) // not valid for strings!"));
             assertThat(result.getOutput(), containsString("ERROR: 1"));
         });

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/WarmupTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/WarmupTest.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class WarmupTest {
+    @Test
+    public void providingNoInputPrintsHelpExits0() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--help"), result -> {
+            assertThat(result.getOutput(), not(containsString("warmup")));
+        });
+    }
+
+    @Test
+    public void warmupDoesNotWorkWithoutEnvvar() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("warmup"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/model/main.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+namespace smithy.example
+
+@aws.protocols#restJson1
+service Foo {}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/smithy-build.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.0",
+    "maven": {
+        "dependencies": ["software.amazon.smithy:smithy-aws-traits:${SMITHY_VERSION}"]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/bad-smithy-version/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/bad-smithy-version/smithy-build.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0",
+    "maven": {
+        // This dependency does not exist, so it can't resolve.
+        "dependencies": ["software.amazon.smithy:smithy-model:[999.999.999]"]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/invalid-model/model/invalid.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/invalid-model/model/invalid.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+namespace smithy.example
+
+@range(min: 10, max: 100) // not valid for strings!
+string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/lower-smithy-version/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/lower-smithy-version/smithy-build.json
@@ -1,0 +1,11 @@
+// Smithy CLI will ignore the older version of Smithy in this file and use the
+// version shipped with the CLI.
+{
+    "version": "1.0",
+    "maven": {
+        "dependencies": [
+            "software.amazon.smithy.typescript:smithy-typescript-codegen:0.12.0",
+            "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.12.0"
+        ]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-auth/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-auth/smithy-build.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0",
+    "maven": {
+        "repositories": [
+            {
+                "url": "https://localhost:1234/maven/not/there",
+                "httpCredentials": "xxx:yyy"
+            }
+        ],
+        "dependencies": [
+            "software.amazon.smithy:smithy-aws-iam-traits:${SMITHY_VERSION}"
+        ]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+namespace smithy.example
+
+string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
@@ -1,4 +1,16 @@
-$version: "2.0"
+// Use a 1.0 model to use an enum trait without a warning.
+$version: "1.0"
 namespace smithy.example
 
+// This is used for assertions around de-duping files because duplicate enum values would fail validation.
+@enum([
+    {
+        value: "FOO",
+        name: "FOO"
+    },
+    {
+        value: "BAR",
+        name: "BAR"
+    }
+])
 string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/smithy-build.json
@@ -1,0 +1,4 @@
+{
+    "version": "1.0",
+    "sources": ["model"]
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-no-config/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-no-config/model/main.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+namespace smithy.example
+
+string MyString

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Ansi.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Ansi.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Styles text using ANSI color codes.
+ */
+public enum Ansi {
+
+    /**
+     * Writes using ANSI colors if it detects that the environment supports color.
+     */
+    AUTO {
+        private final Ansi delegate = Ansi.detect();
+
+        @Override
+        public String style(String text, Style... styles) {
+            return delegate.style(text, styles);
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            delegate.style(appendable, text, styles);
+        }
+    },
+
+    /**
+     * Does not write any color.
+     */
+    NO_COLOR {
+        @Override
+        public String style(String text, Style... styles) {
+            return text;
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            try {
+                appendable.append(text);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    },
+
+    /**
+     * Writes with ANSI colors.
+     */
+    FORCE_COLOR {
+        @Override
+        public String style(String text, Style... styles) {
+            StringBuilder builder = new StringBuilder();
+            style(builder, text, styles);
+            return builder.toString();
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            try {
+                appendable.append("\033[");
+                boolean isAfterFirst = false;
+                for (Style style : styles) {
+                    if (isAfterFirst) {
+                        appendable.append(';');
+                    }
+                    appendable.append(style.toString());
+                    isAfterFirst = true;
+                }
+                appendable.append('m');
+                appendable.append(text);
+                appendable.append("\033[0m");
+            } catch (IOException e) {
+                throw new CliError("Error writing output", 2, e);
+            }
+        }
+    };
+
+    /**
+     * Detects if ANSI colors are supported and returns the appropriate Ansi enum variant.
+     *
+     * <p>This method differs from using the {@link Ansi#AUTO} variant directly because it will detect any changes
+     * to the environment that might enable or disable colors.
+     *
+     * @return Returns the detected ANSI color enum variant.
+     */
+    public static Ansi detect() {
+        return isAnsiEnabled() ? FORCE_COLOR : NO_COLOR;
+    }
+
+    /**
+     * Styles text using ANSI color codes.
+     *
+     * @param text Text to style.
+     * @param styles Styles to apply.
+     * @return Returns the styled text.
+     */
+    public abstract String style(String text, Style... styles);
+
+    /**
+     * Styles text using ANSI color codes and writes it to an Appendable.
+     *
+     * @param appendable Where to write styled text.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    public abstract void style(Appendable appendable, String text, Style... styles);
+
+    private static boolean isAnsiEnabled() {
+        if (EnvironmentVariable.FORCE_COLOR.isSet()) {
+            return true;
+        }
+
+        // Disable colors if NO_COLOR is set to anything.
+        if (EnvironmentVariable.NO_COLOR.isSet()) {
+            return false;
+        }
+
+        String term = EnvironmentVariable.TERM.get();
+
+        // If term is set to "dumb", then don't use colors.
+        if (Objects.equals(term, "dumb")) {
+            return false;
+        }
+
+        // If TERM isn't set at all and Windows is detected, then don't use colors.
+        if (term == null && System.getProperty("os.name").contains("win")) {
+            return false;
+        }
+
+        // Disable colors if no console is associated.
+        return System.console() != null;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * A command line argument receiver.
@@ -27,7 +26,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * If any receiver rejects a non-positional argument, the CLI will
  * exit with an error.
  */
-@SmithyUnstableApi
 public interface ArgumentReceiver {
     /**
      * Test if the given value-less option is accepted by the receiver.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
@@ -24,8 +24,8 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * <p>All non-positional arguments of a {@link Command} need a
  * corresponding receiver to accept it through either
  * {@link #testOption(String)} or {@link #testParameter(String)}.
- * If a non-positional argument is not accepted by any receiver,
- * the CLI will exit with an error.
+ * If any receiver rejects a non-positional argument, the CLI will
+ * exit with an error.
  */
 @SmithyUnstableApi
 public interface ArgumentReceiver {
@@ -52,7 +52,7 @@ public interface ArgumentReceiver {
      * processing.
      *
      * @param name Name of the parameter to test.
-     * @return Returns a consumer if accepted or null if not accepted.
+     * @return Returns a consumer if accepted or null if rejected.
      */
     default Consumer<String> testParameter(String name) {
         return null;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Arguments.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Arguments.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Command line arguments list to evaluate.
@@ -35,7 +34,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * subscribers via {@link #onComplete(BiConsumer)}. These subscribers are
  * invoked when all arguments have been parsed.
  */
-@SmithyUnstableApi
 public final class Arguments {
 
     private final String[] args;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
@@ -18,10 +18,9 @@ package software.amazon.smithy.cli;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
- * This class provides a very basic CLI abstraction.
+ * This class provides a basic CLI abstraction.
  *
  * <p>Why are we not using a library for this? Because parsing command line
  * options isn't difficult, we don't need to take a dependency, this code
@@ -29,7 +28,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * CLI features are supported in case we want to migrate to a library or
  * event a different language.
  */
-@SmithyUnstableApi
 public final class Cli {
 
     private static final Logger LOGGER = Logger.getLogger(Cli.class.getName());
@@ -72,9 +70,10 @@ public final class Cli {
         StandardOptions standardOptions = new StandardOptions();
         arguments.addReceiver(standardOptions);
 
-        // Use or disable ANSI escapes in the printers.
-        CliPrinter out = new CliPrinter.ColorPrinter(stdoutPrinter, standardOptions);
-        CliPrinter err = new CliPrinter.ColorPrinter(stdErrPrinter, standardOptions);
+        // Use or disable ANSI escapes in the printers. Note that determining the color setting is deferred
+        // using a Supplier to allow the CLI parameters to be fully resolved.
+        CliPrinter out = new CliPrinter.ColorPrinter(stdoutPrinter, standardOptions::colorSetting);
+        CliPrinter err = new CliPrinter.ColorPrinter(stdErrPrinter, standardOptions::colorSetting);
 
         // Setup logging after parsing all arguments.
         arguments.onComplete((opts, positional) -> {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -18,12 +18,11 @@ package software.amazon.smithy.cli;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.function.Consumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
+import java.util.function.Supplier;
 
 /**
  * Handles text output of the CLI.
  */
-@SmithyUnstableApi
 public interface CliPrinter {
     /**
      * Prints text to the writer and appends a new line.
@@ -88,12 +87,12 @@ public interface CliPrinter {
      */
     final class ColorPrinter implements CliPrinter {
         private final CliPrinter delegate;
-        private final StandardOptions options;
+        private final Supplier<StandardOptions.ColorSetting> colorSettingSupplier;
         private final boolean ansiSupported;
 
-        public ColorPrinter(CliPrinter delegate, StandardOptions options) {
+        public ColorPrinter(CliPrinter delegate, Supplier<StandardOptions.ColorSetting> colorSettingSupplier) {
             this.delegate = delegate;
-            this.options = options;
+            this.colorSettingSupplier = colorSettingSupplier;
             this.ansiSupported = isAnsiColorSupported();
         }
 
@@ -108,7 +107,7 @@ public interface CliPrinter {
 
         @Override
         public String style(String text, Style... styles) {
-            if (options.forceColor() || (!options.noColor() && ansiSupported)) {
+            if (colorSettingSupplier.get() != StandardOptions.ColorSetting.NO_COLOR && ansiSupported) {
                 return delegate.style(text, styles);
             } else {
                 return text;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -17,8 +17,6 @@ package software.amazon.smithy.cli;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /**
  * Handles text output of the CLI.
@@ -63,55 +61,6 @@ public interface CliPrinter {
             result = style(result.substring(0, positionOfName), Style.RED, Style.UNDERLINE)
                      + result.substring(positionOfName);
             println(result);
-        }
-    }
-
-    /**
-     * CliPrinter that calls a Consumer that accepts a CharSequence.
-     */
-    final class ConsumerPrinter implements CliPrinter {
-        private final Consumer<CharSequence> consumer;
-
-        public ConsumerPrinter(Consumer<CharSequence> consumer) {
-            this.consumer = consumer;
-        }
-
-        @Override
-        public void println(String text) {
-            consumer.accept(text + System.lineSeparator());
-        }
-    }
-
-    /**
-     * A CliPrinter that prints ANSI colors if able and allowed.
-     */
-    final class ColorPrinter implements CliPrinter {
-        private final CliPrinter delegate;
-        private final Supplier<StandardOptions.ColorSetting> colorSettingSupplier;
-        private final boolean ansiSupported;
-
-        public ColorPrinter(CliPrinter delegate, Supplier<StandardOptions.ColorSetting> colorSettingSupplier) {
-            this.delegate = delegate;
-            this.colorSettingSupplier = colorSettingSupplier;
-            this.ansiSupported = isAnsiColorSupported();
-        }
-
-        private static boolean isAnsiColorSupported() {
-            return System.console() != null && System.getenv().get("TERM") != null;
-        }
-
-        @Override
-        public void println(String text) {
-            delegate.println(text);
-        }
-
-        @Override
-        public String style(String text, Style... styles) {
-            if (colorSettingSupplier.get() != StandardOptions.ColorSetting.NO_COLOR && ansiSupported) {
-                return delegate.style(text, styles);
-            } else {
-                return text;
-            }
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
@@ -47,8 +47,7 @@ public interface Command {
     /**
      * Gets the long description of the command.
      *
-     * @param printer CliPrinter used in case formatting is needed via
-     *                {@link CliPrinter#style(String, Style...)}.
+     * @param printer Printer used to style strings.
      * @return Returns the long description.
      */
     default String getDocumentation(CliPrinter printer) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
@@ -32,6 +32,15 @@ public interface Command {
     String getName();
 
     /**
+     * Return true to hide this command from help output.
+     *
+     * @return Return true if this is a hidden command.
+     */
+    default boolean isHidden() {
+        return false;
+    }
+
+    /**
      * Gets a short summary of the command that's shown in the main help.
      *
      * @return Returns the short help description.
@@ -81,25 +90,24 @@ public interface Command {
             this.classLoader = classLoader;
         }
 
-        /**
-         * @return Returns the configured printer for stdout.
-         */
         public CliPrinter stdout() {
             return stdout;
         }
 
-        /**
-         * @return Returns the configured printer for stderr.
-         */
         public CliPrinter stderr() {
             return stderr;
         }
 
-        /**
-         * @return Returns the configured class loader to use to load additional classes/resources.
-         */
         public ClassLoader classLoader() {
-            return classLoader;
+            return classLoader == null ? getClass().getClassLoader() : classLoader;
+        }
+
+        public boolean hasClassLoader() {
+            return classLoader != null;
+        }
+
+        public Env withClassLoader(ClassLoader classLoader) {
+            return classLoader == this.classLoader ? this : new Env(stdout, stderr, classLoader);
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
@@ -15,12 +15,9 @@
 
 package software.amazon.smithy.cli;
 
-import software.amazon.smithy.utils.SmithyUnstableApi;
-
 /**
  * Represents a CLI command.
  */
-@SmithyUnstableApi
 public interface Command {
     /**
      * Gets the name of the command.
@@ -100,10 +97,6 @@ public interface Command {
 
         public ClassLoader classLoader() {
             return classLoader == null ? getClass().getClassLoader() : classLoader;
-        }
-
-        public boolean hasClassLoader() {
-            return classLoader != null;
         }
 
         public Env withClassLoader(ClassLoader classLoader) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ConfigOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ConfigOptions.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+
+public final class ConfigOptions implements ArgumentReceiver {
+
+    private static final Logger LOGGER = Logger.getLogger(ConfigOptions.class.getName());
+    private final List<String> config = new ArrayList<>();
+
+    @Override
+    public void registerHelp(HelpPrinter printer) {
+        printer.param("--config", "-c", "CONFIG_PATH...",
+                      "Path to smithy-build.json configuration (defaults to './smithy-build.json'). "
+                      + "This option can be repeated and each configured will be merged.");
+    }
+
+    @Override
+    public Consumer<String> testParameter(String name) {
+        switch (name) {
+            case "--config":
+            case "-c":
+                return config::add;
+            default:
+                return null;
+        }
+    }
+
+    public List<String> config() {
+        List<String> config = this.config;
+        if (config.isEmpty()) {
+            Path defaultConfig = Paths.get("smithy-build.json").toAbsolutePath();
+            if (Files.exists(defaultConfig)) {
+                LOGGER.fine("Detected smithy-build.json at " + defaultConfig);
+                config = Collections.singletonList(defaultConfig.toString());
+            }
+        }
+        return config;
+    }
+
+    public SmithyBuildConfig createSmithyBuildConfig() {
+        long startTime = System.nanoTime();
+        SmithyBuildConfig smithyBuildConfig;
+        List<String> config = config();
+
+        if (config.isEmpty()) {
+            smithyBuildConfig = SmithyBuildConfig.builder().version(SmithyBuild.VERSION).build();
+        } else {
+            LOGGER.fine(() -> String.format("Loading Smithy configs: [%s]", String.join(" ", config)));
+            SmithyBuildConfig.Builder configBuilder = SmithyBuildConfig.builder();
+            // Set the lastModified time in millis of the builder to the latest modified date of any config.
+            long newestLastModified = 0;
+            for (String configFile : config) {
+                File file = new File(configFile);
+                newestLastModified = Math.max(newestLastModified, file.lastModified());
+                configBuilder.load(file.toPath());
+            }
+            configBuilder.lastModifiedInMillis(newestLastModified);
+            smithyBuildConfig = configBuilder.build();
+        }
+
+        LOGGER.fine(() -> "Smithy config load time in ms: " + ((System.nanoTime() - startTime) / 1000000));
+        return smithyBuildConfig;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -28,6 +28,11 @@ public enum EnvironmentVariable {
     /** The current version of the CLI. This is set automatically by the CLI. */
     SMITHY_VERSION;
 
+    /**
+     * Gets the system property or the environment variable for the property, in that order.
+     *
+     * @return Returns the found system property or environment variable or null.
+     */
     public String getValue() {
         String name = toString();
         String value = System.getProperty(name);
@@ -37,6 +42,11 @@ public enum EnvironmentVariable {
         return value;
     }
 
+    /**
+     * Sets a system property for the environment variable.
+     *
+     * @param value Value to set.
+     */
     public void setValue(String value) {
         System.setProperty(toString(), value);
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -16,25 +16,70 @@
 package software.amazon.smithy.cli;
 
 /**
- * Publicly available Smithy environment variables / system properties.
+ * Environment variables used by the Smithy CLI.
  */
 public enum EnvironmentVariable {
-    /** A custom location for the Maven local repository cache. */
+    /**
+     * A custom location for the Maven local repository cache.
+     *
+     * <p>Example: {@code ~/.m2/repository}
+     */
     SMITHY_MAVEN_CACHE,
 
-    /** A pipe-delimited list of Maven repositories to use. */
+    /**
+     * A pipe-delimited list of Maven repositories to use.
+     *
+     * <p>Example: {@code https://example.com/repo1|https://example.com/repo2}
+     */
     SMITHY_MAVEN_REPOS,
 
+    /**
+     * Configures if and how the Smithy CLI handles dependencies declared in smithy-build.json files.
+     *
+     * <ul>
+     *     <li>ignore: ignore dependencies and assume that they are provided by the caller of the CLI.</li>
+     *     <li>forbid: forbids dependencies from being declared and will fail the CLI if dependencies are declared.</li>
+     *     <li>standard: the assumed default, will automatically resolve dependencies using Apache Maven.</li>
+     * </ul>
+     */
+    SMITHY_DEPENDENCY_MODE {
+        @Override
+        public String get() {
+            String result = super.get();
+            return result == null ? "standard" : result;
+        }
+    },
+
     /** The current version of the CLI. This is set automatically by the CLI. */
-    SMITHY_VERSION;
+    SMITHY_VERSION,
 
     /**
-     * Gets the system property or the environment variable for the property, in that order.
+     * If set to any value, disable ANSI colors in the output.
+     */
+    NO_COLOR,
+
+    /**
+     * If set to any value, force enables the support of ANSI colors in the output.
+     */
+    FORCE_COLOR,
+
+    /**
+     * Used to detect if ANSI colors are supported.
      *
+     * <ul>
+     *     <li>If set to "dumb" colors are disabled.</li>
+     *     <li>If not set and the operating system is detected as Windows, colors are disabled.</li>
+     * </ul>
+     */
+    TERM;
+
+    /**
+     * Gets a system property or environment variable by name, in that order.
+     *
+     * @param name Variable to get.
      * @return Returns the found system property or environment variable or null.
      */
-    public String getValue() {
-        String name = toString();
+    public static String getByName(String name) {
         String value = System.getProperty(name);
         if (value == null) {
             value = System.getenv(name);
@@ -43,11 +88,36 @@ public enum EnvironmentVariable {
     }
 
     /**
+     * Returns true if the system property or environment variables is set.
+     *
+     * @return Returns true if set.
+     */
+    public boolean isSet() {
+        return get() != null;
+    }
+
+    /**
+     * Gets the system property or the environment variable for the property, in that order.
+     *
+     * @return Returns the found system property or environment variable or null.
+     */
+    public String get() {
+        return getByName(toString());
+    }
+
+    /**
      * Sets a system property for the environment variable.
      *
      * @param value Value to set.
      */
-    public void setValue(String value) {
+    public void set(String value) {
         System.setProperty(toString(), value);
+    }
+
+    /**
+     * Clears the system property for the variable.
+     */
+    public void clear() {
+        System.clearProperty(toString());
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+/**
+ * Publicly available Smithy environment variables / system properties.
+ */
+public enum EnvironmentVariable {
+    /** A custom location for the Maven local repository cache. */
+    SMITHY_MAVEN_CACHE,
+
+    /** A pipe-delimited list of Maven repositories to use. */
+    SMITHY_MAVEN_REPOS,
+
+    /** The current version of the CLI. This is set automatically by the CLI. */
+    SMITHY_VERSION;
+
+    public String getValue() {
+        String name = toString();
+        String value = System.getProperty(name);
+        if (value == null) {
+            value = System.getenv(name);
+        }
+        return value;
+    }
+
+    public void setValue(String value) {
+        System.setProperty(toString(), value);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -21,7 +21,7 @@ import java.util.StringTokenizer;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
- * Generates and prints structured help output to a {@link CliPrinter}.
+ * Generates and prints structured help output.
  */
 public final class HelpPrinter {
     private final String name;
@@ -128,7 +128,7 @@ public final class HelpPrinter {
         LineWrapper builder = new LineWrapper(maxWidth);
 
         builder.appendWithinLine("Usage: ")
-                .appendWithinLine(printer.style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
+                .appendWithinLine(printer.ansi().style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
                 .space();
 
         // Calculate the column manually to account for possible styles interfering with the current column number.
@@ -166,14 +166,15 @@ public final class HelpPrinter {
     }
 
     private void writeArgHelp(CliPrinter printer, LineWrapper builder, Arg arg) {
+        Ansi ansi = printer.ansi();
         if (arg.longName != null) {
-            builder.appendWithinLine(printer.style(arg.longName, Style.YELLOW));
+            builder.appendWithinLine(ansi.style(arg.longName, Style.YELLOW));
             if (arg.shortName != null) {
                 builder.appendWithinLine(", ");
             }
         }
         if (arg.shortName != null) {
-            builder.appendWithinLine(printer.style(arg.shortName, Style.YELLOW));
+            builder.appendWithinLine(ansi.style(arg.shortName, Style.YELLOW));
         }
         if (arg.exampleValue != null) {
             builder.space().appendWithinLine(arg.exampleValue);
@@ -209,16 +210,17 @@ public final class HelpPrinter {
         }
 
         String toShortArgs(CliPrinter printer) {
+            Ansi ansi = printer.ansi();
             StringBuilder builder = new StringBuilder();
             builder.append('[');
             if (longName != null) {
-                builder.append(printer.style(longName, Style.YELLOW));
+                builder.append(ansi.style(longName, Style.YELLOW));
                 if (shortName != null) {
                     builder.append(" | ");
                 }
             }
             if (shortName != null) {
-                builder.append(printer.style(shortName, Style.YELLOW));
+                builder.append(ansi.style(shortName, Style.YELLOW));
             }
             if (exampleValue != null) {
                 builder.append(' ').append(exampleValue);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -18,13 +18,11 @@ package software.amazon.smithy.cli;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Generates and prints structured help output to a {@link CliPrinter}.
  */
-@SmithyUnstableApi
 public final class HelpPrinter {
     private final String name;
     private int maxWidth = 80;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
@@ -132,9 +132,9 @@ final class LoggingUtil {
             if (isLoggable(record)) {
                 String formatted = formatter.format(record);
                 if (record.getLevel().equals(Level.SEVERE)) {
-                    printer.println(printer.style(formatted, Style.RED));
+                    printer.println(formatted, Style.RED);
                 } else if (record.getLevel().equals(Level.WARNING)) {
-                    printer.println(printer.style(formatted, Style.YELLOW));
+                    printer.println(formatted, Style.YELLOW);
                 } else {
                     printer.println(formatted);
                 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.cli;
 import java.util.List;
 import software.amazon.smithy.cli.commands.SmithyCommand;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
+import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
 import software.amazon.smithy.utils.IoUtils;
 
 /**
@@ -109,6 +110,12 @@ public final class SmithyCli {
      * @return Returns the created CLI.
      */
     public Cli createCli() {
+        if (dependencyResolverFactory == null) {
+            dependencyResolverFactory = (config, env) -> {
+                return new MavenDependencyResolver(EnvironmentVariable.SMITHY_MAVEN_CACHE.getValue());
+            };
+        }
+
         return new Cli(new SmithyCommand(dependencyResolverFactory), classLoader);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -112,7 +112,7 @@ public final class SmithyCli {
     public Cli createCli() {
         if (dependencyResolverFactory == null) {
             dependencyResolverFactory = (config, env) -> {
-                return new MavenDependencyResolver(EnvironmentVariable.SMITHY_MAVEN_CACHE.getValue());
+                return new MavenDependencyResolver(EnvironmentVariable.SMITHY_MAVEN_CACHE.get());
             };
         }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import software.amazon.smithy.model.validation.Severity;
 
 /**
@@ -30,10 +31,10 @@ public final class StandardOptions implements ArgumentReceiver {
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
-    public static final String NO_COLOR = "--no-color";
-    public static final String FORCE_COLOR = "--force-color";
     public static final String LOGGING = "--logging";
     public static final String SEVERITY = "--severity";
+
+    private static final Logger LOGGER = Logger.getLogger(StandardOptions.class.getName());
 
     private boolean help;
     private boolean version;
@@ -42,19 +43,6 @@ public final class StandardOptions implements ArgumentReceiver {
     private boolean quiet;
     private boolean debug;
     private boolean stackTrace;
-    private ColorSetting colorSetting;
-
-    /** Specifies the color setting of the CLI. */
-    public enum ColorSetting {
-        /** Use colors if the CLI detects they are supported. */
-        AUTO,
-
-        /** Disable colors. Set with --no-color. */
-        NO_COLOR,
-
-        /** Force colors. Set with --force-color. */
-        FORCE_COLOR
-    }
 
     @Override
     public void registerHelp(HelpPrinter printer) {
@@ -62,8 +50,6 @@ public final class StandardOptions implements ArgumentReceiver {
         printer.option(DEBUG, null, "Display debug information");
         printer.option(QUIET, null, "Silence output except errors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
-        printer.option(NO_COLOR, null, "Disable ANSI colors");
-        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.param(LOGGING, null, "LOG_LEVEL",
                             "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
                             + "FINE, ALL.");
@@ -98,11 +84,11 @@ public final class StandardOptions implements ArgumentReceiver {
             case STACKTRACE:
                 stackTrace = true;
                 return true;
-            case NO_COLOR:
-                colorSetting = ColorSetting.NO_COLOR;
+            case "--no-color":
+                LOGGER.warning("--no-color is no longer supported. Use the NO_COLOR environment variable.");
                 return true;
-            case FORCE_COLOR:
-                colorSetting = ColorSetting.FORCE_COLOR;
+            case "--force-color":
+                LOGGER.warning("--force-color is no longer supported. Use the FORCE_COLOR environment variable.");
                 return true;
             default:
                 return false;
@@ -157,9 +143,5 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public boolean stackTrace() {
         return stackTrace;
-    }
-
-    public ColorSetting colorSetting() {
-        return colorSetting;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -28,6 +28,7 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public static final String HELP_SHORT = "-h";
     public static final String HELP = "--help";
+    public static final String VERSION = "--version";
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
@@ -37,6 +38,7 @@ public final class StandardOptions implements ArgumentReceiver {
     public static final String SEVERITY = "--severity";
 
     private boolean help;
+    private boolean version;
     private Severity severity = Severity.WARNING;
     private Level logging = Level.WARNING;
     private boolean quiet;
@@ -67,6 +69,9 @@ public final class StandardOptions implements ArgumentReceiver {
             case HELP:
             case HELP_SHORT:
                 help = true;
+                return true;
+            case VERSION:
+                version = true;
                 return true;
             case DEBUG:
                 debug = true;
@@ -122,6 +127,10 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public boolean help() {
         return help;
+    }
+
+    public boolean version() {
+        return version;
     }
 
     public Severity severity() {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -18,12 +18,10 @@ package software.amazon.smithy.cli;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import software.amazon.smithy.model.validation.Severity;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Options available to all commands.
  */
-@SmithyInternalApi
 public final class StandardOptions implements ArgumentReceiver {
 
     public static final String HELP_SHORT = "-h";
@@ -44,23 +42,33 @@ public final class StandardOptions implements ArgumentReceiver {
     private boolean quiet;
     private boolean debug;
     private boolean stackTrace;
-    private boolean noColor;
-    private boolean forceColor;
+    private ColorSetting colorSetting;
+
+    /** Specifies the color setting of the CLI. */
+    public enum ColorSetting {
+        /** Use colors if the CLI detects they are supported. */
+        AUTO,
+
+        /** Disable colors. Set with --no-color. */
+        NO_COLOR,
+
+        /** Force colors. Set with --force-color. */
+        FORCE_COLOR
+    }
 
     @Override
     public void registerHelp(HelpPrinter printer) {
-        printer.option(HELP, HELP_SHORT, "Prints this help output");
+        printer.option(HELP, HELP_SHORT, "Print help output");
         printer.option(DEBUG, null, "Display debug information");
-        printer.option(QUIET, null, "Silences all output except errors");
+        printer.option(QUIET, null, "Silence output except errors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
-        printer.option(NO_COLOR, null, "Explicitly disable ANSI colors");
-        printer.option(FORCE_COLOR, null, "Explicitly enable ANSI colors");
+        printer.option(NO_COLOR, null, "Disable ANSI colors");
+        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.param(LOGGING, null, "LOG_LEVEL",
-                            "Sets the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
+                            "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
                             + "FINE, ALL.");
-        printer.param(SEVERITY, null, "SEVERITY", "Sets the minimum reported validation severity to "
-                                                      + "report. Set to one of NOTE, WARNING (default), "
-                                                      + "DANGER, ERROR");
+        printer.param(SEVERITY, null, "SEVERITY", "Set the minimum reported validation severity (one of NOTE, "
+                                                  + "WARNING [default setting], DANGER, ERROR).");
     }
 
     @Override
@@ -91,12 +99,10 @@ public final class StandardOptions implements ArgumentReceiver {
                 stackTrace = true;
                 return true;
             case NO_COLOR:
-                noColor = true;
-                forceColor = false;
+                colorSetting = ColorSetting.NO_COLOR;
                 return true;
             case FORCE_COLOR:
-                noColor = false;
-                forceColor = true;
+                colorSetting = ColorSetting.FORCE_COLOR;
                 return true;
             default:
                 return false;
@@ -153,11 +159,7 @@ public final class StandardOptions implements ArgumentReceiver {
         return stackTrace;
     }
 
-    public boolean noColor() {
-        return noColor;
-    }
-
-    public boolean forceColor() {
-        return forceColor;
+    public ColorSetting colorSetting() {
+        return colorSetting;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -15,109 +15,59 @@
 
 package software.amazon.smithy.cli;
 
-import java.util.function.IntConsumer;
-
 /**
  * Parameters used to change the ANSI public style of text.
  */
-@FunctionalInterface
-public interface Style {
+public enum Style {
+    BOLD(1),
+    FAINT(2),
+    ITALIC(3),
+    UNDERLINE(4),
 
-    Style BOLD = new SingularCode(1);
-    Style FAINT = new SingularCode(2);
-    Style ITALIC = new SingularCode(3);
-    Style UNDERLINE = new SingularCode(4);
+    BLACK(30),
+    RED(31),
+    GREEN(32),
+    YELLOW(33),
+    BLUE(34),
+    MAGENTA(35),
+    CYAN(36),
+    WHITE(37),
 
-    Style BLACK = new SingularCode(30);
-    Style RED = new SingularCode(31);
-    Style GREEN = new SingularCode(32);
-    Style YELLOW = new SingularCode(33);
-    Style BLUE = new SingularCode(34);
-    Style MAGENTA = new SingularCode(35);
-    Style CYAN = new SingularCode(36);
-    Style WHITE = new SingularCode(37);
+    BRIGHT_BLACK(90),
+    BRIGHT_RED(91),
+    BRIGHT_GREEN(92),
+    BRIGHT_YELLOW(93),
+    BRIGHT_BLUE(94),
+    BRIGHT_MAGENTA(95),
+    BRIGHT_CYAN(96),
+    BRIGHT_WHITE(97),
 
-    Style BRIGHT_BLACK = new SingularCode(90);
-    Style BRIGHT_RED = new SingularCode(91);
-    Style BRIGHT_GREEN = new SingularCode(92);
-    Style BRIGHT_YELLOW = new SingularCode(93);
-    Style BRIGHT_BLUE = new SingularCode(94);
-    Style BRIGHT_MAGENTA = new SingularCode(95);
-    Style BRIGHT_CYAN = new SingularCode(96);
-    Style BRIGHT_WHITE = new SingularCode(97);
+    BG_BLACK(40),
+    BG_RED(41),
+    BG_GREEN(42),
+    BG_YELLOW(43),
+    BG_BLUE(44),
+    BG_MAGENTA(45),
+    BG_CYAN(46),
+    BG_WHITE(47),
 
-    Style BG_BLACK = new SingularCode(40);
-    Style BG_RED = new SingularCode(41);
-    Style BG_GREEN = new SingularCode(42);
-    Style BG_YELLOW = new SingularCode(43);
-    Style BG_BLUE = new SingularCode(44);
-    Style BG_MAGENTA = new SingularCode(45);
-    Style BG_CYAN = new SingularCode(46);
-    Style BG_WHITE = new SingularCode(47);
+    BG_BRIGHT_BLACK(100),
+    BG_BRIGHT_RED(101),
+    BG_BRIGHT_GREEN(102),
+    BG_BRIGHT_YELLOW(103),
+    BG_BRIGHT_BLUE(104),
+    BG_BRIGHT_MAGENTA(105),
+    BG_BRIGHT_CYAN(106),
+    BG_BRIGHT_WHITE(107);
 
-    Style BG_BRIGHT_BLACK = new SingularCode(100);
-    Style BG_BRIGHT_RED = new SingularCode(101);
-    Style BG_BRIGHT_GREEN = new SingularCode(102);
-    Style BG_BRIGHT_YELLOW = new SingularCode(103);
-    Style BG_BRIGHT_BLUE = new SingularCode(104);
-    Style BG_BRIGHT_MAGENTA = new SingularCode(105);
-    Style BG_BRIGHT_CYAN = new SingularCode(106);
-    Style BG_BRIGHT_WHITE = new SingularCode(107);
+    private final String code;
 
-    /**
-     * Pushes one or more ANSI color codes to the consumer.
-     *
-     * <p>Most implementations will push a single code, but multiple
-     * codes are needed to do things like use 8-bit colors
-     * (e.g., 38+5+206 to make pink foreground text).
-     *
-     * @param codeConsumer Consumer to push integers to.
-     */
-    void pushCodes(IntConsumer codeConsumer);
-
-    /**
-     * Formats the given text with ANSI escapes.
-     *
-     * <p>Each {@code styles} is one or more ANSI escape codes in the format of
-     * "1", "38;5;206" to create an 8-bit color, etc.
-     *
-     * @param text Text to format.
-     * @param styles Styles to apply.
-     * @return Returns the formatted text, and then resets the formatting.
-     * @see <a href="https://man7.org/linux/man-pages/man4/console_codes.4.html">ANSI console codes</a>
-     */
-    static String format(String text, Style... styles) {
-        StringBuilder result = new StringBuilder("\033[");
-        IntConsumer consumer = result::append;
-        boolean isAfterFirst = false;
-
-        for (Style style : styles) {
-            if (isAfterFirst) {
-                result.append(';');
-            }
-            style.pushCodes(consumer);
-            isAfterFirst = true;
-        }
-
-        result.append('m');
-        result.append(text);
-        result.append("\033[0m");
-        return result.toString();
+    Style(int code) {
+        this.code = String.valueOf(code);
     }
 
-    /**
-     * A simple implementation of {@code Style} that pushes a single code.
-     */
-    final class SingularCode implements Style {
-        private final int code;
-
-        public SingularCode(int code) {
-            this.code = code;
-        }
-
-        @Override
-        public void pushCodes(IntConsumer codeConsumer) {
-            codeConsumer.accept(code);
-        }
+    @Override
+    public String toString() {
+        return code;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -16,12 +16,10 @@
 package software.amazon.smithy.cli;
 
 import java.util.function.IntConsumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Parameters used to change the ANSI public style of text.
  */
-@SmithyUnstableApi
 @FunctionalInterface
 public interface Style {
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -15,20 +15,20 @@
 
 package software.amazon.smithy.cli.commands;
 
-import java.util.Collections;
 import java.util.List;
-import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ModelSerializer;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
-public final class AstCommand extends SimpleCommand {
+public final class AstCommand extends ClasspathCommand {
 
-    public AstCommand(String parentCommandName) {
-        super(parentCommandName);
+    public AstCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -42,13 +42,8 @@ public final class AstCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return Collections.singletonList(new BuildOptions());
-    }
-
-    @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true);
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
         ModelSerializer serializer = ModelSerializer.builder().build();
         env.stdout().println(Node.prettyPrintJson(serializer.serialize(model)));
         return 0;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -22,12 +22,10 @@ import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ModelSerializer;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class AstCommand extends ClasspathCommand {
+final class AstCommand extends ClasspathCommand {
 
-    public AstCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+    AstCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.cli.commands;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -161,15 +163,10 @@ final class BuildCommand extends ClasspathCommand {
         @Override
         public void accept(String name, Throwable exception) {
             failedProjections.add(name);
-            StringBuilder message = new StringBuilder(
-                    String.format("%nProjection %s failed: %s%n", name, exception.toString()));
-
-            for (StackTraceElement element : exception.getStackTrace()) {
-                message.append(element).append(System.lineSeparator());
-            }
-
-            // Always print errors.
-            printer.println(printer.style(message.toString(), Style.RED));
+            StringWriter writer = new StringWriter();
+            writer.write(String.format("%nProjection %s failed: %s%n", name, exception.toString()));
+            exception.printStackTrace(new PrintWriter(writer));
+            printer.println(printer.style(writer.toString(), Style.RED));
         }
 
         @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.ProjectionResult;
 import software.amazon.smithy.build.SmithyBuild;
@@ -39,13 +38,10 @@ import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.Severity;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class BuildCommand extends ClasspathCommand {
-    private static final Logger LOGGER = Logger.getLogger(BuildCommand.class.getName());
+final class BuildCommand extends ClasspathCommand {
 
-    public BuildCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+    BuildCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -15,8 +15,6 @@
 
 package software.amazon.smithy.cli.commands;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -38,17 +36,17 @@ import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.Severity;
-import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
-public final class BuildCommand extends SimpleCommand {
+public final class BuildCommand extends ClasspathCommand {
     private static final Logger LOGGER = Logger.getLogger(BuildCommand.class.getName());
 
-    public BuildCommand(String parentCommandName) {
-        super(parentCommandName);
+    public BuildCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -62,8 +60,6 @@ public final class BuildCommand extends SimpleCommand {
     }
 
     private static final class Options implements ArgumentReceiver {
-        private final List<String> config = new ArrayList<>();
-        private String output;
         private String projection;
         private String plugin;
 
@@ -75,11 +71,6 @@ public final class BuildCommand extends SimpleCommand {
         @Override
         public Consumer<String> testParameter(String name) {
             switch (name) {
-                case "--config":
-                case "-c":
-                    return config::add;
-                case "--output":
-                    return value -> output = value;
                 case "--projection":
                     return value -> projection = value;
                 case "--plugin":
@@ -91,57 +82,34 @@ public final class BuildCommand extends SimpleCommand {
 
         @Override
         public void registerHelp(HelpPrinter printer) {
-            printer.param("--config", "-c", "CONFIG_PATH...",
-                          "Path to smithy-build.json configuration (defaults to './smithy-build.json'). This option "
-                          + "can be repeated and each configured will be merged.");
             printer.param("--projection", null, "PROJECTION_NAME", "Only generate artifacts for this projection.");
             printer.param("--plugin", null, "PLUGIN_NAME", "Only generate artifacts for this plugin.");
-            printer.param("--output", null, "OUTPUT_PATH",
-                          "Where to write artifacts (defaults to './build/smithy').");
         }
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return ListUtils.of(new BuildOptions(), new Options());
+    protected void addAdditionalArgumentReceivers(List<ArgumentReceiver> receivers) {
+        receivers.add(new Options());
     }
 
     @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         Options options = arguments.getReceiver(Options.class);
+        BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
-        String output = options.output;
-
-        LOGGER.fine(() -> String.format("Building Smithy model sources: %s", models));
-        SmithyBuildConfig.Builder configBuilder = SmithyBuildConfig.builder();
-        List<String> config = getConfig(options);
-
-        if (!config.isEmpty()) {
-            LOGGER.fine(() -> String.format("Loading Smithy configs: [%s]", String.join(" ", config)));
-            config.forEach(file -> configBuilder.load(Paths.get(file)));
-        } else {
-            configBuilder.version(SmithyBuild.VERSION);
-        }
-
-        if (output != null) {
-            configBuilder.outputDirectory(output);
-            try {
-                Files.createDirectories(Paths.get(output));
-                LOGGER.info(() -> "Output directory set to: " + output);
-            } catch (IOException e) {
-                throw new CliError("Unable to create Smithy output directory: " + e.getMessage());
-            }
-        }
-
-        SmithyBuildConfig smithyBuildConfig = configBuilder.build();
+        ClassLoader classLoader = env.classLoader();
 
         // Build the model and fail if there are errors. Prints errors to stdout.
         // Configure whether the build is quiet or not based on the --quiet option.
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), standardOptions.quiet());
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), standardOptions.quiet(), config);
 
-        SmithyBuild smithyBuild = SmithyBuild.create(env.classLoader())
-                .config(smithyBuildConfig)
+        SmithyBuild smithyBuild = SmithyBuild.create(classLoader)
+                .config(config)
                 .model(model);
+
+        if (buildOptions.output() != null) {
+            smithyBuild.outputDirectory(buildOptions.output());
+        }
 
         if (options.plugin != null) {
             smithyBuild.pluginFilter(name -> name.equals(options.plugin));
@@ -179,14 +147,6 @@ public final class BuildCommand extends SimpleCommand {
         }
 
         return 0;
-    }
-
-    private List<String> getConfig(Options options) {
-        List<String> config = options.config;
-        if (config.isEmpty() && Files.exists(Paths.get("smithy-build.json"))) {
-            config = Collections.singletonList("smithy-build.json");
-        }
-        return config;
     }
 
     private static final class ResultConsumer implements Consumer<ProjectionResult>, BiConsumer<String, Throwable> {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -15,13 +15,8 @@
 
 package software.amazon.smithy.cli.commands;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
-import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
-import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.HelpPrinter;
 
 /**
@@ -30,39 +25,22 @@ import software.amazon.smithy.cli.HelpPrinter;
 final class BuildOptions implements ArgumentReceiver {
 
     public static final String ALLOW_UNKNOWN_TRAITS = "--allow-unknown-traits";
-    public static final String DISCOVER = "--discover";
-    public static final String DISCOVER_SHORT = "-d";
-    public static final String DISCOVER_CLASSPATH = "--discover-classpath";
-    public static final String DEPENDENCY_MODE = "--dependency-mode";
     public static final String MODELS = "<MODELS>";
 
     private String discoverClasspath;
     private boolean allowUnknownTraits;
     private boolean discover;
-    private DependencyMode dependencyMode = DependencyMode.STANDARD;
     private String output;
-
-    /** Dependency resolution mode of the CLI. */
-    public enum DependencyMode {
-        /** Standard dependency resolution mode, resolving dependencies using Maven. */
-        STANDARD,
-
-        /** Disables dependency resolution by ignoring dependencies. */
-        IGNORE,
-
-        /** Forbids dependency resolution. If dependencies are declared, the CLI will fail to run. */
-        FORBID
-    }
 
     @Override
     public void registerHelp(HelpPrinter printer) {
         printer.option(ALLOW_UNKNOWN_TRAITS, null, "Ignore unknown traits when validating models");
+        /*
+        Hide these for now until we figure out a plan forward for these.
         printer.option(DISCOVER, "-d", "Enable model discovery, merging in models found inside of jars");
         printer.param(DISCOVER_CLASSPATH, null, "CLASSPATH",
                             "Enable model discovery using a custom classpath for models");
-        printer.option(DEPENDENCY_MODE, null, "(ignore|forbid|standard) Allow dependencies to be ignored or forbidden. "
-                                              + "Defaults to 'standard', allowing dependencies to be declared and "
-                                              + "resolved using Maven.");
+        */
         printer.param("--output", null, "OUTPUT_PATH",
                       "Where to write Smithy artifacts, caches, and other files (defaults to './build/smithy').");
         printer.positional(MODELS, "Model files and directories to load");
@@ -74,8 +52,8 @@ final class BuildOptions implements ArgumentReceiver {
             case ALLOW_UNKNOWN_TRAITS:
                 allowUnknownTraits = true;
                 return true;
-            case DISCOVER:
-            case DISCOVER_SHORT:
+            case "--discover":
+            case "-d":
                 discover = true;
                 return true;
             default:
@@ -88,18 +66,8 @@ final class BuildOptions implements ArgumentReceiver {
         switch (name) {
             case "--output":
                 return value -> output = value;
-            case DISCOVER_CLASSPATH:
+            case "--discover-classpath":
                 return value -> discoverClasspath = value;
-            case DEPENDENCY_MODE:
-                return value -> {
-                    try {
-                        dependencyMode = DependencyMode.valueOf(value.toUpperCase(Locale.ENGLISH));
-                    } catch (IllegalArgumentException e) {
-                        List<DependencyMode> expected = Arrays.asList(DependencyMode.values());
-                        throw new CliError(String.format("Invalid %s parameter: '%s'. Expected one of: %s",
-                                                         DEPENDENCY_MODE, value, expected));
-                    }
-                };
             default:
                 return null;
         }
@@ -117,15 +85,7 @@ final class BuildOptions implements ArgumentReceiver {
         return discover;
     }
 
-    public DependencyMode dependencyMode() {
-        return dependencyMode;
-    }
-
     public String output() {
         return output;
-    }
-
-    public boolean useModelDiscovery(SmithyBuildConfig config) {
-        return discover() || (config.getMaven().isPresent() && dependencyMode == DependencyMode.STANDARD);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -23,13 +23,11 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.HelpPrinter;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Arguments available to commands that load and build models.
  */
-@SmithyInternalApi
-public final class BuildOptions implements ArgumentReceiver {
+final class BuildOptions implements ArgumentReceiver {
 
     public static final String ALLOW_UNKNOWN_TRAITS = "--allow-unknown-traits";
     public static final String DISCOVER = "--discover";
@@ -58,13 +56,13 @@ public final class BuildOptions implements ArgumentReceiver {
 
     @Override
     public void registerHelp(HelpPrinter printer) {
-        printer.option(ALLOW_UNKNOWN_TRAITS, null, "Ignores unknown traits when validating models");
-        printer.option(DISCOVER, "-d", "Enables model discovery, merging in models found inside of jars");
+        printer.option(ALLOW_UNKNOWN_TRAITS, null, "Ignore unknown traits when validating models");
+        printer.option(DISCOVER, "-d", "Enable model discovery, merging in models found inside of jars");
         printer.param(DISCOVER_CLASSPATH, null, "CLASSPATH",
-                            "Enables model discovery using a custom classpath for models");
-        printer.option(DEPENDENCY_MODE, null, "(ignore|forbid|standard) Allows dependencies to be ignored or forbidden "
-                                              + "by setting to 'ignore' or 'forbid'. Defaults to 'standard', allowing "
-                                              + "dependencies to be declared and resolved using Maven.");
+                            "Enable model discovery using a custom classpath for models");
+        printer.option(DEPENDENCY_MODE, null, "(ignore|forbid|standard) Allow dependencies to be ignored or forbidden. "
+                                              + "Defaults to 'standard', allowing dependencies to be declared and "
+                                              + "resolved using Maven.");
         printer.param("--output", null, "OUTPUT_PATH",
                       "Where to write Smithy artifacts, caches, and other files (defaults to './build/smithy').");
         printer.positional(MODELS, "Model files and directories to load");

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ClasspathCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ClasspathCommand.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.MavenConfig;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.ConfigOptions;
+import software.amazon.smithy.cli.EnvironmentVariable;
+import software.amazon.smithy.cli.SmithyCli;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
+import software.amazon.smithy.cli.dependencies.DependencyResolverException;
+import software.amazon.smithy.cli.dependencies.FileCacheResolver;
+import software.amazon.smithy.cli.dependencies.FilterCliVersionResolver;
+import software.amazon.smithy.cli.dependencies.ResolvedArtifact;
+
+abstract class ClasspathCommand extends SimpleCommand {
+
+    /**
+     * The minimum Smithy version range allowed for dependencies to declare so
+     * that they are compatible with this version of the Smithy CLI.
+     *
+     * <p>This version should generally not need to change unless some major new
+     * feature or change is made to Smithy in the current major version range,
+     * or a major version bump is done on Smithy itself.
+     */
+    private static final String MINIMUM_ALLOWED_SMITHY_VERSION = "1.25.2";
+
+    private static final Logger LOGGER = Logger.getLogger(ClasspathCommand.class.getName());
+    private static final MavenRepository CENTRAL = MavenRepository.builder()
+            .url("https://repo.maven.apache.org/maven2")
+            .build();
+    private final DependencyResolver.Factory dependencyResolverFactory;
+
+    ClasspathCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName);
+        this.dependencyResolverFactory = dependencyResolverFactory;
+    }
+
+    @Override
+    protected final List<ArgumentReceiver> createArgumentReceivers() {
+        List<ArgumentReceiver> receivers = new ArrayList<>();
+        receivers.add(new ConfigOptions());
+        receivers.add(new BuildOptions());
+        addAdditionalArgumentReceivers(receivers);
+        return receivers;
+    }
+
+    @Override
+    protected final int run(Arguments arguments, Env env, List<String> positional) {
+        BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
+        ThreadResult threadResult = new ThreadResult();
+        ConfigOptions configOptions = arguments.getReceiver(ConfigOptions.class);
+        SmithyBuildConfig config = configOptions.createSmithyBuildConfig();
+
+        runTaskWithClasspath(buildOptions, config, env, classLoader -> {
+            Env updatedEnv = env.withClassLoader(classLoader);
+            threadResult.returnCode = runWithClassLoader(config, arguments, updatedEnv, positional);
+        });
+
+        return threadResult.returnCode;
+    }
+
+    private static final class ThreadResult {
+        int returnCode;
+    }
+
+    protected void addAdditionalArgumentReceivers(List<ArgumentReceiver> receivers) {
+    }
+
+    abstract int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> positional);
+
+    private void runTaskWithClasspath(
+            BuildOptions buildOptions,
+            SmithyBuildConfig smithyBuildConfig,
+            Env env,
+            Consumer<ClassLoader> consumer
+    ) {
+        BuildOptions.DependencyMode mode = buildOptions.dependencyMode();
+        Set<String> dependencies = smithyBuildConfig.getMaven()
+                .map(MavenConfig::getDependencies)
+                .orElse(Collections.emptySet());
+        boolean useIsolation = mode == BuildOptions.DependencyMode.STANDARD && !dependencies.isEmpty();
+
+        if (mode == BuildOptions.DependencyMode.FORBID && !dependencies.isEmpty()) {
+            throw new DependencyResolverException(String.format(
+                    "%s is set to 'forbid', but the following Maven dependencies are defined in smithy-build.json: "
+                    + "%s. Dependencies are forbidden in this configuration.",
+                    BuildOptions.DEPENDENCY_MODE, dependencies));
+        } else if (mode == BuildOptions.DependencyMode.IGNORE && !dependencies.isEmpty()) {
+            LOGGER.warning(() -> String.format(
+                    "%s is set to 'ignore', and the following Maven dependencies are defined in smithy-build.json: "
+                    + "%s. If the build fails, then you may need to manually configure the classpath.",
+                    BuildOptions.DEPENDENCY_MODE, dependencies));
+        }
+
+        if (useIsolation) {
+            long start = System.nanoTime();
+            List<Path> files = resolveDependencies(buildOptions, smithyBuildConfig, env,
+                                                   smithyBuildConfig.getMaven().get());
+            long end = System.nanoTime();
+            LOGGER.fine(() -> "Dependency resolution time in ms: " + ((end - start) / 1000000));
+            new IsolatedRunnable(files, getClass().getClassLoader(), consumer).run();
+            LOGGER.fine(() -> "Command time in ms: " + ((System.nanoTime() - end) / 1000000));
+        } else {
+            consumer.accept(getClass().getClassLoader());
+        }
+    }
+
+    private List<Path> resolveDependencies(
+            BuildOptions buildOptions,
+            SmithyBuildConfig smithyBuildConfig,
+            Env env,
+            MavenConfig maven
+    ) {
+        DependencyResolver baseResolver = dependencyResolverFactory.create(smithyBuildConfig, env);
+        long lastModified = smithyBuildConfig.getLastModifiedInMillis();
+        DependencyResolver delegate = new FilterCliVersionResolver(SmithyCli.getVersion(), baseResolver);
+        DependencyResolver resolver = new FileCacheResolver(getCacheFile(buildOptions), lastModified, delegate);
+        addDefaultConfiguration(resolver);
+        addConfiguredMavenRepos(smithyBuildConfig, resolver);
+        maven.getDependencies().forEach(resolver::addDependency);
+        List<ResolvedArtifact> artifacts = resolver.resolve();
+        LOGGER.fine(() -> "Classpath resolved with Maven: " + artifacts);
+
+        List<Path> result = new ArrayList<>(artifacts.size());
+        for (ResolvedArtifact artifact : artifacts) {
+            result.add(artifact.getPath());
+        }
+
+        return result;
+    }
+
+    private static void addDefaultConfiguration(DependencyResolver resolver) {
+        // Add provided Smithy CLI dependencies, allowing for a range of compatible versions up to, but not
+        // exceeding the current version of the CLI.
+        String version = String.format("[%s,%s]", MINIMUM_ALLOWED_SMITHY_VERSION, SmithyCli.getVersion());
+        resolver.addDependency("software.amazon.smithy:smithy-model:" + version);
+        resolver.addDependency("software.amazon.smithy:smithy-utils:" + version);
+        resolver.addDependency("software.amazon.smithy:smithy-build:" + version);
+        resolver.addDependency("software.amazon.smithy:smithy-diff:" + version);
+    }
+
+    private static void addConfiguredMavenRepos(SmithyBuildConfig config, DependencyResolver resolver) {
+        // Environment variables take precedence over config files.
+        String envRepos = EnvironmentVariable.SMITHY_MAVEN_REPOS.getValue();
+        if (envRepos != null) {
+            for (String repo : envRepos.split("\\|")) {
+                resolver.addRepository(MavenRepository.builder().url(repo.trim()).build());
+            }
+        }
+
+        Set<MavenRepository> configuredRepos = config.getMaven()
+                .map(MavenConfig::getRepositories)
+                .orElse(Collections.emptySet());
+
+        if (!configuredRepos.isEmpty()) {
+            configuredRepos.forEach(resolver::addRepository);
+        } else if (envRepos == null) {
+            LOGGER.finest(() -> String.format("maven.repositories is not defined in smithy-build.json and the %s "
+                                              + "environment variable is not set. Defaulting to Maven Central.",
+                                              EnvironmentVariable.SMITHY_MAVEN_REPOS));
+            resolver.addRepository(CENTRAL);
+        }
+    }
+
+    private File getCacheFile(BuildOptions buildOptions) {
+        String output = buildOptions.output();
+        Path buildPath = output == null ? SmithyBuild.getDefaultOutputDirectory() : Paths.get(output);
+        return buildPath.resolve("classpath.json").toFile();
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.ConfigOptions;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class CleanCommand extends SimpleCommand {
+
+    private static final Logger LOGGER = Logger.getLogger(CleanCommand.class.getName());
+
+    public CleanCommand(String parentCommandName) {
+        super(parentCommandName);
+    }
+
+    @Override
+    protected List<ArgumentReceiver> createArgumentReceivers() {
+        return ListUtils.of(new ConfigOptions());
+    }
+
+    @Override
+    public String getName() {
+        return "clean";
+    }
+
+    @Override
+    public String getSummary() {
+        return "Removes Smithy build artifacts";
+    }
+
+    @Override
+    protected int run(Arguments arguments, Env env, List<String> positional) {
+        ConfigOptions options = arguments.getReceiver(ConfigOptions.class);
+        SmithyBuildConfig config = options.createSmithyBuildConfig();
+        Path dir = config.getOutputDirectory()
+                .map(Paths::get)
+                .orElseGet(SmithyBuild::getDefaultOutputDirectory);
+        LOGGER.fine(() -> "Deleting directory: " + dir);
+        if (!IoUtils.rmdir(dir)) {
+            LOGGER.fine(() -> "Directory does not exist: " + dir);
+        }
+        LOGGER.fine(() -> "Deleted directory " + dir);
+        return 0;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
@@ -26,14 +26,12 @@ import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.ConfigOptions;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class CleanCommand extends SimpleCommand {
+final class CleanCommand extends SimpleCommand {
 
     private static final Logger LOGGER = Logger.getLogger(CleanCommand.class.getName());
 
-    public CleanCommand(String parentCommandName) {
+    CleanCommand(String parentCommandName) {
         super(parentCommandName);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Command;
+import software.amazon.smithy.cli.EnvironmentVariable;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.model.Model;
@@ -101,8 +102,17 @@ final class CommandUtils {
     ) {
         if (options.discoverClasspath() != null) {
             discoverModelsWithClasspath(options.discoverClasspath(), assembler);
-        } else if (options.useModelDiscovery(config)) {
+        } else if (shouldDiscoverDependencies(options, config)) {
             assembler.discoverModels(baseLoader);
+        }
+    }
+
+    private static boolean shouldDiscoverDependencies(BuildOptions options, SmithyBuildConfig config) {
+        if (options.discover()) {
+            return true;
+        } else {
+            return config.getMaven().isPresent()
+                   && EnvironmentVariable.SMITHY_DEPENDENCY_MODE.get().equals("standard");
         }
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -62,10 +62,10 @@ final class CommandUtils {
             if (event.getSeverity().ordinal() >= minSeverity.ordinal()) {
                 if (event.getSeverity() == Severity.WARNING) {
                     // Only log warnings when not quiet
-                    printer.println(printer.style(formatter.format(event), Style.YELLOW));
+                    printer.println(formatter.format(event), Style.YELLOW);
                 } else if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
                     // Always output error and danger events, even when quiet.
-                    printer.println(printer.style(formatter.format(event), Style.RED));
+                    printer.println(formatter.format(event), Style.RED);
                 } else {
                     printer.println(formatter.format(event));
                 }
@@ -74,6 +74,7 @@ final class CommandUtils {
 
         CommandUtils.handleModelDiscovery(buildOptions, assembler, classLoader, config);
         CommandUtils.handleUnknownTraitsOption(buildOptions, assembler);
+
         config.getSources().forEach(assembler::addImport);
         models.forEach(assembler::addImport);
         config.getImports().forEach(assembler::addImport);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -35,13 +35,11 @@ import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class DiffCommand extends ClasspathCommand {
+final class DiffCommand extends ClasspathCommand {
     private static final Logger LOGGER = Logger.getLogger(DiffCommand.class.getName());
 
-    public DiffCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+    DiffCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -122,13 +122,14 @@ final class DiffCommand extends ClasspathCommand {
 
         // Print the "framing" style output to stderr only if !quiet.
         if (!standardOptions.quiet()) {
-            CliPrinter stderr = env.stderr();
-            if (hasDanger) {
-                stderr.println(stderr.style("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD));
-            } else if (hasWarning) {
-                stderr.println(stderr.style("Smithy diff detected warnings", Style.BRIGHT_YELLOW, Style.BOLD));
-            } else {
-                stderr.println(stderr.style("Smithy diff complete", Style.BRIGHT_GREEN, Style.BOLD));
+            try (CliPrinter.Buffer buffer = env.stderr().buffer()) {
+                if (hasDanger) {
+                    buffer.println("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD);
+                } else if (hasWarning) {
+                    buffer.println("Smithy diff detected warnings", Style.BRIGHT_YELLOW, Style.BOLD);
+                } else {
+                    buffer.println("Smithy diff complete", Style.BRIGHT_GREEN, Style.BOLD);
+                }
             }
         }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/IsolatedRunnable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/IsolatedRunnable.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.function.Consumer;
+import software.amazon.smithy.cli.CliError;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+final class IsolatedRunnable implements Runnable {
+
+    private final ClassLoader classLoader;
+    private final Consumer<ClassLoader> consumer;
+
+    IsolatedRunnable(Collection<Path> artifacts, ClassLoader parent, Consumer<ClassLoader> consumer) {
+        this(createClassLoaderFromPaths(artifacts, parent), consumer);
+    }
+
+    private IsolatedRunnable(ClassLoader classLoader, Consumer<ClassLoader> consumer) {
+        this.classLoader = classLoader;
+        this.consumer = consumer;
+    }
+
+    private static ClassLoader createClassLoaderFromPaths(Collection<Path> artifacts, ClassLoader parent) {
+        return new URLClassLoader(createUrlsFromPaths(artifacts), parent);
+    }
+
+    private static URL[] createUrlsFromPaths(Collection<Path> paths) {
+        URL[] urls = new URL[paths.size()];
+        int i = 0;
+        for (Path artifact : paths) {
+            try {
+                urls[i++] = artifact.toUri().toURL();
+            } catch (MalformedURLException e) {
+                throw new CliError("Error creating class loader: " + artifact);
+            }
+        }
+
+        return urls;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Thread thread = new Thread(() -> consumer.accept(classLoader));
+            thread.setContextClassLoader(classLoader);
+            ExceptionHandler handler = new ExceptionHandler();
+            thread.setUncaughtExceptionHandler(handler);
+            thread.start();
+            thread.join();
+            if (handler.e != null) {
+                throw new CliError(handler.e.getMessage(), 1, handler.e);
+            }
+        } catch (InterruptedException e) {
+            throw new CliError(e.getMessage(), 1, e);
+        }
+    }
+
+    private static final class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+        volatile Throwable e;
+
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            this.e = e;
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/IsolatedRunnable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/IsolatedRunnable.java
@@ -22,9 +22,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.function.Consumer;
 import software.amazon.smithy.cli.CliError;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
-@SmithyUnstableApi
 final class IsolatedRunnable implements Runnable {
 
     private final ClassLoader classLoader;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -37,12 +37,10 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.IoUtils;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class SelectCommand extends ClasspathCommand {
+final class SelectCommand extends ClasspathCommand {
 
-    public SelectCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+    SelectCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -22,10 +22,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.HelpPrinter;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
@@ -35,14 +37,13 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.IoUtils;
-import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
-public final class SelectCommand extends SimpleCommand {
+public final class SelectCommand extends ClasspathCommand {
 
-    public SelectCommand(String parentCommandName) {
-        super(parentCommandName);
+    public SelectCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -104,17 +105,17 @@ public final class SelectCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return ListUtils.of(new BuildOptions(), new Options());
+    protected void addAdditionalArgumentReceivers(List<ArgumentReceiver> receivers) {
+        receivers.add(new Options());
     }
 
     @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         CliPrinter stdout = env.stdout();
         Options options = arguments.getReceiver(Options.class);
 
         // Don't write the summary, but do write danger/errors to STDERR.
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true);
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
         Selector selector = options.selector();
 
         if (!options.vars()) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.HelpPrinter;
@@ -51,7 +52,15 @@ abstract class SimpleCommand implements Command {
 
         List<String> positionalArguments = arguments.finishParsing();
 
-        if (arguments.getReceiver(StandardOptions.class).help()) {
+        StandardOptions options = arguments.getReceiver(StandardOptions.class);
+
+        // Version is only supported on the root-level command, but the argument has
+        // to be available to all commands to make that work.
+        if (arguments.getReceiver(StandardOptions.class).version()) {
+            throw new CliError("Unexpected CLI argument: --version");
+        }
+
+        if (options.help()) {
             printHelp(arguments, env.stdout());
             return 0;
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
-import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -33,7 +32,6 @@ import software.amazon.smithy.utils.StringUtils;
  * <p>When -h or --help is found, the help for the command is printed
  * to stdout and exits with code 0.
  */
-@SmithyInternalApi
 abstract class SimpleCommand implements Command {
 
     private static final Logger LOGGER = Logger.getLogger(SimpleCommand.class.getName());

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.cli.commands;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
@@ -60,8 +61,9 @@ public class SmithyCommand implements Command {
 
     @Override
     public void printHelp(Arguments arguments, CliPrinter printer) {
+        Ansi ansi = printer.ansi();
         printer.println(String.format("Usage: %s [-h | --help] [--version] <command> [<args>]",
-                                      printer.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
+                                      ansi.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
         printer.println("");
         printer.println("Available commands:");
 
@@ -77,7 +79,7 @@ public class SmithyCommand implements Command {
         for (Command command : commands) {
             if (!command.isHidden()) {
                 printer.println(String.format("    %-" + longestName + "s %s",
-                                              printer.style(command.getName(), Style.YELLOW),
+                                              ansi.style(command.getName(), Style.YELLOW),
                                               command.getSummary()));
             }
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.cli.commands;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
@@ -26,7 +27,6 @@ import software.amazon.smithy.cli.SmithyCli;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
-import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -34,17 +34,8 @@ public class SmithyCommand implements Command {
 
     private final List<Command> commands;
 
-    public SmithyCommand() {
-        this(null);
-    }
-
     public SmithyCommand(DependencyResolver.Factory dependencyResolverFactory) {
-        if (dependencyResolverFactory == null) {
-            dependencyResolverFactory = (config, env) -> {
-                return new MavenDependencyResolver(EnvironmentVariable.SMITHY_MAVEN_CACHE.getValue());
-            };
-        }
-
+        Objects.requireNonNull(dependencyResolverFactory);
         commands = Arrays.asList(
             new ValidateCommand(getName(), dependencyResolverFactory),
             new BuildCommand(getName(), dependencyResolverFactory),

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -81,12 +81,14 @@ public class SmithyCommand implements Command {
                                               command.getSummary()));
             }
         }
+
+        printer.println("");
     }
 
     @Override
     public int execute(Arguments arguments, Env env) {
-        // Set the current CLI version as a system property so it can be used in config files.
-        EnvironmentVariable.SMITHY_VERSION.setValue(SmithyCli.getVersion());
+        // Set the current CLI version as a system property, so it can be used in config files.
+        EnvironmentVariable.SMITHY_VERSION.set(SmithyCli.getVersion());
 
         String command = arguments.shift();
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
@@ -59,17 +59,15 @@ import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.SimpleParser;
-import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
-@SmithyInternalApi
 @SuppressWarnings("deprecation")
-public final class Upgrade1to2Command extends SimpleCommand {
+final class Upgrade1to2Command extends SimpleCommand {
     private static final Logger LOGGER = Logger.getLogger(Upgrade1to2Command.class.getName());
     private static final Pattern VERSION_1 = Pattern.compile("(?m)^\\s*\\$\\s*version:\\s*\"1\\.0\"\\s*$");
     private static final Pattern VERSION_2 = Pattern.compile("(?m)^\\s*\\$\\s*version:\\s*\"2\\.0\"\\s*$");
 
-    public Upgrade1to2Command(String parentCommandName) {
+    Upgrade1to2Command(String parentCommandName) {
         super(parentCommandName);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
@@ -25,7 +25,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +41,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
-import software.amazon.smithy.cli.HelpPrinter;
+import software.amazon.smithy.cli.ConfigOptions;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelAssembler;
@@ -69,47 +68,14 @@ public final class Upgrade1to2Command extends SimpleCommand {
     private static final Logger LOGGER = Logger.getLogger(Upgrade1to2Command.class.getName());
     private static final Pattern VERSION_1 = Pattern.compile("(?m)^\\s*\\$\\s*version:\\s*\"1\\.0\"\\s*$");
     private static final Pattern VERSION_2 = Pattern.compile("(?m)^\\s*\\$\\s*version:\\s*\"2\\.0\"\\s*$");
-    private static final EnumSet<ShapeType> HAD_DEFAULT_VALUE_IN_1_0 = EnumSet.of(
-            ShapeType.BYTE,
-            ShapeType.SHORT,
-            ShapeType.INTEGER,
-            ShapeType.LONG,
-            ShapeType.FLOAT,
-            ShapeType.DOUBLE,
-            ShapeType.BOOLEAN);
 
     public Upgrade1to2Command(String parentCommandName) {
         super(parentCommandName);
     }
 
-    private static final class Options implements ArgumentReceiver {
-        private String config = "smithy-build.json";
-
-        @Override
-        public boolean testOption(String name) {
-            return false;
-        }
-
-        @Override
-        public Consumer<String> testParameter(String name) {
-            switch (name) {
-                case "--config":
-                case "-c":
-                    return c -> this.config = c;
-                default:
-                    return null;
-            }
-        }
-
-        @Override
-        public void registerHelp(HelpPrinter printer) {
-            printer.param("--config", "-c", "CONFIG_PATH", "Path to smithy-build.json configuration.");
-        }
-    }
-
     @Override
     protected List<ArgumentReceiver> createArgumentReceivers() {
-        return Arrays.asList(new Options(), new BuildOptions());
+        return Arrays.asList(new ConfigOptions(), new BuildOptions());
     }
 
     @Override
@@ -124,16 +90,13 @@ public final class Upgrade1to2Command extends SimpleCommand {
 
     @Override
     protected int run(Arguments arguments, Env env, List<String> models) {
-        Options commandOptions = arguments.getReceiver(Options.class);
-
-        // Use the provided smithy-build.json file
-        SmithyBuildConfig.Builder configBuilder = SmithyBuildConfig.builder();
-        if (Files.exists(Paths.get(commandOptions.config))) {
-            configBuilder.load(Paths.get(commandOptions.config).toAbsolutePath());
-        }
+        ClassLoader classLoader = env.classLoader();
+        ConfigOptions configOptions = arguments.getReceiver(ConfigOptions.class);
+        SmithyBuildConfig smithyBuildConfig = configOptions.createSmithyBuildConfig();
 
         // Set an output into a temporary directory - we don't actually care about
         // the serialized output.
+        SmithyBuildConfig.Builder configBuilder = smithyBuildConfig.toBuilder();
         Path tempDir;
         try {
             tempDir = Files.createTempDirectory("smithyUpgrade");
@@ -141,11 +104,12 @@ public final class Upgrade1to2Command extends SimpleCommand {
             throw new CliError("Unable to create temporary working directory: " + e);
         }
         configBuilder.outputDirectory(tempDir.toString());
+        SmithyBuildConfig temporaryConfig = configBuilder.build();
 
-        Model initialModel = CommandUtils.buildModel(arguments, models, env, env.stderr(), true);
+        Model initialModel = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, smithyBuildConfig);
 
-        SmithyBuild smithyBuild = SmithyBuild.create(env.classLoader())
-                .config(configBuilder.build())
+        SmithyBuild smithyBuild = SmithyBuild.create(classLoader)
+                .config(temporaryConfig)
                 // Only build the source projection
                 .projectionFilter(name -> name.equals("source"))
                 // The only traits we care about looking at are in the prelude,

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -15,21 +15,21 @@
 
 package software.amazon.smithy.cli.commands;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
-import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.StandardOptions;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
-public final class ValidateCommand extends SimpleCommand {
+public final class ValidateCommand extends ClasspathCommand {
 
     private static final Logger LOGGER = Logger.getLogger(ValidateCommand.class.getName());
 
-    public ValidateCommand(String parentCommandName) {
-        super(parentCommandName);
+    public ValidateCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -43,15 +43,9 @@ public final class ValidateCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return Collections.singletonList(new BuildOptions());
-    }
-
-    @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
-        LOGGER.info(() -> "Validating Smithy model sources: " + models);
-        CommandUtils.buildModel(arguments, models, env, env.stdout(), standardOptions.quiet());
+        CommandUtils.buildModel(arguments, models, env, env.stdout(), standardOptions.quiet(), config);
         LOGGER.info("Smithy validation complete");
         return 0;
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -21,14 +21,12 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class ValidateCommand extends ClasspathCommand {
+final class ValidateCommand extends ClasspathCommand {
 
     private static final Logger LOGGER = Logger.getLogger(ValidateCommand.class.getName());
 
-    public ValidateCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+    ValidateCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.cli.commands;
 
 import java.util.StringJoiner;
+import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Style;
@@ -38,12 +39,13 @@ final class Validator {
         int shapeCount = result.getResult().isPresent() ? result.getResult().get().toSet().size() : 0;
         boolean isFailed = errors > 0 || dangers > 0;
         boolean hasEvents = warnings > 0 || notes > 0 || isFailed;
+        Ansi ansi = printer.ansi();
 
         StringBuilder output = new StringBuilder();
         if (isFailed) {
-            output.append(printer.style("FAILURE: ", Style.RED, Style.BOLD));
+            output.append(ansi.style("FAILURE: ", Style.RED, Style.BOLD));
         } else {
-            output.append(printer.style("SUCCESS: ", Style.GREEN, Style.BOLD));
+            output.append(ansi.style("SUCCESS: ", Style.GREEN, Style.BOLD));
         }
         output.append("Validated ").append(shapeCount).append(" shapes");
 
@@ -51,21 +53,21 @@ final class Validator {
             output.append(' ').append('(');
             StringJoiner joiner = new StringJoiner(", ");
             if (errors > 0) {
-                appendSummaryCount(joiner, printer, "ERROR", errors, Style.BRIGHT_RED);
+                appendSummaryCount(joiner, ansi, "ERROR", errors, Style.BRIGHT_RED);
             }
 
             if (dangers > 0) {
-                appendSummaryCount(joiner, printer, "DANGER", dangers, Style.RED);
+                appendSummaryCount(joiner, ansi, "DANGER", dangers, Style.RED);
             }
 
             if (warnings > 0) {
-                appendSummaryCount(joiner, printer, "WARNING", warnings, Style.YELLOW);
+                appendSummaryCount(joiner, ansi, "WARNING", warnings, Style.YELLOW);
             }
 
             if (notes > 0) {
-                appendSummaryCount(joiner, printer, "NOTE", notes, Style.WHITE);
+                appendSummaryCount(joiner, ansi, "NOTE", notes, Style.WHITE);
             }
-            output.append(joiner.toString());
+            output.append(joiner);
             output.append(')');
         }
 
@@ -76,13 +78,7 @@ final class Validator {
         }
     }
 
-    private static void appendSummaryCount(
-            StringJoiner joiner,
-            CliPrinter printer,
-            String label,
-            int count,
-            Style color
-    ) {
-        joiner.add(printer.style(label, color) + ": " + count);
+    private static void appendSummaryCount(StringJoiner joiner, Ansi ansi, String label, int count, Style color) {
+        joiner.add(ansi.style(label, color) + ": " + count);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import software.amazon.smithy.build.model.MavenRepository;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.EnvironmentVariable;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
 
@@ -53,7 +54,7 @@ final class WarmupCommand extends ClasspathCommand {
 
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
-        if (System.getenv("SMITHY_WARMUP_INTERNAL_ONLY") == null) {
+        if (EnvironmentVariable.getByName("SMITHY_WARMUP_INTERNAL_ONLY") == null) {
             throw new UnsupportedOperationException("The warmup command is for internal use only and may "
                                                     + "be removed in the future");
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.cli.commands;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -82,7 +81,7 @@ final class WarmupCommand extends ClasspathCommand {
 
             new ValidateCommand("a", (c, e) -> resolver).execute(arguments, env);
             new BuildCommand("a", (c, e) -> resolver).execute(arguments, env);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
+import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class WarmupCommand extends ClasspathCommand {
+
+    private static final Logger LOGGER = Logger.getLogger(WarmupCommand.class.getName());
+
+    public WarmupCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
+    }
+
+    @Override
+    public String getName() {
+        return "warmup";
+    }
+
+    @Override
+    public String getSummary() {
+        return "Creates caches for faster subsequent executions";
+    }
+
+    @Override
+    public boolean isHidden() {
+        return true;
+    }
+
+    @Override
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
+        if (System.getenv("SMITHY_WARMUP_INTERNAL_ONLY") == null) {
+            throw new UnsupportedOperationException("The warmup command is for internal use only and may "
+                                                    + "be removed in the future");
+        }
+
+        LOGGER.info(() -> "Warming up Smithy CLI");
+
+        try {
+            Path tempDirWithPrefix = Files.createTempDirectory("smithy-warmup");
+            DependencyResolver resolver = new MavenDependencyResolver(tempDirWithPrefix.toString());
+
+            resolve(resolver);
+            // Resolve again, but find it in the cache.
+            resolve(resolver);
+
+            // Create and load SmithyBuild files.
+            File buildFile = tempDirWithPrefix.resolve("smithy-build.json").toFile();
+            try (FileWriter writer = new FileWriter(buildFile)) {
+                writer.write("{\n"
+                             + "  \"version\": \"1.0\",\n"
+                             + "  \"maven\": {\"dependencies\": [\"software.amazon.smithy:smithy-model:1.23.1\"]}\n"
+                             + "}");
+            }
+
+            SmithyBuildConfig.builder().load(buildFile.toPath()).build();
+
+            new ValidateCommand("a", (c, e) -> resolver).execute(arguments, env);
+            new BuildCommand("a", (c, e) -> resolver).execute(arguments, env);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return 0;
+    }
+
+    private void resolve(DependencyResolver resolver) {
+        resolver.addRepository(MavenRepository.builder().url("https://repo.maven.apache.org/maven2").build());
+        resolver.addDependency("software.amazon.smithy:smithy-model:1.23.0");
+        resolver.resolve();
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
@@ -27,14 +27,12 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class WarmupCommand extends ClasspathCommand {
+final class WarmupCommand extends ClasspathCommand {
 
     private static final Logger LOGGER = Logger.getLogger(WarmupCommand.class.getName());
 
-    public WarmupCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+    WarmupCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolver.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.util.List;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.Command;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Resolves Maven dependencies for the Smithy CLI.
+ */
+@SmithyUnstableApi
+public interface DependencyResolver {
+    /**
+     * Add a Maven repository.
+     *
+     * @param repository Repository to add.
+     * @throws DependencyResolverException When the repository is invalid.
+     */
+    void addRepository(MavenRepository repository);
+
+    /**
+     * Add a dependency.
+     *
+     * <p>Coordinates must be given a group ID, artifact ID, and version in the form
+     * of "groupId:artifactId:version". Coordinates support Maven dependency ranges.
+     * Coordinates do not support LATEST, SNAPSHOT, latest-release, latest.*, or
+     * Gradle style "+" syntax.
+     *
+     * @param coordinates Dependency coordinates to add.
+     * @throws DependencyResolverException When the dependency is invalid.
+     */
+    void addDependency(String coordinates);
+
+    /**
+     * Resolves artifacts for the configured dependencies.
+     *
+     * @return Returns the resolved artifacts, including file on disk and coordinates.
+     * @throws DependencyResolverException If dependency resolution fails.
+     */
+    List<ResolvedArtifact> resolve();
+
+    /**
+     * Responsible for creating a {@link DependencyResolver} for the CLI,
+     * optionally based on configuration.
+     */
+    @FunctionalInterface
+    interface Factory {
+        /**
+         * Creates a {@link DependencyResolver} optionally based on the loaded build configuration.
+         *
+         * @param config smithy-build.json configuration.
+         * @param env Command environment, including stderr and stdout printers.
+         * @return Returns the created resolver.
+         */
+        DependencyResolver create(SmithyBuildConfig config, Command.Env env);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolver.java
@@ -19,12 +19,10 @@ import java.util.List;
 import software.amazon.smithy.build.model.MavenRepository;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Command;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Resolves Maven dependencies for the Smithy CLI.
  */
-@SmithyUnstableApi
 public interface DependencyResolver {
     /**
      * Add a Maven repository.
@@ -62,9 +60,9 @@ public interface DependencyResolver {
     @FunctionalInterface
     interface Factory {
         /**
-         * Creates a {@link DependencyResolver} optionally based on the loaded build configuration.
+         * Creates a {@link DependencyResolver}.
          *
-         * @param config smithy-build.json configuration.
+         * @param config smithy-build.json configuration that can be used to configure the resolver.
          * @param env Command environment, including stderr and stdout printers.
          * @return Returns the created resolver.
          */

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolverException.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolverException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+/**
+ * Exception encountered while attempting to resolve dependencies.
+ */
+public final class DependencyResolverException extends RuntimeException {
+    public DependencyResolverException(String message) {
+        super(message);
+    }
+
+    public DependencyResolverException(Throwable previous) {
+        this(previous.getMessage(), previous);
+    }
+
+    public DependencyResolverException(String message, Throwable previous) {
+        super(message, previous);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
@@ -44,6 +44,11 @@ public final class FileCacheResolver implements DependencyResolver {
     private final File location;
     private final long referenceTimeInMillis;
 
+    /**
+     * @param location The location to the cache.
+     * @param referenceTimeInMillis Invalidate cache items if this time is newer than the cache item time.
+     * @param delegate Resolver to delegate to when dependencies aren't cached.
+     */
     public FileCacheResolver(File location, long referenceTimeInMillis, DependencyResolver delegate) {
         this.location = location;
         this.referenceTimeInMillis = referenceTimeInMillis;
@@ -74,7 +79,7 @@ public final class FileCacheResolver implements DependencyResolver {
         return result;
     }
 
-    List<ResolvedArtifact> load() {
+    private List<ResolvedArtifact> load() {
         // Invalidate the cache if smithy-build.json was updated after the cache was written.
         Path filePath = location.toPath();
         if (!Files.exists(filePath)) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.model.loader.ModelSyntaxException;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+
+/**
+ * A resolver that loads and caches resolved artifacts to a JSON file if
+ * the cache is fresh and resolved artifacts haven't been updated after a
+ * given reference point in time.
+ */
+public final class FileCacheResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(FileCacheResolver.class.getName());
+    private final DependencyResolver delegate;
+    private final File location;
+    private final long referenceTimeInMillis;
+
+    public FileCacheResolver(File location, long referenceTimeInMillis, DependencyResolver delegate) {
+        this.location = location;
+        this.referenceTimeInMillis = referenceTimeInMillis;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void addRepository(MavenRepository repository) {
+        delegate.addRepository(repository);
+    }
+
+    @Override
+    public void addDependency(String coordinates) {
+        delegate.addDependency(coordinates);
+    }
+
+    @Override
+    public List<ResolvedArtifact> resolve() {
+        List<ResolvedArtifact> cachedResult = load();
+
+        if (!cachedResult.isEmpty()) {
+            LOGGER.fine(() -> "Classpath found in cache: " + cachedResult);
+            return cachedResult;
+        }
+
+        List<ResolvedArtifact> result = delegate.resolve();
+        save(result);
+        return result;
+    }
+
+    List<ResolvedArtifact> load() {
+        // Invalidate the cache if smithy-build.json was updated after the cache was written.
+        Path filePath = location.toPath();
+        if (!Files.exists(filePath)) {
+            return Collections.emptyList();
+        } else if (!isCacheValid(location)) {
+            invalidate(filePath);
+            return Collections.emptyList();
+        }
+
+        ObjectNode node;
+        try (InputStream stream = Files.newInputStream(filePath)) {
+            node = Node.parse(stream, location.toString()).expectObjectNode();
+        } catch (ModelSyntaxException | IOException e) {
+            throw new DependencyResolverException("Error loading dependency cache file from " + filePath, e);
+        }
+
+        List<ResolvedArtifact> result = new ArrayList<>(node.getStringMap().size());
+        for (Map.Entry<String, Node> entry : node.getStringMap().entrySet()) {
+            Path location = Paths.get(entry.getValue().expectStringNode().getValue());
+            // Invalidate the cache if the JAR file was updated after the cache was written.
+            if (isArtifactUpdatedSinceReferenceTime(location)) {
+                invalidate(filePath);
+                return Collections.emptyList();
+            }
+            result.add(ResolvedArtifact.fromCoordinates(location, entry.getKey()));
+        }
+
+        return result;
+    }
+
+    private void save(List<ResolvedArtifact> result) {
+        Path filePath = location.toPath();
+        Path parent = filePath.getParent();
+        if (parent == null) {
+            throw new DependencyResolverException("Invalid classpath cache location: " + location);
+        }
+
+        try {
+            Files.createDirectories(parent);
+            ObjectNode.Builder builder = Node.objectNodeBuilder();
+            for (ResolvedArtifact artifact : result) {
+                builder.withMember(artifact.getCoordinates(), artifact.getPath().toString());
+            }
+            ObjectNode objectNode = builder.build();
+            Files.write(filePath, Node.printJson(objectNode).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new DependencyResolverException("Unable to write classpath cache file: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean isCacheValid(File file) {
+        return referenceTimeInMillis <= file.lastModified() && file.length() > 0;
+    }
+
+    private boolean isArtifactUpdatedSinceReferenceTime(Path path) {
+        File file = path.toFile();
+        return !file.exists() || (referenceTimeInMillis > 0 && file.lastModified() > referenceTimeInMillis);
+    }
+
+    private void invalidate(Path filePath) {
+        try {
+            if (Files.exists(filePath)) {
+                LOGGER.fine("Invalidating dependency cache file: " + location);
+                Files.delete(filePath);
+            }
+        } catch (IOException e) {
+            throw new DependencyResolverException("Unable to delete cache file: " + e.getMessage(), e);
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolver.java
@@ -28,6 +28,9 @@ import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Removes Smithy CLI dependencies that conflict with the JARs used by the CLI.
+ *
+ * <p>This makes creating a dedicated ClassLoader simpler because Smithy dependencies are provided by the parent
+ * class loader when running the CLI.
  */
 public final class FilterCliVersionResolver implements DependencyResolver {
 
@@ -39,6 +42,10 @@ public final class FilterCliVersionResolver implements DependencyResolver {
     private final String version;
     private final DependencyResolver delegate;
 
+    /**
+     * @param version Version of the Smithy CLI.
+     * @param delegate Resolver to resolve dependencies and filter.
+     */
     public FilterCliVersionResolver(String version, DependencyResolver delegate) {
         this.version = version;
         this.delegate = delegate;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolver.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionScheme;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.SetUtils;
+
+/**
+ * Removes Smithy CLI dependencies that conflict with the JARs used by the CLI.
+ */
+public final class FilterCliVersionResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(FilterCliVersionResolver.class.getName());
+    private static final String SMITHY_GROUP = "software.amazon.smithy";
+    private static final Set<String> CLI_ARTIFACTS = SetUtils.of(
+            "smithy-utils", "smithy-model", "smithy-build", "smithy-cli", "smithy-diff");
+
+    private final String version;
+    private final DependencyResolver delegate;
+
+    public FilterCliVersionResolver(String version, DependencyResolver delegate) {
+        this.version = version;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void addRepository(MavenRepository repository) {
+        delegate.addRepository(repository);
+    }
+
+    @Override
+    public void addDependency(String coordinates) {
+        delegate.addDependency(coordinates);
+    }
+
+    @Override
+    public List<ResolvedArtifact> resolve() {
+        List<ResolvedArtifact> artifacts = delegate.resolve();
+
+        // Don't cache an empty file.
+        if (artifacts.isEmpty()) {
+            return artifacts;
+        }
+
+        VersionScheme versionScheme = new GenericVersionScheme();
+        Version parsedSmithyVersion = getMavenVersion(version, versionScheme);
+        List<String> replacements = new ArrayList<>();
+        List<ResolvedArtifact> filtered = new ArrayList<>();
+
+        for (ResolvedArtifact artifact : artifacts) {
+            if (artifact.getGroupId().equals(SMITHY_GROUP) && CLI_ARTIFACTS.contains(artifact.getArtifactId())) {
+                // The resolved artifact version does not match the version used by the CLI. In this case,
+                // the resolved version must not be newer than that used by the CLI.
+                Version artifactVersion = getMavenVersion(artifact.getVersion(), versionScheme);
+                int compare = artifactVersion.compareTo(parsedSmithyVersion);
+                if (compare > 0) {
+                    throw new DependencyResolverException(
+                            "The Smithy CLI is at version " + parsedSmithyVersion + ", but dependencies resolved to "
+                            + "use a newer, incompatible version of " + artifact.getCoordinates() + ". Please "
+                            + "update the Smithy CLI.");
+                } else if (compare < 0) {
+                    replacements.add("- Replaced " + artifact.getCoordinates());
+                }
+            } else {
+                filtered.add(artifact);
+            }
+        }
+
+        if (!replacements.isEmpty()) {
+            String contents = String.join(System.lineSeparator(), replacements);
+            LOGGER.info("Resolved dependencies were replaced with dependencies used by the Smithy CLI ("
+                        + version + "). If the CLI fails due to issues like unknown classes, methods, missing "
+                        + "traits, etc, then consider upgrading your dependencies to match the version of the CLI "
+                        + "or modifying your declared dependencies."
+                        + System.lineSeparator() + contents);
+        }
+
+        return filtered;
+    }
+
+    private static Version getMavenVersion(String input, VersionScheme versionScheme) {
+        try {
+            return versionScheme.parseVersion(input);
+        } catch (InvalidVersionSpecificationException e) {
+            throw new DependencyResolverException("Unable to parse dependency version: " + input, e);
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import static org.eclipse.aether.util.artifact.JavaScopes.COMPILE;
+import static org.eclipse.aether.util.artifact.JavaScopes.RUNTIME;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.AuthenticationContext;
+import org.eclipse.aether.repository.AuthenticationDigest;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Resolves Maven dependencies for the Smithy CLI using Maven resolvers.
+ */
+@SmithyUnstableApi
+public final class MavenDependencyResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(DependencyResolver.class.getName());
+
+    private final List<RemoteRepository> remoteRepositories = new ArrayList<>();
+    private final List<Dependency> dependencies = new ArrayList<>();
+    private final DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+    private final DependencyFilter filter = DependencyFilterUtils.classpathFilter(RUNTIME, COMPILE);
+    private final RepositorySystem repositorySystem;
+
+    public MavenDependencyResolver() {
+        this(null);
+    }
+
+    public MavenDependencyResolver(String cacheLocation) {
+        final DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
+        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
+        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+        locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
+            @Override
+            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
+                throw new DependencyResolverException(exception);
+            }
+        });
+
+        repositorySystem = locator.getService(RepositorySystem.class);
+
+        // Sets a default maven local to the default local repo of the user.
+        if (cacheLocation == null) {
+            String userHome = System.getProperty("user.home");
+            cacheLocation = Paths.get(userHome, ".m2", "repository").toString();
+        }
+
+        LocalRepository local = new LocalRepository(cacheLocation);
+        session.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(session, local));
+    }
+
+    @Override
+    public void addRepository(MavenRepository repository) {
+        try {
+            URI uri = new URI(repository.getUrl());
+            String name = uri.getHost();
+            String userInfo = uri.getUserInfo();
+            RemoteRepository.Builder builder = new RemoteRepository.Builder(name, "default", repository.getUrl());
+            if (userInfo != null) {
+                LOGGER.finest(() -> "Setting username and password for " + name + " using URI authority");
+                addUserInfoAuth(uri, userInfo, builder);
+            }
+            repository.getHttpCredentials().ifPresent(credentials -> addUserInfoAuth(uri, credentials, builder));
+            remoteRepositories.add(builder.build());
+        } catch (URISyntaxException e) {
+            throw new DependencyResolverException("Invalid Maven repository URL: " + repository.getUrl()
+                                                  + ": " + e.getMessage());
+        }
+    }
+
+    private void addUserInfoAuth(URI uri, String userInfo, RemoteRepository.Builder builder) {
+        String[] parts = userInfo.split(":", 2);
+        if (parts.length != 2) {
+            throw new DependencyResolverException("Invalid credentials provided for " + uri);
+        }
+        builder.setAuthentication(new MavenAuth(parts[0], parts[1]));
+    }
+
+    @Override
+    public void addDependency(String coordinates) {
+        addDependency(coordinates, "compile");
+    }
+
+    public void addDependency(String coordinates, String scope) {
+        Dependency dependency;
+        dependency = createDependency(coordinates, scope);
+        dependencies.add(dependency);
+    }
+
+    @Override
+    public List<ResolvedArtifact> resolve() {
+        if (remoteRepositories.isEmpty()) {
+            LOGGER.warning("No Maven repositories are configured, so only the local repository cache is being used");
+        }
+
+        final List<ArtifactResult> results = resolveMavenArtifacts();
+        final List<ResolvedArtifact> artifacts = new ArrayList<>(results.size());
+        for (ArtifactResult result : results) {
+            Artifact artifact = result.getArtifact();
+            artifacts.add(new ResolvedArtifact(artifact.getFile().toPath(), artifact.getGroupId(),
+                                               artifact.getArtifactId(), artifact.getVersion()));
+        }
+        return artifacts;
+    }
+
+    private static Dependency createDependency(String coordinates, String scope) {
+        Artifact artifact;
+        try {
+            artifact = new DefaultArtifact(coordinates);
+        } catch (IllegalArgumentException e) {
+            throw new DependencyResolverException("Invalid dependency: " + e.getMessage());
+        }
+        if (artifact.isSnapshot()) {
+            throw new DependencyResolverException("Snapshot dependencies are not supported: " + artifact);
+        }
+        validateDependencyVersion(artifact);
+        return new Dependency(artifact, scope);
+    }
+
+    private static void validateDependencyVersion(Artifact artifact) {
+        String version = artifact.getVersion();
+        if (version.equals("LATEST")) {
+            throw new DependencyResolverException("LATEST dependencies are not supported: " + artifact);
+        } else if (version.equals("latest-status") || version.startsWith("latest.")) {
+            throw new DependencyResolverException("Gradle style latest dependencies are not supported: " + artifact);
+        } else if (version.equals("RELEASE")) {
+            throw new DependencyResolverException("RELEASE dependencies are not supported: " + artifact);
+        } else if (version.contains("+")) {
+            throw new DependencyResolverException("'+' dependencies are not supported: " + artifact);
+        }
+    }
+
+    private List<ArtifactResult> resolveMavenArtifacts() {
+        LOGGER.fine(() -> "Resolving Maven dependencies for Smithy CLI; repos: "
+                          + remoteRepositories + "; dependencies: " + dependencies);
+        CollectRequest collectRequest = new CollectRequest();
+        collectRequest.setRepositories(remoteRepositories);
+        collectRequest.setDependencies(dependencies);
+        DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, filter);
+
+        try {
+            List<ArtifactResult> results = repositorySystem
+                    .resolveDependencies(session, dependencyRequest)
+                    .getArtifactResults();
+            LOGGER.fine(() -> "Resolved Maven dependencies: " + results);
+            return results;
+        } catch (DependencyResolutionException e) {
+            throw new DependencyResolverException(e);
+        }
+    }
+
+    /**
+     * Based on Maven's StringAuthentication.
+     */
+    private static final class MavenAuth implements Authentication {
+        private final String key;
+        private final String value;
+
+        private MavenAuth(String key, String value) {
+            if (StringUtils.isEmpty(key)) {
+                throw new IllegalArgumentException("Authentication key must be provided");
+            }
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public void fill(AuthenticationContext context, String key, Map<String, String> data) {
+            context.put(this.key, value);
+        }
+
+        @Override
+        public void digest(AuthenticationDigest digest) {
+            digest.update(key, value);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj == null || !getClass().equals(obj.getClass())) {
+                return false;
+            }
+            MavenAuth that = (MavenAuth) obj;
+            return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return key + "=****";
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
@@ -50,13 +50,11 @@ import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import software.amazon.smithy.build.model.MavenRepository;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Resolves Maven dependencies for the Smithy CLI using Maven resolvers.
  */
-@SmithyUnstableApi
 public final class MavenDependencyResolver implements DependencyResolver {
 
     private static final Logger LOGGER = Logger.getLogger(DependencyResolver.class.getName());
@@ -71,6 +69,9 @@ public final class MavenDependencyResolver implements DependencyResolver {
         this(null);
     }
 
+    /**
+     * @param cacheLocation Maven local cache location.
+     */
     public MavenDependencyResolver(String cacheLocation) {
         final DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
         locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
@@ -89,6 +90,7 @@ public final class MavenDependencyResolver implements DependencyResolver {
         if (cacheLocation == null) {
             String userHome = System.getProperty("user.home");
             cacheLocation = Paths.get(userHome, ".m2", "repository").toString();
+            LOGGER.fine("Set default Maven local cache location to ~/.m2/repository");
         }
 
         LocalRepository local = new LocalRepository(cacheLocation);
@@ -124,13 +126,7 @@ public final class MavenDependencyResolver implements DependencyResolver {
 
     @Override
     public void addDependency(String coordinates) {
-        addDependency(coordinates, "compile");
-    }
-
-    public void addDependency(String coordinates, String scope) {
-        Dependency dependency;
-        dependency = createDependency(coordinates, scope);
-        dependencies.add(dependency);
+        dependencies.add(createDependency(coordinates, "compile"));
     }
 
     @Override
@@ -196,7 +192,7 @@ public final class MavenDependencyResolver implements DependencyResolver {
     }
 
     /**
-     * Based on Maven's StringAuthentication.
+     * Based on Maven's StringAuthentication. There doesn't appear to be another way to do this.
      */
     private static final class MavenAuth implements Authentication {
         private final String key;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * An artifact resolved from a repository that provides the path on disk where the artifact
+ * was downloaded, and the coordinates of the artifact.
+ */
+@SmithyUnstableApi
+public final class ResolvedArtifact {
+    private final Path path;
+    private final String coordinates;
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    public ResolvedArtifact(Path path, String groupId, String artifactId, String version) {
+        this(path, groupId + ':' + artifactId + ':' + version, groupId, artifactId, version);
+    }
+
+    private ResolvedArtifact(Path path, String coordinates, String groupId, String artifactId, String version) {
+        this.coordinates = Objects.requireNonNull(coordinates);
+        this.path = Objects.requireNonNull(path);
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    /**
+     * Creates a resolved artifact from a file path and Maven coordinates string.
+     *
+     * @param location    Location of the artifact.
+     * @param coordinates Maven coordinates (e.g., group:artifact:version).
+     * @return Returns the created artifact.
+     * @throws DependencyResolverException if the provided coordinates are invalid.
+     */
+    public static ResolvedArtifact fromCoordinates(Path location, String coordinates) {
+        String[] parts = coordinates.split(":");
+        if (parts.length != 3) {
+            throw new DependencyResolverException("Invalid Maven coordinates: " + coordinates);
+        }
+        return new ResolvedArtifact(location, coordinates, parts[0], parts[1], parts[2]);
+    }
+
+    /**
+     * Get the path to the artifact on disk.
+     *
+     * @return Returns the location of the downloaded artifact.
+     */
+    public Path getPath() {
+        return path;
+    }
+
+    /**
+     * Get the resolved coordinates (e.g., group:artifact:version).
+     *
+     * @return Returns the resolved coordinates.
+     */
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    /**
+     * @return Get the group ID of the artifact.
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return Get the artifact ID of the artifact.
+     */
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @return Get the version of the artifact.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "{path=" + path + ", coordinates='" + coordinates + "'}";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(coordinates, path);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof ResolvedArtifact)) {
+            return false;
+        }
+        ResolvedArtifact artifact = (ResolvedArtifact) o;
+        return path.equals(artifact.path) && coordinates.equals(artifact.coordinates);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
@@ -17,13 +17,11 @@ package software.amazon.smithy.cli.dependencies;
 
 import java.nio.file.Path;
 import java.util.Objects;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * An artifact resolved from a repository that provides the path on disk where the artifact
  * was downloaded, and the coordinates of the artifact.
  */
-@SmithyUnstableApi
 public final class ResolvedArtifact {
     private final Path path;
     private final String coordinates;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/package-info.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * Everything in this package should be considered an implementation detail;
+ * the only stable interface of the Smithy CLI is passing in a list of
+ * arguments from the command line.
+ */
+@SmithyUnstableApi
+package software.amazon.smithy.cli;
+
+import software.amazon.smithy.utils.SmithyUnstableApi;

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.cli;
+
+final class BufferPrinter implements CliPrinter {
+
+    private final StringBuilder builder = new StringBuilder();
+
+    @Override
+    public void println(String text) {
+        synchronized (this) {
+            builder.append(text + "\n");
+        }
+    }
+
+    @Override
+    public Ansi ansi() {
+        return Ansi.NO_COLOR;
+    }
+
+    @Override
+    public String toString() {
+        // normalize line endings for tests.
+        return builder.toString().replace("\r\n", "\n").replace("\r", "\n");
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
@@ -18,10 +18,15 @@ package software.amazon.smithy.cli;
 public final class CliUtils {
 
     public static Result runSmithy(String... args) {
-        return run(SmithyCli.create().createCli(), args);
+        try {
+            EnvironmentVariable.NO_COLOR.set("true");
+            return run(SmithyCli.create().createCli(), args);
+        } finally {
+            EnvironmentVariable.NO_COLOR.clear();
+        }
     }
 
-    public static Result run(Cli cli, String... args) {
+    private static Result run(Cli cli, String... args) {
         CapturedPrinter stdout = new CapturedPrinter();
         CapturedPrinter stderr = new CapturedPrinter();
         cli.stdout(stdout);

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
@@ -27,8 +27,8 @@ public final class CliUtils {
     }
 
     private static Result run(Cli cli, String... args) {
-        CapturedPrinter stdout = new CapturedPrinter();
-        CapturedPrinter stderr = new CapturedPrinter();
+        CliPrinter stdout = new BufferPrinter();
+        CliPrinter stderr = new BufferPrinter();
         cli.stdout(stdout);
         cli.stderr(stderr);
         int result;
@@ -40,16 +40,7 @@ public final class CliUtils {
             result = e.code;
         }
 
-        return new Result(result, stdout.result.toString(), stderr.result.toString());
-    }
-
-    private static class CapturedPrinter implements CliPrinter {
-        private final StringBuilder result = new StringBuilder();
-
-        @Override
-        public synchronized void println(String text) {
-            result.append(text).append(System.lineSeparator());
-        }
+        return new Result(result, stdout.toString(), stderr.toString());
     }
 
     public static final class Result {

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
@@ -204,24 +204,4 @@ public class HelpPrinterTest {
                 + "    --foo, -f\n"
                 + "        The foo value\n"));
     }
-
-    private static final class BufferPrinter implements CliPrinter {
-        private final StringBuilder builder = new StringBuilder();
-
-        @Override
-        public void println(String text) {
-            builder.append(text);
-        }
-
-        @Override
-        public String style(String text, Style... styles) {
-            return text;
-        }
-
-        @Override
-        public String toString() {
-            // normalize line endings for tests.
-            return builder.toString().replace("\r\n", "\n").replace("\r", "\n");
-        }
-    }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/IsolatedRunnableTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/IsolatedRunnableTest.java
@@ -1,0 +1,32 @@
+package software.amazon.smithy.cli.commands;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.cli.CliError;
+
+public class IsolatedRunnableTest {
+    @Test
+    public void runsInThread() {
+        Runnable isolated = new IsolatedRunnable(Collections.emptyList(), getClass().getClassLoader(), cl -> {
+            try {
+                Class<?> c = cl.loadClass("software.amazon.smithy.cli.commands.IsolatedRunnableTest$TestClass");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        isolated.run();
+    }
+
+    @Test
+    public void runsInThreadAndRethrows() {
+        Runnable isolated = new IsolatedRunnable(Collections.emptyList(), getClass().getClassLoader(), cl -> {
+            throw new RuntimeException("Hello from thread");
+        });
+
+        Assertions.assertThrows(CliError.class, isolated::run);
+    }
+
+    public static final class TestClass {}
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
@@ -1,0 +1,107 @@
+package software.amazon.smithy.cli.dependencies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.ListUtils;
+
+public class FileCacheResolverTest {
+    @Test
+    public void proxiesCallsToDelegate() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        Mock mock = new Mock(ListUtils.of());
+        DependencyResolver resolver = new FileCacheResolver(cache, System.currentTimeMillis(), mock);
+        MavenRepository repo = MavenRepository.builder().url("https://example.com").build();
+        resolver.addDependency("com.foo:baz-bar:1.0.0");
+        resolver.addRepository(repo);
+
+        assertThat(mock.repositories, contains(repo));
+        assertThat(mock.coordinates, contains("com.foo:baz-bar:1.0.0"));
+    }
+
+    @Test
+    public void ignoresAndDeletesEmptyCacheFiles() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".json");
+
+        List<ResolvedArtifact> result = ListUtils.of(
+                ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0"));
+        Mock mock = new Mock(result);
+        DependencyResolver resolver = new FileCacheResolver(cache, System.currentTimeMillis(), mock);
+
+        // Delete the cache before resolving to ensure missing files are ignored by the cache.
+        assertThat(cache.delete(), is(true));
+        assertThat(resolver.resolve(), equalTo(result));
+    }
+
+    @Test
+    public void loadsCacheFromDelegateWhenCacheMissingAndSaves() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".json");
+        Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
+
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
+        List<ResolvedArtifact> result = new ArrayList<>();
+        result.add(artifact);
+
+        Mock mock = new Mock(result);
+        DependencyResolver resolver = new FileCacheResolver(cache, jar.lastModified(), mock);
+        List<ResolvedArtifact> resolved = resolver.resolve();
+
+        assertThat(resolved, contains(artifact));
+        assertThat(IoUtils.readUtf8File(cache.toPath()), containsString("com.foo:bar:1.0.0"));
+
+        // Remove the canned entry from the mock to ensure the cache is working before delegating.
+        result.clear();
+
+        // Calling it again will load from the cached file.
+        assertThat(resolver.resolve(), contains(artifact));
+
+        // The cache should still be there.
+        assertThat(IoUtils.readUtf8File(cache.toPath()), containsString("com.foo:bar:1.0.0"));
+
+        // Removing the cache artifact invalidates the cache.
+        assertThat(jar.delete(), is(true));
+
+        assertThat(resolver.resolve(), empty());
+        assertThat(IoUtils.readUtf8File(cache.toPath()), containsString("{}"));
+    }
+
+    private static final class Mock implements DependencyResolver {
+        final List<ResolvedArtifact> artifacts;
+        final List<MavenRepository> repositories = new ArrayList<>();
+        final List<String> coordinates = new ArrayList<>();
+
+        Mock(List<ResolvedArtifact> artifacts) {
+            this.artifacts = artifacts;
+        }
+
+        @Override
+        public void addRepository(MavenRepository repository) {
+            repositories.add(repository);
+        }
+
+        @Override
+        public void addDependency(String coordinates) {
+            this.coordinates.add(coordinates);
+        }
+
+        @Override
+        public List<ResolvedArtifact> resolve() {
+            return artifacts;
+        }
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolverTest.java
@@ -1,0 +1,91 @@
+package software.amazon.smithy.cli.dependencies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.ListUtils;
+
+public class FilterCliVersionResolverTest {
+    @Test
+    public void doesNothingWhenEmpty() {
+        FilterCliVersionResolver filter = new FilterCliVersionResolver("1.26.0", new DependencyResolver() {
+            @Override
+            public void addRepository(MavenRepository repository) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addDependency(String coordinates) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ResolvedArtifact> resolve() {
+                return Collections.emptyList();
+            }
+        });
+
+        assertThat(filter.resolve(), empty());
+    }
+
+    @Test
+    public void filtersMatchingDependencies() {
+        FilterCliVersionResolver filter = new FilterCliVersionResolver("1.26.0", new DependencyResolver() {
+            @Override
+            public void addRepository(MavenRepository repository) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addDependency(String coordinates) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ResolvedArtifact> resolve() {
+                return Arrays.asList(
+                    ResolvedArtifact.fromCoordinates(Paths.get("/a"), "software.amazon.smithy:smithy-model:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/b"), "software.amazon.smithy:smithy-utils:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/c"), "software.amazon.smithy:smithy-other:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/d"), "software.amazon.foo:foo-other:1.0.0")
+                );
+            }
+        });
+
+        assertThat(filter.resolve(), contains(
+            ResolvedArtifact.fromCoordinates(Paths.get("/c"), "software.amazon.smithy:smithy-other:1.25.0"),
+            ResolvedArtifact.fromCoordinates(Paths.get("/d"), "software.amazon.foo:foo-other:1.0.0")
+        ));
+    }
+
+    @Test
+    public void failsWhenResolvedDependenciesGreaterThanCli() {
+        FilterCliVersionResolver filter = new FilterCliVersionResolver("1.26.0", new DependencyResolver() {
+            @Override
+            public void addRepository(MavenRepository repository) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addDependency(String coordinates) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ResolvedArtifact> resolve() {
+                return ListUtils.of(ResolvedArtifact.fromCoordinates(Paths.get("/a"),
+                                                                     "software.amazon.smithy:smithy-model:1.27.0"));
+            }
+        });
+
+        Assertions.assertThrows(DependencyResolverException.class, filter::resolve);
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolverTest.java
@@ -1,0 +1,61 @@
+package software.amazon.smithy.cli.dependencies;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.build.model.MavenRepository;
+
+// This test does some light validation checks. Actual resolution is tested through integ tests.
+public class MavenDependencyResolverTest {
+    @Test
+    public void allowsValidDependenciesAndRepos() {
+        DependencyResolver resolver = new MavenDependencyResolver();
+        resolver.addRepository(MavenRepository.builder().url("https://example.com").build());
+        resolver.addRepository(MavenRepository.builder()
+                .url("https://mvn.example.com")
+                .httpCredentials("user:pass")
+                .build());
+        resolver.addDependency("com.foo:baz1:1.0.0");
+        resolver.addDependency("com.foo:baz2:[1.0.0]");
+        resolver.addDependency("com.foo:baz3:[1.0.0,]");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidDependencies")
+    public void validatesDependencies(String value) {
+        DependencyResolver resolver = new MavenDependencyResolver();
+
+        DependencyResolverException e = Assertions.assertThrows(DependencyResolverException.class, () -> {
+            resolver.addDependency(value);
+        });
+    }
+
+    public static Stream<Arguments> invalidDependencies() {
+        return Stream.of(
+            Arguments.of("X"),
+            Arguments.of("smithy.foo:bar:1.25.0-SNAPSHOT"),
+            Arguments.of("smithy.foo:bar:RELEASE"),
+            Arguments.of("smithy.foo:bar:latest-status"),
+            Arguments.of("smithy.foo:bar:LATEST"),
+            Arguments.of("smithy.foo:bar:1.25.0+"),
+            Arguments.of("a::1.2.0"),
+            Arguments.of(":b:1.2.0"),
+            Arguments.of("a:b:"),
+            Arguments.of("a:b: ")
+        );
+    }
+
+    @Test
+    public void repositoryNeedsValidUrl() {
+        DependencyResolver resolver = new MavenDependencyResolver();
+
+        Assertions.assertThrows(DependencyResolverException.class, () -> {
+            resolver.addRepository(MavenRepository.builder()
+                    .url("!nope://")
+                    .build());
+        });
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/ResolvedArtifactTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/ResolvedArtifactTest.java
@@ -1,0 +1,54 @@
+package software.amazon.smithy.cli.dependencies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ResolvedArtifactTest {
+    @Test
+    public void loadsFromCoordinates() {
+        Path path = Paths.get("/a");
+        String coordinates = "com.foo:baz-bam:1.2.0";
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(path, coordinates);
+
+        assertThat(artifact.getPath(), equalTo(path));
+        assertThat(artifact.getCoordinates(), equalTo(coordinates));
+        assertThat(artifact.getGroupId(), equalTo("com.foo"));
+        assertThat(artifact.getArtifactId(), equalTo("baz-bam"));
+        assertThat(artifact.getVersion(), equalTo("1.2.0"));
+    }
+
+    @Test
+    public void createsCoordinatesStringFromParts() {
+        Path path = Paths.get("/a");
+        ResolvedArtifact artifact = new ResolvedArtifact(path, "com.foo", "baz-bam", "1.2.0");
+
+        assertThat(artifact.getPath(), equalTo(path));
+        assertThat(artifact.getCoordinates(), equalTo("com.foo:baz-bam:1.2.0"));
+        assertThat(artifact.getGroupId(), equalTo("com.foo"));
+        assertThat(artifact.getArtifactId(), equalTo("baz-bam"));
+        assertThat(artifact.getVersion(), equalTo("1.2.0"));
+    }
+
+    @Test
+    public void validatesCoordinatesNotTooManyParts() {
+        Path path = Paths.get("/a");
+        String coordinates = "com.foo:baz-bam:1.2.0:boo";
+
+        Assertions.assertThrows(DependencyResolverException.class,
+                                () -> ResolvedArtifact.fromCoordinates(path, coordinates));
+    }
+
+    @Test
+    public void validatesCoordinatesEnoughParts() {
+        Path path = Paths.get("/a");
+        String coordinates = "com.foo:baz-bam";
+
+        Assertions.assertThrows(DependencyResolverException.class,
+                                () -> ResolvedArtifact.fromCoordinates(path, coordinates));
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -266,7 +266,8 @@ public final class ModelAssembler {
                 throw new ModelImportException("Error loading the contents of " + importPath, e);
             }
         } else if (Files.isRegularFile(importPath)) {
-            inputStreamModels.put(importPath.toString(), () -> {
+            // Use an absolute path for better de-duping of the same file.
+            inputStreamModels.put(importPath.toAbsolutePath().toString(), () -> {
                 try {
                     return Files.newInputStream(importPath);
                 } catch (IOException e) {
@@ -309,8 +310,8 @@ public final class ModelAssembler {
 
         if (key.startsWith("file:")) {
             try {
-                // Paths.get ensures paths are normalized for Windows too.
-                key = Paths.get(url.toURI()).toString();
+                // Use an absolute Path to ensure paths are normalized for Windows too, and better de-duping.
+                key = Paths.get(url.toURI()).toAbsolutePath().toString();
             } catch (URISyntaxException e) {
                 key = key.substring(5);
             }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/IoUtilsTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/IoUtilsTest.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,6 +26,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Random;
 import org.junit.jupiter.api.Assertions;
@@ -109,5 +113,39 @@ public class IoUtilsTest {
 
         assertThat(code, not(0));
         assertThat(sb.toString(), not(emptyString()));
+    }
+
+    @Test
+    public void deletesDirectories() throws IOException {
+        Path path = Files.createTempDirectory("delete_empty_dir");
+        Files.write(path.resolve("foo"), "hello".getBytes(StandardCharsets.UTF_8));
+        Path nested = path.resolve("a").resolve("b");
+        Files.createDirectories(nested);
+        Files.write(nested.resolve("baz"), "hello".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(Files.exists(path), is(true));
+        assertThat(Files.exists(nested), is(true));
+
+        IoUtils.rmdir(path);
+
+        assertThat(Files.exists(path), is(false));
+        assertThat(Files.exists(nested), is(false));
+    }
+
+    @Test
+    public void rmDirIgnoresIfNotExists() throws IOException {
+        Path path = Files.createTempDirectory("delete_empty_dir");
+        Files.delete(path);
+
+        assertThat(IoUtils.rmdir(path), is(false));
+    }
+
+    @Test
+    public void rmDirFailsWhenNotDir() throws IOException {
+        Path path = Files.createTempFile("foo", ".baz");
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> IoUtils.rmdir(path));
+
+        Files.delete(path);
     }
 }

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -25,5 +25,5 @@ ext {
 }
 
 dependencies {
-    implementation project(":smithy-cli")
+    implementation project(path: ":smithy-cli", configuration: "shadow")
 }


### PR DESCRIPTION
This commit adds the ability to resolve dependencies in the Smithy CLI. This allows end users to author models, generate code, and other activities from the Smithy CLI without needing to use tools like Gradle or Maven. This lowers the up-front learning curve of most Smithy use cases to author models and generate code. Writing Java library code, model build plugins, or transforms is out of scope of the Smithy CLI. Such use cases require the use of tools like Gradle or Maven.

To add dependencies, update smithy-build.json with a "maven" key-value pair, which takes "dependencies" and "repositories":

```
{
    "version": "1.0",
    "maven": {
        "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.26.0"]
    }
}
```

When no "repositories" are present, the CLI assumes Maven Central. When the repository member is set, there are no defaults.

```
{
    "version": "1.0",
    "maven": {
        "repositories": [
            {
                "url": "https://example.com",
                "httpCredentials": "${USERNAME}:${PASSWORD}"
            }
        ],
        "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.26.0"]
    }
}
```

To support dependency resolution in the CLI, this commit also introduces the ``--version`` option to display the current version.

```
smithy --version
1.26.0
```

The ``smithy clean`` command was added since it was very useful to test dependency resolution by removing the classpath cache file to force them to be re-resolved.

```
smithy clean
```

Using the Smithy CLI directly means that tools like Gradle aren't automatically detecting the model directory and adding sources. To account for this, the `sources` property was added to smithy-build.json. It acts like `imports`, but the models contained in `sources` are considered part of the model being built rather than just a dependency (i.e., the sources plugin will contain these models).

```
{
    "version": "1.0",
    "sources": ["model"]
}
```

Other changes:
* This commit also prints out more useful exceptions when --stacktrace is on since wrapping things in a DependencyRunnable obscured the underlying issue.
* To actually test maven resolution, this commit also adds integration tests for the CLI (./gradlew :smithy-cli:integ).
* --disable-dependencies can be passed to make the CLI _not_ resolve dependencies. This is useful when using the CLI with other tools that are responsible for resolving dependencies (e.g., Gradle).
* This commit attempts to make GitHub actions run the CLI integration tests when using Java 11+ (not 8 since it relies on using jlink to build the CLI).
* The binaries created by the CLI were renamed to match the naming conventions of other popular projects
* The CLI wrapper bash script was updated to suppress JAVA_OPTS notifications and to improve its performance. The CLI wrapper script is based on the wrapper used by Gradle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
