### PR TITLE
Add missing regions and fix typo in partitions.json

### DIFF
--- a/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/language/partitions.json
+++ b/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/language/partitions.json
@@ -6,7 +6,7 @@
       "regionRegex": "^(us|eu|ap|sa|ca|me|af)-\\w+-\\d+$",
       "regions": {
         "af-south-1": {},
-        "af-east-1": {},
+        "ap-east-1": {},
         "ap-northeast-1": {},
         "ap-northeast-2": {},
         "ap-northeast-3": {},
@@ -21,6 +21,7 @@
         "eu-west-1": {},
         "eu-west-2": {},
         "eu-west-3": {},
+        "me-central-1": {},
         "me-south-1": {},
         "sa-east-1": {},
         "us-east-1": {},
@@ -80,6 +81,8 @@
         "dualStackDnsSuffix": "c2s.ic.gov"
       },
       "regions": {
+        "us-iso-east-1":  {},
+        "us-iso-west-1": {},
         "aws-iso-global": {}
       }
     },
@@ -94,6 +97,7 @@
         "dualStackDnsSuffix": "sc2s.sgov.gov"
       },
       "regions": {
+        "us-isob-east-1": {},
         "aws-iso-b-global": {}
       }
     }


### PR DESCRIPTION
*Description of changes:*
While there are plans to remove partitions.json from the smithy repository, it is currently being used and contains typos (`af-east-1` and is missing a few regions).  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
