### PR TITLE
Add typechecking to EndpointRuleset build

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/EndpointRuleSet.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/EndpointRuleSet.java
@@ -229,7 +229,9 @@ public final class EndpointRuleSet extends MandatorySourceLocation implements Ty
 
         @Override
         public EndpointRuleSet build() {
-            return new EndpointRuleSet(this);
+            EndpointRuleSet ruleSet = new EndpointRuleSet(this);
+            ruleSet.typecheck();
+            return ruleSet;
         }
     }
 }

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/IntegrationTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/IntegrationTest.java
@@ -126,7 +126,7 @@ public class IntegrationTest {
             EndpointRuleSet ruleset = EndpointRuleSet.fromNode(validationTestCase.contents());
             ruleset.typeCheck(new Scope<>());
         });
-        //validationTestCase.overrideComments(error.toString());
+        // validationTestCase.overrideComments(error.toString());
         assertEquals(
                 validationTestCase.comments().replaceAll("\\s+", " ").trim(),
                 error.toString().replaceAll("\\s+", " ").trim());

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/IntegrationTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/IntegrationTest.java
@@ -123,10 +123,9 @@ public class IntegrationTest {
     @MethodSource("invalidTestCases")
     void checkInvalidRules(ValidationTestCase validationTestCase) throws IOException {
         RuleError error = assertThrows(RuleError.class, () -> {
-            EndpointRuleSet ruleset = EndpointRuleSet.fromNode(validationTestCase.contents());
-            ruleset.typeCheck(new Scope<>());
+            EndpointRuleSet.fromNode(validationTestCase.contents());
         });
-        // validationTestCase.overrideComments(error.toString());
+        //validationTestCase.overrideComments(error.toString());
         assertEquals(
                 validationTestCase.comments().replaceAll("\\s+", " ").trim(),
                 error.toString().replaceAll("\\s+", " ").trim());

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/bool-equals-unset.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/bool-equals-unset.json5
@@ -1,5 +1,6 @@
+// when parsing endpoint ruleset
 // while typechecking booleanEquals(true, UseDualStack)
-//   at invalid-rules/bool-equals-unset.json5:21
+//   at invalid-rules/bool-equals-unset.json5:22
 // Unexpected type in the second argument: Expected Bool but found Option<Bool>   
 //   hint: use `assign` in a condition or `isSet(UseDualStack)` to prove that this value is non-null
 {

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/cant-template-bool.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/cant-template-bool.json5
@@ -1,11 +1,12 @@
+// when parsing endpoint ruleset
 // while typechecking
-//   at invalid-rules/cant-template-bool.json5:19
+//   at invalid-rules/cant-template-bool.json5:20
 // while typechecking the endpoint
-//   at invalid-rules/cant-template-bool.json5:21
+//   at invalid-rules/cant-template-bool.json5:22
 // while checking the URL
 // while typechecking "{enabled}.amazonaws.com"
 // while typechecking the template `"{enabled}.amazonaws.com"`
-//   at invalid-rules/cant-template-bool.json5:22
+//   at invalid-rules/cant-template-bool.json5:23
 // Expected string but found Bool
 {
   "version": "1.2",

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/empty-tree-rule.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/empty-tree-rule.json5
@@ -1,4 +1,5 @@
-//   at invalid-rules/empty-tree-rule.json5:13
+// when parsing endpoint ruleset
+//   at invalid-rules/empty-tree-rule.json5:14
 // Tree rule contains no rules!
 {
   "version": "1.2",

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/field-in-wrong-tree.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/field-in-wrong-tree.json5
@@ -1,11 +1,12 @@
+// when parsing endpoint ruleset
 // while typechecking
-//   at invalid-rules/field-in-wrong-tree.json5:40
+//   at invalid-rules/field-in-wrong-tree.json5:41
 // while typechecking the endpoint
-//   at invalid-rules/field-in-wrong-tree.json5:42
+//   at invalid-rules/field-in-wrong-tree.json5:43
 // while checking the URL
 // while typechecking "{partitionResult#name}.amazonaws.com"
 // while typechecking the template `"{partitionResult#name}.amazonaws.com"`
-//   at invalid-rules/field-in-wrong-tree.json5:43
+//   at invalid-rules/field-in-wrong-tree.json5:44
 // while checking {partitionResult#name}
 // while typechecking partitionResult#name
 // while typechecking partitionResult

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/invalid-slice.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/invalid-slice.json5
@@ -1,11 +1,12 @@
+// when parsing endpoint ruleset
 // while typechecking `bucket is set, handle bucket specific endpoints`
-//   at invalid-rules/invalid-slice.json5:18
+//   at invalid-rules/invalid-slice.json5:19
 // while typechecking the endpoint
-//   at invalid-rules/invalid-slice.json5:39
+//   at invalid-rules/invalid-slice.json5:40
 // while checking the URL
 // while typechecking "{bucketArn#accountId}.{bucketArn#resourceId[2]}.{bucketArn#region}"
 // while typechecking the template `"{bucketArn#accountId}.{bucketArn#resourceId[2]}.{bucketArn#region}"`
-//   at invalid-rules/invalid-slice.json5:40
+//   at invalid-rules/invalid-slice.json5:41
 // Expected string but found Option<String>. hint: use `assign` in a condition or `isSet` to prove that this value is non-null
 {
   "version": "1.2",

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/no-shadowing-assignments.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/no-shadowing-assignments.json5
@@ -1,5 +1,6 @@
-//   at invalid-rules/no-shadowing-assignments.json5:25
-// Invalid shadowing of `Region` (first declared on line 17)
+// when parsing endpoint ruleset
+//   at invalid-rules/no-shadowing-assignments.json5:26
+// Invalid shadowing of `Region` (first declared on line 18)
 {
   "version": "1.2",
   "parameters": {

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/no-shadowing-params.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/no-shadowing-params.json5
@@ -1,5 +1,6 @@
-//   at invalid-rules/no-shadowing-params.json5:22
-// Invalid shadowing of `Region` (first declared on line 6)
+// when parsing endpoint ruleset
+//   at invalid-rules/no-shadowing-params.json5:23
+// Invalid shadowing of `Region` (first declared on line 7)
 {
   "version": "1.2",
   "parameters": {

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/only-refs-coerce-isset.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/only-refs-coerce-isset.json5
@@ -1,17 +1,18 @@
+// when parsing endpoint ruleset
 // while typechecking `region is set`
-//   at invalid-rules/only-refs-coerce-isset.json5:28
+//   at invalid-rules/only-refs-coerce-isset.json5:29
 // while checking nested rule in tree rule
 // while typechecking `bucket is set, handle bucket specific endpoints`
-//   at invalid-rules/only-refs-coerce-isset.json5:49
+//   at invalid-rules/only-refs-coerce-isset.json5:50
 // while checking nested rule in tree rule
 // while typechecking `bucket is set and is an arn`
-//   at invalid-rules/only-refs-coerce-isset.json5:63
+//   at invalid-rules/only-refs-coerce-isset.json5:64
 // while typechecking the endpoint
-//   at invalid-rules/only-refs-coerce-isset.json5:86
+//   at invalid-rules/only-refs-coerce-isset.json5:87
 // while checking the URL
 // while typechecking "https://{bucketArn#resourceId[1]}-{bucketArn#accountId}.{bucketArn#region}.{partitionResult#dnsSuffix}"
 // while typechecking the template `"https://{bucketArn#resourceId[1]}-{bucketArn#accountId}.{bucketArn#region}.{partitionResult#dnsSuffix}"`
-//   at invalid-rules/only-refs-coerce-isset.json5:87
+//   at invalid-rules/only-refs-coerce-isset.json5:88
 // Expected string but found Option<String>. hint: use `assign` in a condition or `isSet` to prove that this value is non-null
 {
   "version": "1.2",

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/string-equals-unset.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/string-equals-unset.json5
@@ -1,5 +1,6 @@
+// when parsing endpoint ruleset
 // while typechecking stringEquals("local", Region)
-//   at invalid-rules/string-equals-unset.json5:17
+//   at invalid-rules/string-equals-unset.json5:18
 // Unexpected type in the second argument: Expected String but found Option<String>   
 //   hint: use `assign` in a condition or `isSet(Region)` to prove that this value is non-null
 {

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/unknown-field.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/unknown-field.json5
@@ -1,11 +1,12 @@
+// when parsing endpoint ruleset
 // while typechecking
-//   at invalid-rules/unknown-field.json5:22
+//   at invalid-rules/unknown-field.json5:23
 // while typechecking the endpoint
-//   at invalid-rules/unknown-field.json5:34
+//   at invalid-rules/unknown-field.json5:35
 // while checking the URL
 // while typechecking "{partitionResult#nme}.amazonaws.com"
 // while typechecking the template `"{partitionResult#nme}.amazonaws.com"`
-//   at invalid-rules/unknown-field.json5:35
+//   at invalid-rules/unknown-field.json5:36
 // while checking {partitionResult#nme}
 // while typechecking partitionResult#nme
 // {name=String, dnsSuffix=String, dualStackDnsSuffix=String, supportsDualStack=Bool, supportsFIPS=Bool} does not contain field nme

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/unset-in-wrong-tree.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/unset-in-wrong-tree.json5
@@ -1,11 +1,12 @@
+// when parsing endpoint ruleset
 // while typechecking
-//   at invalid-rules/unset-in-wrong-tree.json5:35
+//   at invalid-rules/unset-in-wrong-tree.json5:36
 // while typechecking the endpoint
-//   at invalid-rules/unset-in-wrong-tree.json5:37
+//   at invalid-rules/unset-in-wrong-tree.json5:38
 // while checking the URL
 // while typechecking "{region}.amazonaws.com"
 // while typechecking the template `"{region}.amazonaws.com"`
-//   at invalid-rules/unset-in-wrong-tree.json5:38
+//   at invalid-rules/unset-in-wrong-tree.json5:39
 // Expected string but found Option<String>. hint: use `assign` in a condition or `isSet` to prove that this value is non-null
 {
   "version": "1.2",

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/wrong-default-type.json5
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/invalid-rules/wrong-default-type.json5
@@ -1,4 +1,5 @@
-//   at invalid-rules/wrong-default-type.json5:6
+// when parsing endpoint ruleset
+//   at invalid-rules/wrong-default-type.json5:7
 // Invalid type for field "default": Type must match parameter type. Expected String, found Bool.
 {
   "version": "1.2",


### PR DESCRIPTION
*Description of changes:*
Typechecking was previously not done during build - it required users to explicitly call typecheck on their rules - resulting in invalid rulesets not being caught.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
