### PR TITLE
Improve member not targeting a property error message to better hint at fix

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceOperationInputOutputValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceOperationInputOutputValidator.java
@@ -221,9 +221,8 @@ public final class ResourceOperationInputOutputValidator extends AbstractValidat
                         properties.get(propertyName).toString())));
             }
         } else if (!identifierMembers.contains(member.getMemberName())) {
-            events.add(error(member, String.format("Member `%s` does not target a property for resource `%s`",
-                    member.getMemberName(),
-                    resource.getId().toString())));
+            events.add(error(member, String.format("Member `%s` does not target a property or identifier"
+                    + " for resource `%s`", member.getMemberName(), resource.getId().toString())));
         }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-properties/invalid-output-identifier.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-properties/invalid-output-identifier.errors
@@ -1,1 +1,1 @@
-[ERROR] com.example#CreateResourceOutput$id: Member `id` does not target a property for resource `com.example#Resource1` | ResourceOperationInputOutput
+[ERROR] com.example#CreateResourceOutput$id: Member `id` does not target a property or identifier for resource `com.example#Resource1` | ResourceOperationInputOutput

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-properties/resource-properties-errors.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/resource-properties/resource-properties-errors.errors
@@ -1,4 +1,4 @@
 [ERROR] smithy.example#GetForecastOutput: This shape contains members with conflicting property names that resolve to 'chanceOfRain': chanceOfRain, chancesOfRain | ResourceOperationInputOutput
 [ERROR] smithy.example#GetForecastInput: This shape contains members with conflicting property names that resolve to 'chanceOfRain': chancesOfRain, howLikelyToRain | ResourceOperationInputOutput
-[ERROR] smithy.example#GetForecastInput$memberIsNotProperty: Member `memberIsNotProperty` does not target a property for resource `smithy.example#Forecast` | ResourceOperationInputOutput
+[ERROR] smithy.example#GetForecastInput$memberIsNotProperty: Member `memberIsNotProperty` does not target a property or identifier for resource `smithy.example#Forecast` | ResourceOperationInputOutput
 [ERROR] smithy.example#Forecast: The resource property `booleanProperty` has a conflicting target shape `smithy.api#String` on the `read` operation which targets `smithy.api#Boolean`. | ResourceOperationInputOutput


### PR DESCRIPTION
*Issue #, if available:*
When a resource properties block is present in a resource shape, all members of instance operations must be an identifier, property, or somehow marked as `@notProperty`. Implicit identifier bindings are formed through indirect requirements (name, target shape match, required) but the modeler may miss any of them -- likely the  `@required` trait, especially when using target elision syntax. The validator for properties uses the identifier binding index as a filter, however this binding index won't see an intended ID as such if it's missing the @required trait as clearly as the modeler does and leads to an error message that may be confusing in isolation. This change attempts to orient a modeler correctly to more correctly understand what possible mistakes were made.

Note: given the scenario mentioned, core validation will also produce another error at the same time:
```
[ERROR] ... This operation does not form a valid instance operation when bound to resource `...`. All of the identifiers of the resource were not implicitly or explicitly bound to the input of the operation. Expected the following identifier bindings: [required member named `...` that targets `...`]
```

Whether the intend for the member to be an identifier or property, or neither at all is ambiguous. Elision syntax makes it clear to the modeler, but the validator has no visibility there. A further improvement might be to suppress the property error if the identifier error is observed.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
