### PR TITLE
Add coverage for `intEnum` in `restJson1` protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -11,6 +11,8 @@ use aws.protocoltests.shared#DateTime
 use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
+use aws.protocoltests.shared#IntegerEnum
+use aws.protocoltests.shared#IntegerEnumList
 use aws.protocoltests.shared#HttpDate
 use aws.protocoltests.shared#IntegerList
 use aws.protocoltests.shared#StringList
@@ -134,6 +136,23 @@ apply InputAndOutputWithHeaders @httpRequestTests([
             headerEnumList: ["Foo", "Bar", "Baz"],
         }
     },
+    {
+        id: "RestJsonInputAndOutputWithIntEnumHeaders",
+        documentation: "Tests requests with intEnum header bindings",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/InputAndOutputWithHeaders",
+        headers: {
+            "X-IntegerEnum": "1",
+            "X-IntegerEnumList": "1, 2, 3"
+        },
+        body: "",
+        params: {
+            headerIntegerEnum: 1,
+            headerIntegerEnumList: [1, 2, 3],
+        }
+    },
+
     {
         id: "RestJsonSupportsNaNFloatHeaderInputs",
         documentation: "Supports handling NaN float header values.",
@@ -280,6 +299,20 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         }
     },
     {
+        id: "RestJsonInputAndOutputWithIntEnumHeaders",
+        documentation: "Tests responses with intEnum header bindings",
+        protocol: restJson1,
+        code: 200,
+        headers: {
+            "X-IntegerEnum": "1",
+            "X-IntegerEnumList": "1, 2, 3"
+        },
+        params: {
+            headerIntegerEnum: 1,
+            headerIntegerEnumList: [1, 2, 3],
+        }
+    },
+    {
         id: "RestJsonSupportsNaNFloatHeaderOutputs",
         documentation: "Supports handling NaN float header values.",
         protocol: restJson1,
@@ -371,6 +404,12 @@ structure InputAndOutputWithHeadersIO {
 
     @httpHeader("X-EnumList")
     headerEnumList: FooEnumList,
+
+    @httpHeader("X-IntegerEnum")
+    headerIntegerEnum: IntegerEnum,
+
+    @httpHeader("X-IntegerEnumList")
+    headerIntegerEnumList: IntegerEnumList,
 }
 
 /// Null and empty headers are not sent over the wire.

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -11,6 +11,8 @@ use aws.protocoltests.shared#BooleanList
 use aws.protocoltests.shared#DoubleList
 use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
+use aws.protocoltests.shared#IntegerEnum
+use aws.protocoltests.shared#IntegerEnumList
 use aws.protocoltests.shared#IntegerList
 use aws.protocoltests.shared#IntegerSet
 use aws.protocoltests.shared#StringList
@@ -71,6 +73,10 @@ apply AllQueryStringTypes @httpRequestTests([
             "EnumList=Foo",
             "EnumList=Baz",
             "EnumList=Bar",
+            "IntegerEnum=1",
+            "IntegerEnumList=1",
+            "IntegerEnumList=2",
+            "IntegerEnumList=3",
         ],
         params: {
             queryString: "Hello there",
@@ -91,6 +97,8 @@ apply AllQueryStringTypes @httpRequestTests([
             queryTimestampList: [1, 2, 3],
             queryEnum: "Foo",
             queryEnumList: ["Foo", "Baz", "Bar"],
+            queryIntegerEnum: 1,
+            queryIntegerEnumList: [1, 2, 3],
         }
     },
     {
@@ -242,6 +250,12 @@ structure AllQueryStringTypesInput {
 
     @httpQuery("EnumList")
     queryEnumList: FooEnumList,
+
+    @httpQuery("IntegerEnum")
+    queryIntegerEnum: IntegerEnum,
+
+    @httpQuery("IntegerEnumList")
+    queryIntegerEnumList: IntegerEnumList,
 
     @httpQueryParams
     queryParamsMapOfStringList: StringListMap,

--- a/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
@@ -8,6 +8,7 @@ use aws.protocols#restJson1
 use aws.protocoltests.shared#BooleanList
 use aws.protocoltests.shared#EpochSeconds
 use aws.protocoltests.shared#FooEnumList
+use aws.protocoltests.shared#IntegerEnumList
 use aws.protocoltests.shared#GreetingList
 use aws.protocoltests.shared#IntegerList
 use aws.protocoltests.shared#NestedStringList
@@ -65,6 +66,10 @@ apply JsonLists @httpRequestTests([
                       "Foo",
                       "0"
                   ],
+                  "intEnumList": [
+                      1,
+                      2
+                  ],
                   "nestedStringList": [
                       [
                           "foo",
@@ -112,6 +117,10 @@ apply JsonLists @httpRequestTests([
             "enumList": [
                 "Foo",
                 "0"
+            ],
+            "intEnumList": [
+                1,
+                2
             ],
             "nestedStringList": [
                 [
@@ -204,6 +213,10 @@ apply JsonLists @httpResponseTests([
                       "Foo",
                       "0"
                   ],
+                  "intEnumList": [
+                      1,
+                      2
+                  ],
                   "nestedStringList": [
                       [
                           "foo",
@@ -251,6 +264,10 @@ apply JsonLists @httpResponseTests([
             "enumList": [
                 "Foo",
                 "0"
+            ],
+            "intEnumList": [
+                1,
+                2
             ],
             "nestedStringList": [
                 [
@@ -323,6 +340,8 @@ structure JsonListsInputOutput {
     timestampList: TimestampList,
 
     enumList: FooEnumList,
+
+    intEnumList: IntegerEnumList,
 
     nestedStringList: NestedStringList,
 

--- a/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-structs.smithy
@@ -10,6 +10,10 @@ use aws.protocoltests.shared#FooEnum
 use aws.protocoltests.shared#FooEnumList
 use aws.protocoltests.shared#FooEnumSet
 use aws.protocoltests.shared#FooEnumMap
+use aws.protocoltests.shared#IntegerEnum
+use aws.protocoltests.shared#IntegerEnumList
+use aws.protocoltests.shared#IntegerEnumSet
+use aws.protocoltests.shared#IntegerEnumMap
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
@@ -617,6 +621,110 @@ structure JsonEnumsInputOutput {
     fooEnumList: FooEnumList,
     fooEnumSet: FooEnumSet,
     fooEnumMap: FooEnumMap,
+}
+
+/// This example serializes intEnums as top level properties, in lists, sets, and maps.
+@idempotent
+@http(uri: "/JsonIntEnums", method: "PUT")
+operation JsonIntEnums {
+    input: JsonIntEnumsInputOutput,
+    output: JsonIntEnumsInputOutput
+}
+
+apply JsonIntEnums @httpRequestTests([
+    {
+        id: "RestJsonJsonIntEnums",
+        documentation: "Serializes intEnums as integers",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/JsonIntEnums",
+        body: """
+              {
+                  "integerEnum1": 1,
+                  "integerEnum2": 2,
+                  "integerEnum3": 3,
+                  "integerEnumList": [
+                      1,
+                      2,
+                      3
+                  ],
+                  "integerEnumSet": [
+                      1,
+                      2
+                  ],
+                  "integerEnumMap": {
+                      "abc": 1,
+                      "def": 2
+                  }
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            integerEnum1: 1,
+            integerEnum2: 2,
+            integerEnum3: 3,
+            integerEnumList: [1, 2, 3],
+            integerEnumSet: [1, 2],
+            integerEnumMap: {
+                "abc": 1,
+                "def": 2
+            }
+        }
+    }
+])
+
+apply JsonIntEnums @httpResponseTests([
+    {
+        id: "RestJsonJsonIntEnums",
+        documentation: "Serializes intEnums as integers",
+        protocol: restJson1,
+        code: 200,
+        body: """
+              {
+                  "integerEnum1": 1,
+                  "integerEnum2": 2,
+                  "integerEnum3": 3,
+                  "integerEnumList": [
+                      1,
+                      2,
+                      3
+                  ],
+                  "integerEnumSet": [
+                      1,
+                      2
+                  ],
+                  "integerEnumMap": {
+                      "abc": 1,
+                      "def": 2
+                  }
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            integerEnum1: 1,
+            integerEnum2: 2,
+            integerEnum3: 3,
+            integerEnumList: [1, 2, 3],
+            integerEnumSet: [1, 2],
+            integerEnumMap: {
+                "abc": 1,
+                "def": 2
+            }
+        }
+    }
+])
+
+structure JsonIntEnumsInputOutput {
+    integerEnum1: IntegerEnum,
+    integerEnum2: IntegerEnum,
+    integerEnum3: IntegerEnum,
+    integerEnumList: IntegerEnumList,
+    integerEnumSet: IntegerEnumSet,
+    integerEnumMap: IntegerEnumMap,
 }
 
 /// Recursive shapes

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -73,6 +73,7 @@ service RestJson {
         SimpleScalarProperties,
         JsonTimestamps,
         JsonEnums,
+        JsonIntEnums,
         RecursiveShapes,
         JsonLists,
         JsonMaps,

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -120,3 +120,23 @@ structure GreetingStruct {
 list GreetingList {
     member: GreetingStruct
 }
+
+intEnum IntegerEnum {
+    A = 1
+    B = 2
+    C = 3
+}
+
+list IntegerEnumList {
+    member: IntegerEnum
+}
+
+@uniqueItems
+list IntegerEnumSet {
+     member: IntegerEnum
+}
+
+map IntegerEnumMap {
+     key: String,
+     value: IntegerEnum
+}


### PR DESCRIPTION
*Description of changes:*

As part of IDL 2.0, the `intEnum` shape was added. The following changes add several test cases using an `intEnum` shape (and/or aggregates) under the `restJson1` protocol test suite. Included is a set of shared types, which target `intEnum` and aggregate-shapes of `intEnum`, and may be used in follow-up changes to other protocol test suites (awsJson*, *Query, etc.).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
