### PR TITLE
Move useIntegerType to jsonschema

### DIFF
--- a/docs/source-2.0/guides/generating-cloudformation-resources.rst
+++ b/docs/source-2.0/guides/generating-cloudformation-resources.rst
@@ -483,6 +483,27 @@ disableFeatures (``[string]``)
             }
         }
 
+.. _generate-cloudformation-jsonschema-setting-useIntegerType:
+
+useIntegerType (``boolean``)
+    Set to true to use the ``integer`` type when converting ``byte``, ``short``,
+    ``integer``, and ``long`` shapes.
+
+    By default, these shape types are converted with a type of ``number``.
+
+    .. code-block:: json
+
+        {
+            "version": "2.0",
+            "plugins": {
+                "cloudformation": {
+                    "service": "smithy.example#Queues",
+                    "organizationName": "Smithy",
+                    "useIntegerType": true
+                }
+            }
+        }
+
 .. _generate-cloudformation-other-traits:
 
 --------------------------------------

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -110,6 +110,7 @@ public class JsonSchemaConfig {
     private ShapeId service;
     private boolean supportNonNumericFloats = false;
     private boolean enableOutOfServiceReferences = false;
+    private boolean useIntegerType;
 
     public JsonSchemaConfig() {
         nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
@@ -383,5 +384,23 @@ public class JsonSchemaConfig {
      */
     public void setEnableOutOfServiceReferences(boolean enableOutOfServiceReferences) {
         this.enableOutOfServiceReferences = enableOutOfServiceReferences;
+    }
+
+
+    public boolean getUseIntegerType() {
+        return useIntegerType;
+    }
+
+    /**
+     * Set to true to use the "integer" type when converting {@code byte},
+     * {@code short}, {@code integer}, and {@code long} shapes to Json Schema.
+     *
+     * <p>By default, these shape types are converted to Json Schema with a type
+     * of "number".
+     *
+     * @param useIntegerType True to use "integer".
+     */
+    public void setUseIntegerType(boolean useIntegerType) {
+        this.useIntegerType = useIntegerType;
     }
 }

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -129,22 +129,27 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
 
     @Override
     public Schema byteShape(ByteShape shape) {
-        return buildSchema(shape, createBuilder(shape, "number"));
+        return buildIntegerSchema(shape);
     }
 
     @Override
     public Schema shortShape(ShortShape shape) {
-        return buildSchema(shape, createBuilder(shape, "number"));
+        return buildIntegerSchema(shape);
     }
 
     @Override
     public Schema integerShape(IntegerShape shape) {
-        return buildSchema(shape, createBuilder(shape, "number"));
+        return buildIntegerSchema(shape);
     }
 
     @Override
     public Schema longShape(LongShape shape) {
-        return buildSchema(shape, createBuilder(shape, "number"));
+        return buildIntegerSchema(shape);
+    }
+
+    private Schema buildIntegerSchema(Shape shape) {
+        String type = converter.getConfig().getUseIntegerType() ? "integer" : "number";
+        return buildSchema(shape, createBuilder(shape, type));
     }
 
     @Override

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
@@ -270,6 +270,25 @@ public class JsonSchemaConverterTest {
     }
 
     @Test
+    public void convertsIntegersWhenConfigSet() {
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setUseIntegerType(true);
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("integer-types.smithy"))
+                .assemble()
+                .unwrap();
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .model(model)
+                .config(config)
+                .build()
+                .convert();
+
+        Node expected = Node.parse(
+                IoUtils.toUtf8String(getClass().getResourceAsStream("integer-types.jsonschema.json")));
+        Node.assertEquals(document.toNode(), expected);
+    }
+
+    @Test
     public void supportsRangeTrait() {
         IntegerShape shape = IntegerShape.builder()
                 .id("smithy.example#Number")

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/integer-types.jsonschema.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/integer-types.jsonschema.json
@@ -1,0 +1,21 @@
+{
+    "definitions": {
+        "Integers": {
+            "type": "object",
+            "properties": {
+                "byte": {
+                    "type": "integer"
+                },
+                "int": {
+                    "type": "integer"
+                },
+                "long": {
+                    "type": "integer"
+                },
+                "short": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/integer-types.smithy
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/integer-types.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure Integers {
+    byte: Byte
+    short: Short
+    int: Integer
+    long: Long
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -82,8 +82,6 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private Map<String, Node> jsonAdd = Collections.emptyMap();
     private List<String> externalDocs = ListUtils.of(
             "Homepage", "API Reference", "User Guide", "Developer Guide", "Reference", "Guide");
-    private boolean useIntegerType;
-
     private OpenApiVersion version = OpenApiVersion.VERSION_3_0_2;
 
     public OpenApiConfig() {
@@ -310,23 +308,6 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setExternalDocs(List<String> externalDocs) {
         this.externalDocs = Objects.requireNonNull(externalDocs);
-    }
-
-    public boolean getUseIntegerType() {
-        return useIntegerType;
-    }
-
-    /**
-     * Set to true to use the "integer" type when converting {@code byte},
-     * {@code short}, {@code integer}, and {@code long} shapes to OpenAPI.
-     *
-     * <p>By default, these shape types are converted to OpenAPI with a type
-     * of "number".
-     *
-     * @param useIntegerType True to use "integer".
-     */
-    public void setUseIntegerType(boolean useIntegerType) {
-        this.useIntegerType = useIntegerType;
     }
 
     public OpenApiVersion getVersion() {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
@@ -61,15 +61,8 @@ public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
             builder.putExtension("deprecated", Node.from(true));
         }
 
-        // Handle OpenAPI's custom "integer" type.
-        // https://swagger.io/specification/#data-types
         boolean useOpenApiIntegerType = config instanceof OpenApiConfig
                 && ((OpenApiConfig) config).getUseIntegerType();
-        if (useOpenApiIntegerType) {
-            if (shape.isByteShape() || shape.isShortShape() || shape.isIntegerShape() || shape.isLongShape()) {
-                builder.type("integer");
-            }
-        }
 
         // Don't overwrite an existing format setting.
         if (!builder.getFormat().isPresent()) {


### PR DESCRIPTION
The integer type is a sort of vaugely supported thing in json schema, not jsut OpenAPI. So this moves that configuration up to the generic settings so it can also be applied to cloudformation and any future derivative tooling.

The int32 / int64 formats were kept to openapi since that *isn't* referenced in the the json schema spec.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
