### PR TITLE
publish docs via SSH

### DIFF
--- a/mkdocs
+++ b/mkdocs
@@ -25,7 +25,7 @@ fi
 
 # Clone a copy of smithy into a staging directory
 rm -rf /tmp/_smithy-docs
-git clone https://github.com/awslabs/smithy.git --branch gh-pages --single-branch /tmp/_smithy-docs
+git clone git@github.com:awslabs/smithy.git --branch gh-pages --single-branch /tmp/_smithy-docs
 cd /tmp/_smithy-docs
 git checkout gh-pages
 cd -


### PR DESCRIPTION
This updates the mkdocs script to perform git operations over SSH instead of HTTPS.

With this change, the resulting temp directory used for publishing docs is setup with the correct remotes:
```
╰─⠠⠵ git remote -v
origin	git@github.com:awslabs/smithy.git (fetch)
origin	git@github.com:awslabs/smithy.git (push)
```

When the script then performs the docs branch push, `git push origin gh-pages`, it will be over SSH instead of HTTPS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
