### PR TITLE
Fix grammar for MapMembers

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -198,7 +198,7 @@ string support defined in :rfc:`7405`.
     ElidedListMember        :%s"$member"
     ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] *`WS` `MapMembers`
-    MapMembers              :"{" *`WS` `MapKey` `BR` `MapValue` *`WS` "}"
+    MapMembers              :"{" *`WS` `MapKey` `WS` `MapValue` *`WS` "}"
     MapKey                  :`TraitStatements` (`ElidedMapKey` / `ExplicitMapKey`)
     MapValue                :`TraitStatements` (`ElidedMapValue` / `ExplicitMapValue`)
     ElidedMapKey            :%s"$key"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/maps-2.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/maps-2.0.json
@@ -1,0 +1,136 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.example#A": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
+            }
+        },
+        "com.example#B": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String"
+            },
+            "value": {
+                "target": "com.example#String"
+            }
+        },
+        "com.example#C": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String"
+            },
+            "value": {
+                "target": "com.example#String"
+            },
+            "traits": {
+                "smithy.api#deprecated": {}
+            }
+        },
+        "com.example#D": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String"
+            },
+            "value": {
+                "target": "com.example#String"
+            },
+            "traits": {
+                "smithy.api#deprecated": {},
+                "smithy.api#since": "1.0"
+            }
+        },
+        "com.example#E": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String",
+                "traits": {
+                    "smithy.api#internal": {},
+                    "smithy.api#since": "1.1"
+                }
+            },
+            "value": {
+                "target": "com.example#String"
+            },
+            "traits": {
+                "smithy.api#deprecated": {},
+                "smithy.api#since": "1.0"
+            }
+        },
+        "com.example#F": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String",
+                "traits": {
+                    "smithy.api#internal": {},
+                    "smithy.api#since": "1.1"
+                }
+            },
+            "value": {
+                "target": "com.example#String",
+                "traits": {
+                    "smithy.api#internal": {},
+                    "smithy.api#since": "1.1"
+                }
+            },
+            "traits": {
+                "smithy.api#deprecated": {},
+                "smithy.api#since": "1.0"
+            }
+        },
+        "com.example#G": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String",
+                "traits": {
+                    "smithy.api#internal": {},
+                    "smithy.api#since": "1.1"
+                }
+            },
+            "value": {
+                "target": "com.example#String",
+                "traits": {
+                    "smithy.api#since": "1.2"
+                }
+            },
+            "traits": {
+                "smithy.api#deprecated": {},
+                "smithy.api#since": "1.0"
+            }
+        },
+        "com.example#H": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String"
+            },
+            "value": {
+                "target": "com.example#String"
+            }
+        },
+        "com.example#I": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String"
+            },
+            "value": {
+                "target": "com.example#String"
+            }
+        },
+        "com.example#J": {
+            "type": "map",
+            "key": {
+                "target": "com.example#String"
+            },
+            "value": {
+                "target": "com.example#String"
+            }
+        },
+        "com.example#String": {
+            "type": "string"
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/maps-2.0.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/maps-2.0.smithy
@@ -1,0 +1,57 @@
+$version: "2.0"
+namespace com.example
+
+map A {
+    key: smithy.api#String,
+    value: smithy.api#String
+}
+map B{key:String, value:String}
+
+@deprecated
+map C {
+    key: String,
+    value: String
+}
+
+@deprecated
+@since("1.0")
+map D { key : String ,value: String }
+
+@deprecated
+@since("1.0")
+map E {
+    @internal @since("1.1") key: String ,
+    value:String, // trailing comma
+}
+
+@deprecated @since("1.0")
+map F {
+    @internal
+    @since("1.1")
+    key: String,
+
+    @internal
+    @since("1.1")
+    value: String
+}
+
+@deprecated @since("1.0")
+map G {
+    @internal
+    @since("1.1")
+    key: String
+,
+    @since("1.2")
+    value: String
+}
+
+string String
+
+map H{key:String value:String}
+
+map I {
+    key:String
+    value:String
+}
+
+map J {key:String,,,value:String}


### PR DESCRIPTION
MapMembers grammar was incorrectly stating a BR was required between the key and value, but actually WS is required. This was already reflected in the implementation, and the previous grammar was at odds with being able to use a comma to separate the key and value members. I added a new test case for 2.0 models and map parsing.

Closes #1511

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
