### PR TITLE
Add warnings for private access on traits

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
 import software.amazon.smithy.model.neighbor.Relationship;
+import software.amazon.smithy.model.neighbor.RelationshipType;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -35,7 +36,7 @@ public final class PrivateAccessValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        NeighborProvider provider = NeighborProviderIndex.of(model).getReverseProvider();
+        NeighborProvider provider = NeighborProviderIndex.of(model).getReverseProviderWithTraitRelationships();
 
         List<ValidationEvent> events = new ArrayList<>();
         for (Shape privateShape : model.getShapesWithTrait(PrivateTrait.class)) {
@@ -49,12 +50,25 @@ public final class PrivateAccessValidator extends AbstractValidator {
         String namespace = shape.getId().getNamespace();
         for (Relationship rel : relationships) {
             if (!rel.getShape().getId().getNamespace().equals(namespace)) {
-                events.add(error(rel.getShape(), String.format(
-                        "This shape has an invalid %s relationship that targets a private shape, `%s`, in "
-                        + "another namespace.",
-                        rel.getRelationshipType().toString().toLowerCase(Locale.US),
-                        rel.getNeighborShape().get().getId())));
+                ValidationEvent privateAccessValidationEvent = getPrivateAccessValidationEvent(rel);
+                events.add(privateAccessValidationEvent);
             }
+        }
+    }
+
+    private ValidationEvent getPrivateAccessValidationEvent(Relationship relationship) {
+        String message = String.format(
+                "This shape has an invalid %s relationship that targets a private shape, `%s`, in another namespace.",
+                relationship.getRelationshipType().toString().toLowerCase(Locale.US),
+                relationship.getNeighborShape().get().getId());
+
+        // For now, emit a warning for trait relationships instead of an error. This is because private access on trait
+        // relationships was not being validated in the past, so emitting a warning maintains backward compatibility.
+        // This will be upgraded to an error in the future.
+        if (relationship.getRelationshipType().equals(RelationshipType.TRAIT)) {
+            return warning(relationship.getShape(), message);
+        } else {
+            return error(relationship.getShape(), message);
         }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-access.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-access.errors
@@ -6,3 +6,4 @@
 [ERROR] smithy.example#InvalidOperation: This shape has an invalid output relationship that targets a private shape, `smithy.private#InvalidOperationOutput`, in another namespace. | PrivateAccess
 [ERROR] smithy.example#InvalidService: This shape has an invalid operation relationship that targets a private shape, `smithy.private#PrivateOperation`, in another namespace. | PrivateAccess
 [ERROR] smithy.example#InvalidStructure$invalid: This shape has an invalid member_target relationship that targets a private shape, `smithy.private#PrivateString`, in another namespace. | PrivateAccess
+[WARNING] smithy.example#InvalidTraitApplication: This shape has an invalid trait relationship that targets a private shape, `smithy.private#privateTrait`, in another namespace. | PrivateAccess

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-access.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-access.json
@@ -50,6 +50,20 @@
                 }
             ]
         },
+        "smithy.example#InvalidTraitApplication": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.private#privateTrait": {}
+            }
+        },
+        "smithy.private#privateTrait": {
+            "type": "structure",
+            "traits": {
+                "smithy.api#trait": {},
+                "smithy.api#private": {}
+            }
+        },
         "smithy.private#InvalidOperationInput": {
             "type": "structure",
             "members": {
@@ -64,6 +78,9 @@
                 },
                 "map": {
                     "target": "smithy.example#InvalidMap"
+                },
+                "traitApplication": {
+                    "target": "smithy.example#InvalidTraitApplication"
                 }
             },
             "traits": {
@@ -85,6 +102,9 @@
                 },
                 "map": {
                     "target": "smithy.example#InvalidMap"
+                },
+                "traitApplication": {
+                    "target": "smithy.example#InvalidTraitApplication"
                 }
             },
             "traits": {


### PR DESCRIPTION
Previously, it was possible to refer to a trait marked with `@private` from another namespace. This commit makes doing this cause a warning. A warning is used instead of an error to maintain backward compatibility, but it will be upgraded to an error in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
