### PR TITLE
Update links to point to smithy.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1195,14 +1195,14 @@ from Smithy `Node`s. ([#301](https://github.com/awslabs/smithy/pull/301))
 #### Trait updates
 
 * Individual protocols are now defined as individual traits that are annotated with
-[the `protocolDefinition` trait.](https://awslabs.github.io/smithy/1.0/spec/core/protocol-traits.html#protocoldefinition-trait) [BC]
+[the `protocolDefinition` trait.](https://smithy.io/2.0/spec/protocol-traits.html#protocoldefinition-trait) [BC]
   ([#273](https://github.com/awslabs/smithy/pull/273), [#280](https://github.com/awslabs/smithy/pull/280), [#379](https://github.com/awslabs/smithy/pull/379),
     [#390](https://github.com/awslabs/smithy/pull/390))
-  * Previously listed [AWS protocols now have trait implementations.](https://awslabs.github.io/smithy/1.0/spec/aws/index.html#aws-protocols)
+  * Previously listed [AWS protocols now have trait implementations.](https://smithy.io/2.0/aws/index.html#aws-protocols)
 * Individual authentication schemes are now defined as individual traits that are annotated with
-[the `authDefinition` trait.](https://awslabs.github.io/smithy/1.0/spec/core/auth-traits.html#authdefinition-trait) [BC]
+[the `authDefinition` trait.](https://smithy.io/2.0/spec/authentication-traits.html#authdefinition-trait) [BC]
   ([#273](https://github.com/awslabs/smithy/pull/273), [#280](https://github.com/awslabs/smithy/pull/280))
-  * Previously listed [authentication schemes now have trait implementations.](https://awslabs.github.io/smithy/1.0/spec/core/auth-traits.html)
+  * Previously listed [authentication schemes now have trait implementations.](https://smithy.io/2.0/spec/authentication-traits.html)
 * The `smithy.api#enum` trait is now a list of enum definitions instead of a map of string keys to
 enum definitions to improve clarity and encourage adding more properties to definitions. [BC] ([#326](https://github.com/awslabs/smithy/pull/326))
 * The `aws.api#streaming` trait is now applied to shapes directly instead of members. [BC] ([#340](https://github.com/awslabs/smithy/pull/340))

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ resource City {
     resources: [Forecast]
 }
 
-// See the full example at https://awslabs.github.io/smithy/quickstart.html#complete-example
+// See the full example at https://smithy.io/2.0/quickstart.html#complete-example
 ```
 
 Find out more about modeling a service with Smithy in the [Quick Start
@@ -81,10 +81,10 @@ of the Smithy Gradle Plugin repository.
 
 This library is licensed under the Apache 2.0 License.
 
-[docs]: https://awslabs.github.io/smithy/
-[specs]: https://awslabs.github.io/smithy/2.0/spec/
-[javadocs]: https://awslabs.github.io/smithy/javadoc/latest/
-[quickstart]: https://awslabs.github.io/smithy/quickstart.html
+[docs]: https://smithy.io/
+[specs]: https://smithy.io/2.0/spec/
+[javadocs]: https://smithy.io/javadoc/latest/
+[quickstart]: https://smithy.io/2.0/quickstart.html
 [Smithy Gradle Plugin]: https://github.com/awslabs/smithy-gradle-plugin/
-[`smithy-build.json`]: https://awslabs.github.io/smithy/2.0/guides/building-models/build-config.html#using-smithy-build-json
-[building]: https://awslabs.github.io/smithy/2.0/guides/building-models/index.html
+[`smithy-build.json`]: https://smithy.io/2.0/guides/building-models/build-config.html#using-smithy-build-json
+[building]: https://smithy.io/2.0/guides/building-models/index.html

--- a/docs/smithy/lexer.py
+++ b/docs/smithy/lexer.py
@@ -25,7 +25,7 @@ __all__ = ["SmithyLexer"]
 
 class SmithyLexer(RegexLexer):
     name = "Smithy"
-    url = "https://awslabs.github.io/smithy/"
+    url = "https://smithy.io/"
     filenames = ["*.smithy"]
     aliases = ["smithy"]
 

--- a/docs/source-1.0/conf.py
+++ b/docs/source-1.0/conf.py
@@ -12,4 +12,4 @@ version = release
 
 html_theme_options['source_directory'] = "docs/source-1.0"
 html_theme_options['announcement'] = '''<strong>⚠️ You are viewing version 1.0.</strong><br/>
-Version 2.0 is available at <a href="https://awslabs.github.io/smithy/2.0/">https://awslabs.github.io/smithy/2.0/</a>.'''
+Version 2.0 is available at <a href="https://smithy.io/2.0/">https://smithy.io/2.0/</a>.'''

--- a/docs/source-1.0/guides/generating-cloudformation-resources.rst
+++ b/docs/source-1.0/guides/generating-cloudformation-resources.rst
@@ -559,10 +559,10 @@ service providers. See the `Javadocs`_ for more information.
 .. _modeling a resource provider: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html
 .. _develop the resource provider: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-develop.html
 .. _CloudFormation Command Line Interface: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html
-.. _Smithy Resource: https://awslabs.github.io/smithy/1.0/spec/core/model.html#resource
+.. _Smithy Resource: https://smithy.io/1.0/spec/core/model.html#resource
 .. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin
 .. _type name: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-typeName
-.. _Javadocs: https://awslabs.github.io/smithy/javadoc/__smithy_version__/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/Smithy2CfnExtension.html
+.. _Javadocs: https://smithy.io/javadoc/__smithy_version__/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/Smithy2CfnExtension.html
 .. _the handlers section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-handlers
 .. _the deprecatedProperties section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-deprecatedproperties
 .. _the required property section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-required

--- a/docs/source-1.0/index.rst
+++ b/docs/source-1.0/index.rst
@@ -6,7 +6,7 @@ Smithy
 
 .. danger:: You are viewing version 1.0
 
-    Version 2.0 is available at `<https://awslabs.github.io/smithy/2.0/>`_
+    Version 2.0 is available at `<https://smithy.io/2.0/>`_
 
 
 Read more
@@ -24,11 +24,11 @@ Read more
     :caption: Implementations
     :maxdepth: 1
 
-    Implementations <https://awslabs.github.io/smithy/implementations.html>
+    Implementations <https://smithy.io/2.0/implementations.html>
     ts-ssdk/index
 
 .. toctree::
     :caption: Project links
 
     Source code <https://github.com/awslabs/smithy>
-    2.0 Documentation <https://awslabs.github.io/smithy/2.0/>
+    2.0 Documentation <https://smithy.io/2.0/>

--- a/docs/source-1.0/redirects
+++ b/docs/source-1.0/redirects
@@ -57,4 +57,4 @@
 1.0/guides/evolving-models.rst guides/evolving-models.rst
 1.0/guides/migrating-idl-1-to-2.rst guides/migrating-idl-1-to-2.rst
 1.0/guides/style-guide.rst guides/style-guide.rst
-implementations.rst https://awslabs.github.io/smithy/implementations.html
+implementations.rst https://smithy.io/implementations.html

--- a/docs/source-1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source-1.0/spec/http-protocol-compliance-tests.rst
@@ -836,4 +836,4 @@ specific types of malformed values.
     }
 
 .. _CommonMark: https://spec.commonmark.org/
-.. _CodeWriter: https://awslabs.github.io/smithy/javadoc/1.13.1/software/amazon/smithy/utils/CodeWriter.html
+.. _CodeWriter: https://smithy.io/javadoc/__smithy_version__/software/amazon/smithy/utils/CodeWriter.html

--- a/docs/source-2.0/additional-specs/http-protocol-compliance-tests.rst
+++ b/docs/source-2.0/additional-specs/http-protocol-compliance-tests.rst
@@ -797,4 +797,4 @@ specific types of malformed values.
     }
 
 .. _CommonMark: https://spec.commonmark.org/
-.. _CodeWriter: https://awslabs.github.io/smithy/javadoc/1.13.1/software/amazon/smithy/utils/CodeWriter.html
+.. _CodeWriter: https://smithy.io/javadoc/__smithy_version__/software/amazon/smithy/utils/CodeWriter.html

--- a/docs/source-2.0/guides/generating-cloudformation-resources.rst
+++ b/docs/source-2.0/guides/generating-cloudformation-resources.rst
@@ -582,10 +582,10 @@ service providers. See the `Javadocs`_ for more information.
 .. _modeling a resource provider: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html
 .. _develop the resource provider: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-develop.html
 .. _CloudFormation Command Line Interface: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html
-.. _Smithy Resource: https://awslabs.github.io/smithy/1.0/spec/core/model.html#resource
+.. _Smithy Resource: https://smithy.io/2.0/spec/service-types.html#resource
 .. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin
 .. _type name: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-typeName
-.. _Javadocs: https://awslabs.github.io/smithy/javadoc/__smithy_version__/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/Smithy2CfnExtension.html
+.. _Javadocs: https://smithy.io/javadoc/__smithy_version__/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/Smithy2CfnExtension.html
 .. _the handlers section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-handlers
 .. _the deprecatedProperties section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-deprecatedproperties
 .. _the required property section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-required

--- a/docs/source-2.0/index.rst
+++ b/docs/source-2.0/index.rst
@@ -149,4 +149,4 @@ Read more
 
     implementations
     Source code <https://github.com/awslabs/smithy>
-    1.0 Documentation <https://awslabs.github.io/smithy/1.0/>
+    1.0 Documentation <https://smithy.io/1.0/>

--- a/mkdocs
+++ b/mkdocs
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script updates the documentation hosted at
-# http://awslabs.github.io/smithy/. There is a y/n prompt before a publish
+# https://smithy.io/. There is a y/n prompt before a publish
 # is performed to allow for a spot-check of the changes.
 #
 # This script will run `pip3 install -r requirements.txt` in the docs

--- a/smithy-aws-apigateway-traits/README.md
+++ b/smithy-aws-apigateway-traits/README.md
@@ -1,4 +1,4 @@
 # Smithy AWS API Gateway traits
 
-See the [Smithy specification](https://awslabs.github.io/smithy/1.0/spec/)
+See the [Smithy specification](https://smithy.io/2.0/spec/)
 for details on how these traits are used.

--- a/smithy-aws-cloudformation-traits/README.md
+++ b/smithy-aws-cloudformation-traits/README.md
@@ -1,4 +1,4 @@
 # Smithy AWS CloudFormation traits
 
-See the [Smithy specification](https://awslabs.github.io/smithy/spec/)
+See the [Smithy specification](https://smithy.io/spec/)
 for details on how these traits are used.

--- a/smithy-aws-iam-traits/README.md
+++ b/smithy-aws-iam-traits/README.md
@@ -1,4 +1,4 @@
 # Smithy AWS IAM traits
 
-See the [Smithy specification](https://awslabs.github.io/smithy/1.0/spec/)
+See the [Smithy specification](https://smithy.io/2.0/spec/)
 for details on how these traits are used.

--- a/smithy-aws-protocol-tests/model/restJson1/http-checksums.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-checksums.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP checksum trait(s).
-// See: https://awslabs.github.io/smithy/1.0/spec/core/behavior-traits.html#httpchecksumrequired-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpchecksumrequired-trait
 $version: "2.0"
 
 namespace aws.protocoltests.restjson

--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP header bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httpheader-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP URI label bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httplabel-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httplabel-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP payload bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httppayload-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httppayload-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test httpPrefix headers.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httpprefixheaders-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpprefixheaders-trait
 
 $version: "2.0"
 
@@ -13,7 +13,7 @@ use aws.protocoltests.shared#StringMap
 /// This examples adds headers to the input of a request and response by prefix.
 @readonly
 @http(uri: "/HttpPrefixHeaders", method: "GET")
-@externalDocumentation("httpPrefixHeaders Trait": "https://awslabs.github.io/smithy/1.0/spec/http.html#httpprefixheaders-trait")
+@externalDocumentation("httpPrefixHeaders Trait": "https://smithy.io/2.0/spec/http-bindings.html#httpprefixheaders-trait")
 operation HttpPrefixHeaders  {
     input: HttpPrefixHeadersInput,
     output: HttpPrefixHeadersOutput

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -1,6 +1,6 @@
 // This file defines test cases that test HTTP query string bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httpquery-trait and
-// https://awslabs.github.io/smithy/1.0/spec/http.html#httpqueryparams-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpquery-trait and
+// https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-response-code.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP response code bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#httpresponsecode-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpresponsecode-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/streaming.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP streaming bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/core/stream-traits.html?highlight=streaming#streaming-trait
+// See: https://smithy.io/2.0/spec/streaming.html
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP header bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httpheader-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP URI label bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httplabel-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httplabel-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP payload bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httppayload-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httppayload-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test httpPrefix headers.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httpprefixheaders-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpprefixheaders-trait
 
 $version: "2.0"
 
@@ -12,7 +12,7 @@ use smithy.test#httpResponseTests
 /// This examples adds headers to the input of a request and response by prefix.
 @readonly
 @http(uri: "/HttpPrefixHeaders", method: "GET")
-@externalDocumentation("httpPrefixHeaders Trait": "https://awslabs.github.io/smithy/1.0/spec/http.html#httpprefixheaders-trait")
+@externalDocumentation("httpPrefixHeaders Trait": "https://smithy.io/2.0/spec/http-bindings.html#httpprefixheaders-trait")
 operation HttpPrefixHeaders {
     input: HttpPrefixHeadersInputOutput,
     output: HttpPrefixHeadersInputOutput

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -1,6 +1,6 @@
 // This file defines test cases that test HTTP query string bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/http.html#httpquery-trait and
-// https://awslabs.github.io/smithy/1.0/spec/http.html#httpqueryparams-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpquery-trait and
+// https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait
 
 $version: "2.0"
 

--- a/smithy-aws-protocol-tests/model/restXml/http-response-code.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-response-code.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases that test HTTP response code bindings.
-// See: https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#httpresponsecode-trait
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpresponsecode-trait
 
 $version: "2.0"
 

--- a/smithy-aws-traits/README.md
+++ b/smithy-aws-traits/README.md
@@ -2,5 +2,5 @@
 
 Provides traits and validators that are used by most AWS services.
 
-See the [Smithy specification](https://awslabs.github.io/smithy/1.0/spec/)
+See the [Smithy specification](https://smithy.io/2.0/spec/)
 for details on how these traits are used.

--- a/smithy-build/README.md
+++ b/smithy-build/README.md
@@ -4,5 +4,5 @@ This module is a library used to validate Smithy models, create filtered
 projections of a model, and generate build artifacts.
 
 
-- [Online documentation](https://awslabs.github.io/smithy/guides/building-models/build-config.html)
+- [Online documentation](https://smithy.io/2.0/guides/building-models/build-config.html)
 - [Documentation source](https://github.com/awslabs/smithy/blob/main/docs/source/guides/building-models/build-config.rst)


### PR DESCRIPTION
This also updates them to point to 2.0 where relevant


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
