### PR TITLE
Fix docs and fail on nitpicky doc warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,10 +11,10 @@ clean:
 	-rm -rf build/*
 
 html1:
-	@$(SPHINXBUILD) -M html "source-1.0" "build/1.0" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M html "source-1.0" "build/1.0" $(SPHINXOPTS) -W --keep-going -n $(O)
 
 html2:
-	@$(SPHINXBUILD) -M html "source-2.0" "build/2.0" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M html "source-2.0" "build/2.0" $(SPHINXOPTS) -W --keep-going -n $(O)
 
 html: html1 html2 merge-versions
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ author = u'Amazon Web Services'
 
 # -- General configuration ------------------------------------------------
 
-extensions = ['sphinx_inline_tabs', 'sphinx_copybutton', 'smithy']
+extensions = ['sphinx_copybutton', 'smithy']
 templates_path = ['../_templates', '../root-redirects']
 
 pygments_style = "default"

--- a/docs/source-1.0/conf.py
+++ b/docs/source-1.0/conf.py
@@ -3,6 +3,7 @@ shared_config = "../conf.py"
 with open(shared_config) as file:
     exec(file.read())
 
+# TODO: Migrate to use the 2.0 tabs library.
 extensions.append("sphinx_tabs.tabs")
 
 # Place version specific overrides after here.

--- a/docs/source-1.0/spec/aws/aws-json.rst.template
+++ b/docs/source-1.0/spec/aws/aws-json.rst.template
@@ -192,52 +192,6 @@ In ``awsJson1_1``, servers SHOULD only send the error's
 for both protocols. See `Operation error serialization`_ for full details on how to
 deserialize errors for |quoted shape name|.
 
-.. smithy-trait:: aws.protocols#awsQueryError
-.. _aws.protocols#awsQueryError-trait:
-
-------------------------------------------
-``aws.protocols#awsQueryCompatible`` trait
-------------------------------------------
-
-Summary
-    When using the :ref:`awsQuery <aws.protocols#awsQuery-trait>` protocol,
-    custom ``Code`` and ``HTTP response code`` values can be defined for an error response via
-    the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>` trait.
-
-    The ``awsQueryCompatible`` trait allows services to backward compatibly migrate from ``awsQuery`` to
-    :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trait>` without removing values defined in the ``awsQueryError`` trait.
-
-    This trait adds the ``x-amzn-query-error`` header in the form of ``Code;Fault`` to error responses.
-    ``Code`` is the value defined in the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>`,
-    and ``Fault`` is one of ``Sender`` or ``Receiver``.
-
-Trait selector
-    ``service [trait|awsJson1_0]``
-
-Value type
-    Annotation trait
-
-.. code-block:: smithy
-
-    $version: "1"
-    use aws.protocols#awsQueryCompatible
-    use aws.protocols#awsQueryError
-    use aws.protocols#awsJson1_0
-
-    @awsQueryCompatible
-    @awsJson1_0
-    service MyService {
-        version: "2020-02-05"
-    }
-
-    @awsQueryError(
-        code: "InvalidThing",
-        httpResponseCode: 400,
-    )
-    @error("client")
-    structure InvalidThingException {
-        message: String
-    }
 
 -------------------------
 Protocol compliance tests

--- a/docs/source-1.0/spec/aws/aws-query-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-query-protocol.rst
@@ -576,6 +576,54 @@ The following example defines an error that uses a custom "Code" of
         }
 
 
+.. smithy-trait:: aws.protocols#awsQueryCompatible
+.. _aws.protocols#awsQueryCompatible-trait:
+
+------------------------------------------
+``aws.protocols#awsQueryCompatible`` trait
+------------------------------------------
+
+Summary
+    When using the :ref:`awsQuery <aws.protocols#awsQuery-trait>` protocol,
+    custom ``Code`` and ``HTTP response code`` values can be defined for an error response via
+    the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>` trait.
+
+    The ``awsQueryCompatible`` trait allows services to backward compatibly migrate from ``awsQuery`` to
+    :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trait>` without removing values defined in the ``awsQueryError`` trait.
+
+    This trait adds the ``x-amzn-query-error`` header in the form of ``Code;Fault`` to error responses.
+    ``Code`` is the value defined in the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>`,
+    and ``Fault`` is one of ``Sender`` or ``Receiver``.
+
+Trait selector
+    ``service [trait|awsJson1_0]``
+
+Value type
+    Annotation trait
+
+.. code-block:: smithy
+
+    $version: "1"
+    use aws.protocols#awsQueryCompatible
+    use aws.protocols#awsQueryError
+    use aws.protocols#awsJson1_0
+
+    @awsQueryCompatible
+    @awsJson1_0
+    service MyService {
+        version: "2020-02-05"
+    }
+
+    @awsQueryError(
+        code: "InvalidThing",
+        httpResponseCode: 400,
+    )
+    @error("client")
+    structure InvalidThingException {
+        message: String
+    }
+
+
 .. _awsQuery-compliance-tests:
 
 -------------------------

--- a/docs/source-2.0/aws/protocols/aws-json.rst.template
+++ b/docs/source-2.0/aws/protocols/aws-json.rst.template
@@ -195,52 +195,6 @@ In ``awsJson1_1``, servers SHOULD only send the error's
 for both protocols. See `Operation error serialization`_ for full details on how to
 deserialize errors for |quoted shape name|.
 
-.. smithy-trait:: aws.protocols#awsQueryError
-.. _aws.protocols#awsQueryError-trait:
-
-------------------------------------------
-``aws.protocols#awsQueryCompatible`` trait
-------------------------------------------
-
-Summary
-    When using the :ref:`awsQuery <aws.protocols#awsQuery-trait>` protocol,
-    custom ``Code`` and ``HTTP response code`` values can be defined for an error response via
-    the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>` trait.
-
-    The ``awsQueryCompatible`` trait allows services to backward compatibly migrate from ``awsQuery`` to
-    :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trait>` without removing values defined in the ``awsQueryError`` trait.
-
-    This trait adds the ``x-amzn-query-error`` header in the form of ``Code;Fault`` to error responses.
-    ``Code`` is the value defined in the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>`,
-    and ``Fault`` is one of ``Sender`` or ``Receiver``.
-
-Trait selector
-    ``service [trait|awsJson1_0]``
-
-Value type
-    Annotation trait
-
-.. code-block:: smithy
-
-    $version: "2"
-    use aws.protocols#awsQueryCompatible
-    use aws.protocols#awsQueryError
-    use aws.protocols#awsJson1_0
-
-    @awsQueryCompatible
-    @awsJson1_0
-    service MyService {
-        version: "2020-02-05"
-    }
-
-    @awsQueryError(
-        code: "InvalidThing",
-        httpResponseCode: 400,
-    )
-    @error("client")
-    structure InvalidThingException {
-        message: String
-    }
 
 -------------------------
 Protocol compliance tests

--- a/docs/source-2.0/aws/protocols/aws-query-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-query-protocol.rst
@@ -536,6 +536,55 @@ The following example defines an error that uses a custom "Code" of
         message: String
     }
 
+
+.. smithy-trait:: aws.protocols#awsQueryCompatible
+.. _aws.protocols#awsQueryCompatible-trait:
+
+------------------------------------------
+``aws.protocols#awsQueryCompatible`` trait
+------------------------------------------
+
+Summary
+    When using the :ref:`awsQuery <aws.protocols#awsQuery-trait>` protocol,
+    custom ``Code`` and ``HTTP response code`` values can be defined for an error response via
+    the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>` trait.
+
+    The ``awsQueryCompatible`` trait allows services to backward compatibly migrate from ``awsQuery`` to
+    :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trait>` without removing values defined in the ``awsQueryError`` trait.
+
+    This trait adds the ``x-amzn-query-error`` header in the form of ``Code;Fault`` to error responses.
+    ``Code`` is the value defined in the :ref:`awsQueryError <aws.protocols#awsQueryError-trait>`,
+    and ``Fault`` is one of ``Sender`` or ``Receiver``.
+
+Trait selector
+    ``service [trait|awsJson1_0]``
+
+Value type
+    Annotation trait
+
+.. code-block:: smithy
+
+    $version: "2"
+    use aws.protocols#awsQueryCompatible
+    use aws.protocols#awsQueryError
+    use aws.protocols#awsJson1_0
+
+    @awsQueryCompatible
+    @awsJson1_0
+    service MyService {
+        version: "2020-02-05"
+    }
+
+    @awsQueryError(
+        code: "InvalidThing",
+        httpResponseCode: 400,
+    )
+    @error("client")
+    structure InvalidThingException {
+        message: String
+    }
+
+
 .. _awsQuery-compliance-tests:
 
 -------------------------

--- a/docs/source-2.0/conf.py
+++ b/docs/source-2.0/conf.py
@@ -3,6 +3,9 @@ shared_config = "../conf.py"
 with open(shared_config) as file:
     exec(file.read())
 
+# TODO: Migrate the 1.0 docs to use this, and move this to the main conf.py.
+extensions.append('sphinx_inline_tabs')
+
 # Place version specific overrides after here.
 html_title = "Smithy 2.0"
 release = u'2.0'


### PR DESCRIPTION
Fixes docs so that they don't emit warnings and will now fail doc builds on nitpicky documentation warnings.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
