### PR TITLE
Refactor CLI printing and colors

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -163,8 +163,12 @@
         <module name="RightCurly">
             <property name="id" value="RightCurlyAlone"/>
             <property name="option" value="alone"/>
-            <property name="tokens"
-                      value="CLASS_DEF, METHOD_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+            <property name="tokens" value="LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAloneOrSingle"/>
+            <property name="option" value="alone_or_singleline"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF"/>
         </module>
 
         <!-- Checks for common coding problems               -->

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 public final class IntegUtils {
 
@@ -47,7 +48,7 @@ public final class IntegUtils {
     }
 
     public static void run(String projectName, List<String> args, Consumer<RunResult> consumer) {
-        run(projectName, args, Collections.emptyMap(), consumer);
+        run(projectName, args, MapUtils.of(EnvironmentVariable.NO_COLOR.toString(), "true"), consumer);
     }
 
     public static void run(String projectName, List<String> args, Map<String, String> env,

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
@@ -18,9 +18,11 @@ package software.amazon.smithy.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 public class RootCommandTest {
     @Test
@@ -36,6 +38,9 @@ public class RootCommandTest {
         IntegUtils.run("simple-config-sources", ListUtils.of("-h"), result -> {
             assertThat(result.getExitCode(), equalTo(0));
             ensureHelpOutput(result);
+
+            // We force NO_COLOR by default in the run method. Test that's honored here.
+            assertThat(result.getOutput(), not(containsString("[0m")));
         });
     }
 
@@ -68,6 +73,17 @@ public class RootCommandTest {
         IntegUtils.run("simple-config-sources", ListUtils.of("--foo"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
             assertThat(result.getOutput(), containsString("Unknown argument or command: --foo"));
+        });
+    }
+
+    @Test
+    public void runsWithColors() {
+        IntegUtils.run("simple-config-sources",
+                       ListUtils.of("--help"),
+                       MapUtils.of(EnvironmentVariable.FORCE_COLOR.toString(), "true"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("[0m"));
         });
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Ansi.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Ansi.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Styles text using ANSI color codes.
+ */
+public enum Ansi {
+
+    /**
+     * Writes using ANSI colors if it detects that the environment supports color.
+     */
+    AUTO {
+        private final Ansi delegate = Ansi.detect();
+
+        @Override
+        public String style(String text, Style... styles) {
+            return delegate.style(text, styles);
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            delegate.style(appendable, text, styles);
+        }
+    },
+
+    /**
+     * Does not write any color.
+     */
+    NO_COLOR {
+        @Override
+        public String style(String text, Style... styles) {
+            return text;
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            try {
+                appendable.append(text);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    },
+
+    /**
+     * Writes with ANSI colors.
+     */
+    FORCE_COLOR {
+        @Override
+        public String style(String text, Style... styles) {
+            StringBuilder builder = new StringBuilder();
+            style(builder, text, styles);
+            return builder.toString();
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            try {
+                appendable.append("\033[");
+                boolean isAfterFirst = false;
+                for (Style style : styles) {
+                    if (isAfterFirst) {
+                        appendable.append(';');
+                    }
+                    appendable.append(style.toString());
+                    isAfterFirst = true;
+                }
+                appendable.append('m');
+                appendable.append(text);
+                appendable.append("\033[0m");
+            } catch (IOException e) {
+                throw new CliError("Error writing output", 2, e);
+            }
+        }
+    };
+
+    /**
+     * Detects if ANSI colors are supported and returns the appropriate Ansi enum variant.
+     *
+     * <p>This method differs from using the {@link Ansi#AUTO} variant directly because it will detect any changes
+     * to the environment that might enable or disable colors.
+     *
+     * @return Returns the detected ANSI color enum variant.
+     */
+    public static Ansi detect() {
+        return isAnsiEnabled() ? FORCE_COLOR : NO_COLOR;
+    }
+
+    /**
+     * Styles text using ANSI color codes.
+     *
+     * @param text Text to style.
+     * @param styles Styles to apply.
+     * @return Returns the styled text.
+     */
+    public abstract String style(String text, Style... styles);
+
+    /**
+     * Styles text using ANSI color codes and writes it to an Appendable.
+     *
+     * @param appendable Where to write styled text.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    public abstract void style(Appendable appendable, String text, Style... styles);
+
+    private static boolean isAnsiEnabled() {
+        if (EnvironmentVariable.FORCE_COLOR.isSet()) {
+            return true;
+        }
+
+        // Disable colors if NO_COLOR is set to anything.
+        if (EnvironmentVariable.NO_COLOR.isSet()) {
+            return false;
+        }
+
+        String term = EnvironmentVariable.TERM.get();
+
+        // If term is set to "dumb", then don't use colors.
+        if (Objects.equals(term, "dumb")) {
+            return false;
+        }
+
+        // If TERM isn't set at all and Windows is detected, then don't use colors.
+        if (term == null && System.getProperty("os.name").contains("win")) {
+            return false;
+        }
+
+        // Disable colors if no console is associated.
+        return System.console() != null;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
@@ -61,7 +61,5 @@ public interface ArgumentReceiver {
      *
      * @param printer Printer to modify.
      */
-    default void registerHelp(HelpPrinter printer) {
-        // do nothing by default.
-    }
+    default void registerHelp(HelpPrinter printer) {}
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -15,14 +15,59 @@
 
 package software.amazon.smithy.cli;
 
+import java.io.BufferedWriter;
+import java.io.Flushable;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.function.Consumer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Handles text output of the CLI.
  */
-public interface CliPrinter {
+@FunctionalInterface
+public interface CliPrinter extends Flushable {
+
+    /**
+     * Create a new CliPrinter from a PrintWriter.
+     *
+     * @param ansi Ansi color settings to use.
+     * @param printWriter PrintWriter to write to.
+     * @return Returns the created CliPrinter.
+     */
+    static CliPrinter fromPrintWriter(Ansi ansi, PrintWriter printWriter) {
+        return new CliPrinter() {
+            @Override
+            public void println(String text) {
+                printWriter.println(text);
+            }
+
+            @Override
+            public Ansi ansi() {
+                return ansi;
+            }
+
+            @Override
+            public void flush() {
+                printWriter.flush();
+            }
+        };
+    }
+
+    /**
+     * Create a new CliPrinter from an OutputStream.
+     *
+     * @param ansi Ansi color settings to use.
+     * @param stream OutputStream to write to.
+     * @return Returns the created CliPrinter.
+     */
+    static CliPrinter fromOutputStream(Ansi ansi, OutputStream stream) {
+        Charset charset = StandardCharsets.UTF_8;
+        PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(stream, charset)), false);
+        return fromPrintWriter(ansi, writer);
+    }
+
     /**
      * Prints text to the writer and appends a new line.
      *
@@ -31,86 +76,111 @@ public interface CliPrinter {
     void println(String text);
 
     /**
-     * Styles the given text using ANSI escape sequences.
+     * Prints a styled line of text using ANSI colors.
      *
-     * <p>It is strongly recommended to use the constants defined in
-     * {@link Style} to provide valid combinations of ANSI color escape
-     * codes.
-     *
-     * @param text Text to style.
-     * @param styles ANSI escape codes.
-     * @return Returns the styled text.
+     * @param text Text to style and write.
+     * @param styles Styles to apply.
      */
-    default String style(String text, Style... styles) {
-        return Style.format(text, styles);
+    default void println(String text, Style... styles) {
+        println(ansi().style(text, styles));
     }
 
     /**
-     * Print an exception to the printer.
+     * Flushes any buffers in the printer.
+     */
+    default void flush() {}
+
+    /**
+     * Gets the ANSI color style setting used by the printer.
      *
-     * @param e Exception to print.
-     * @param stacktrace Whether to include a stack trace.
+     * @return Returns the ANSI color style.
      */
-    default void printException(Throwable e, boolean stacktrace) {
-        if (!stacktrace) {
-            println(style(e.getMessage(), Style.RED));
-        } else {
-            StringWriter writer = new StringWriter();
-            e.printStackTrace(new PrintWriter(writer));
-            String result = writer.toString();
-            int positionOfName = result.indexOf(':');
-            result = style(result.substring(0, positionOfName), Style.RED, Style.UNDERLINE)
-                     + result.substring(positionOfName);
-            println(result);
-        }
+    default Ansi ansi() {
+        return Ansi.AUTO;
     }
 
     /**
-     * CliPrinter that calls a Consumer that accepts a CharSequence.
+     * Creates a {@link Buffer} used to build up a long string of text.
+     *
+     * @return Returns the buffer. Call {@link Buffer#close()} or use try-with-resources to write to the printer.
      */
-    final class ConsumerPrinter implements CliPrinter {
-        private final Consumer<CharSequence> consumer;
-
-        public ConsumerPrinter(Consumer<CharSequence> consumer) {
-            this.consumer = consumer;
-        }
-
-        @Override
-        public void println(String text) {
-            consumer.accept(text + System.lineSeparator());
-        }
+    default Buffer buffer() {
+        return new Buffer(this);
     }
 
     /**
-     * A CliPrinter that prints ANSI colors if able and allowed.
+     * A buffer associated with a {@link CliPrinter} used to build up a string of ANSI color stylized text.
+     *
+     * <p>This class is not thread safe; it's a convenient way to build up a long string of text that uses ANSI styles
+     * before ultimately calling {@link #close()}, which writes it to the attached printer.
      */
-    final class ColorPrinter implements CliPrinter {
-        private final CliPrinter delegate;
-        private final StandardOptions options;
-        private final boolean ansiSupported;
+    final class Buffer implements Appendable, AutoCloseable {
+        private final CliPrinter printer;
+        private final StringBuilder builder = new StringBuilder();
 
-        public ColorPrinter(CliPrinter delegate, StandardOptions options) {
-            this.delegate = delegate;
-            this.options = options;
-            this.ansiSupported = isAnsiColorSupported();
-        }
-
-        private static boolean isAnsiColorSupported() {
-            return System.console() != null && System.getenv().get("TERM") != null;
+        private Buffer(CliPrinter printer) {
+            this.printer = printer;
         }
 
         @Override
-        public void println(String text) {
-            delegate.println(text);
+        public String toString() {
+            return builder.toString();
         }
 
         @Override
-        public String style(String text, Style... styles) {
-            if (options.forceColor() || (!options.noColor() && ansiSupported)) {
-                return delegate.style(text, styles);
-            } else {
-                return text;
-            }
+        public Buffer append(CharSequence csq) {
+            builder.append(csq);
+            return this;
+        }
+
+        @Override
+        public Buffer append(CharSequence csq, int start, int end) {
+            builder.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public Buffer append(char c) {
+            builder.append(c);
+            return this;
+        }
+
+        /**
+         * Writes styled text to the builder using the CliPrinter's Ansi settings.
+         *
+         * @param text Text to write.
+         * @param styles Styles to apply to the text.
+         * @return Returns self.
+         */
+        public Buffer print(String text, Style... styles) {
+            printer.ansi().style(this, text, styles);
+            return this;
+        }
+
+        /**
+         * Prints a line of styled text to the buffer.
+         *
+         * @param text Text to print.
+         * @param styles Styles to apply.
+         * @return Returns self.
+         */
+        public Buffer println(String text, Style... styles) {
+            return print(text, styles).println();
+        }
+
+        /**
+         * Writes a system-dependent new line.
+         *
+         * @return Returns the buffer.
+         */
+        public Buffer println() {
+            return append(System.lineSeparator());
+        }
+
+        @Override
+        public void close() {
+            printer.println(builder.toString());
+            builder.setLength(0);
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -30,22 +30,28 @@ import java.nio.charset.StandardCharsets;
 public interface CliPrinter extends Flushable {
 
     /**
+     * Prints text to the writer and appends a new line.
+     *
+     * @param text Text to print.
+     */
+    void println(String text);
+
+    /**
+     * Flushes any buffers in the printer.
+     */
+    default void flush() {}
+
+    /**
      * Create a new CliPrinter from a PrintWriter.
      *
-     * @param ansi Ansi color settings to use.
      * @param printWriter PrintWriter to write to.
      * @return Returns the created CliPrinter.
      */
-    static CliPrinter fromPrintWriter(Ansi ansi, PrintWriter printWriter) {
+    static CliPrinter fromPrintWriter(PrintWriter printWriter) {
         return new CliPrinter() {
             @Override
             public void println(String text) {
                 printWriter.println(text);
-            }
-
-            @Override
-            public Ansi ansi() {
-                return ansi;
             }
 
             @Override
@@ -58,129 +64,12 @@ public interface CliPrinter extends Flushable {
     /**
      * Create a new CliPrinter from an OutputStream.
      *
-     * @param ansi Ansi color settings to use.
      * @param stream OutputStream to write to.
      * @return Returns the created CliPrinter.
      */
-    static CliPrinter fromOutputStream(Ansi ansi, OutputStream stream) {
+    static CliPrinter fromOutputStream(OutputStream stream) {
         Charset charset = StandardCharsets.UTF_8;
         PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(stream, charset)), false);
-        return fromPrintWriter(ansi, writer);
-    }
-
-    /**
-     * Prints text to the writer and appends a new line.
-     *
-     * @param text Text to print.
-     */
-    void println(String text);
-
-    /**
-     * Prints a styled line of text using ANSI colors.
-     *
-     * @param text Text to style and write.
-     * @param styles Styles to apply.
-     */
-    default void println(String text, Style... styles) {
-        println(ansi().style(text, styles));
-    }
-
-    /**
-     * Flushes any buffers in the printer.
-     */
-    default void flush() {}
-
-    /**
-     * Gets the ANSI color style setting used by the printer.
-     *
-     * @return Returns the ANSI color style.
-     */
-    default Ansi ansi() {
-        return Ansi.AUTO;
-    }
-
-    /**
-     * Creates a {@link Buffer} used to build up a long string of text.
-     *
-     * @return Returns the buffer. Call {@link Buffer#close()} or use try-with-resources to write to the printer.
-     */
-    default Buffer buffer() {
-        return new Buffer(this);
-    }
-
-    /**
-     * A buffer associated with a {@link CliPrinter} used to build up a string of ANSI color stylized text.
-     *
-     * <p>This class is not thread safe; it's a convenient way to build up a long string of text that uses ANSI styles
-     * before ultimately calling {@link #close()}, which writes it to the attached printer.
-     */
-    final class Buffer implements Appendable, AutoCloseable {
-        private final CliPrinter printer;
-        private final StringBuilder builder = new StringBuilder();
-
-        private Buffer(CliPrinter printer) {
-            this.printer = printer;
-        }
-
-        @Override
-        public String toString() {
-            return builder.toString();
-        }
-
-        @Override
-        public Buffer append(CharSequence csq) {
-            builder.append(csq);
-            return this;
-        }
-
-        @Override
-        public Buffer append(CharSequence csq, int start, int end) {
-            builder.append(csq, start, end);
-            return this;
-        }
-
-        @Override
-        public Buffer append(char c) {
-            builder.append(c);
-            return this;
-        }
-
-        /**
-         * Writes styled text to the builder using the CliPrinter's Ansi settings.
-         *
-         * @param text Text to write.
-         * @param styles Styles to apply to the text.
-         * @return Returns self.
-         */
-        public Buffer print(String text, Style... styles) {
-            printer.ansi().style(this, text, styles);
-            return this;
-        }
-
-        /**
-         * Prints a line of styled text to the buffer.
-         *
-         * @param text Text to print.
-         * @param styles Styles to apply.
-         * @return Returns self.
-         */
-        public Buffer println(String text, Style... styles) {
-            return print(text, styles).println();
-        }
-
-        /**
-         * Writes a system-dependent new line.
-         *
-         * @return Returns the buffer.
-         */
-        public Buffer println() {
-            return append(System.lineSeparator());
-        }
-
-        @Override
-        public void close() {
-            printer.println(builder.toString());
-            builder.setLength(0);
-        }
+        return fromPrintWriter(writer);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorFormatter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorFormatter.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+/**
+ * Styles text using color codes.
+ *
+ * @see AnsiColorFormatter for the ANSI implementation.
+ */
+public interface ColorFormatter {
+    /**
+     * Styles text using the given styles.
+     *
+     * @param text Text to style.
+     * @param styles Styles to apply.
+     * @return Returns the styled text.
+     */
+    String style(String text, Style... styles);
+
+    /**
+     * Styles text using the given styles and writes it to an Appendable.
+     *
+     * @param appendable Where to write styled text.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    void style(Appendable appendable, String text, Style... styles);
+
+    /**
+     * Print a styled line of text to the given {@code printer}.
+     *
+     * @param printer Printer to write to.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    default void println(CliPrinter printer, String text, Style... styles) {
+        printer.println(style(text, styles));
+    }
+
+    /**
+     * Creates a {@link PrinterBuffer} used to build up a long string of styled text.
+     *
+     * <p>Call {@link PrinterBuffer#close()} or use try-with-resources to write to the printer.
+     *
+     * @return Returns the buffer.
+     */
+    default PrinterBuffer printerBuffer(CliPrinter printer) {
+        return new PrinterBuffer(this, printer);
+    }
+
+    /**
+     * A buffer associated with a {@link CliPrinter} used to build up a string of colored text.
+     *
+     * <p>Use {@link #close()} to write to the associated {@link CliPrinter}, or wrap the buffer in a
+     * try-with-resources block.
+     */
+    final class PrinterBuffer implements Appendable, AutoCloseable {
+        private final ColorFormatter colors;
+        private final CliPrinter printer;
+        private final StringBuilder builder = new StringBuilder();
+        private boolean pendingNewline;
+        private final String newline = System.lineSeparator();
+
+        private PrinterBuffer(ColorFormatter colors, CliPrinter printer) {
+            this.colors = colors;
+            this.printer = printer;
+        }
+
+        @Override
+        public String toString() {
+            String result = builder.toString();
+            if (pendingNewline) {
+                result += newline;
+            }
+            return result;
+        }
+
+        @Override
+        public PrinterBuffer append(CharSequence csq) {
+            handleNewline();
+            builder.append(csq);
+            return this;
+        }
+
+        private void handleNewline() {
+            if (pendingNewline) {
+                builder.append(newline);
+                pendingNewline = false;
+            }
+        }
+
+        @Override
+        public PrinterBuffer append(CharSequence csq, int start, int end) {
+            handleNewline();
+            builder.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public PrinterBuffer append(char c) {
+            handleNewline();
+            builder.append(c);
+            return this;
+        }
+
+        /**
+         * Writes styled text to the builder using the CliPrinter's color settings.
+         *
+         * @param text Text to write.
+         * @param styles Styles to apply to the text.
+         * @return Returns self.
+         */
+        public PrinterBuffer print(String text, Style... styles) {
+            handleNewline();
+            colors.style(this, text, styles);
+            return this;
+        }
+
+        /**
+         * Prints a line of styled text to the buffer.
+         *
+         * @param text Text to print.
+         * @param styles Styles to apply.
+         * @return Returns self.
+         */
+        public PrinterBuffer println(String text, Style... styles) {
+            print(text, styles);
+            return println();
+        }
+
+        /**
+         * Writes a system-dependent new line.
+         *
+         * @return Returns the buffer.
+         */
+        public PrinterBuffer println() {
+            handleNewline();
+            pendingNewline = true;
+            return this;
+        }
+
+        @Override
+        public void close() {
+            printer.println(builder.toString());
+            builder.setLength(0);
+            pendingNewline = false;
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
@@ -47,10 +47,10 @@ public interface Command {
     /**
      * Gets the long description of the command.
      *
-     * @param printer Printer used to style strings.
+     * @param colors Color formatter to use for styling help.
      * @return Returns the long description.
      */
-    default String getDocumentation(CliPrinter printer) {
+    default String getDocumentation(ColorFormatter colors) {
         return "";
     }
 
@@ -58,9 +58,10 @@ public interface Command {
      * Prints help output.
      *
      * @param arguments Arguments that have been parsed so far.
+     * @param colors Color formatter to use.
      * @param printer Where to write help.
      */
-    void printHelp(Arguments arguments, CliPrinter printer);
+    void printHelp(Arguments arguments, ColorFormatter colors, CliPrinter printer);
 
     /**
      * Executes the command using the provided arguments.
@@ -78,12 +79,18 @@ public interface Command {
 
         private final CliPrinter stdout;
         private final CliPrinter stderr;
+        private final ColorFormatter colors;
         private final ClassLoader classLoader;
 
-        public Env(CliPrinter stdout, CliPrinter stderr, ClassLoader classLoader) {
+        public Env(ColorFormatter colors, CliPrinter stdout, CliPrinter stderr, ClassLoader classLoader) {
+            this.colors = colors;
             this.stdout = stdout;
             this.stderr = stderr;
             this.classLoader = classLoader;
+        }
+
+        public ColorFormatter colors() {
+            return colors;
         }
 
         public CliPrinter stdout() {
@@ -99,7 +106,7 @@ public interface Command {
         }
 
         public Env withClassLoader(ClassLoader classLoader) {
-            return classLoader == this.classLoader ? this : new Env(stdout, stderr, classLoader);
+            return classLoader == this.classLoader ? this : new Env(colors, stdout, stderr, classLoader);
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -51,7 +51,27 @@ public enum EnvironmentVariable {
     },
 
     /** The current version of the CLI. This is set automatically by the CLI. */
-    SMITHY_VERSION;
+    SMITHY_VERSION,
+
+    /**
+     * If set to any value, disable ANSI colors in the output.
+     */
+    NO_COLOR,
+
+    /**
+     * If set to any value, force enables the support of ANSI colors in the output.
+     */
+    FORCE_COLOR,
+
+    /**
+     * Used to detect if ANSI colors are supported.
+     *
+     * <ul>
+     *     <li>If set to "dumb" colors are disabled.</li>
+     *     <li>If not set and the operating system is detected as Windows, colors are disabled.</li>
+     * </ul>
+     */
+    TERM;
 
     /**
      * Gets a system property or environment variable by name, in that order.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -21,7 +21,7 @@ import java.util.StringTokenizer;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
- * Generates and prints structured help output to a {@link CliPrinter}.
+ * Generates and prints structured help output.
  */
 public final class HelpPrinter {
     private final String name;
@@ -128,7 +128,7 @@ public final class HelpPrinter {
         LineWrapper builder = new LineWrapper(maxWidth);
 
         builder.appendWithinLine("Usage: ")
-                .appendWithinLine(printer.style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
+                .appendWithinLine(printer.ansi().style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
                 .space();
 
         // Calculate the column manually to account for possible styles interfering with the current column number.
@@ -166,14 +166,15 @@ public final class HelpPrinter {
     }
 
     private void writeArgHelp(CliPrinter printer, LineWrapper builder, Arg arg) {
+        Ansi ansi = printer.ansi();
         if (arg.longName != null) {
-            builder.appendWithinLine(printer.style(arg.longName, Style.YELLOW));
+            builder.appendWithinLine(ansi.style(arg.longName, Style.YELLOW));
             if (arg.shortName != null) {
                 builder.appendWithinLine(", ");
             }
         }
         if (arg.shortName != null) {
-            builder.appendWithinLine(printer.style(arg.shortName, Style.YELLOW));
+            builder.appendWithinLine(ansi.style(arg.shortName, Style.YELLOW));
         }
         if (arg.exampleValue != null) {
             builder.space().appendWithinLine(arg.exampleValue);
@@ -209,16 +210,17 @@ public final class HelpPrinter {
         }
 
         String toShortArgs(CliPrinter printer) {
+            Ansi ansi = printer.ansi();
             StringBuilder builder = new StringBuilder();
             builder.append('[');
             if (longName != null) {
-                builder.append(printer.style(longName, Style.YELLOW));
+                builder.append(ansi.style(longName, Style.YELLOW));
                 if (shortName != null) {
                     builder.append(" | ");
                 }
             }
             if (shortName != null) {
-                builder.append(printer.style(shortName, Style.YELLOW));
+                builder.append(ansi.style(shortName, Style.YELLOW));
             }
             if (exampleValue != null) {
                 builder.append(' ').append(exampleValue);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -122,24 +122,25 @@ public final class HelpPrinter {
     /**
      * Prints the generated help to the given printer.
      *
+     * @param colors Color formatter.
      * @param printer CliPrinter to write to.
      */
-    public void print(CliPrinter printer) {
+    public void print(ColorFormatter colors, CliPrinter printer) {
         LineWrapper builder = new LineWrapper(maxWidth);
 
         builder.appendWithinLine("Usage: ")
-                .appendWithinLine(printer.ansi().style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
+                .appendWithinLine(colors.style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
                 .space();
 
         // Calculate the column manually to account for possible styles interfering with the current column number.
         builder.indent("Usage: ".length() + name.length() + 1);
 
         for (Arg arg : args) {
-            builder.appendWithinLine(arg.toShortArgs(printer)).space();
+            builder.appendWithinLine(arg.toShortArgs(colors)).space();
         }
 
         if (positional != null) {
-            builder.appendWithinLine(positional.toShortArgs(printer));
+            builder.appendWithinLine(positional.toShortArgs(colors));
         }
 
         builder.indent(0).newLine();
@@ -151,11 +152,11 @@ public final class HelpPrinter {
         builder.newLine();
 
         for (Arg arg : args) {
-            writeArgHelp(printer, builder, arg);
+            writeArgHelp(colors, builder, arg);
         }
 
         if (positional != null) {
-            writeArgHelp(printer, builder, positional);
+            writeArgHelp(colors, builder, positional);
         }
 
         if (!StringUtils.isEmpty(documentation)) {
@@ -165,16 +166,15 @@ public final class HelpPrinter {
         printer.println(builder.toString());
     }
 
-    private void writeArgHelp(CliPrinter printer, LineWrapper builder, Arg arg) {
-        Ansi ansi = printer.ansi();
+    private void writeArgHelp(ColorFormatter colors, LineWrapper builder, Arg arg) {
         if (arg.longName != null) {
-            builder.appendWithinLine(ansi.style(arg.longName, Style.YELLOW));
+            builder.appendWithinLine(colors.style(arg.longName, Style.YELLOW));
             if (arg.shortName != null) {
                 builder.appendWithinLine(", ");
             }
         }
         if (arg.shortName != null) {
-            builder.appendWithinLine(ansi.style(arg.shortName, Style.YELLOW));
+            builder.appendWithinLine(colors.style(arg.shortName, Style.YELLOW));
         }
         if (arg.exampleValue != null) {
             builder.space().appendWithinLine(arg.exampleValue);
@@ -209,18 +209,17 @@ public final class HelpPrinter {
             return new Arg(name, null, null, description);
         }
 
-        String toShortArgs(CliPrinter printer) {
-            Ansi ansi = printer.ansi();
+        String toShortArgs(ColorFormatter colors) {
             StringBuilder builder = new StringBuilder();
             builder.append('[');
             if (longName != null) {
-                builder.append(ansi.style(longName, Style.YELLOW));
+                builder.append(colors.style(longName, Style.YELLOW));
                 if (shortName != null) {
                     builder.append(" | ");
                 }
             }
             if (shortName != null) {
-                builder.append(ansi.style(shortName, Style.YELLOW));
+                builder.append(colors.style(shortName, Style.YELLOW));
             }
             if (exampleValue != null) {
                 builder.append(' ').append(exampleValue);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
@@ -132,9 +132,9 @@ final class LoggingUtil {
             if (isLoggable(record)) {
                 String formatted = formatter.format(record);
                 if (record.getLevel().equals(Level.SEVERE)) {
-                    printer.println(printer.style(formatted, Style.RED));
+                    printer.println(formatted, Style.RED);
                 } else if (record.getLevel().equals(Level.WARNING)) {
-                    printer.println(printer.style(formatted, Style.YELLOW));
+                    printer.println(formatted, Style.YELLOW);
                 } else {
                     printer.println(formatted);
                 }
@@ -142,11 +142,9 @@ final class LoggingUtil {
         }
 
         @Override
-        public void flush() {
-        }
+        public void flush() {}
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Options available to all commands.
@@ -30,8 +29,9 @@ public final class StandardOptions implements ArgumentReceiver {
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
+    public static final String NO_COLOR = "--no-color";
+    public static final String FORCE_COLOR = "--force-color";
     public static final String LOGGING = "--logging";
-    private static final Logger LOGGER = Logger.getLogger(StandardOptions.class.getName());
 
     private boolean help;
     private boolean version;
@@ -39,12 +39,15 @@ public final class StandardOptions implements ArgumentReceiver {
     private boolean quiet;
     private boolean debug;
     private boolean stackTrace;
+    private AnsiColorFormatter colorSetting = AnsiColorFormatter.AUTO;
 
     @Override
     public void registerHelp(HelpPrinter printer) {
         printer.option(HELP, HELP_SHORT, "Print help output");
         printer.option(DEBUG, null, "Display debug information");
         printer.option(QUIET, null, "Silence output except errors");
+        printer.option(NO_COLOR, null, "Disable ANSI colors");
+        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
         printer.param(LOGGING, null, "LOG_LEVEL",
                             "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
@@ -76,11 +79,11 @@ public final class StandardOptions implements ArgumentReceiver {
             case STACKTRACE:
                 stackTrace = true;
                 return true;
-            case "--no-color":
-                LOGGER.warning("--no-color is no longer supported. Use the NO_COLOR environment variable.");
+            case NO_COLOR:
+                colorSetting = AnsiColorFormatter.NO_COLOR;
                 return true;
-            case "--force-color":
-                LOGGER.warning("--force-color is no longer supported. Use the FORCE_COLOR environment variable.");
+            case FORCE_COLOR:
+                colorSetting = AnsiColorFormatter.FORCE_COLOR;
                 return true;
             default:
                 return false;
@@ -123,5 +126,9 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public boolean stackTrace() {
         return stackTrace;
+    }
+
+    public AnsiColorFormatter colorSetting() {
+        return colorSetting;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Options available to all commands.
@@ -29,9 +30,8 @@ public final class StandardOptions implements ArgumentReceiver {
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
-    public static final String NO_COLOR = "--no-color";
-    public static final String FORCE_COLOR = "--force-color";
     public static final String LOGGING = "--logging";
+    private static final Logger LOGGER = Logger.getLogger(StandardOptions.class.getName());
 
     private boolean help;
     private boolean version;
@@ -39,8 +39,6 @@ public final class StandardOptions implements ArgumentReceiver {
     private boolean quiet;
     private boolean debug;
     private boolean stackTrace;
-    private boolean noColor;
-    private boolean forceColor;
 
     @Override
     public void registerHelp(HelpPrinter printer) {
@@ -48,8 +46,6 @@ public final class StandardOptions implements ArgumentReceiver {
         printer.option(DEBUG, null, "Display debug information");
         printer.option(QUIET, null, "Silence output except errors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
-        printer.option(NO_COLOR, null, "Disable ANSI colors");
-        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.param(LOGGING, null, "LOG_LEVEL",
                             "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
                             + "FINE, ALL.");
@@ -80,13 +76,11 @@ public final class StandardOptions implements ArgumentReceiver {
             case STACKTRACE:
                 stackTrace = true;
                 return true;
-            case NO_COLOR:
-                noColor = true;
-                forceColor = false;
+            case "--no-color":
+                LOGGER.warning("--no-color is no longer supported. Use the NO_COLOR environment variable.");
                 return true;
-            case FORCE_COLOR:
-                noColor = false;
-                forceColor = true;
+            case "--force-color":
+                LOGGER.warning("--force-color is no longer supported. Use the FORCE_COLOR environment variable.");
                 return true;
             default:
                 return false;
@@ -129,13 +123,5 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public boolean stackTrace() {
         return stackTrace;
-    }
-
-    public boolean noColor() {
-        return noColor;
-    }
-
-    public boolean forceColor() {
-        return forceColor;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.cli;
 
 /**
- * ANSI color codes and styles for use with {@link Ansi} or {@link CliPrinter}.
+ * Colors and styles for use with {@link AnsiColorFormatter} or {@link CliPrinter}.
  */
 public enum Style {
     BOLD(1),
@@ -60,14 +60,13 @@ public enum Style {
     BG_BRIGHT_CYAN(106),
     BG_BRIGHT_WHITE(107);
 
-    private final String code;
+    private final String ansiColorCode;
 
-    Style(int code) {
-        this.code = String.valueOf(code);
+    Style(int ansiColorCode) {
+        this.ansiColorCode = String.valueOf(ansiColorCode);
     }
 
-    @Override
-    public String toString() {
-        return code;
+    public String getAnsiColorCode() {
+        return ansiColorCode;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -15,109 +15,59 @@
 
 package software.amazon.smithy.cli;
 
-import java.util.function.IntConsumer;
-
 /**
- * Parameters used to change the ANSI public style of text.
+ * ANSI color codes and styles for use with {@link Ansi} or {@link CliPrinter}.
  */
-@FunctionalInterface
-public interface Style {
+public enum Style {
+    BOLD(1),
+    FAINT(2),
+    ITALIC(3),
+    UNDERLINE(4),
 
-    Style BOLD = new SingularCode(1);
-    Style FAINT = new SingularCode(2);
-    Style ITALIC = new SingularCode(3);
-    Style UNDERLINE = new SingularCode(4);
+    BLACK(30),
+    RED(31),
+    GREEN(32),
+    YELLOW(33),
+    BLUE(34),
+    MAGENTA(35),
+    CYAN(36),
+    WHITE(37),
 
-    Style BLACK = new SingularCode(30);
-    Style RED = new SingularCode(31);
-    Style GREEN = new SingularCode(32);
-    Style YELLOW = new SingularCode(33);
-    Style BLUE = new SingularCode(34);
-    Style MAGENTA = new SingularCode(35);
-    Style CYAN = new SingularCode(36);
-    Style WHITE = new SingularCode(37);
+    BRIGHT_BLACK(90),
+    BRIGHT_RED(91),
+    BRIGHT_GREEN(92),
+    BRIGHT_YELLOW(93),
+    BRIGHT_BLUE(94),
+    BRIGHT_MAGENTA(95),
+    BRIGHT_CYAN(96),
+    BRIGHT_WHITE(97),
 
-    Style BRIGHT_BLACK = new SingularCode(90);
-    Style BRIGHT_RED = new SingularCode(91);
-    Style BRIGHT_GREEN = new SingularCode(92);
-    Style BRIGHT_YELLOW = new SingularCode(93);
-    Style BRIGHT_BLUE = new SingularCode(94);
-    Style BRIGHT_MAGENTA = new SingularCode(95);
-    Style BRIGHT_CYAN = new SingularCode(96);
-    Style BRIGHT_WHITE = new SingularCode(97);
+    BG_BLACK(40),
+    BG_RED(41),
+    BG_GREEN(42),
+    BG_YELLOW(43),
+    BG_BLUE(44),
+    BG_MAGENTA(45),
+    BG_CYAN(46),
+    BG_WHITE(47),
 
-    Style BG_BLACK = new SingularCode(40);
-    Style BG_RED = new SingularCode(41);
-    Style BG_GREEN = new SingularCode(42);
-    Style BG_YELLOW = new SingularCode(43);
-    Style BG_BLUE = new SingularCode(44);
-    Style BG_MAGENTA = new SingularCode(45);
-    Style BG_CYAN = new SingularCode(46);
-    Style BG_WHITE = new SingularCode(47);
+    BG_BRIGHT_BLACK(100),
+    BG_BRIGHT_RED(101),
+    BG_BRIGHT_GREEN(102),
+    BG_BRIGHT_YELLOW(103),
+    BG_BRIGHT_BLUE(104),
+    BG_BRIGHT_MAGENTA(105),
+    BG_BRIGHT_CYAN(106),
+    BG_BRIGHT_WHITE(107);
 
-    Style BG_BRIGHT_BLACK = new SingularCode(100);
-    Style BG_BRIGHT_RED = new SingularCode(101);
-    Style BG_BRIGHT_GREEN = new SingularCode(102);
-    Style BG_BRIGHT_YELLOW = new SingularCode(103);
-    Style BG_BRIGHT_BLUE = new SingularCode(104);
-    Style BG_BRIGHT_MAGENTA = new SingularCode(105);
-    Style BG_BRIGHT_CYAN = new SingularCode(106);
-    Style BG_BRIGHT_WHITE = new SingularCode(107);
+    private final String code;
 
-    /**
-     * Pushes one or more ANSI color codes to the consumer.
-     *
-     * <p>Most implementations will push a single code, but multiple
-     * codes are needed to do things like use 8-bit colors
-     * (e.g., 38+5+206 to make pink foreground text).
-     *
-     * @param codeConsumer Consumer to push integers to.
-     */
-    void pushCodes(IntConsumer codeConsumer);
-
-    /**
-     * Formats the given text with ANSI escapes.
-     *
-     * <p>Each {@code styles} is one or more ANSI escape codes in the format of
-     * "1", "38;5;206" to create an 8-bit color, etc.
-     *
-     * @param text Text to format.
-     * @param styles Styles to apply.
-     * @return Returns the formatted text, and then resets the formatting.
-     * @see <a href="https://man7.org/linux/man-pages/man4/console_codes.4.html">ANSI console codes</a>
-     */
-    static String format(String text, Style... styles) {
-        StringBuilder result = new StringBuilder("\033[");
-        IntConsumer consumer = result::append;
-        boolean isAfterFirst = false;
-
-        for (Style style : styles) {
-            if (isAfterFirst) {
-                result.append(';');
-            }
-            style.pushCodes(consumer);
-            isAfterFirst = true;
-        }
-
-        result.append('m');
-        result.append(text);
-        result.append("\033[0m");
-        return result.toString();
+    Style(int code) {
+        this.code = String.valueOf(code);
     }
 
-    /**
-     * A simple implementation of {@code Style} that pushes a single code.
-     */
-    final class SingularCode implements Style {
-        private final int code;
-
-        public SingularCode(int code) {
-            this.code = code;
-        }
-
-        @Override
-        public void pushCodes(IntConsumer codeConsumer) {
-            codeConsumer.accept(code);
-        }
+    @Override
+    public String toString() {
+        return code;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.cli.commands;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -125,12 +127,12 @@ final class BuildCommand extends ClasspathCommand {
             Style ansiColor = resultConsumer.failedProjections.isEmpty()
                               ? Style.BRIGHT_GREEN
                               : Style.BRIGHT_YELLOW;
-            env.stderr().println(env.stderr().style(
+            env.stderr().println(
                     String.format("Smithy built %s projection(s), %s plugin(s), and %s artifacts",
                                   resultConsumer.projectionCount,
                                   resultConsumer.pluginCount,
                                   resultConsumer.artifactCount),
-                    Style.BOLD, ansiColor));
+                    Style.BOLD, ansiColor);
         }
 
         // Throw an exception if any errors occurred.
@@ -161,33 +163,32 @@ final class BuildCommand extends ClasspathCommand {
         @Override
         public void accept(String name, Throwable exception) {
             failedProjections.add(name);
-            StringBuilder message = new StringBuilder(
-                    String.format("%nProjection %s failed: %s%n", name, exception.toString()));
-
-            for (StackTraceElement element : exception.getStackTrace()) {
-                message.append(element).append(System.lineSeparator());
-            }
-
-            // Always print errors.
-            printer.println(printer.style(message.toString(), Style.RED));
+            StringWriter writer = new StringWriter();
+            writer.write(String.format("%nProjection %s failed: %s%n", name, exception.toString()));
+            exception.printStackTrace(new PrintWriter(writer));
+            printer.println(writer.toString(), Style.RED);
         }
 
         @Override
         public void accept(ProjectionResult result) {
+            try (CliPrinter.Buffer buffer = printer.buffer()) {
+                printProjectionResult(buffer, result);
+            }
+        }
+
+        private void printProjectionResult(CliPrinter.Buffer buffer, ProjectionResult result) {
             if (result.isBroken()) {
                 // Write out validation errors as they occur.
                 failedProjections.add(result.getProjectionName());
-                StringBuilder message = new StringBuilder(System.lineSeparator());
-                message.append(result.getProjectionName())
-                        .append(" has a model that failed validation")
-                        .append(System.lineSeparator());
+                buffer
+                        .println()
+                        .print(result.getProjectionName(), Style.RED)
+                        .println(" has a model that failed validation");
                 result.getEvents().forEach(event -> {
                     if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
-                        message.append(event).append(System.lineSeparator());
+                        buffer.println(event.toString(), Style.RED);
                     }
                 });
-                // Always print errors.
-                printer.println(printer.style(message.toString(), Style.RED));
             } else {
                 // Only increment the projection count if it succeeded.
                 projectionCount.incrementAndGet();
@@ -202,7 +203,7 @@ final class BuildCommand extends ClasspathCommand {
             if (!quiet) {
                 String message = String.format("Completed projection %s (%d shapes): %s",
                                                result.getProjectionName(), result.getModel().toSet().size(), root);
-                printer.println(printer.style(message, Style.GREEN));
+                buffer.println(message, Style.GREEN);
             }
 
             // Increment the total number of artifacts written.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.EnvironmentVariable;
 import software.amazon.smithy.cli.StandardOptions;
@@ -55,6 +56,7 @@ final class CommandUtils {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
         BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
         Severity minSeverity = buildOptions.severity(standardOptions);
+        ColorFormatter colors = env.colors();
 
         assembler.validationEventListener(event -> {
             // Only log events that are >= --severity. Note that setting --quiet inherently
@@ -62,10 +64,10 @@ final class CommandUtils {
             if (event.getSeverity().ordinal() >= minSeverity.ordinal()) {
                 if (event.getSeverity() == Severity.WARNING) {
                     // Only log warnings when not quiet
-                    printer.println(formatter.format(event), Style.YELLOW);
+                    colors.println(printer, formatter.format(event), Style.YELLOW);
                 } else if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
                     // Always output error and danger events, even when quiet.
-                    printer.println(formatter.format(event), Style.RED);
+                    colors.println(printer, formatter.format(event), Style.RED);
                 } else {
                     printer.println(formatter.format(event));
                 }
@@ -79,7 +81,7 @@ final class CommandUtils {
         config.getImports().forEach(assembler::addImport);
 
         ValidatedResult<Model> result = assembler.assemble();
-        Validator.validate(quietValidation, env.stderr(), result);
+        Validator.validate(quietValidation, colors, env.stderr(), result);
         return result.getResult().orElseThrow(() -> new RuntimeException("Expected Validator to throw"));
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -62,10 +62,10 @@ final class CommandUtils {
             if (event.getSeverity().ordinal() >= minSeverity.ordinal()) {
                 if (event.getSeverity() == Severity.WARNING) {
                     // Only log warnings when not quiet
-                    printer.println(printer.style(formatter.format(event), Style.YELLOW));
+                    printer.println(formatter.format(event), Style.YELLOW);
                 } else if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
                     // Always output error and danger events, even when quiet.
-                    printer.println(printer.style(formatter.format(event), Style.RED));
+                    printer.println(formatter.format(event), Style.RED);
                 } else {
                     printer.println(formatter.format(event));
                 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -24,7 +24,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
-import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
@@ -122,7 +122,7 @@ final class DiffCommand extends ClasspathCommand {
 
         // Print the "framing" style output to stderr only if !quiet.
         if (!standardOptions.quiet()) {
-            try (CliPrinter.Buffer buffer = env.stderr().buffer()) {
+            try (ColorFormatter.PrinterBuffer buffer = env.colors().printerBuffer(env.stderr())) {
                 if (hasDanger) {
                     buffer.println("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD);
                 } else if (hasWarning) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -122,13 +122,14 @@ final class DiffCommand extends ClasspathCommand {
 
         // Print the "framing" style output to stderr only if !quiet.
         if (!standardOptions.quiet()) {
-            CliPrinter stderr = env.stderr();
-            if (hasDanger) {
-                stderr.println(stderr.style("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD));
-            } else if (hasWarning) {
-                stderr.println(stderr.style("Smithy diff detected warnings", Style.BRIGHT_YELLOW, Style.BOLD));
-            } else {
-                stderr.println(stderr.style("Smithy diff complete", Style.BRIGHT_GREEN, Style.BOLD));
+            try (CliPrinter.Buffer buffer = env.stderr().buffer()) {
+                if (hasDanger) {
+                    buffer.println("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD);
+                } else if (hasWarning) {
+                    buffer.println("Smithy diff detected warnings", Style.BRIGHT_YELLOW, Style.BOLD);
+                } else {
+                    buffer.println("Smithy diff complete", Style.BRIGHT_GREEN, Style.BOLD);
+                }
             }
         }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
@@ -55,7 +56,7 @@ final class SelectCommand extends ClasspathCommand {
     }
 
     @Override
-    public String getDocumentation(CliPrinter printer) {
+    public String getDocumentation(ColorFormatter colors) {
         return "By default, each matching shape ID is printed to stdout on a new line. Pass --vars to print out a "
                + "JSON array that contains a 'shape' and 'vars' property, where the 'vars' property is a map of "
                + "each variable that was captured when the shape was matched.";

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
@@ -59,7 +60,7 @@ abstract class SimpleCommand implements Command {
         }
 
         if (options.help()) {
-            printHelp(arguments, env.stdout());
+            printHelp(arguments, env.colors(), env.stdout());
             return 0;
         }
 
@@ -68,12 +69,12 @@ abstract class SimpleCommand implements Command {
     }
 
     @Override
-    public void printHelp(Arguments arguments, CliPrinter printer) {
+    public void printHelp(Arguments arguments, ColorFormatter colors, CliPrinter printer) {
         String name = StringUtils.isEmpty(parentCommandName) ? getName() : parentCommandName + " " + getName();
         HelpPrinter.fromArguments(name, arguments)
                 .summary(getSummary())
-                .documentation(getDocumentation(printer))
-                .print(printer);
+                .documentation(getDocumentation(colors))
+                .print(colors, printer);
     }
 
     /**

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -18,10 +18,10 @@ package software.amazon.smithy.cli.commands;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.EnvironmentVariable;
 import software.amazon.smithy.cli.SmithyCli;
@@ -58,10 +58,9 @@ public final class SmithyCommand implements Command {
     }
 
     @Override
-    public void printHelp(Arguments arguments, CliPrinter printer) {
-        Ansi ansi = printer.ansi();
+    public void printHelp(Arguments arguments, ColorFormatter colors, CliPrinter printer) {
         printer.println(String.format("Usage: %s [-h | --help] [--version] <command> [<args>]",
-                                      ansi.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
+                                      colors.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
         printer.println("");
         printer.println("Available commands:");
 
@@ -77,7 +76,7 @@ public final class SmithyCommand implements Command {
         for (Command command : commands) {
             if (!command.isHidden()) {
                 printer.println(String.format("    %-" + longestName + "s %s",
-                                              ansi.style(command.getName(), Style.YELLOW),
+                                              colors.style(command.getName(), Style.YELLOW),
                                               command.getSummary()));
             }
         }
@@ -99,13 +98,13 @@ public final class SmithyCommand implements Command {
             StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
 
             if (standardOptions.help()) {
-                printHelp(arguments, env.stdout());
+                printHelp(arguments, env.colors(), env.stdout());
                 return 0;
             } else if (standardOptions.version()) {
                 env.stdout().println(SmithyCli.getVersion());
                 return 0;
             } else {
-                printHelp(arguments, env.stderr());
+                printHelp(arguments, env.colors(), env.stderr());
                 return 1;
             }
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.cli.commands;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
@@ -58,8 +59,9 @@ public final class SmithyCommand implements Command {
 
     @Override
     public void printHelp(Arguments arguments, CliPrinter printer) {
+        Ansi ansi = printer.ansi();
         printer.println(String.format("Usage: %s [-h | --help] [--version] <command> [<args>]",
-                                      printer.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
+                                      ansi.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
         printer.println("");
         printer.println("Available commands:");
 
@@ -75,10 +77,12 @@ public final class SmithyCommand implements Command {
         for (Command command : commands) {
             if (!command.isHidden()) {
                 printer.println(String.format("    %-" + longestName + "s %s",
-                                              printer.style(command.getName(), Style.YELLOW),
+                                              ansi.style(command.getName(), Style.YELLOW),
                                               command.getSummary()));
             }
         }
+
+        printer.println("");
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -16,9 +16,9 @@
 package software.amazon.smithy.cli.commands;
 
 import java.util.StringJoiner;
-import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.Severity;
@@ -31,7 +31,7 @@ final class Validator {
 
     private Validator() {}
 
-    static void validate(boolean quiet, CliPrinter printer, ValidatedResult<Model> result) {
+    static void validate(boolean quiet, ColorFormatter colors, CliPrinter printer, ValidatedResult<Model> result) {
         int notes = result.getValidationEvents(Severity.NOTE).size();
         int warnings = result.getValidationEvents(Severity.WARNING).size();
         int errors = result.getValidationEvents(Severity.ERROR).size();
@@ -39,13 +39,12 @@ final class Validator {
         int shapeCount = result.getResult().isPresent() ? result.getResult().get().toSet().size() : 0;
         boolean isFailed = errors > 0 || dangers > 0;
         boolean hasEvents = warnings > 0 || notes > 0 || isFailed;
-        Ansi ansi = printer.ansi();
 
         StringBuilder output = new StringBuilder();
         if (isFailed) {
-            output.append(ansi.style("FAILURE: ", Style.RED, Style.BOLD));
+            output.append(colors.style("FAILURE: ", Style.RED, Style.BOLD));
         } else {
-            output.append(ansi.style("SUCCESS: ", Style.GREEN, Style.BOLD));
+            output.append(colors.style("SUCCESS: ", Style.GREEN, Style.BOLD));
         }
         output.append("Validated ").append(shapeCount).append(" shapes");
 
@@ -53,19 +52,19 @@ final class Validator {
             output.append(' ').append('(');
             StringJoiner joiner = new StringJoiner(", ");
             if (errors > 0) {
-                appendSummaryCount(joiner, ansi, "ERROR", errors, Style.BRIGHT_RED);
+                appendSummaryCount(joiner, colors, "ERROR", errors, Style.BRIGHT_RED);
             }
 
             if (dangers > 0) {
-                appendSummaryCount(joiner, ansi, "DANGER", dangers, Style.RED);
+                appendSummaryCount(joiner, colors, "DANGER", dangers, Style.RED);
             }
 
             if (warnings > 0) {
-                appendSummaryCount(joiner, ansi, "WARNING", warnings, Style.YELLOW);
+                appendSummaryCount(joiner, colors, "WARNING", warnings, Style.YELLOW);
             }
 
             if (notes > 0) {
-                appendSummaryCount(joiner, ansi, "NOTE", notes, Style.WHITE);
+                appendSummaryCount(joiner, colors, "NOTE", notes, Style.WHITE);
             }
             output.append(joiner);
             output.append(')');
@@ -78,7 +77,12 @@ final class Validator {
         }
     }
 
-    private static void appendSummaryCount(StringJoiner joiner, Ansi ansi, String label, int count, Style color) {
-        joiner.add(ansi.style(label, color) + ": " + count);
+    private static void appendSummaryCount(
+            StringJoiner joiner,
+            ColorFormatter colors,
+            String label,
+            int count,
+            Style color) {
+        joiner.add(colors.style(label, color) + ": " + count);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.cli.commands;
 
 import java.util.StringJoiner;
+import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Style;
@@ -38,12 +39,13 @@ final class Validator {
         int shapeCount = result.getResult().isPresent() ? result.getResult().get().toSet().size() : 0;
         boolean isFailed = errors > 0 || dangers > 0;
         boolean hasEvents = warnings > 0 || notes > 0 || isFailed;
+        Ansi ansi = printer.ansi();
 
         StringBuilder output = new StringBuilder();
         if (isFailed) {
-            output.append(printer.style("FAILURE: ", Style.RED, Style.BOLD));
+            output.append(ansi.style("FAILURE: ", Style.RED, Style.BOLD));
         } else {
-            output.append(printer.style("SUCCESS: ", Style.GREEN, Style.BOLD));
+            output.append(ansi.style("SUCCESS: ", Style.GREEN, Style.BOLD));
         }
         output.append("Validated ").append(shapeCount).append(" shapes");
 
@@ -51,21 +53,21 @@ final class Validator {
             output.append(' ').append('(');
             StringJoiner joiner = new StringJoiner(", ");
             if (errors > 0) {
-                appendSummaryCount(joiner, printer, "ERROR", errors, Style.BRIGHT_RED);
+                appendSummaryCount(joiner, ansi, "ERROR", errors, Style.BRIGHT_RED);
             }
 
             if (dangers > 0) {
-                appendSummaryCount(joiner, printer, "DANGER", dangers, Style.RED);
+                appendSummaryCount(joiner, ansi, "DANGER", dangers, Style.RED);
             }
 
             if (warnings > 0) {
-                appendSummaryCount(joiner, printer, "WARNING", warnings, Style.YELLOW);
+                appendSummaryCount(joiner, ansi, "WARNING", warnings, Style.YELLOW);
             }
 
             if (notes > 0) {
-                appendSummaryCount(joiner, printer, "NOTE", notes, Style.WHITE);
+                appendSummaryCount(joiner, ansi, "NOTE", notes, Style.WHITE);
             }
-            output.append(joiner.toString());
+            output.append(joiner);
             output.append(')');
         }
 
@@ -76,13 +78,7 @@ final class Validator {
         }
     }
 
-    private static void appendSummaryCount(
-            StringJoiner joiner,
-            CliPrinter printer,
-            String label,
-            int count,
-            Style color
-    ) {
-        joiner.add(printer.style(label, color) + ": " + count);
+    private static void appendSummaryCount(StringJoiner joiner, Ansi ansi, String label, int count, Style color) {
+        joiner.add(ansi.style(label, color) + ": " + count);
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.cli;
+
+final class BufferPrinter implements CliPrinter {
+
+    private final StringBuilder builder = new StringBuilder();
+
+    @Override
+    public void println(String text) {
+        synchronized (this) {
+            builder.append(text + "\n");
+        }
+    }
+
+    @Override
+    public Ansi ansi() {
+        return Ansi.NO_COLOR;
+    }
+
+    @Override
+    public String toString() {
+        // normalize line endings for tests.
+        return builder.toString().replace("\r\n", "\n").replace("\r", "\n");
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
@@ -12,11 +12,6 @@ final class BufferPrinter implements CliPrinter {
     }
 
     @Override
-    public Ansi ansi() {
-        return Ansi.NO_COLOR;
-    }
-
-    @Override
     public String toString() {
         // normalize line endings for tests.
         return builder.toString().replace("\r\n", "\n").replace("\r", "\n");

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
@@ -63,4 +63,18 @@ public class CliTest {
         assertThat(result.code(), equalTo(0));
         assertThat(result.stderr(), containsString("Running CLI command"));
     }
+
+    @Test
+    public void canForceColors() {
+        CliUtils.Result result = CliUtils.runSmithyWithAutoColors("--force-color", "--help");
+
+        assertThat(result.stdout(), containsString("[0m"));
+    }
+
+    @Test
+    public void canForceDisableColors() {
+        CliUtils.Result result = CliUtils.runSmithyWithAutoColors("--no-color", "--help");
+
+        assertThat(result.stdout(), not(containsString("[0m")));
+    }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
@@ -27,6 +27,10 @@ public final class CliUtils {
         }
     }
 
+    public static Result runSmithyWithAutoColors(String... args) {
+        return run(SmithyCli.create().createCli(), args);
+    }
+
     private static Result run(Cli cli, String... args) {
         CliPrinter stdout = new BufferPrinter();
         CliPrinter stderr = new BufferPrinter();

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/ColorFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/ColorFormatterTest.java
@@ -1,0 +1,45 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+public class ColorFormatterTest {
+    @Test
+    public void writesToPrinterWhenClosed() {
+        BufferPrinter printer = new BufferPrinter();
+        ColorFormatter formatter = AnsiColorFormatter.FORCE_COLOR;
+        String expected ="abc\nHello\n\n\033[31mRed\033[0m\n\n\n0\n";
+
+        try (ColorFormatter.PrinterBuffer buffer = formatter.printerBuffer(printer)) {
+            buffer.append('a');
+            buffer.append("bc");
+            buffer.println();
+            buffer.println("Hello");
+            buffer.println();
+            buffer.println("Red", Style.RED);
+            buffer.println();
+            buffer.println();
+            buffer.append('0');
+            // ensure that toString does not add the newline.
+            assertThat(buffer.toString(), equalTo(expected.trim()));
+        }
+
+        assertThat(printer.toString(), equalTo(expected));
+    }
+
+    @Test
+    public void appendsNewlineIfNeededInToString() {
+        BufferPrinter printer = new BufferPrinter();
+        ColorFormatter formatter = AnsiColorFormatter.FORCE_COLOR;
+        String expected ="abc\n";
+
+        try (ColorFormatter.PrinterBuffer buffer = formatter.printerBuffer(printer)) {
+            buffer.println("abc");
+            assertThat(buffer.toString(), equalTo(expected));
+        }
+
+        assertThat(printer.toString(), equalTo(expected));
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
@@ -204,24 +204,4 @@ public class HelpPrinterTest {
                 + "    --foo, -f\n"
                 + "        The foo value\n"));
     }
-
-    private static final class BufferPrinter implements CliPrinter {
-        private final StringBuilder builder = new StringBuilder();
-
-        @Override
-        public void println(String text) {
-            builder.append(text);
-        }
-
-        @Override
-        public String style(String text, Style... styles) {
-            return text;
-        }
-
-        @Override
-        public String toString() {
-            // normalize line endings for tests.
-            return builder.toString().replace("\r\n", "\n").replace("\r", "\n");
-        }
-    }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
@@ -11,7 +11,7 @@ public class HelpPrinterTest {
     public void worksWithNoArguments() {
         BufferPrinter printer = new BufferPrinter();
         HelpPrinter help = new HelpPrinter("foo");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), containsString("Usage: foo"));
     }
@@ -21,7 +21,7 @@ public class HelpPrinterTest {
         BufferPrinter printer = new BufferPrinter();
         HelpPrinter help = new HelpPrinter("foo");
         help.option("--foo", "-f", "The foo value");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -37,7 +37,7 @@ public class HelpPrinterTest {
         help.option("--foo", "-f", "The foo value");
         help.option("--bar", null, "The bar value");
         help.option(null, "-b", "What is this");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] [--bar] [-b] \n"
@@ -58,7 +58,7 @@ public class HelpPrinterTest {
         help.option("--bar", null, "The bar value");
         help.option(null, "-b", "What is this");
         help.param("--baz", "-a", "BAZ", "The baz param");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] [--bar] [-b] [--baz | -a BAZ] \n"
@@ -82,7 +82,7 @@ public class HelpPrinterTest {
         help.option("--bar", null, "The bar value");
         help.option(null, "-b", "What is this");
         help.param("--baz", "-a", "BAZ", "The baz param");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] [--bar] [-b] [--baz | -a BAZ] [FILE...]\n"
@@ -107,7 +107,7 @@ public class HelpPrinterTest {
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -127,7 +127,7 @@ public class HelpPrinterTest {
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -148,7 +148,7 @@ public class HelpPrinterTest {
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -171,7 +171,7 @@ public class HelpPrinterTest {
         help.documentation("Goodbye1 Goodbye2 Goodbye3 Goodbye4 Goodbye5 Goodbye6 Goodbye7 Goodbye8 Goodbye9 "
                            + "Goodbye10 Goodbye11 Goodbye12 Goodbye13 Goodbye14 Goodbye15 Goodbye16 Goodbye17 "
                            + "Goodbye18 Goodbye19 Goodbye20 Goodbye21.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -194,7 +194,7 @@ public class HelpPrinterTest {
         HelpPrinter help = new HelpPrinter("foo");
         help.option("--foo", "-f", "The foo value");
         help.summary("Hello1\r\nHello2\r\rHello3\rHello4.\r");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"


### PR DESCRIPTION
Printing from the CLI previously often resulted in hard to read output because messages were flushed on each newline rather than each log message/write to stdout/stderr, causing contiguous strings of text that contain newlines (like model validation events) to be interleaved between threads. This change updates the CLI to use a PrintWriter instead of a PrintStream to fix this. Additionally, added a new API for creating grouped sections of text from a CliPrinter that includes styling methods.

Forcing color/no_color is now also done through environment variables (FORCE_COLOR, NO_COLOR). This matches lots of other CLI tools.

The way in which colors are detected and rendered is updated too. This change introduces ColorFormatter, and an Ansi enum that contains AUTO, FORCE_COLOR, and NO_COLOR members. AUTO will auto-detect whether colors are supported using a heuristic, and dispatch to FORCE_COLOR and NO_COLOR based on if colors are supported. The CLI now passes around a ColorFormatter in addition to stdout/stderr CliPrinter instances. ColorFormatter could potentially be swapped out for other implementations too (like a markdown renderer).

The hueristic used to detect colors is now:
1. Is FORCE_COLOR set? colors
2. Is NO_COLOR set? no colors
3. Is TERM set and set to "dumb"? no colors
4. Is TERM null and the OS is Windows? no colors
5. Is a System console detected (i.e., interactive CLI that isn't redirected)? colors
6. no colors

I also updated checkstyle to allow for empty methods with braces on the same line to accomodate some of the implementations I was added. I then went and made similar changes to classes in the CLI package to use this approach.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
