### PR TITLE
Add Maven dependency resolution to the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
           distribution: 'zulu'
 
       - name: Clean and build
-        run: ./gradlew clean build -Plog-tests
+        run: ./gradlew clean build -Plog-tests --stacktrace
+
+      - name: CLI integration tests
+        if: matrix.java >= 17
+        run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -163,8 +163,12 @@
         <module name="RightCurly">
             <property name="id" value="RightCurlyAlone"/>
             <property name="option" value="alone"/>
-            <property name="tokens"
-                      value="CLASS_DEF, METHOD_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+            <property name="tokens" value="LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAloneOrSingle"/>
+            <property name="option" value="alone_or_singleline"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF"/>
         </module>
 
         <!-- Checks for common coding problems               -->

--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -148,4 +148,15 @@
         <Class name="software.amazon.smithy.model.shapes.ShapeId$ShapeIdFactory"/>
         <Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/>
     </Match>
+
+    <!-- The FileWriter API that specifies a Charset is not available in Java 8 -->
+    <Match>
+        <Class name="software.amazon.smithy.cli.commands.WarmupCommand"/>
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
+    </Match>
+
+    <!-- SecurityManager is deprecated and scheduled for removal, so this isn't a good check. -->
+    <Match>
+        <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
+    </Match>
 </FindBugsFilter>

--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -41,14 +41,15 @@ The configuration file accepts the following properties:
         added as sources. Sources are relative to the configuration file.
     * - imports
       - ``[string]``
-      - Provides a list of relative imports to combine into a single model.
-        Imports are a kind of local dependency: they aren't considered part of
-        model being built, but are required to build the model. When a
-        directory is encountered, all files in the entire directory tree are
-        imported. Note that build systems MAY choose to rely on other
-        mechanisms for importing models and forming a composite model.
-        Imports defined at the top-level are used in every projection. Imports
-        are relative to the configuration file.
+      - Provides a list of model files and directories to load when validating
+        and building the model. Imports are a local dependency: they are not
+        considered part of model package being built, but are required to build
+        the model package. Models added through ``imports`` are not present in
+        the output of the built-in ``sources`` plugin.
+
+        When a directory is encountered, all files in the entire directory
+        tree are imported. Imports defined at the top-level are used in every
+        projection. Imports are relative to the configuration file.
     * - projections
       - ``map<string, object>``
       - A map of projection names to projection configurations.
@@ -162,7 +163,7 @@ Maven picks the highest version of each project that satisfies all the hard
 requirements of the dependencies on that project. If no version satisfies
 all the hard requirements, dependency resolution fails.
 
-The following table defines version requirement syntax as defined in
+The following table demonstrates version requirement syntax as defined in
 the `official Maven documentation`_:
 
 .. list-table:: Dependency version syntax
@@ -231,7 +232,7 @@ the following configuration:
             file. Instead, use :ref:`environment variables <build_envars>` to
             keep credentials out of source control.
 
-.. code-block::
+.. code-block:: json
 
     {
         "version": "1.0",
@@ -256,7 +257,7 @@ SMITHY_MAVEN_REPOS environment variable
 
 When using the Smithy CLI, the ``SMITHY_MAVEN_REPOS`` environment variable can
 be used to configure Maven repositories automatically. The
-``SMITHY_MAVEN_REPOS`` environment variable is a pipe-delimited value ("|")
+``SMITHY_MAVEN_REPOS`` environment variable is a pipe-delimited value (``|``)
 that contains the URL of each repository to use.
 
 .. code-block::

--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -33,14 +33,22 @@ The configuration file accepts the following properties:
         projection will create a subdirectory named after the projection, and
         the artifacts from the projection, including a ``model.json`` file,
         will be placed in the directory.
+    * - sources
+      - ``[string]``
+      - Provides a list of relative files or directories that contain the
+        models that are considered the source models of the build. When a
+        directory is encountered, all files in the entire directory tree are
+        added as sources. Sources are relative to the configuration file.
     * - imports
-      - ``string[]``
+      - ``[string]``
       - Provides a list of relative imports to combine into a single model.
-        When a directory is encountered, all files and all files within all
-        subdirectories are imported. Note that build systems MAY choose to rely
-        on other mechanisms for importing models and forming a composite model.
-        These imports are used in every projection. Note: imports are relative
-        to the configuration file.
+        Imports are a kind of local dependency: they aren't considered part of
+        model being built, but are required to build the model. When a
+        directory is encountered, all files in the entire directory tree are
+        imported. Note that build systems MAY choose to rely on other
+        mechanisms for importing models and forming a composite model.
+        Imports defined at the top-level are used in every projection. Imports
+        are relative to the configuration file.
     * - projections
       - ``map<string, object>``
       - A map of projection names to projection configurations.
@@ -54,6 +62,11 @@ The configuration file accepts the following properties:
       - If a plugin can't be found, Smithy will by default fail the build. This
         setting can be set to ``true`` to allow the build to progress even if
         a plugin can't be found on the classpath.
+    * - maven
+      - :ref:`maven-configuration` structure
+      - Defines Java Maven dependencies needed to build the model.
+        Dependencies are used to bring in model imports, build plugins,
+        validators, transforms, and other extensions.
 
 The following is an example ``smithy-build.json`` configuration:
 
@@ -62,7 +75,13 @@ The following is an example ``smithy-build.json`` configuration:
     {
         "version": "1.0",
         "outputDirectory": "build/output",
+        "sources": ["model"],
         "imports": ["foo.json", "some/directory"],
+        "maven": {
+            "dependencies": [
+                "software.amazon.smithy:smithy-aws-traits:__smithy_version__"
+            ]
+        },
         "projections": {
             "my-abstract-projection": {
                 "abstract": true
@@ -100,6 +119,166 @@ The following is an example ``smithy-build.json`` configuration:
     }
 
 
+.. _maven-configuration:
+
+Maven configuration
+===================
+
+Maven dependencies and repositories can be defined in smithy-build.json files,
+and the Smithy CLI will automatically resolve these dependencies using the
+`Apache Maven`_ dependency resolver.
+
+The ``maven`` property accepts the following configuration:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - dependencies
+      - ``[string]``
+      - A list of Maven dependency coordinates in the form of
+        ``groupId:artifactId:version``. The Smithy CLI will search each
+        registered Maven repository for the dependency.
+    * - repositories
+      - ``[`` :ref:`maven-repositories` ``]``
+      - A list of Maven repositories to search for dependencies. If no
+        repositories are defined and the :ref:`SMITHY_MAVEN_REPOS environment variable <SMITHY_MAVEN_REPOS>`
+        is not defined, then this value defaults to `Maven Central`_.
+
+
+Dependency versions
+-------------------
+
+Maven dependencies are defined using GAV coordinates
+(``groupId:artifactId:version``). The version of a dependency can specify
+*version requirements* that are used to control how versions are resolved.
+Requirements can be given as *soft requirements*, meaning the version can be
+replaced by other versions found in the dependency graph. Hard requirements
+can be used to mandate a particular version and override soft requirements.
+Maven picks the highest version of each project that satisfies all the hard
+requirements of the dependencies on that project. If no version satisfies
+all the hard requirements, dependency resolution fails.
+
+The following table defines version requirement syntax as defined in
+the `official Maven documentation`_:
+
+.. list-table:: Dependency version syntax
+    :header-rows: 1
+    :widths: 20 80
+
+    * - Version
+      - Description
+    * - ``1.0``
+      - Soft requirement for 1.0. Use 1.0 if no other version appears earlier
+        in the dependency tree.
+    * - ``[1.0]``
+      - Hard requirement for 1.0. Use 1.0 and only 1.0.
+    * - ``(,1.0]``
+      - Hard requirement for any version <= 1.0.
+    * - ``[1.2,1.3]``
+      - Hard requirement for any version between 1.2 and 1.3 inclusive.
+    * - ``[1.0,2.0)``
+      - 1.0 <= x < 2.0; Hard requirement for any version between 1.0 inclusive
+        and 2.0 exclusive.
+    * - ``[1.5,)``
+      - Hard requirement for any version greater than or equal to 1.5.
+    * - ``(,1.0],[1.2,)``
+      - Multiple requirements are separated by commas. This requirement
+        forbids version 1.1 by adding a hard requirement for any version less
+        than or equal to 1.0 or greater than or equal to 1.2.
+    * - ``(,1.1),(1.1,)``
+      - Hard requirement for any version except 1.1 (for example, if 1.1
+        has a critical vulnerability).
+
+
+Unsupported version requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* LATEST, SNAPSHOT, RELEASE, latest-status, and latest.* versions are not
+  supported.
+* Gradle style ``+`` versions are not supported.
+
+
+.. _maven-repositories:
+
+Maven Repositories
+------------------
+
+The ``repositories`` property accepts a list of structures that each accept
+the following configuration:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - url
+      - ``string``
+      - The URL of the repository (for example, ``https://repo.maven.apache.org/maven2``).
+    * - httpCredentials
+      - ``string``
+      - HTTP basic or digest credentials to use with the repository.
+        Credentials are provided in the form of "username:password".
+
+        .. warning::
+
+            Credentials SHOULD NOT be defined statically in a smithy-build.json
+            file. Instead, use :ref:`environment variables <build_envars>` to
+            keep credentials out of source control.
+
+.. code-block::
+
+    {
+        "version": "1.0",
+        "maven": {
+            "repositories": [
+                {
+                    "url": "https://my_domain-111122223333.d.codeartifact.region.amazonaws.com/maven/my_repo/",
+                    "httpCredentials": "aws:${CODEARTIFACT_AUTH_TOKEN}"
+                }
+            ],
+            "dependencies": [
+                "software.amazon.smithy:smithy-aws-traits:__smithy_version__"
+            ]
+        }
+    }
+
+
+.. _SMITHY_MAVEN_REPOS:
+
+SMITHY_MAVEN_REPOS environment variable
+---------------------------------------
+
+When using the Smithy CLI, the ``SMITHY_MAVEN_REPOS`` environment variable can
+be used to configure Maven repositories automatically. The
+``SMITHY_MAVEN_REPOS`` environment variable is a pipe-delimited value ("|")
+that contains the URL of each repository to use.
+
+.. code-block::
+
+    SMITHY_MAVEN_REPOS="https://repo.maven.apache.org/maven2|https://example.repo.com/maven"
+
+Credentials can be provided in the URL. For example:
+
+.. code-block::
+
+    SMITHY_MAVEN_REPOS='https://user:password@example.repo.com/maven'
+
+When repositories are provided through the ``SMITHY_MAVEN_REPOS`` environment
+variable, no default repositories are assumed when resolving the
+``maven.repositories`` setting.
+
+.. important::
+
+    Repositories defined in ``SMITHY_MAVEN_REPOS`` take precedence over
+    repositories defined through smithy-build.json configuration.
+
+
 .. _projections:
 
 Projections
@@ -129,11 +308,12 @@ A projection accepts the following configuration:
         Smithy will not build artifacts for abstract projections. Abstract
         projections must not define ``imports`` or ``plugins``.
     * - imports
-      - ``string[]``
+      - ``[string]``
       - Provides a list of relative imports to include when building this
-        specific projection. When a directory is encountered, all files and
-        all files within all subdirectories are imported. Note: imports are
-        relative to the configuration file.
+        specific projection (in addition to any imports defined at the
+        top-level). When a directory is encountered, all files in the
+        directory tree are imported. Note: imports are relative to the
+        configuration file.
     * - transforms
       - ``list<Transforms>``
       - Defines the transformations to apply to the projection.
@@ -1401,3 +1581,6 @@ ignored. A Smithy manifest file is stored in a JAR as ``META-INF/smithy/manifest
 All model files referenced by the manifest are relative to ``META-INF/smithy/``.
 
 .. _Java SPI: https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html
+.. _Apache Maven: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
+.. _Maven Central: https://search.maven.org
+.. _official Maven documentation: https://maven.apache.org/pom.html#dependency-version-requirement-specification

--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -25,7 +25,7 @@ ext {
 }
 
 dependencies {
-    implementation project(":smithy-cli")
+    implementation project(path: ":smithy-cli", configuration: "shadow")
     implementation project(":smithy-protocol-test-traits")
     implementation project(":smithy-aws-traits")
     api project(":smithy-validation-model")

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -93,6 +93,15 @@ public final class SmithyBuild {
     }
 
     /**
+     * Gets the default directory where smithy-build artifacts are written.
+     *
+     * @return Returns the build output path.
+     */
+    public static Path getDefaultOutputDirectory() {
+        return DefaultPathHolder.DEFAULT_PATH;
+    }
+
+    /**
      * Builds the model and applies all projections.
      *
      * <p>This method loads all projections, projected models, and their
@@ -169,6 +178,9 @@ public final class SmithyBuild {
      */
     public SmithyBuild config(SmithyBuildConfig config) {
         this.config = config;
+        for (String source : config.getSources()) {
+            sources.add(Paths.get(source));
+        }
         return this;
     }
 
@@ -391,5 +403,14 @@ public final class SmithyBuild {
     public SmithyBuild pluginFilter(Predicate<String> pluginFilter) {
         this.pluginFilter = Objects.requireNonNull(pluginFilter);
         return this;
+    }
+
+    // Lazy initialization holder class idiom.
+    private static final class DefaultPathHolder {
+        private static final Path DEFAULT_PATH = resolveDefaultPath();
+
+        private static Path resolveDefaultPath() {
+            return Paths.get(".").toAbsolutePath().normalize().resolve("build").resolve("smithy");
+        }
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -179,9 +179,16 @@ public final class SmithyBuild {
     public SmithyBuild config(SmithyBuildConfig config) {
         this.config = config;
         for (String source : config.getSources()) {
-            sources.add(Paths.get(source));
+            addSource(Paths.get(source));
         }
         return this;
+    }
+
+    // Add a source path using absolute paths to better de-conflict source files. ModelAssembler also
+    // de-conflicts imports with absolute paths, but this ensures the same file doesn't appear twice in
+    // the build plugin output (though it does not use realpath to de-conflict based on symlinks).
+    private void addSource(Path path) {
+        sources.add(path.toAbsolutePath());
     }
 
     /**
@@ -377,7 +384,9 @@ public final class SmithyBuild {
      * @return Returns the builder.
      */
     public SmithyBuild registerSources(Path... pathToSources) {
-        Collections.addAll(sources, pathToSources);
+        for (Path path : pathToSources) {
+            addSource(path);
+        }
         return this;
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuildImpl.java
@@ -92,7 +92,7 @@ final class SmithyBuildImpl {
             outputDirectory = Paths.get(config.getOutputDirectory().get());
         } else {
             // Default the output directory to the current working directory + "./build/smithy"
-            outputDirectory = Paths.get(".").toAbsolutePath().normalize().resolve("build").resolve("smithy");
+            outputDirectory = SmithyBuild.getDefaultOutputDirectory();
         }
 
         // Create the transformers for each projection.

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenConfig.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.model;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.utils.BuilderRef;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class MavenConfig implements ToSmithyBuilder<MavenConfig> {
+
+    private final Set<String> dependencies;
+    private final Set<MavenRepository> repositories;
+
+    private MavenConfig(Builder builder) {
+        this.dependencies = builder.dependencies.copy();
+        this.repositories =  builder.repositories.copy();
+    }
+
+    public static MavenConfig fromNode(Node node) {
+        MavenConfig.Builder builder = builder();
+        node.expectObjectNode()
+                .warnIfAdditionalProperties(ListUtils.of("dependencies", "repositories"))
+                .getArrayMember("dependencies", StringNode::getValue, builder::dependencies)
+                .getArrayMember("repositories", MavenRepository::fromNode, builder::repositories);
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Gets the repositories.
+     *
+     * @return Returns the repositories in an insertion ordered set.
+     */
+    public Set<MavenRepository> getRepositories() {
+        return repositories;
+    }
+
+    /**
+     * Gets the dependencies.
+     *
+     * @return Returns the dependencies in an insertion ordered set.
+     */
+    public Set<String> getDependencies() {
+        return dependencies;
+    }
+
+    public MavenConfig merge(MavenConfig other) {
+        MavenConfig.Builder builder = toBuilder();
+        builder.dependencies.get().addAll(other.getDependencies());
+
+        if (other.repositories != null) {
+            builder.repositories.get().addAll(other.repositories);
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().repositories(repositories).dependencies(dependencies);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dependencies, repositories);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (!(obj instanceof MavenConfig)) {
+            return false;
+        }
+
+        MavenConfig other = (MavenConfig) obj;
+        return dependencies.equals(other.dependencies) && Objects.equals(repositories, other.repositories);
+    }
+
+    public static final class Builder implements SmithyBuilder<MavenConfig> {
+        private final BuilderRef<Set<String>> dependencies = BuilderRef.forOrderedSet();
+        private final BuilderRef<Set<MavenRepository>> repositories = BuilderRef.forOrderedSet();
+
+        private Builder() {}
+
+        @Override
+        public MavenConfig build() {
+            return new MavenConfig(this);
+        }
+
+        public Builder dependencies(Collection<String> dependencies) {
+            this.dependencies.clear();
+            this.dependencies.get().addAll(dependencies);
+            return this;
+        }
+
+        public Builder repositories(Collection<MavenRepository> repositories) {
+            this.repositories.clear();
+            if (repositories != null) {
+                this.repositories.get().addAll(repositories);
+            }
+            return this;
+        }
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenRepository.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenRepository.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
+
+    private final String url;
+    private final String httpCredentials;
+
+    public MavenRepository(Builder builder) {
+        this.url = SmithyBuilder.requiredState("url", builder.url);
+        this.httpCredentials = builder.httpCredentials;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static MavenRepository fromNode(Node node) {
+        Builder builder = builder();
+        node.expectObjectNode()
+                .warnIfAdditionalProperties(Arrays.asList("url", "httpCredentials"))
+                .expectStringMember("url", builder::url)
+                .getStringMember("httpCredentials", builder::httpCredentials);
+        return builder.build();
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public Optional<String> getHttpCredentials() {
+        return Optional.ofNullable(httpCredentials);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().url(url).httpCredentials(httpCredentials);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(url, httpCredentials);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof MavenRepository)) {
+            return false;
+        }
+        MavenRepository mavenRepo = (MavenRepository) o;
+        return Objects.equals(url, mavenRepo.url) && Objects.equals(httpCredentials, mavenRepo.httpCredentials);
+    }
+
+    public static final class Builder implements SmithyBuilder<MavenRepository> {
+        private String url;
+        private String httpCredentials;
+
+        private Builder() {}
+
+        @Override
+        public MavenRepository build() {
+            return new MavenRepository(this);
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder httpCredentials(String httpCredentials) {
+            this.httpCredentials = httpCredentials;
+            if (httpCredentials != null) {
+                int position = httpCredentials.indexOf(':');
+                if (position < 1 || position == httpCredentials.length() - 1) {
+                    throw new IllegalArgumentException("Invalid httpCredentials: expected in the format of user:pass");
+                }
+            }
+            return this;
+        }
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/SmithyBuildConfig.java
@@ -41,20 +41,30 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     private static final Set<String> BUILTIN_PLUGINS = SetUtils.of("build-info", "model", "sources");
 
     private final String version;
+    private final List<String> sources;
     private final List<String> imports;
     private final String outputDirectory;
     private final Map<String, ProjectionConfig> projections;
     private final Map<String, ObjectNode> plugins;
     private final boolean ignoreMissingPlugins;
+    private final MavenConfig maven;
+    private final long lastModifiedInMillis;
 
     private SmithyBuildConfig(Builder builder) {
         SmithyBuilder.requiredState("version", builder.version);
         version = builder.version;
         outputDirectory = builder.outputDirectory;
+        sources = builder.sources.copy();
         imports = builder.imports.copy();
         projections = builder.projections.copy();
         plugins = builder.plugins.copy();
         ignoreMissingPlugins = builder.ignoreMissingPlugins;
+        maven = builder.maven;
+        lastModifiedInMillis = builder.lastModifiedInMillis;
+
+        if (outputDirectory != null && outputDirectory.isEmpty()) {
+            throw new IllegalArgumentException("outputDirectory must be set to a valid directory");
+        }
     }
 
     public static SmithyBuildConfig fromNode(Node node) {
@@ -78,8 +88,18 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
      * <code>
      * {
      *     "version": "1.0",
+     *     "sources": ["model"],
      *     "imports": ["foo.json", "baz.json"],
      *     "outputDirectory": "build/output",
+     *     "maven" {
+     *          "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.26.1"],
+     *          "repositories": [
+     *              {
+     *                  "url": "https://example.com/maven",
+     *                  "httpCredentials": "${MAVEN_USER}:${MAVEN_PASSWORD}"
+     *              }
+     *          ]
+     *     }
      *     "projections": {
      *         "projection-name": {
      *             "transforms": [
@@ -116,10 +136,12 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         return builder()
                 .version(version)
                 .outputDirectory(outputDirectory)
+                .sources(sources)
                 .imports(imports)
                 .projections(projections)
                 .plugins(plugins)
-                .ignoreMissingPlugins(ignoreMissingPlugins);
+                .ignoreMissingPlugins(ignoreMissingPlugins)
+                .maven(maven);
     }
 
     /**
@@ -132,7 +154,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
-     * Gets the paths to all of the models to import.
+     * Gets the paths to all the models to import.
      *
      * <p>Paths can point to individual model files or directories.
      * All models stored in all recursive directories will be imported.
@@ -144,6 +166,19 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
+     * Gets the paths to all model sources.
+     *
+     * <p>Paths can point to individual model files or directories.
+     * All models stored in all recursive directories will be imported.
+     * Each found Smithy model will be considered a source model.
+     *
+     * @return Gets the list of models to import.
+     */
+    public List<String> getSources() {
+        return sources;
+    }
+
+    /**
      * @return Gets the optional output directory to store artifacts.
      */
     public Optional<String> getOutputDirectory() {
@@ -151,7 +186,7 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
-     * Gets all of the configured projections.
+     * Gets all the configured projections.
      *
      * @return Gets the available projections as a map of name to config.
      */
@@ -181,15 +216,41 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
     }
 
     /**
+     * Gets Maven dependency configuration.
+     *
+     * <p>Note that smithy-build does not directly resolve or use dependencies.
+     * It's up to other packages like the Smithy CLI to use a dependency resolver
+     * based on smithy-build.json configuration and call smithy-build with
+     * the appropriate classpath.
+     *
+     * @return Returns Maven dependency information.
+     */
+    public Optional<MavenConfig> getMaven() {
+        return Optional.ofNullable(maven);
+    }
+
+    /**
+     * Get the last modified time of the configuration file.
+     *
+     * @return Returns the last modified time in milliseconds since the epoch.
+     */
+    public long getLastModifiedInMillis() {
+        return lastModifiedInMillis;
+    }
+
+    /**
      * Builder used to create a {@link SmithyBuildConfig}.
      */
     public static final class Builder implements SmithyBuilder<SmithyBuildConfig> {
         private final BuilderRef<List<String>> imports = BuilderRef.forList();
+        private final BuilderRef<List<String>> sources = BuilderRef.forList();
         private final BuilderRef<Map<String, ProjectionConfig>> projections = BuilderRef.forOrderedMap();
         private final BuilderRef<Map<String, ObjectNode>> plugins = BuilderRef.forOrderedMap();
         private String version;
         private String outputDirectory;
         private boolean ignoreMissingPlugins;
+        private MavenConfig maven;
+        private long lastModifiedInMillis = 0;
 
         Builder() {}
 
@@ -238,6 +299,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
             node.expectObjectNode()
                     .expectStringMember("version", this::version)
                     .getStringMember("outputDirectory", this::outputDirectory)
+                    .getArrayMember("sources", s -> SmithyBuildUtils.resolveImportPath(basePath, s),
+                                    values -> sources.get().addAll(values))
                     .getArrayMember("imports", s -> SmithyBuildUtils.resolveImportPath(basePath, s),
                                     values -> imports.get().addAll(values))
                     .getObjectMember("projections", v -> {
@@ -251,7 +314,8 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
                             plugins.get().put(entry.getKey(), entry.getValue().expectObjectNode());
                         }
                     })
-                    .getBooleanMember("ignoreMissingPlugins", this::ignoreMissingPlugins);
+                    .getBooleanMember("ignoreMissingPlugins", this::ignoreMissingPlugins)
+                    .getMember("maven", MavenConfig::fromNode, this::maven);
             return this;
         }
 
@@ -264,9 +328,18 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         public Builder merge(SmithyBuildConfig config) {
             config.getOutputDirectory().ifPresent(this::outputDirectory);
             version(config.getVersion());
+            sources.get().addAll(config.getSources());
             imports.get().addAll(config.getImports());
             projections.get().putAll(config.getProjections());
             plugins.get().putAll(config.getPlugins());
+
+            if (config.getMaven().isPresent()) {
+                if (maven == null) {
+                    maven = config.maven;
+                } else {
+                    maven = maven.merge(config.maven);
+                }
+            }
 
             // If either one wants to ignore missing plugins, then ignore them.
             if (config.isIgnoreMissingPlugins()) {
@@ -296,6 +369,18 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
         public Builder imports(Collection<String> imports) {
             this.imports.clear();
             this.imports.get().addAll(imports);
+            return this;
+        }
+
+        /**
+         * Replaces sources on the config.
+         *
+         * @param sources Sources to set.
+         * @return Returns the builder.
+         */
+        public Builder sources(Collection<String> sources) {
+            this.sources.clear();
+            this.sources.get().addAll(sources);
             return this;
         }
 
@@ -331,6 +416,16 @@ public final class SmithyBuildConfig implements ToSmithyBuilder<SmithyBuildConfi
          */
         public Builder ignoreMissingPlugins(boolean ignoreMissingPlugins) {
             this.ignoreMissingPlugins = ignoreMissingPlugins;
+            return this;
+        }
+
+        public Builder maven(MavenConfig maven) {
+            this.maven = maven;
+            return this;
+        }
+
+        public Builder lastModifiedInMillis(long lastModifiedInMillis) {
+            this.lastModifiedInMillis = lastModifiedInMillis;
             return this;
         }
     }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenConfigTest.java
@@ -1,0 +1,82 @@
+package software.amazon.smithy.build.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+
+public class MavenConfigTest {
+    @Test
+    public void hasNoDefaultsBuiltInToThePojo() {
+        MavenConfig config = MavenConfig.builder().build();
+
+        assertThat(config.getRepositories(), empty());
+    }
+
+    @Test
+    public void loadsEmptyConfig() {
+        MavenConfig config = MavenConfig.fromNode(Node.objectNode());
+
+        assertThat(config.getDependencies(), empty());
+        assertThat(config.getRepositories(), empty());
+    }
+
+    @Test
+    public void loadsFromNodeAndOverridesMavenCentral() {
+        MavenConfig config = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v"))
+                .withMember("repositories", Node.fromNodes(Node.objectNode().withMember("url", "https://example.com")))
+                .build());
+
+        assertThat(config.getDependencies(), contains("g:a:v"));
+        assertThat(config.getRepositories(), hasSize(1));
+        assertThat(config.getRepositories().iterator().next().getUrl(), equalTo("https://example.com"));
+    }
+
+    @Test
+    public void convertToBuilder() {
+        MavenConfig config1 = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v"))
+                .withMember("repositories", Node.fromNodes(Node.objectNode().withMember("url", "https://example.com")))
+                .build());
+        MavenConfig config2 = config1.toBuilder().build();
+
+        assertThat(config1, equalTo(config1));
+        assertThat(config1, equalTo(config2));
+    }
+
+    @Test
+    public void mergesConfigs() {
+        MavenConfig config1 = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v"))
+                .withMember("repositories", Node.fromNodes(Node.objectNode().withMember("url", "https://example.com")))
+                .build());
+        MavenConfig config2 = MavenConfig.fromNode(Node.objectNodeBuilder()
+                .withMember("dependencies", Node.fromStrings("g:a:v", "a:a:a"))
+                .withMember("repositories", Node.fromNodes(
+                        Node.objectNode().withMember("url", "https://example.com"),
+                        Node.objectNode().withMember("url", "https://m2.example.com")))
+                .build());
+        MavenConfig merged = config1.merge(config2);
+
+        List<MavenRepository> repos = new ArrayList<>(config1.getRepositories());
+        repos.add(MavenRepository.builder().url("https://m2.example.com").build());
+
+        List<String> dependencies = new ArrayList<>();
+        dependencies.add("g:a:v");
+        dependencies.add("a:a:a");
+
+        MavenConfig expectedMerge = MavenConfig.builder()
+            .repositories(repos)
+            .dependencies(dependencies)
+            .build();
+
+        assertThat(merged, equalTo(expectedMerge));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenRepositoryTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/MavenRepositoryTest.java
@@ -1,0 +1,59 @@
+package software.amazon.smithy.build.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+
+public class MavenRepositoryTest {
+    @Test
+    public void validatesHttpCredentialsValidColon() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MavenRepository.builder().url("https://example.com").httpCredentials(":").build();
+        });
+    }
+
+    @Test
+    public void validatesHttpCredentialsHasColon() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MavenRepository.builder().url("https://example.com").httpCredentials("foo").build();
+        });
+    }
+
+    @Test
+    public void validatesHttpCredentialsColonNotAtBeginning() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MavenRepository.builder().url("https://example.com").httpCredentials(":foo").build();
+        });
+    }
+
+    @Test
+    public void hasUrlAndAuth() {
+        MavenRepository repo1 = MavenRepository.builder()
+                .url("https://example.com")
+                .httpCredentials("user:pass")
+                .build();
+        MavenRepository repo2 = repo1.toBuilder().build();
+
+        assertThat(repo1.getUrl(), equalTo("https://example.com"));
+        assertThat(repo1.getHttpCredentials(), equalTo(Optional.of("user:pass")));
+        assertThat(repo2.getUrl(), equalTo("https://example.com"));
+        assertThat(repo2.getHttpCredentials(), equalTo(Optional.of("user:pass")));
+        assertThat(repo1, equalTo(repo1));
+        assertThat(repo1, equalTo(repo2));
+    }
+
+    @Test
+    public void loadsFromNode() {
+        MavenRepository repo = MavenRepository.fromNode(Node.objectNodeBuilder()
+                .withMember("url", "https://example.com")
+                .withMember("httpCredentials", "user:pass")
+                .build());
+
+        assertThat(repo.getUrl(), equalTo("https://example.com"));
+        assertThat(repo.getHttpCredentials(), equalTo(Optional.of("user:pass")));
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/model/SmithyBuildConfigTest.java
@@ -210,4 +210,47 @@ public class SmithyBuildConfigTest {
         assertThat(config.getImports(), contains(cwd.resolve("foo.json").toString()));
         assertThat(config.getProjections().get("a").getImports(), contains(cwd.resolve("baz.json").toString()));
     }
+
+    @Test
+    public void outputDirCannotBeEmpty() throws IOException {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            SmithyBuildConfig.builder()
+                    .version("1.0")
+                    .outputDirectory("")
+                    .build();
+        });
+    }
+
+    @Test
+    public void mergingTakesOtherMavenConfigWhenHasNone() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder().version("1").build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("a:b:1.0.0")).build())
+                .build();
+
+        assertThat(a.toBuilder().merge(b).build().getMaven(), equalTo(b.getMaven()));
+    }
+
+    @Test
+    public void mergingTakesSelfMavenConfigWhenOtherHasNone() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("a:b:1.0.0")).build())
+                .build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1").build();
+
+        assertThat(a.toBuilder().merge(b).build().getMaven(), equalTo(a.getMaven()));
+    }
+
+    @Test
+    public void mergingCombinesMavenConfigsWhenBothPresent() {
+        SmithyBuildConfig a = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("c:d:1.0.0")).build())
+                .build();
+        SmithyBuildConfig b = SmithyBuildConfig.builder().version("1")
+                .maven(MavenConfig.builder().dependencies(ListUtils.of("a:b:1.0.0", "c:d:1.0.0")).build())
+                .build();
+
+        assertThat(a.toBuilder().merge(b).build().getMaven().get().getDependencies(),
+                   contains("c:d:1.0.0", "a:b:1.0.0"));
+    }
 }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/plugins/SourcesPluginTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/plugins/SourcesPluginTest.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.build.plugins;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.net.URISyntaxException;
@@ -11,8 +12,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.SmithyBuildResult;
 import software.amazon.smithy.build.SourcesConflictException;
 import software.amazon.smithy.build.model.ProjectionConfig;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.utils.ListUtils;
@@ -181,5 +185,27 @@ public class SourcesPluginTest {
                 .build();
 
         Assertions.assertThrows(SourcesConflictException.class, () -> new SourcesPlugin().execute(context));
+    }
+
+    @Test
+    public void copiesModelsDefinedInConfigAsSources() throws URISyntaxException {
+        SmithyBuildConfig config = SmithyBuildConfig.builder()
+                .load(Paths.get(getClass().getResource("sources/copiesModelsDefinedInConfigAsSources.json").toURI()))
+                .build();
+        SmithyBuild b = new SmithyBuild();
+        b.fileManifestFactory(p -> new MockManifest());
+        b.config(config);
+        SmithyBuildResult result = b.build();
+
+        MockManifest manifest = (MockManifest) result
+                .getProjectionResult("source")
+                .get()
+                .getPluginManifest("sources")
+                .get();
+
+        assertThat(manifest.getFileString("manifest").get(), containsString("a.smithy"));
+        assertThat(manifest.getFileString("manifest").get(), not(containsString("d.smithy")));
+        assertThat(manifest.hasFile("a.smithy"), is(true));
+        assertThat(manifest.hasFile("d.smithy"), is(false));
     }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources/copiesModelsDefinedInConfigAsSources.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources/copiesModelsDefinedInConfigAsSources.json
@@ -1,0 +1,5 @@
+{
+    "version": "1.0",
+    "sources": ["a.smithy"],
+    "imports": ["../notsources/d.smithy"]
+}

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -15,9 +15,12 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+import java.nio.file.Paths
+
 plugins {
     id "application"
     id "org.beryx.runtime" version "1.12.7"
+    id 'com.github.johnrengelman.shadow' version "7.1.2"
 }
 
 description = "This module implements the Smithy command line interface."
@@ -27,25 +30,111 @@ ext {
     moduleName = "software.amazon.smithy.cli"
     imageJreVersion = "17"
     correttoRoot = "https://corretto.aws/downloads/latest/amazon-corretto-${imageJreVersion}"
+    generatedResourcesDir = file("$buildDir/generated-resources")
+}
+
+dependencies {
+    // Keeps these as exported transitive dependencies.
+    implementation project(":smithy-model")
+    implementation project(":smithy-build")
+    implementation project(":smithy-diff")
+
+    // This is needed to ensure the above dependencies are added to the runtime image.
+    shadow project(":smithy-model")
+    shadow project(":smithy-build")
+    shadow project(":smithy-diff")
+
+    // These maven resolver dependencies are shaded into the smithy-cli JAR.
+    implementation "org.apache.maven:maven-resolver-provider:3.8.6"
+    implementation "org.apache.maven.resolver:maven-resolver-api:1.9.2"
+    implementation "org.apache.maven.resolver:maven-resolver-spi:1.9.2"
+    implementation "org.apache.maven.resolver:maven-resolver-util:1.9.2"
+    implementation "org.apache.maven.resolver:maven-resolver-impl:1.9.2"
+    implementation "org.apache.maven.resolver:maven-resolver-connector-basic:1.9.2"
+    implementation "org.apache.maven.resolver:maven-resolver-transport-file:1.9.2"
+    implementation "org.apache.maven.resolver:maven-resolver-transport-http:1.9.2"
+    implementation "org.slf4j:slf4j-jdk14:1.7.36" // Route slf4j used by Maven through JUL like the rest of Smithy.
+}
+
+// ------ Shade Maven dependency resolvers into the JAR. -------
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+    }
+}
+
+shadowJar {
+    // Replace the normal JAR with the shaded JAR.
+    archiveClassifier.set('')
+
+    mergeServiceFiles()
+
+    // Shade dependencies to prevent conflicts with other dependencies.
+    relocate('org.slf4j', 'software.amazon.smithy.cli.shaded.slf4j')
+    relocate('org.eclipse', 'software.amazon.smithy.cli.shaded.eclipse')
+    relocate('org.apache', 'software.amazon.smithy.cli.shaded.apache')
+    relocate('org.sonatype', 'software.amazon.smithy.cli.shaded.sonatype')
+    relocate('org.codehaus', 'software.amazon.smithy.cli.shaded.codehaus')
+
+    // If other javax packages are ever pulled in, we'll need to update this list. This is more deliberate about
+    // what's shaded to ensure that things like javax.net.ssl.SSLSocketFactory are not inadvertently shaded.
+    relocate('javax.annotation', 'software.amazon.smithy.cli.shaded.javax.annotation')
+    relocate('javax.inject', 'software.amazon.smithy.cli.shaded.javax.inject')
+
+    // Don't shade Smithy dependencies into the CLI. These are normal dependencies that we want our consumers
+    // to resolve.
+    dependencies {
+        exclude(project(':smithy-utils'))
+        exclude(project(':smithy-model'))
+        exclude(project(':smithy-build'))
+        exclude(project(':smithy-diff'))
+    }
+}
+
+tasks['jar'].finalizedBy(tasks['shadowJar'])
+
+// ------ Generate a file that contains the Smithy CLI version number. -------
+
+task generateVersionFile {
+    ext.versionFile = file("$generatedResourcesDir/software/amazon/smithy/cli/cli-version")
+    outputs.file(versionFile)
+    doLast {
+        versionFile.text = "${project.version}"
+    }
+}
+
+sourceSets.main.output.dir generatedResourcesDir, builtBy: generateVersionFile
+
+// ------ Setup CLI binary -------
+
+// This setting is needed by the Shadow plugin for some reason to define a main application class.
+mainClassName = "software.amazon.smithy.cli.SmithyCli"
+
+application {
+    mainClass = "${mainClassName}"
+    applicationName = "smithy"
 }
 
 // Detect which OS and arch is running to create an application class data sharing
-// archive for the current platform.
+// archive for the current platform. This is not how we'll ultimately build and release images.
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-    ext.set("imageOs", "win64")
+    ext.set("imageOs", "windows-x64")
 } else if (Os.isFamily(Os.FAMILY_MAC)) {
     if (Os.isArch("aarch64")) {
-        ext.set("imageOs", "osx-aarch_64")
-    } else if (Os.isArch("x86_64")) {
-        ext.set("imageOs", "osx-x86_64")
+        ext.set("imageOs", "darwin-aarch64")
+    } else if (Os.isArch("x86_64") || Os.isArch("amd64")) {
+        ext.set("imageOs", "darwin-x86_64")
     } else {
         println("No JDK for ${System.getProperty("os.arch")}")
         ext.set("imageOs", "")
     }
 } else if (Os.isFamily(Os.FAMILY_UNIX)) {
     if (Os.isArch("aarch")) {
-        ext.set("imageOs", "linux-aarch_64")
-    } else if (Os.isArch("x86_64")) {
+        ext.set("imageOs", "linux-aarch64")
+    } else if (Os.isArch("x86_64") || Os.isArch("amd64")) {
         ext.set("imageOs", "linux-x86_64")
     } else {
         println("No JDK for ${System.getProperty("os.arch")}")
@@ -56,24 +145,31 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     ext.set("imageOs", "")
 }
 
-dependencies {
-    implementation project(":smithy-model")
-    implementation project(":smithy-build")
-    implementation project(":smithy-linters")
-    implementation project(":smithy-diff")
+// This is needed in order for integration tests to find the build jlink CLI.
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    ext.set("smithyBinary", Paths.get(
+            "${project.buildDir}", "image", "smithy-cli-${imageOs}", "bin", "smithy.bat").toString())
+} else {
+    ext.set("smithyBinary", Paths.get(
+            "${project.buildDir}", "image", "smithy-cli-${imageOs}", "bin", "smithy").toString())
 }
-
-application {
-    mainClass = "software.amazon.smithy.cli.SmithyCli"
-    applicationName = "smithy"
-}
+System.setProperty("SMITHY_BINARY", "${smithyBinary}")
 
 runtime {
-    addOptions("--compress", "0", "--strip-debug", "--no-header-files", "--no-man-pages")
-    addModules("java.logging", "java.xml")
+    addOptions("--compress", "2", "--strip-debug", "--no-header-files", "--no-man-pages")
+    addModules("java.logging", "java.xml", "java.naming")
 
     launcher {
+        // This script is a combination of the default startup script used by the badass runtime
+        // plugin, and the upstream source it's based on:
+        // https://raw.githubusercontent.com/gradle/gradle/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+        // Using the Gradle wrapper script as-is results in a huge startup penalty, so I instead updated parts of the
+        // script that didn't affect performance, and kept others that did. Namely, the set and eval code of the Gradle
+        // startup script is significantly slower than what was used by the plugin.
+        unixScriptTemplate = file('config/unixStartScript.txt')
         jvmArgs = [
+            // Disable this when attempting to profile the CLI. In 99% of use cases this isn't not necessary.
+            '-XX:-UsePerfData',
             '-Xshare:auto',
             '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
         ]
@@ -83,38 +179,70 @@ runtime {
         jdkHome = jdkDownload("${correttoRoot}-x64-linux-jdk.tar.gz")
     }
 
-    targetPlatform("linux-aarch_64") {
+    targetPlatform("linux-aarch64") {
         jdkHome = jdkDownload("${correttoRoot}-aarch64-linux-jdk.tar.gz")
     }
 
-    targetPlatform("osx-x86_64") {
+    targetPlatform("darwin-x86_64") {
         jdkHome = jdkDownload("${correttoRoot}-x64-macos-jdk.tar.gz")
     }
 
-    targetPlatform("osx-aarch_64") {
+    targetPlatform("darwin-aarch64") {
         jdkHome = jdkDownload("${correttoRoot}-aarch64-macos-jdk.tar.gz")
     }
 
-    targetPlatform("win64") {
+    targetPlatform("windows-x64") {
         jdkHome = jdkDownload("${correttoRoot}-x64-windows-jdk.zip")
     }
 }
 
 // First, call validate with no args and create a class list to use application class data sharing.
-tasks.register("createClassList", Exec) {
+tasks.register("_createClassList", Exec) {
     environment("SMITHY_OPTS", "-XX:DumpLoadedClassList=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.lst")
-    commandLine("${project.buildDir}/image/smithy-cli-${imageOs}/bin/smithy", "validate")
+    environment("SMITHY_WARMUP_INTERNAL_ONLY", "true")
+    commandLine("$smithyBinary", "warmup", "--discover")
 }
 
 // Next, actually dump out the archive of the collected classes. This is platform specific,
 // so it can only be done for the current OS+architecture.
-tasks.register("dumpArchive", Exec) {
+tasks.register("_dumpArchive", Exec) {
     environment("SMITHY_OPTS", "-Xshare:dump -XX:SharedArchiveFile=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.jsa -XX:SharedClassListFile=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.lst")
-    commandLine("${project.buildDir}/image/smithy-cli-${imageOs}/bin/smithy", "validate")
+    environment("SMITHY_WARMUP_INTERNAL_ONLY", "true")
+    commandLine("$smithyBinary", "warmup", "--discover")
 }
 
 // Can't do CDS if the OS and architecture is not one of our targets.
 if (!imageOs.isEmpty()) {
-    tasks["dumpArchive"].dependsOn("createClassList")
-    tasks["runtime"].finalizedBy("dumpArchive")
+    tasks["_dumpArchive"].dependsOn("_createClassList")
+    tasks["runtime"].finalizedBy("_dumpArchive")
 }
+
+// Always shadow the JAR and replace the JAR by the shadowed JAR.
+tasks['jar'].finalizedBy("shadowJar")
+
+// Prevent https://docs.gradle.org/7.3.3/userguide/validation_problems.html#implicit_dependency issues between
+// the runtime image and shadowJar tasks.
+tasks['distZip'].dependsOn("shadowJar")
+tasks['distTar'].dependsOn("shadowJar")
+tasks['startScripts'].dependsOn("shadowJar")
+tasks["runtime"].dependsOn("shadowJar")
+
+// ------ Setup integration testing -------
+
+sourceSets {
+    create("it") {
+        compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
+        runtimeClasspath += output + compileClasspath + sourceSets["test"].runtimeClasspath
+    }
+}
+
+task integ(type: Test) {
+    useJUnitPlatform()
+    systemProperty "SMITHY_BINARY", "${smithyBinary}"
+    testClassesDirs = sourceSets["it"].output.classesDirs
+    classpath = sourceSets["it"].runtimeClasspath
+    maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+}
+
+// Runtime images need to be created before integration tests can run.
+tasks["integ"].dependsOn("runtime")

--- a/smithy-cli/config/unixStartScript.txt
+++ b/smithy-cli/config/unixStartScript.txt
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+
+# Resolve links: \$0 may be a link
+app_path=\$0
+
+# Need this for daisy-chained symlinks.
+while
+    APP_HOME=\${app_path%"\${app_path##*/}"}  # leaves a trailing /; empty if no leading path
+    [ -h "\$app_path" ]
+do
+    ls=\$( ls -ld "\$app_path" )
+    link=\${ls#*' -> '}
+    case \$link in             #(
+      /*)   app_path=\$link ;; #(
+      *)    app_path=\$APP_HOME\$link ;;
+    esac
+done
+
+# This is normally unused
+# shellcheck disable=SC2034
+APP_BASE_NAME=\${0##*/}
+APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "\$( uname )" in               #(
+  CYGWIN* )         cygwin=true  ;; #(
+  Darwin* )         darwin=true  ;; #(
+  MSYS* | MINGW* )  msys=true    ;; #(
+  NONSTOP* )        nonstop=true ;;
+esac
+
+CLASSPATH="\$APP_HOME/lib/*"
+JAVA_HOME="\$APP_HOME"
+JAVACMD="\$JAVA_HOME/bin/java"
+
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if "\$cygwin" || "\$msys" ; then
+    APP_HOME=\$( cygpath --path --mixed "\$APP_HOME" )
+    CLASSPATH=\$( cygpath --path --mixed "\$CLASSPATH" )
+    JAVACMD=\$( cygpath --unix "\$JAVACMD" )
+
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    for arg do
+        if
+            case \$arg in                                #(
+              -*)   false ;;                            # don't mess with options #(
+              /?*)  t=\${arg#/} t=/\${t%%/*}              # looks like a POSIX filepath
+                    [ -e "\$t" ] ;;                      #(
+              *)    false ;;
+            esac
+        then
+            arg=\$( cygpath --path --ignore --mixed "\$arg" )
+        fi
+        # Roll the args list around exactly as many times as the number of
+        # args, so each arg winds up back in the position where it started, but
+        # possibly modified.
+        #
+        # NB: a `for` loop captures its iteration list before it begins, so
+        # changing the positional parameters here affects neither the number of
+        # iterations, nor the values presented in `arg`.
+        shift                   # remove old arg
+        set -- "\$@" "\$arg"      # push replacement arg
+    done
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\\\n "\$i" | sed "s/'/'\\\\\\\\''/g;1s/^/'/;\\\$s/\\\$/' \\\\\\\\/" ; done
+    echo " "
+}
+APP_ARGS=\$(save "\$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- \$JAVA_TOOL_OPTIONS \$DEFAULT_JVM_OPTS \$CDS_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
+
+# Unset this environment variable before calling Java to prevent it from appearing in stderr.
+# Instead, the value stored in this variable is passed in to the command in the previous line manually.
+unset JAVA_TOOL_OPTIONS
+
+<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %>cd "\$APP_HOME/bin" && <% } %>exec "\$JAVACMD" "\$@"

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
@@ -1,0 +1,38 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class CleanCommandTest {
+    @Test
+    public void exitNormallyIfBuildDirMissing() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("clean"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), hasLength(0));
+        });
+    }
+
+    @Test
+    public void deletesContentsOfBuildDir() {
+        IntegUtils.withProject("simple-config-sources", root -> {
+            try {
+                Path created = Files.createDirectories(root.resolve("build").resolve("smithy").resolve("foo"));
+                assertThat(Files.exists(created), is(true));
+                RunResult result = IntegUtils.run(root, ListUtils.of("clean"));
+                assertThat(Files.exists(created), is(false));
+                assertThat(result.getExitCode(), is(0));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.utils.IoUtils;
+
+public final class IntegUtils {
+
+    private IntegUtils() {}
+
+    public static void withProject(String projectName, Consumer<Path> consumer) {
+        withTempDir(projectName, path -> {
+            copyProject(projectName, path);
+            consumer.accept(path);
+        });
+    }
+
+    public static void run(String projectName, List<String> args, Consumer<RunResult> consumer) {
+        run(projectName, args, Collections.emptyMap(), consumer);
+    }
+
+    public static void run(String projectName, List<String> args, Map<String, String> env,
+            Consumer<RunResult> consumer) {
+        withProject(projectName, path -> consumer.accept(run(path, args, env)));
+    }
+
+    public static void runWithEmptyCache(String projectName, List<String> args, Map<String, String> env,
+            Consumer<RunResult> consumer) {
+        try {
+            String cacheDir = Files.createTempDirectory("foo").toString();
+            Map<String, String> actualEnv = new HashMap<>(env);
+            actualEnv.put(EnvironmentVariable.SMITHY_MAVEN_CACHE.toString(), cacheDir);
+            withProject(projectName, path -> consumer.accept(run(path, args, actualEnv)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static RunResult run(Path root, List<String> args) {
+        return run(root, args, Collections.emptyMap());
+    }
+
+    public static RunResult run(Path root, List<String> args, Map<String, String> env) {
+        List<String> smithyCommand = createSmithyCommand(args);
+        StringBuilder output = new StringBuilder();
+        int exitCode = IoUtils.runCommand(smithyCommand, root, output, env);
+        return new RunResult(smithyCommand, exitCode, output.toString(), root);
+    }
+
+    private static List<String> createSmithyCommand(List<String> args) {
+        String smithyBinary = System.getProperty("SMITHY_BINARY");
+        if (smithyBinary != null) {
+            List<String> result = new ArrayList<>(args.size() + 1);
+            result.add(smithyBinary);
+            result.addAll(args);
+            return result;
+        }
+
+        throw new RuntimeException("No SMITHY_BINARY location was set. Did you build the Smithy jlink CLI?");
+    }
+
+    private static void withTempDir(String name, Consumer<Path> consumer) {
+        try {
+            Path path = Files.createTempDirectory(name.replace("/", "_"));
+            try {
+                consumer.accept(path);
+            } finally {
+                IoUtils.rmdir(path);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void copyProject(String name, Path dest) {
+        try {
+            URL url = IntegUtils.class.getResource("projects/" + name);
+            if (url == null) {
+                throw new IllegalArgumentException("Invalid project name: " + name);
+            }
+            Path source = Paths.get(url.toURI());
+            copyDirectory(source, dest);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void copyDirectory(Path from, Path to) throws IOException {
+        Files.walkFileTree(from, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                // Create parent directories if they don't exist.
+                Path targetDir = to.resolve(from.relativize(dir));
+                try {
+                    Files.copy(dir, targetDir);
+                } catch (FileAlreadyExistsException e) {
+                    // do nothing
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.copy(file, to.resolve(from.relativize(file)), StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 public final class IntegUtils {
 
@@ -47,7 +48,7 @@ public final class IntegUtils {
     }
 
     public static void run(String projectName, List<String> args, Consumer<RunResult> consumer) {
-        run(projectName, args, Collections.emptyMap(), consumer);
+        run(projectName, args, MapUtils.of(EnvironmentVariable.NO_COLOR.toString(), "true"), consumer);
     }
 
     public static void run(String projectName, List<String> args, Map<String, String> env,

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -1,0 +1,197 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+
+public class MavenResolverTest {
+    @Test
+    public void resolvesDependenciesFromMavenCentralDefault() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
+
+    @Test
+    public void resolveDependenciesWithDebugInfo() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "--debug", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("Resolving Maven dependencies for Smithy CLI"));
+            assertThat(result.getOutput(), containsString("Dependency resolution time in ms"));
+        });
+    }
+
+    @Test
+    public void lowerSmithyVersionsAreUpgradedToNewerVersions() {
+        IntegUtils.run("lower-smithy-version", ListUtils.of("validate", "--logging", "FINE"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("Replaced software.amazon.smithy:smithy-model:1.25.2"));
+        });
+    }
+
+    @Test
+    public void lowerSmithyVersionsAreUpgradedToNewerVersionsQuiet() {
+        IntegUtils.run("lower-smithy-version", ListUtils.of("validate", "--quiet"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), not(containsString("Replacing software.amazon.smithy:smithy-model:jar:1.0.0 with software.amazon.smithy:smithy-model:" + SmithyCli.getVersion())));
+        });
+    }
+
+    @Test
+    public void failsWhenBadVersionRequested() {
+        IntegUtils.run("bad-smithy-version", ListUtils.of("validate"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("software.amazon.smithy:smithy-model:jar:[999.999.999]"));
+        });
+    }
+
+    // TODO: This test could be better and actually test that auth works somehow.
+    @Test
+    public void usesCustomRepoWithAuth() {
+        IntegUtils.runWithEmptyCache("maven-auth", ListUtils.of("validate", "--debug"),
+                                     Collections.emptyMap(), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("with xxx=****"));
+        });
+    }
+
+    @Test
+    public void ignoresEmptyCacheFiles() {
+        IntegUtils.withProject("aws-model", path -> {
+            try {
+                Files.createDirectories(path.resolve("build").resolve("smithy"));
+                Files.write(path.resolve("build").resolve("smithy").resolve("classpath.json"),
+                            "".getBytes(StandardCharsets.UTF_8));
+                RunResult result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+
+                assertThat(result.getExitCode(), is(0));
+                assertThat(result.getOutput(), containsString("Invalidating dependency cache"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void deletesStaleCacheFiles() {
+        IntegUtils.withProject("aws-model", path -> {
+            // Do the first run and expect it to resolve, cache, and work.
+            RunResult result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            assertThat(result.hasFile("build", "smithy", "classpath.json"), is(true));
+
+            // Update the config file lastModified time to force the cache to be invalidated.
+            assertThat(result.resolve(result.getRoot(), "smithy-build.json").toFile()
+                               .setLastModified(System.currentTimeMillis()), is(true));
+
+            // Do the next run and expect it to resolve, invalidate the cache, and work.
+            result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            assertThat(result.hasFile("build", "smithy", "classpath.json"), is(true));
+            assertThat(result.getOutput(), containsString("Invalidating dependency cache"));
+        });
+    }
+
+    // If a dependency changes, its POM could have changed too, so invalidate the cache.
+    @Test
+    public void invalidatesCacheWhenDependencyChanges() {
+        IntegUtils.withProject("aws-model", path -> {
+            // Do the first run and expect it to resolve, cache, and work.
+            RunResult result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            String cacheContents = result.getFile("build", "smithy", "classpath.json");
+
+            ObjectNode node = Node.parse(cacheContents).expectObjectNode();
+            String location = node.expectStringMember("software.amazon.smithy:smithy-aws-traits:"
+                                                      + SmithyCli.getVersion()).getValue();
+
+            // Set the lastModified of the JAR to the current time, which is > than the time of the config file,
+            // so the cache is invalided.
+            assertThat(new File(location).setLastModified(System.currentTimeMillis()), is(true));
+
+            // Do the next run and expect it to resolve, invalidate the cache, and work.
+            result = IntegUtils.run(path, ListUtils.of("validate", "--debug", "model"));
+            assertThat(result.getExitCode(), is(0));
+            assertThat(result.hasFile("build", "smithy", "classpath.json"), is(true));
+            assertThat(result.getOutput(), containsString("Invalidating dependency cache"));
+        });
+    }
+
+    @Test
+    public void canIgnoreDependencyResolution() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "model"),
+                       MapUtils.of(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.toString(), "ignore"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+
+    @Test
+    public void canForbidDependencyResolution() {
+        IntegUtils.run("aws-model", ListUtils.of("validate", "model"),
+                       MapUtils.of(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.toString(), "forbid"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("set to 'forbid'"));
+        });
+    }
+
+    @Test
+    public void validatesDependencyResolution() {
+        IntegUtils.run("aws-model",
+                       ListUtils.of("validate", "model"),
+                       MapUtils.of(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.toString(), "Beeblebrox"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Beeblebrox"));
+        });
+    }
+
+    @Test
+    public void canDisableMavenLocalDefaultWithEnvSetting() {
+        // Note that running with an empty cache means it can't find the packages at all. Running with a cache
+        // means it could potentially find the packages.
+        IntegUtils.runWithEmptyCache("aws-model",
+                                     ListUtils.of("validate", "--debug", "model"),
+                                     MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(), ""),
+                                     result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+
+    @Test
+    public void canSetMavenReposUsingEnvironmentVariable() {
+        IntegUtils.runWithEmptyCache("aws-model",
+                                     ListUtils.of("validate", "--debug", "model"),
+                                     MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(),
+                                                 "https://repo.maven.apache.org/maven2"),
+                                     result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
+
+    @Test
+    public void setSetMavenRepoWithEnvUsingAuth() {
+        String repo = "https://xxx:yyy@localhost:1234/maven/not/there";
+        IntegUtils.runWithEmptyCache("aws-model",
+                                     ListUtils.of("validate", "--debug", "model"),
+                                     MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(), repo),
+                                     result -> {
+            assertThat(result.getOutput(), containsString("with xxx=****"));
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
@@ -18,9 +18,11 @@ package software.amazon.smithy.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 public class RootCommandTest {
     @Test
@@ -36,6 +38,9 @@ public class RootCommandTest {
         IntegUtils.run("simple-config-sources", ListUtils.of("-h"), result -> {
             assertThat(result.getExitCode(), equalTo(0));
             ensureHelpOutput(result);
+
+            // We force NO_COLOR by default in the run method. Test that's honored here.
+            assertThat(result.getOutput(), not(containsString("[0m")));
         });
     }
 
@@ -68,6 +73,17 @@ public class RootCommandTest {
         IntegUtils.run("simple-config-sources", ListUtils.of("--foo"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
             assertThat(result.getOutput(), containsString("Unknown argument or command: --foo"));
+        });
+    }
+
+    @Test
+    public void runsWithColors() {
+        IntegUtils.run("simple-config-sources",
+                       ListUtils.of("--help"),
+                       MapUtils.of(EnvironmentVariable.FORCE_COLOR.toString(), "true"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("[0m"));
         });
     }
 

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RootCommandTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class RootCommandTest {
+    @Test
+    public void providingNoInputPrintsHelp() {
+        IntegUtils.run("simple-config-sources", ListUtils.of(), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            ensureHelpOutput(result);
+        });
+    }
+
+    @Test
+    public void passing_h_printsHelp() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("-h"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            ensureHelpOutput(result);
+        });
+    }
+
+    @Test
+    public void passingHelpPrintsHelp() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--help"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            ensureHelpOutput(result);
+        });
+    }
+
+    @Test
+    public void supportsVersionPseudoCommand() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--version"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), equalTo(SmithyCli.getVersion()));
+        });
+    }
+
+    @Test
+    public void errorsOnInvalidCommand() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("doesNotExist"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Unknown argument or command: doesNotExist"));
+        });
+    }
+
+    @Test
+    public void errorsOnInvalidArgument() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--foo"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Unknown argument or command: --foo"));
+        });
+    }
+
+    private void ensureHelpOutput(RunResult result) {
+        // Make sure it's the help output.
+        assertThat(result.getOutput(),
+                   containsString("Usage: smithy [-h | --help] [--version] <command> [<args>]"));
+        // Make sure commands are listed.
+        assertThat(result.getOutput(), containsString("Available commands:"));
+        // Check on one of the command's help summary.
+        assertThat(result.getOutput(), containsString("Validates Smithy models"));
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/RunResult.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/RunResult.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.smithy.utils.IoUtils;
+
+final class RunResult {
+    private final List<String> args;
+    private final int exitCode;
+    private final String output;
+    private final Path root;
+    private Path buildDir;
+
+    RunResult(List<String> args, int exitCode, String output, Path root) {
+        this.args = args;
+        this.exitCode = exitCode;
+        this.output = output;
+        this.root = root;
+    }
+
+    List<String> getArgs() {
+        return args;
+    }
+
+    int getExitCode() {
+        return exitCode;
+    }
+
+    String getOutput() {
+        return output;
+    }
+
+    Path getRoot() {
+        return root;
+    }
+
+    Path withBuildDir(String... paths) {
+        Path result = resolve(root, paths);
+        if (!Files.isDirectory(result)) {
+            throw new RuntimeException("Smithy build directory does not exist: " + result);
+        }
+        this.buildDir = result;
+        return result;
+    }
+
+    Path getBuildDir() {
+        if (buildDir == null) {
+            buildDir = resolve(root, "build", "smithy");
+        }
+        return buildDir;
+    }
+
+    boolean hasFile(String... paths) {
+        return Files.exists(resolve(root, paths));
+    }
+
+    String getFile(String... paths) {
+        Path resolved = resolve(root, paths);
+        if (!Files.isRegularFile(resolved)) {
+            throw new IllegalArgumentException("File not found: " + resolved);
+        }
+        return IoUtils.readUtf8File(resolved);
+    }
+
+    boolean hasProjection(String projection) {
+        return Files.isDirectory(getBuildDir().resolve(projection));
+    }
+
+    boolean hasPlugin(String projection, String plugin) {
+        return Files.isDirectory(getArtifactPath(projection, plugin));
+    }
+
+    boolean hasArtifact(String projection, String plugin, String... paths) {
+        return Files.exists(getArtifactPath(projection, plugin, paths));
+    }
+
+    Path getArtifactPath(String projection, String plugin, String... paths) {
+        return resolve(getBuildDir().resolve(projection).resolve(plugin), paths);
+    }
+
+    String getArtifact(String projection, String plugin, String... paths) {
+        return IoUtils.readUtf8File(getArtifactPath(projection, plugin, paths));
+    }
+
+    Path resolve(Path result, String... paths) {
+        for (String path : paths) {
+            result = result.resolve(path);
+        }
+        return result;
+    }
+
+    Set<Path> getFiles() {
+        return getFiles(root);
+    }
+
+    Set<Path> getFiles(Path inDir) {
+        try (Stream<Path> files  = Files.find(inDir, 999, (p, a) -> Files.isRegularFile(p))) {
+            return files.collect(Collectors.toCollection(TreeSet::new));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    Set<Path> getDirectories() {
+        try (Stream<Path> files  = Files.find(root, 999, (p, a) -> Files.isDirectory(p))) {
+            return files.collect(Collectors.toCollection(TreeSet::new));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RunResult{"
+               + "args='" + args + '\''
+               + ", exitCode=" + exitCode
+               + ", output='" + output + '\''
+               +  ", root=" + root + '}';
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
@@ -1,0 +1,33 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+
+public class SelectTest {
+    @Test
+    public void selectsShapeIds() {
+        List<String> args = Arrays.asList("select", "--selector", "string [id|namespace=smithy.example]");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), equalTo("smithy.example#MyString"));
+        });
+    }
+
+    @Test
+    public void selectsVariables() {
+        List<String> args = Arrays.asList("select", "--vars", "--selector", "list $list(*) > member > string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"shape\": \"smithy.api#String\""));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
@@ -69,4 +69,14 @@ public class SmithyBuildTest {
             assertThat(result.getOutput(), containsString("Caused by"));
         });
     }
+
+    @Test
+    public void successfullyDeDupesConfigAndCliArguments() {
+        // The config adds model as a source and so does the CLI. Without de-duping, this would fail due to the
+        // enum being defined twice with the same members. Without de-conflicting in SmithyBuild, the sources plugin
+        // would fail due to finding two files named main.smithy.
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
@@ -1,0 +1,72 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class SmithyBuildTest {
+    @Test
+    public void buildsModelsWithSourcesAndDefaultPlugins() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("build"), this::doSimpleBuildAssertions);
+    }
+
+    @Test
+    public void canSetSpecificConfigFile() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "-c", "smithy-build.json"),
+                       this::doSimpleBuildAssertions);
+    }
+
+    @Test
+    public void registersSourcesFromArguments() {
+        IntegUtils.run("simple-no-config", ListUtils.of("build", "model"), this::doSimpleBuildAssertions);
+    }
+
+    private void doSimpleBuildAssertions(RunResult result) {
+        assertThat(result.getExitCode(), equalTo(0));
+        assertThat(result.getOutput(), containsString("SUCCESS"));
+        assertThat(result.hasProjection("source"), is(true));
+        assertThat(result.hasPlugin("source", "model"), is(true));
+        assertThat(result.hasPlugin("source", "sources"), is(true));
+        assertThat(result.hasPlugin("source", "build-info"), is(true));
+        assertThat(result.hasArtifact("source", "model", "model.json"), is(true));
+        assertThat(result.hasArtifact("source", "sources", "manifest"), is(true));
+        assertThat(result.hasArtifact("source", "sources", "main.smithy"), is(true));
+        assertThat(result.getArtifact("source", "sources", "main.smithy"), containsString("string MyString"));
+    }
+
+    @Test
+    public void canUseQuietOutput() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "--quiet"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), emptyString());
+        });
+    }
+
+    @Test
+    public void showsErrorMessageWhenConfigIsMissing() {
+        String path = Paths.get("does", "not", "exist1234.json").toString();
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "-c", path), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString(path));
+            assertThat(result.getOutput(), not(containsString("java.io.UncheckedIOException")));
+        });
+    }
+
+    @Test
+    public void showsErrorMessageWithStacktraceWhenConfigIsMissing() {
+        String path = Paths.get("does", "not", "exist1234.json").toString();
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "-c", path, "--stacktrace"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString(path));
+            assertThat(result.getOutput(), containsString("java.io.UncheckedIOException"));
+            assertThat(result.getOutput(), containsString("Caused by"));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyBuildTest.java
@@ -79,4 +79,25 @@ public class SmithyBuildTest {
             assertThat(result.getExitCode(), equalTo(0));
         });
     }
+
+    @Test
+    public void canDisableConfigFileDetection() {
+        // Disable the config file detection and don't pass model via positional arguments.
+        // This causes main.smithy to not be loaded.
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "--no-config"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.hasArtifact("source", "sources", "main.smithy"), is(false));
+        });
+    }
+
+    @Test
+    public void failsWhenConfigIsProvidedAndDisabled() {
+        // Disable the config file detection and don't pass model via positional arguments.
+        // This causes main.smithy to not be loaded.
+        IntegUtils.run("simple-config-sources", ListUtils.of("build", "--no-config", "-c", "smithy-build.json"),
+                       result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("Invalid combination of --no-config and --config"));
+        });
+    }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
@@ -1,0 +1,41 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class SmithyValidateTest {
+    @Test
+    public void validatesModelSuccess() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("validate"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("SUCCESS: Validated "));
+            assertThat(result.hasProjection("source"), is(false));
+        });
+    }
+
+    @Test
+    public void validatesModelSuccessQuiet() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("validate", "--quiet"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), emptyString());
+        });
+    }
+
+    @Test
+    public void validatesModelFailure() {
+        IntegUtils.run("invalid-model", ListUtils.of("validate", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("ERROR: smithy.example#MyString (TraitTarget)"));
+            // Normalize windows paths.
+            assertThat(result.getOutput().replace("\\", "/"), containsString("@ model/invalid.smithy"));
+            assertThat(result.getOutput(), containsString("@range(min: 10, max: 100) // not valid for strings!"));
+            assertThat(result.getOutput(), containsString("ERROR: 1"));
+        });
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
@@ -32,8 +32,7 @@ public class SmithyValidateTest {
         IntegUtils.run("invalid-model", ListUtils.of("validate", "model"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
             assertThat(result.getOutput(), containsString("ERROR: smithy.example#MyString (TraitTarget)"));
-            // Normalize windows paths.
-            assertThat(result.getOutput().replace("\\", "/"), containsString("@ model/invalid.smithy"));
+            assertThat(result.getOutput(), containsString("invalid.smithy"));
             assertThat(result.getOutput(), containsString("@range(min: 10, max: 100) // not valid for strings!"));
             assertThat(result.getOutput(), containsString("ERROR: 1"));
         });

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/WarmupTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/WarmupTest.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class WarmupTest {
+    @Test
+    public void providingNoInputPrintsHelpExits0() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("--help"), result -> {
+            assertThat(result.getOutput(), not(containsString("warmup")));
+        });
+    }
+
+    @Test
+    public void warmupDoesNotWorkWithoutEnvvar() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("warmup"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/model/main.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+namespace smithy.example
+
+@aws.protocols#restJson1
+service Foo {}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/aws-model/smithy-build.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.0",
+    "maven": {
+        "dependencies": ["software.amazon.smithy:smithy-aws-traits:${SMITHY_VERSION}"]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/bad-smithy-version/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/bad-smithy-version/smithy-build.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0",
+    "maven": {
+        // This dependency does not exist, so it can't resolve.
+        "dependencies": ["software.amazon.smithy:smithy-model:[999.999.999]"]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/invalid-model/model/invalid.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/invalid-model/model/invalid.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+namespace smithy.example
+
+@range(min: 10, max: 100) // not valid for strings!
+string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/lower-smithy-version/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/lower-smithy-version/smithy-build.json
@@ -1,0 +1,11 @@
+// Smithy CLI will ignore the older version of Smithy in this file and use the
+// version shipped with the CLI.
+{
+    "version": "1.0",
+    "maven": {
+        "dependencies": [
+            "software.amazon.smithy.typescript:smithy-typescript-codegen:0.12.0",
+            "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.12.0"
+        ]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-auth/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-auth/smithy-build.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0",
+    "maven": {
+        "repositories": [
+            {
+                "url": "https://localhost:1234/maven/not/there",
+                "httpCredentials": "xxx:yyy"
+            }
+        ],
+        "dependencies": [
+            "software.amazon.smithy:smithy-aws-iam-traits:${SMITHY_VERSION}"
+        ]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+namespace smithy.example
+
+string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/model/main.smithy
@@ -1,4 +1,16 @@
-$version: "2.0"
+// Use a 1.0 model to use an enum trait without a warning.
+$version: "1.0"
 namespace smithy.example
 
+// This is used for assertions around de-duping files because duplicate enum values would fail validation.
+@enum([
+    {
+        value: "FOO",
+        name: "FOO"
+    },
+    {
+        value: "BAR",
+        name: "BAR"
+    }
+])
 string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-config-sources/smithy-build.json
@@ -1,0 +1,4 @@
+{
+    "version": "1.0",
+    "sources": ["model"]
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-no-config/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/simple-no-config/model/main.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+namespace smithy.example
+
+string MyString

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Ansi.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Ansi.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Styles text using ANSI color codes.
+ */
+public enum Ansi {
+
+    /**
+     * Writes using ANSI colors if it detects that the environment supports color.
+     */
+    AUTO {
+        private final Ansi delegate = Ansi.detect();
+
+        @Override
+        public String style(String text, Style... styles) {
+            return delegate.style(text, styles);
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            delegate.style(appendable, text, styles);
+        }
+    },
+
+    /**
+     * Does not write any color.
+     */
+    NO_COLOR {
+        @Override
+        public String style(String text, Style... styles) {
+            return text;
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            try {
+                appendable.append(text);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    },
+
+    /**
+     * Writes with ANSI colors.
+     */
+    FORCE_COLOR {
+        @Override
+        public String style(String text, Style... styles) {
+            StringBuilder builder = new StringBuilder();
+            style(builder, text, styles);
+            return builder.toString();
+        }
+
+        @Override
+        public void style(Appendable appendable, String text, Style... styles) {
+            try {
+                appendable.append("\033[");
+                boolean isAfterFirst = false;
+                for (Style style : styles) {
+                    if (isAfterFirst) {
+                        appendable.append(';');
+                    }
+                    appendable.append(style.toString());
+                    isAfterFirst = true;
+                }
+                appendable.append('m');
+                appendable.append(text);
+                appendable.append("\033[0m");
+            } catch (IOException e) {
+                throw new CliError("Error writing output", 2, e);
+            }
+        }
+    };
+
+    /**
+     * Detects if ANSI colors are supported and returns the appropriate Ansi enum variant.
+     *
+     * <p>This method differs from using the {@link Ansi#AUTO} variant directly because it will detect any changes
+     * to the environment that might enable or disable colors.
+     *
+     * @return Returns the detected ANSI color enum variant.
+     */
+    public static Ansi detect() {
+        return isAnsiEnabled() ? FORCE_COLOR : NO_COLOR;
+    }
+
+    /**
+     * Styles text using ANSI color codes.
+     *
+     * @param text Text to style.
+     * @param styles Styles to apply.
+     * @return Returns the styled text.
+     */
+    public abstract String style(String text, Style... styles);
+
+    /**
+     * Styles text using ANSI color codes and writes it to an Appendable.
+     *
+     * @param appendable Where to write styled text.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    public abstract void style(Appendable appendable, String text, Style... styles);
+
+    private static boolean isAnsiEnabled() {
+        if (EnvironmentVariable.FORCE_COLOR.isSet()) {
+            return true;
+        }
+
+        // Disable colors if NO_COLOR is set to anything.
+        if (EnvironmentVariable.NO_COLOR.isSet()) {
+            return false;
+        }
+
+        String term = EnvironmentVariable.TERM.get();
+
+        // If term is set to "dumb", then don't use colors.
+        if (Objects.equals(term, "dumb")) {
+            return false;
+        }
+
+        // If TERM isn't set at all and Windows is detected, then don't use colors.
+        if (term == null && System.getProperty("os.name").contains("win")) {
+            return false;
+        }
+
+        // Disable colors if no console is associated.
+        return System.console() != null;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
@@ -61,7 +61,5 @@ public interface ArgumentReceiver {
      *
      * @param printer Printer to modify.
      */
-    default void registerHelp(HelpPrinter printer) {
-        // do nothing by default.
-    }
+    default void registerHelp(HelpPrinter printer) {}
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ArgumentReceiver.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * A command line argument receiver.
@@ -24,10 +23,9 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * <p>All non-positional arguments of a {@link Command} need a
  * corresponding receiver to accept it through either
  * {@link #testOption(String)} or {@link #testParameter(String)}.
- * If a non-positional argument is not accepted by any receiver,
- * the CLI will exit with an error.
+ * If any receiver rejects a non-positional argument, the CLI will
+ * exit with an error.
  */
-@SmithyUnstableApi
 public interface ArgumentReceiver {
     /**
      * Test if the given value-less option is accepted by the receiver.
@@ -52,7 +50,7 @@ public interface ArgumentReceiver {
      * processing.
      *
      * @param name Name of the parameter to test.
-     * @return Returns a consumer if accepted or null if not accepted.
+     * @return Returns a consumer if accepted or null if rejected.
      */
     default Consumer<String> testParameter(String name) {
         return null;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Arguments.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Arguments.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Command line arguments list to evaluate.
@@ -35,7 +34,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * subscribers via {@link #onComplete(BiConsumer)}. These subscribers are
  * invoked when all arguments have been parsed.
  */
-@SmithyUnstableApi
 public final class Arguments {
 
     private final String[] args;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
@@ -17,10 +17,9 @@ package software.amazon.smithy.cli;
 
 import java.util.Arrays;
 import java.util.logging.Logger;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
- * This class provides a very basic CLI abstraction.
+ * This class provides a basic CLI abstraction.
  *
  * <p>Why are we not using a library for this? Because parsing command line
  * options isn't difficult, we don't need to take a dependency, this code
@@ -28,11 +27,9 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * CLI features are supported in case we want to migrate to a library or
  * event a different language.
  */
-@SmithyUnstableApi
 public final class Cli {
 
     private static final Logger LOGGER = Logger.getLogger(Cli.class.getName());
-    private static final boolean ANSI_SUPPORTED = isAnsiColorSupported();
 
     // Delegate to the stdout consumer by default since this can change.
     private CliPrinter stdoutPrinter = new CliPrinter.ConsumerPrinter(str -> System.out.print(str));
@@ -67,8 +64,8 @@ public final class Cli {
         arguments.addReceiver(standardOptions);
 
         // Use or disable ANSI escapes in the printers.
-        CliPrinter out = ansiPrinter(stdoutPrinter, standardOptions);
-        CliPrinter err = ansiPrinter(stdErrPrinter, standardOptions);
+        CliPrinter out = new CliPrinter.ColorPrinter(stdoutPrinter, standardOptions);
+        CliPrinter err = new CliPrinter.ColorPrinter(stdErrPrinter, standardOptions);
 
         // Setup logging after parsing all arguments.
         arguments.onComplete((opts, positional) -> {
@@ -79,7 +76,7 @@ public final class Cli {
         try {
             return command.execute(arguments, new Command.Env(out, err, classLoader));
         } catch (Exception e) {
-            printException(standardOptions.stackTrace(), err, e);
+            err.printException(e, standardOptions.stackTrace());
             throw CliError.wrap(e);
         } finally {
             try {
@@ -87,7 +84,7 @@ public final class Cli {
             } catch (RuntimeException e) {
                 // Show the error, but don't fail the CLI since most invocations are one-time use.
                 err.println(err.style("Unable to restore logging to previous settings", Style.RED));
-                printException(true, err, e);
+                err.printException(e, standardOptions.stackTrace());
             }
         }
     }
@@ -98,58 +95,5 @@ public final class Cli {
 
     public void stderr(CliPrinter printer) {
         stdErrPrinter = printer;
-    }
-
-    /**
-     * Does a really simple check to see if ANSI colors are supported.
-     *
-     * @return Returns true if ANSI probably works.
-     */
-    private static boolean isAnsiColorSupported() {
-        return System.console() != null && System.getenv().get("TERM") != null;
-    }
-
-    private void printException(boolean stacktrace, CliPrinter printer, Throwable throwable) {
-        if (throwable instanceof NullPointerException) {
-            printer.println(stdErrPrinter.style(
-                    "A null pointer exception occurred while running the Smithy CLI. The --stacktrace argument can be "
-                    + "used to get more information. Please open an issue with the Smithy team on GitHub so this can "
-                    + "be investigated: https://github.com/awslabs/smithy/issues", Style.RED));
-        }
-
-        printer.println(printer.style(throwable.getMessage(), Style.RED, Style.BOLD));
-
-        if (stacktrace) {
-            printer.println(printer.style(throwable.getClass().getCanonicalName() + ":", Style.RED, Style.UNDERLINE));
-            for (StackTraceElement element : throwable.getStackTrace()) {
-                printer.println("\tat " + element.toString());
-            }
-        }
-    }
-
-    /**
-     * Creates a CliPrinter that inspects provided options to determine whether
-     * to use ANSI.
-     *
-     * @param delegate Printer to delegate write and formatting to.
-     * @param options Options to query when it's parsed.
-     * @return Returns the created printer.
-     */
-    private static CliPrinter ansiPrinter(CliPrinter delegate, StandardOptions options) {
-        return new CliPrinter() {
-            @Override
-            public void println(String text) {
-                delegate.println(text);
-            }
-
-            @Override
-            public String style(String text, Style... styles) {
-                if (options.forceColor() || (!options.noColor() && ANSI_SUPPORTED)) {
-                    return delegate.style(text, styles);
-                } else {
-                    return text;
-                }
-            }
-        };
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -15,14 +15,59 @@
 
 package software.amazon.smithy.cli;
 
+import java.io.BufferedWriter;
+import java.io.Flushable;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.function.Consumer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Handles text output of the CLI.
  */
-public interface CliPrinter {
+@FunctionalInterface
+public interface CliPrinter extends Flushable {
+
+    /**
+     * Create a new CliPrinter from a PrintWriter.
+     *
+     * @param ansi Ansi color settings to use.
+     * @param printWriter PrintWriter to write to.
+     * @return Returns the created CliPrinter.
+     */
+    static CliPrinter fromPrintWriter(Ansi ansi, PrintWriter printWriter) {
+        return new CliPrinter() {
+            @Override
+            public void println(String text) {
+                printWriter.println(text);
+            }
+
+            @Override
+            public Ansi ansi() {
+                return ansi;
+            }
+
+            @Override
+            public void flush() {
+                printWriter.flush();
+            }
+        };
+    }
+
+    /**
+     * Create a new CliPrinter from an OutputStream.
+     *
+     * @param ansi Ansi color settings to use.
+     * @param stream OutputStream to write to.
+     * @return Returns the created CliPrinter.
+     */
+    static CliPrinter fromOutputStream(Ansi ansi, OutputStream stream) {
+        Charset charset = StandardCharsets.UTF_8;
+        PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(stream, charset)), false);
+        return fromPrintWriter(ansi, writer);
+    }
+
     /**
      * Prints text to the writer and appends a new line.
      *
@@ -31,86 +76,111 @@ public interface CliPrinter {
     void println(String text);
 
     /**
-     * Styles the given text using ANSI escape sequences.
+     * Prints a styled line of text using ANSI colors.
      *
-     * <p>It is strongly recommended to use the constants defined in
-     * {@link Style} to provide valid combinations of ANSI color escape
-     * codes.
-     *
-     * @param text Text to style.
-     * @param styles ANSI escape codes.
-     * @return Returns the styled text.
+     * @param text Text to style and write.
+     * @param styles Styles to apply.
      */
-    default String style(String text, Style... styles) {
-        return Style.format(text, styles);
+    default void println(String text, Style... styles) {
+        println(ansi().style(text, styles));
     }
 
     /**
-     * Print an exception to the printer.
+     * Flushes any buffers in the printer.
+     */
+    default void flush() {}
+
+    /**
+     * Gets the ANSI color style setting used by the printer.
      *
-     * @param e Exception to print.
-     * @param stacktrace Whether to include a stack trace.
+     * @return Returns the ANSI color style.
      */
-    default void printException(Throwable e, boolean stacktrace) {
-        if (!stacktrace) {
-            println(style(e.getMessage(), Style.RED));
-        } else {
-            StringWriter writer = new StringWriter();
-            e.printStackTrace(new PrintWriter(writer));
-            String result = writer.toString();
-            int positionOfName = result.indexOf(':');
-            result = style(result.substring(0, positionOfName), Style.RED, Style.UNDERLINE)
-                     + result.substring(positionOfName);
-            println(result);
-        }
+    default Ansi ansi() {
+        return Ansi.AUTO;
     }
 
     /**
-     * CliPrinter that calls a Consumer that accepts a CharSequence.
+     * Creates a {@link Buffer} used to build up a long string of text.
+     *
+     * @return Returns the buffer. Call {@link Buffer#close()} or use try-with-resources to write to the printer.
      */
-    final class ConsumerPrinter implements CliPrinter {
-        private final Consumer<CharSequence> consumer;
-
-        public ConsumerPrinter(Consumer<CharSequence> consumer) {
-            this.consumer = consumer;
-        }
-
-        @Override
-        public void println(String text) {
-            consumer.accept(text + System.lineSeparator());
-        }
+    default Buffer buffer() {
+        return new Buffer(this);
     }
 
     /**
-     * A CliPrinter that prints ANSI colors if able and allowed.
+     * A buffer associated with a {@link CliPrinter} used to build up a string of ANSI color stylized text.
+     *
+     * <p>This class is not thread safe; it's a convenient way to build up a long string of text that uses ANSI styles
+     * before ultimately calling {@link #close()}, which writes it to the attached printer.
      */
-    final class ColorPrinter implements CliPrinter {
-        private final CliPrinter delegate;
-        private final StandardOptions options;
-        private final boolean ansiSupported;
+    final class Buffer implements Appendable, AutoCloseable {
+        private final CliPrinter printer;
+        private final StringBuilder builder = new StringBuilder();
 
-        public ColorPrinter(CliPrinter delegate, StandardOptions options) {
-            this.delegate = delegate;
-            this.options = options;
-            this.ansiSupported = isAnsiColorSupported();
-        }
-
-        private static boolean isAnsiColorSupported() {
-            return System.console() != null && System.getenv().get("TERM") != null;
+        private Buffer(CliPrinter printer) {
+            this.printer = printer;
         }
 
         @Override
-        public void println(String text) {
-            delegate.println(text);
+        public String toString() {
+            return builder.toString();
         }
 
         @Override
-        public String style(String text, Style... styles) {
-            if (options.forceColor() || (!options.noColor() && ansiSupported)) {
-                return delegate.style(text, styles);
-            } else {
-                return text;
-            }
+        public Buffer append(CharSequence csq) {
+            builder.append(csq);
+            return this;
+        }
+
+        @Override
+        public Buffer append(CharSequence csq, int start, int end) {
+            builder.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public Buffer append(char c) {
+            builder.append(c);
+            return this;
+        }
+
+        /**
+         * Writes styled text to the builder using the CliPrinter's Ansi settings.
+         *
+         * @param text Text to write.
+         * @param styles Styles to apply to the text.
+         * @return Returns self.
+         */
+        public Buffer print(String text, Style... styles) {
+            printer.ansi().style(this, text, styles);
+            return this;
+        }
+
+        /**
+         * Prints a line of styled text to the buffer.
+         *
+         * @param text Text to print.
+         * @param styles Styles to apply.
+         * @return Returns self.
+         */
+        public Buffer println(String text, Style... styles) {
+            return print(text, styles).println();
+        }
+
+        /**
+         * Writes a system-dependent new line.
+         *
+         * @return Returns the buffer.
+         */
+        public Buffer println() {
+            return append(System.lineSeparator());
+        }
+
+        @Override
+        public void close() {
+            printer.println(builder.toString());
+            builder.setLength(0);
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -30,22 +30,28 @@ import java.nio.charset.StandardCharsets;
 public interface CliPrinter extends Flushable {
 
     /**
+     * Prints text to the writer and appends a new line.
+     *
+     * @param text Text to print.
+     */
+    void println(String text);
+
+    /**
+     * Flushes any buffers in the printer.
+     */
+    default void flush() {}
+
+    /**
      * Create a new CliPrinter from a PrintWriter.
      *
-     * @param ansi Ansi color settings to use.
      * @param printWriter PrintWriter to write to.
      * @return Returns the created CliPrinter.
      */
-    static CliPrinter fromPrintWriter(Ansi ansi, PrintWriter printWriter) {
+    static CliPrinter fromPrintWriter(PrintWriter printWriter) {
         return new CliPrinter() {
             @Override
             public void println(String text) {
                 printWriter.println(text);
-            }
-
-            @Override
-            public Ansi ansi() {
-                return ansi;
             }
 
             @Override
@@ -58,129 +64,12 @@ public interface CliPrinter extends Flushable {
     /**
      * Create a new CliPrinter from an OutputStream.
      *
-     * @param ansi Ansi color settings to use.
      * @param stream OutputStream to write to.
      * @return Returns the created CliPrinter.
      */
-    static CliPrinter fromOutputStream(Ansi ansi, OutputStream stream) {
+    static CliPrinter fromOutputStream(OutputStream stream) {
         Charset charset = StandardCharsets.UTF_8;
         PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(stream, charset)), false);
-        return fromPrintWriter(ansi, writer);
-    }
-
-    /**
-     * Prints text to the writer and appends a new line.
-     *
-     * @param text Text to print.
-     */
-    void println(String text);
-
-    /**
-     * Prints a styled line of text using ANSI colors.
-     *
-     * @param text Text to style and write.
-     * @param styles Styles to apply.
-     */
-    default void println(String text, Style... styles) {
-        println(ansi().style(text, styles));
-    }
-
-    /**
-     * Flushes any buffers in the printer.
-     */
-    default void flush() {}
-
-    /**
-     * Gets the ANSI color style setting used by the printer.
-     *
-     * @return Returns the ANSI color style.
-     */
-    default Ansi ansi() {
-        return Ansi.AUTO;
-    }
-
-    /**
-     * Creates a {@link Buffer} used to build up a long string of text.
-     *
-     * @return Returns the buffer. Call {@link Buffer#close()} or use try-with-resources to write to the printer.
-     */
-    default Buffer buffer() {
-        return new Buffer(this);
-    }
-
-    /**
-     * A buffer associated with a {@link CliPrinter} used to build up a string of ANSI color stylized text.
-     *
-     * <p>This class is not thread safe; it's a convenient way to build up a long string of text that uses ANSI styles
-     * before ultimately calling {@link #close()}, which writes it to the attached printer.
-     */
-    final class Buffer implements Appendable, AutoCloseable {
-        private final CliPrinter printer;
-        private final StringBuilder builder = new StringBuilder();
-
-        private Buffer(CliPrinter printer) {
-            this.printer = printer;
-        }
-
-        @Override
-        public String toString() {
-            return builder.toString();
-        }
-
-        @Override
-        public Buffer append(CharSequence csq) {
-            builder.append(csq);
-            return this;
-        }
-
-        @Override
-        public Buffer append(CharSequence csq, int start, int end) {
-            builder.append(csq, start, end);
-            return this;
-        }
-
-        @Override
-        public Buffer append(char c) {
-            builder.append(c);
-            return this;
-        }
-
-        /**
-         * Writes styled text to the builder using the CliPrinter's Ansi settings.
-         *
-         * @param text Text to write.
-         * @param styles Styles to apply to the text.
-         * @return Returns self.
-         */
-        public Buffer print(String text, Style... styles) {
-            printer.ansi().style(this, text, styles);
-            return this;
-        }
-
-        /**
-         * Prints a line of styled text to the buffer.
-         *
-         * @param text Text to print.
-         * @param styles Styles to apply.
-         * @return Returns self.
-         */
-        public Buffer println(String text, Style... styles) {
-            return print(text, styles).println();
-        }
-
-        /**
-         * Writes a system-dependent new line.
-         *
-         * @return Returns the buffer.
-         */
-        public Buffer println() {
-            return append(System.lineSeparator());
-        }
-
-        @Override
-        public void close() {
-            printer.println(builder.toString());
-            builder.setLength(0);
-        }
+        return fromPrintWriter(writer);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -15,13 +15,13 @@
 
 package software.amazon.smithy.cli;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.function.Consumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Handles text output of the CLI.
  */
-@SmithyUnstableApi
 public interface CliPrinter {
     /**
      * Prints text to the writer and appends a new line.
@@ -46,6 +46,26 @@ public interface CliPrinter {
     }
 
     /**
+     * Print an exception to the printer.
+     *
+     * @param e Exception to print.
+     * @param stacktrace Whether to include a stack trace.
+     */
+    default void printException(Throwable e, boolean stacktrace) {
+        if (!stacktrace) {
+            println(style(e.getMessage(), Style.RED));
+        } else {
+            StringWriter writer = new StringWriter();
+            e.printStackTrace(new PrintWriter(writer));
+            String result = writer.toString();
+            int positionOfName = result.indexOf(':');
+            result = style(result.substring(0, positionOfName), Style.RED, Style.UNDERLINE)
+                     + result.substring(positionOfName);
+            println(result);
+        }
+    }
+
+    /**
      * CliPrinter that calls a Consumer that accepts a CharSequence.
      */
     final class ConsumerPrinter implements CliPrinter {
@@ -58,6 +78,39 @@ public interface CliPrinter {
         @Override
         public void println(String text) {
             consumer.accept(text + System.lineSeparator());
+        }
+    }
+
+    /**
+     * A CliPrinter that prints ANSI colors if able and allowed.
+     */
+    final class ColorPrinter implements CliPrinter {
+        private final CliPrinter delegate;
+        private final StandardOptions options;
+        private final boolean ansiSupported;
+
+        public ColorPrinter(CliPrinter delegate, StandardOptions options) {
+            this.delegate = delegate;
+            this.options = options;
+            this.ansiSupported = isAnsiColorSupported();
+        }
+
+        private static boolean isAnsiColorSupported() {
+            return System.console() != null && System.getenv().get("TERM") != null;
+        }
+
+        @Override
+        public void println(String text) {
+            delegate.println(text);
+        }
+
+        @Override
+        public String style(String text, Style... styles) {
+            if (options.forceColor() || (!options.noColor() && ansiSupported)) {
+                return delegate.style(text, styles);
+            } else {
+                return text;
+            }
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorFormatter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorFormatter.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+/**
+ * Styles text using color codes.
+ *
+ * @see AnsiColorFormatter for the ANSI implementation.
+ */
+public interface ColorFormatter {
+    /**
+     * Styles text using the given styles.
+     *
+     * @param text Text to style.
+     * @param styles Styles to apply.
+     * @return Returns the styled text.
+     */
+    String style(String text, Style... styles);
+
+    /**
+     * Styles text using the given styles and writes it to an Appendable.
+     *
+     * @param appendable Where to write styled text.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    void style(Appendable appendable, String text, Style... styles);
+
+    /**
+     * Print a styled line of text to the given {@code printer}.
+     *
+     * @param printer Printer to write to.
+     * @param text Text to write.
+     * @param styles Styles to apply.
+     */
+    default void println(CliPrinter printer, String text, Style... styles) {
+        printer.println(style(text, styles));
+    }
+
+    /**
+     * Creates a {@link PrinterBuffer} used to build up a long string of styled text.
+     *
+     * <p>Call {@link PrinterBuffer#close()} or use try-with-resources to write to the printer.
+     *
+     * @return Returns the buffer.
+     */
+    default PrinterBuffer printerBuffer(CliPrinter printer) {
+        return new PrinterBuffer(this, printer);
+    }
+
+    /**
+     * A buffer associated with a {@link CliPrinter} used to build up a string of colored text.
+     *
+     * <p>Use {@link #close()} to write to the associated {@link CliPrinter}, or wrap the buffer in a
+     * try-with-resources block.
+     */
+    final class PrinterBuffer implements Appendable, AutoCloseable {
+        private final ColorFormatter colors;
+        private final CliPrinter printer;
+        private final StringBuilder builder = new StringBuilder();
+        private boolean pendingNewline;
+        private final String newline = System.lineSeparator();
+
+        private PrinterBuffer(ColorFormatter colors, CliPrinter printer) {
+            this.colors = colors;
+            this.printer = printer;
+        }
+
+        @Override
+        public String toString() {
+            String result = builder.toString();
+            if (pendingNewline) {
+                result += newline;
+            }
+            return result;
+        }
+
+        @Override
+        public PrinterBuffer append(CharSequence csq) {
+            handleNewline();
+            builder.append(csq);
+            return this;
+        }
+
+        private void handleNewline() {
+            if (pendingNewline) {
+                builder.append(newline);
+                pendingNewline = false;
+            }
+        }
+
+        @Override
+        public PrinterBuffer append(CharSequence csq, int start, int end) {
+            handleNewline();
+            builder.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public PrinterBuffer append(char c) {
+            handleNewline();
+            builder.append(c);
+            return this;
+        }
+
+        /**
+         * Writes styled text to the builder using the CliPrinter's color settings.
+         *
+         * @param text Text to write.
+         * @param styles Styles to apply to the text.
+         * @return Returns self.
+         */
+        public PrinterBuffer print(String text, Style... styles) {
+            handleNewline();
+            colors.style(this, text, styles);
+            return this;
+        }
+
+        /**
+         * Prints a line of styled text to the buffer.
+         *
+         * @param text Text to print.
+         * @param styles Styles to apply.
+         * @return Returns self.
+         */
+        public PrinterBuffer println(String text, Style... styles) {
+            print(text, styles);
+            return println();
+        }
+
+        /**
+         * Writes a system-dependent new line.
+         *
+         * @return Returns the buffer.
+         */
+        public PrinterBuffer println() {
+            handleNewline();
+            pendingNewline = true;
+            return this;
+        }
+
+        @Override
+        public void close() {
+            printer.println(builder.toString());
+            builder.setLength(0);
+            pendingNewline = false;
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
@@ -47,10 +47,10 @@ public interface Command {
     /**
      * Gets the long description of the command.
      *
-     * @param printer Printer used to style strings.
+     * @param colors Color formatter to use for styling help.
      * @return Returns the long description.
      */
-    default String getDocumentation(CliPrinter printer) {
+    default String getDocumentation(ColorFormatter colors) {
         return "";
     }
 
@@ -58,9 +58,10 @@ public interface Command {
      * Prints help output.
      *
      * @param arguments Arguments that have been parsed so far.
+     * @param colors Color formatter to use.
      * @param printer Where to write help.
      */
-    void printHelp(Arguments arguments, CliPrinter printer);
+    void printHelp(Arguments arguments, ColorFormatter colors, CliPrinter printer);
 
     /**
      * Executes the command using the provided arguments.
@@ -78,12 +79,18 @@ public interface Command {
 
         private final CliPrinter stdout;
         private final CliPrinter stderr;
+        private final ColorFormatter colors;
         private final ClassLoader classLoader;
 
-        public Env(CliPrinter stdout, CliPrinter stderr, ClassLoader classLoader) {
+        public Env(ColorFormatter colors, CliPrinter stdout, CliPrinter stderr, ClassLoader classLoader) {
+            this.colors = colors;
             this.stdout = stdout;
             this.stderr = stderr;
             this.classLoader = classLoader;
+        }
+
+        public ColorFormatter colors() {
+            return colors;
         }
 
         public CliPrinter stdout() {
@@ -99,7 +106,7 @@ public interface Command {
         }
 
         public Env withClassLoader(ClassLoader classLoader) {
-            return classLoader == this.classLoader ? this : new Env(stdout, stderr, classLoader);
+            return classLoader == this.classLoader ? this : new Env(colors, stdout, stderr, classLoader);
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Command.java
@@ -15,12 +15,9 @@
 
 package software.amazon.smithy.cli;
 
-import software.amazon.smithy.utils.SmithyUnstableApi;
-
 /**
  * Represents a CLI command.
  */
-@SmithyUnstableApi
 public interface Command {
     /**
      * Gets the name of the command.
@@ -32,6 +29,15 @@ public interface Command {
     String getName();
 
     /**
+     * Return true to hide this command from help output.
+     *
+     * @return Return true if this is a hidden command.
+     */
+    default boolean isHidden() {
+        return false;
+    }
+
+    /**
      * Gets a short summary of the command that's shown in the main help.
      *
      * @return Returns the short help description.
@@ -41,8 +47,7 @@ public interface Command {
     /**
      * Gets the long description of the command.
      *
-     * @param printer CliPrinter used in case formatting is needed via
-     *                {@link CliPrinter#style(String, Style...)}.
+     * @param printer Printer used to style strings.
      * @return Returns the long description.
      */
     default String getDocumentation(CliPrinter printer) {
@@ -81,25 +86,20 @@ public interface Command {
             this.classLoader = classLoader;
         }
 
-        /**
-         * @return Returns the configured printer for stdout.
-         */
         public CliPrinter stdout() {
             return stdout;
         }
 
-        /**
-         * @return Returns the configured printer for stderr.
-         */
         public CliPrinter stderr() {
             return stderr;
         }
 
-        /**
-         * @return Returns the configured class loader to use to load additional classes/resources.
-         */
         public ClassLoader classLoader() {
-            return classLoader;
+            return classLoader == null ? getClass().getClassLoader() : classLoader;
+        }
+
+        public Env withClassLoader(ClassLoader classLoader) {
+            return classLoader == this.classLoader ? this : new Env(stdout, stderr, classLoader);
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+/**
+ * Environment variables used by the Smithy CLI.
+ */
+public enum EnvironmentVariable {
+    /**
+     * A custom location for the Maven local repository cache.
+     *
+     * <p>Example: {@code ~/.m2/repository}
+     */
+    SMITHY_MAVEN_CACHE,
+
+    /**
+     * A pipe-delimited list of Maven repositories to use.
+     *
+     * <p>Example: {@code https://example.com/repo1|https://example.com/repo2}
+     */
+    SMITHY_MAVEN_REPOS,
+
+    /**
+     * Configures if and how the Smithy CLI handles dependencies declared in smithy-build.json files.
+     *
+     * <ul>
+     *     <li>ignore: ignore dependencies and assume that they are provided by the caller of the CLI.</li>
+     *     <li>forbid: forbids dependencies from being declared and will fail the CLI if dependencies are declared.</li>
+     *     <li>standard: the assumed default, will automatically resolve dependencies using Apache Maven.</li>
+     * </ul>
+     */
+    SMITHY_DEPENDENCY_MODE {
+        @Override
+        public String get() {
+            String result = super.get();
+            return result == null ? "standard" : result;
+        }
+    },
+
+    /** The current version of the CLI. This is set automatically by the CLI. */
+    SMITHY_VERSION;
+
+    /**
+     * Gets a system property or environment variable by name, in that order.
+     *
+     * @param name Variable to get.
+     * @return Returns the found system property or environment variable or null.
+     */
+    public static String getByName(String name) {
+        String value = System.getProperty(name);
+        if (value == null) {
+            value = System.getenv(name);
+        }
+        return value;
+    }
+
+    /**
+     * Returns true if the system property or environment variables is set.
+     *
+     * @return Returns true if set.
+     */
+    public boolean isSet() {
+        return get() != null;
+    }
+
+    /**
+     * Gets the system property or the environment variable for the property, in that order.
+     *
+     * @return Returns the found system property or environment variable or null.
+     */
+    public String get() {
+        return getByName(toString());
+    }
+
+    /**
+     * Sets a system property for the environment variable.
+     *
+     * @param value Value to set.
+     */
+    public void set(String value) {
+        System.setProperty(toString(), value);
+    }
+
+    /**
+     * Clears the system property for the variable.
+     */
+    public void clear() {
+        System.clearProperty(toString());
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -51,7 +51,27 @@ public enum EnvironmentVariable {
     },
 
     /** The current version of the CLI. This is set automatically by the CLI. */
-    SMITHY_VERSION;
+    SMITHY_VERSION,
+
+    /**
+     * If set to any value, disable ANSI colors in the output.
+     */
+    NO_COLOR,
+
+    /**
+     * If set to any value, force enables the support of ANSI colors in the output.
+     */
+    FORCE_COLOR,
+
+    /**
+     * Used to detect if ANSI colors are supported.
+     *
+     * <ul>
+     *     <li>If set to "dumb" colors are disabled.</li>
+     *     <li>If not set and the operating system is detected as Windows, colors are disabled.</li>
+     * </ul>
+     */
+    TERM;
 
     /**
      * Gets a system property or environment variable by name, in that order.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -21,7 +21,7 @@ import java.util.StringTokenizer;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
- * Generates and prints structured help output to a {@link CliPrinter}.
+ * Generates and prints structured help output.
  */
 public final class HelpPrinter {
     private final String name;
@@ -128,7 +128,7 @@ public final class HelpPrinter {
         LineWrapper builder = new LineWrapper(maxWidth);
 
         builder.appendWithinLine("Usage: ")
-                .appendWithinLine(printer.style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
+                .appendWithinLine(printer.ansi().style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
                 .space();
 
         // Calculate the column manually to account for possible styles interfering with the current column number.
@@ -166,14 +166,15 @@ public final class HelpPrinter {
     }
 
     private void writeArgHelp(CliPrinter printer, LineWrapper builder, Arg arg) {
+        Ansi ansi = printer.ansi();
         if (arg.longName != null) {
-            builder.appendWithinLine(printer.style(arg.longName, Style.YELLOW));
+            builder.appendWithinLine(ansi.style(arg.longName, Style.YELLOW));
             if (arg.shortName != null) {
                 builder.appendWithinLine(", ");
             }
         }
         if (arg.shortName != null) {
-            builder.appendWithinLine(printer.style(arg.shortName, Style.YELLOW));
+            builder.appendWithinLine(ansi.style(arg.shortName, Style.YELLOW));
         }
         if (arg.exampleValue != null) {
             builder.space().appendWithinLine(arg.exampleValue);
@@ -209,16 +210,17 @@ public final class HelpPrinter {
         }
 
         String toShortArgs(CliPrinter printer) {
+            Ansi ansi = printer.ansi();
             StringBuilder builder = new StringBuilder();
             builder.append('[');
             if (longName != null) {
-                builder.append(printer.style(longName, Style.YELLOW));
+                builder.append(ansi.style(longName, Style.YELLOW));
                 if (shortName != null) {
                     builder.append(" | ");
                 }
             }
             if (shortName != null) {
-                builder.append(printer.style(shortName, Style.YELLOW));
+                builder.append(ansi.style(shortName, Style.YELLOW));
             }
             if (exampleValue != null) {
                 builder.append(' ').append(exampleValue);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -18,13 +18,11 @@ package software.amazon.smithy.cli;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Generates and prints structured help output to a {@link CliPrinter}.
  */
-@SmithyUnstableApi
 public final class HelpPrinter {
     private final String name;
     private int maxWidth = 80;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -122,24 +122,25 @@ public final class HelpPrinter {
     /**
      * Prints the generated help to the given printer.
      *
+     * @param colors Color formatter.
      * @param printer CliPrinter to write to.
      */
-    public void print(CliPrinter printer) {
+    public void print(ColorFormatter colors, CliPrinter printer) {
         LineWrapper builder = new LineWrapper(maxWidth);
 
         builder.appendWithinLine("Usage: ")
-                .appendWithinLine(printer.ansi().style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
+                .appendWithinLine(colors.style(name, Style.BRIGHT_WHITE, Style.UNDERLINE))
                 .space();
 
         // Calculate the column manually to account for possible styles interfering with the current column number.
         builder.indent("Usage: ".length() + name.length() + 1);
 
         for (Arg arg : args) {
-            builder.appendWithinLine(arg.toShortArgs(printer)).space();
+            builder.appendWithinLine(arg.toShortArgs(colors)).space();
         }
 
         if (positional != null) {
-            builder.appendWithinLine(positional.toShortArgs(printer));
+            builder.appendWithinLine(positional.toShortArgs(colors));
         }
 
         builder.indent(0).newLine();
@@ -151,11 +152,11 @@ public final class HelpPrinter {
         builder.newLine();
 
         for (Arg arg : args) {
-            writeArgHelp(printer, builder, arg);
+            writeArgHelp(colors, builder, arg);
         }
 
         if (positional != null) {
-            writeArgHelp(printer, builder, positional);
+            writeArgHelp(colors, builder, positional);
         }
 
         if (!StringUtils.isEmpty(documentation)) {
@@ -165,16 +166,15 @@ public final class HelpPrinter {
         printer.println(builder.toString());
     }
 
-    private void writeArgHelp(CliPrinter printer, LineWrapper builder, Arg arg) {
-        Ansi ansi = printer.ansi();
+    private void writeArgHelp(ColorFormatter colors, LineWrapper builder, Arg arg) {
         if (arg.longName != null) {
-            builder.appendWithinLine(ansi.style(arg.longName, Style.YELLOW));
+            builder.appendWithinLine(colors.style(arg.longName, Style.YELLOW));
             if (arg.shortName != null) {
                 builder.appendWithinLine(", ");
             }
         }
         if (arg.shortName != null) {
-            builder.appendWithinLine(ansi.style(arg.shortName, Style.YELLOW));
+            builder.appendWithinLine(colors.style(arg.shortName, Style.YELLOW));
         }
         if (arg.exampleValue != null) {
             builder.space().appendWithinLine(arg.exampleValue);
@@ -209,18 +209,17 @@ public final class HelpPrinter {
             return new Arg(name, null, null, description);
         }
 
-        String toShortArgs(CliPrinter printer) {
-            Ansi ansi = printer.ansi();
+        String toShortArgs(ColorFormatter colors) {
             StringBuilder builder = new StringBuilder();
             builder.append('[');
             if (longName != null) {
-                builder.append(ansi.style(longName, Style.YELLOW));
+                builder.append(colors.style(longName, Style.YELLOW));
                 if (shortName != null) {
                     builder.append(" | ");
                 }
             }
             if (shortName != null) {
-                builder.append(ansi.style(shortName, Style.YELLOW));
+                builder.append(colors.style(shortName, Style.YELLOW));
             }
             if (exampleValue != null) {
                 builder.append(' ').append(exampleValue);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
@@ -132,9 +132,9 @@ final class LoggingUtil {
             if (isLoggable(record)) {
                 String formatted = formatter.format(record);
                 if (record.getLevel().equals(Level.SEVERE)) {
-                    printer.println(printer.style(formatted, Style.RED));
+                    printer.println(formatted, Style.RED);
                 } else if (record.getLevel().equals(Level.WARNING)) {
-                    printer.println(printer.style(formatted, Style.YELLOW));
+                    printer.println(formatted, Style.YELLOW);
                 } else {
                     printer.println(formatted);
                 }
@@ -142,11 +142,9 @@ final class LoggingUtil {
         }
 
         @Override
-        public void flush() {
-        }
+        public void flush() {}
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/SmithyCli.java
@@ -17,13 +17,17 @@ package software.amazon.smithy.cli;
 
 import java.util.List;
 import software.amazon.smithy.cli.commands.SmithyCommand;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
+import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
+import software.amazon.smithy.utils.IoUtils;
 
 /**
  * Entry point of the Smithy CLI.
  */
 public final class SmithyCli {
 
-    private ClassLoader classLoader = getClass().getClassLoader();
+    private ClassLoader classLoader;
+    private DependencyResolver.Factory dependencyResolverFactory;
 
     private SmithyCli() {}
 
@@ -67,6 +71,20 @@ public final class SmithyCli {
     }
 
     /**
+     * Sets a custom dependency resolver factory to use when resolving dependencies.
+     *
+     * <p>Note that the CLI will automatically handle caching the resolved classpath and ensuring that
+     * resolved dependencies are consistent with the versions of JARs used by the CLI.
+     *
+     * @param dependencyResolverFactory Factory to use when resolving dependencies.
+     * @return Returns the CLI.
+     */
+    public SmithyCli dependencyResolverFactory(DependencyResolver.Factory dependencyResolverFactory) {
+        this.dependencyResolverFactory = dependencyResolverFactory;
+        return this;
+    }
+
+    /**
      * Runs the CLI using a list of arguments.
      *
      * @param args Arguments to parse and execute.
@@ -92,6 +110,21 @@ public final class SmithyCli {
      * @return Returns the created CLI.
      */
     public Cli createCli() {
-        return new Cli(new SmithyCommand(), classLoader);
+        if (dependencyResolverFactory == null) {
+            dependencyResolverFactory = (config, env) -> {
+                return new MavenDependencyResolver(EnvironmentVariable.SMITHY_MAVEN_CACHE.get());
+            };
+        }
+
+        return new Cli(new SmithyCommand(dependencyResolverFactory), classLoader);
+    }
+
+    /**
+     * Get the Smithy CLI version of the running CLI.
+     *
+     * @return Returns the CLI version (e.g., "1.26.0").
+     */
+    public static String getVersion() {
+        return IoUtils.readUtf8Resource(SmithyCli.class, "cli-version").trim();
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -17,27 +17,24 @@ package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import software.amazon.smithy.model.validation.Severity;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Options available to all commands.
  */
-@SmithyInternalApi
 public final class StandardOptions implements ArgumentReceiver {
 
     public static final String HELP_SHORT = "-h";
     public static final String HELP = "--help";
+    public static final String VERSION = "--version";
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
     public static final String NO_COLOR = "--no-color";
     public static final String FORCE_COLOR = "--force-color";
     public static final String LOGGING = "--logging";
-    public static final String SEVERITY = "--severity";
 
     private boolean help;
-    private Severity severity = Severity.WARNING;
+    private boolean version;
     private Level logging = Level.WARNING;
     private boolean quiet;
     private boolean debug;
@@ -47,18 +44,15 @@ public final class StandardOptions implements ArgumentReceiver {
 
     @Override
     public void registerHelp(HelpPrinter printer) {
-        printer.option(HELP, HELP_SHORT, "Prints this help output");
+        printer.option(HELP, HELP_SHORT, "Print help output");
         printer.option(DEBUG, null, "Display debug information");
-        printer.option(QUIET, null, "Silences all output except errors");
+        printer.option(QUIET, null, "Silence output except errors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
-        printer.option(NO_COLOR, null, "Explicitly disable ANSI colors");
-        printer.option(FORCE_COLOR, null, "Explicitly enable ANSI colors");
+        printer.option(NO_COLOR, null, "Disable ANSI colors");
+        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.param(LOGGING, null, "LOG_LEVEL",
-                            "Sets the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
+                            "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
                             + "FINE, ALL.");
-        printer.param(SEVERITY, null, "SEVERITY", "Sets the minimum reported validation severity to "
-                                                      + "report. Set to one of NOTE, WARNING (default), "
-                                                      + "DANGER, ERROR");
     }
 
     @Override
@@ -67,6 +61,9 @@ public final class StandardOptions implements ArgumentReceiver {
             case HELP:
             case HELP_SHORT:
                 help = true;
+                return true;
+            case VERSION:
+                version = true;
                 return true;
             case DEBUG:
                 debug = true;
@@ -79,8 +76,6 @@ public final class StandardOptions implements ArgumentReceiver {
                 debug = false;
                 // Automatically set logging level to SEVERE.
                 logging = Level.SEVERE;
-                // Automatically set severity to DANGER.
-                severity = Severity.DANGER;
                 return true;
             case STACKTRACE:
                 stackTrace = true;
@@ -100,32 +95,24 @@ public final class StandardOptions implements ArgumentReceiver {
 
     @Override
     public Consumer<String> testParameter(String name) {
-        switch (name) {
-            case LOGGING:
-                return value -> {
-                    try {
-                        logging = Level.parse(value);
-                    } catch (IllegalArgumentException e) {
-                        throw new CliError("Invalid logging level: " + value);
-                    }
-                };
-            case SEVERITY:
-                return value -> {
-                    severity = Severity.fromString(value).orElseThrow(() -> {
-                        return new CliError("Invalid severity level: " + value);
-                    });
-                };
-            default:
-                return null;
+        if (LOGGING.equals(name)) {
+            return value -> {
+                try {
+                    logging = Level.parse(value);
+                } catch (IllegalArgumentException e) {
+                    throw new CliError("Invalid logging level: " + value);
+                }
+            };
         }
+        return null;
     }
 
     public boolean help() {
         return help;
     }
 
-    public Severity severity() {
-        return severity;
+    public boolean version() {
+        return version;
     }
 
     public Level logging() {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Options available to all commands.
@@ -30,8 +29,9 @@ public final class StandardOptions implements ArgumentReceiver {
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
+    public static final String NO_COLOR = "--no-color";
+    public static final String FORCE_COLOR = "--force-color";
     public static final String LOGGING = "--logging";
-    private static final Logger LOGGER = Logger.getLogger(StandardOptions.class.getName());
 
     private boolean help;
     private boolean version;
@@ -39,12 +39,15 @@ public final class StandardOptions implements ArgumentReceiver {
     private boolean quiet;
     private boolean debug;
     private boolean stackTrace;
+    private AnsiColorFormatter colorSetting = AnsiColorFormatter.AUTO;
 
     @Override
     public void registerHelp(HelpPrinter printer) {
         printer.option(HELP, HELP_SHORT, "Print help output");
         printer.option(DEBUG, null, "Display debug information");
         printer.option(QUIET, null, "Silence output except errors");
+        printer.option(NO_COLOR, null, "Disable ANSI colors");
+        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
         printer.param(LOGGING, null, "LOG_LEVEL",
                             "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
@@ -76,11 +79,11 @@ public final class StandardOptions implements ArgumentReceiver {
             case STACKTRACE:
                 stackTrace = true;
                 return true;
-            case "--no-color":
-                LOGGER.warning("--no-color is no longer supported. Use the NO_COLOR environment variable.");
+            case NO_COLOR:
+                colorSetting = AnsiColorFormatter.NO_COLOR;
                 return true;
-            case "--force-color":
-                LOGGER.warning("--force-color is no longer supported. Use the FORCE_COLOR environment variable.");
+            case FORCE_COLOR:
+                colorSetting = AnsiColorFormatter.FORCE_COLOR;
                 return true;
             default:
                 return false;
@@ -123,5 +126,9 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public boolean stackTrace() {
         return stackTrace;
+    }
+
+    public AnsiColorFormatter colorSetting() {
+        return colorSetting;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/StandardOptions.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.cli;
 
 import java.util.function.Consumer;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Options available to all commands.
@@ -29,9 +30,8 @@ public final class StandardOptions implements ArgumentReceiver {
     public static final String DEBUG = "--debug";
     public static final String QUIET = "--quiet";
     public static final String STACKTRACE = "--stacktrace";
-    public static final String NO_COLOR = "--no-color";
-    public static final String FORCE_COLOR = "--force-color";
     public static final String LOGGING = "--logging";
+    private static final Logger LOGGER = Logger.getLogger(StandardOptions.class.getName());
 
     private boolean help;
     private boolean version;
@@ -39,8 +39,6 @@ public final class StandardOptions implements ArgumentReceiver {
     private boolean quiet;
     private boolean debug;
     private boolean stackTrace;
-    private boolean noColor;
-    private boolean forceColor;
 
     @Override
     public void registerHelp(HelpPrinter printer) {
@@ -48,8 +46,6 @@ public final class StandardOptions implements ArgumentReceiver {
         printer.option(DEBUG, null, "Display debug information");
         printer.option(QUIET, null, "Silence output except errors");
         printer.option(STACKTRACE, null, "Display a stacktrace on error");
-        printer.option(NO_COLOR, null, "Disable ANSI colors");
-        printer.option(FORCE_COLOR, null, "Force the use of ANSI colors");
         printer.param(LOGGING, null, "LOG_LEVEL",
                             "Set the log level (defaults to WARNING). Set to one of OFF, SEVERE, WARNING, INFO, "
                             + "FINE, ALL.");
@@ -80,13 +76,11 @@ public final class StandardOptions implements ArgumentReceiver {
             case STACKTRACE:
                 stackTrace = true;
                 return true;
-            case NO_COLOR:
-                noColor = true;
-                forceColor = false;
+            case "--no-color":
+                LOGGER.warning("--no-color is no longer supported. Use the NO_COLOR environment variable.");
                 return true;
-            case FORCE_COLOR:
-                noColor = false;
-                forceColor = true;
+            case "--force-color":
+                LOGGER.warning("--force-color is no longer supported. Use the FORCE_COLOR environment variable.");
                 return true;
             default:
                 return false;
@@ -129,13 +123,5 @@ public final class StandardOptions implements ArgumentReceiver {
 
     public boolean stackTrace() {
         return stackTrace;
-    }
-
-    public boolean noColor() {
-        return noColor;
-    }
-
-    public boolean forceColor() {
-        return forceColor;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.cli;
 
 /**
- * ANSI color codes and styles for use with {@link Ansi} or {@link CliPrinter}.
+ * Colors and styles for use with {@link AnsiColorFormatter} or {@link CliPrinter}.
  */
 public enum Style {
     BOLD(1),
@@ -60,14 +60,13 @@ public enum Style {
     BG_BRIGHT_CYAN(106),
     BG_BRIGHT_WHITE(107);
 
-    private final String code;
+    private final String ansiColorCode;
 
-    Style(int code) {
-        this.code = String.valueOf(code);
+    Style(int ansiColorCode) {
+        this.ansiColorCode = String.valueOf(ansiColorCode);
     }
 
-    @Override
-    public String toString() {
-        return code;
+    public String getAnsiColorCode() {
+        return ansiColorCode;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -15,109 +15,59 @@
 
 package software.amazon.smithy.cli;
 
-import java.util.function.IntConsumer;
-
 /**
- * Parameters used to change the ANSI public style of text.
+ * ANSI color codes and styles for use with {@link Ansi} or {@link CliPrinter}.
  */
-@FunctionalInterface
-public interface Style {
+public enum Style {
+    BOLD(1),
+    FAINT(2),
+    ITALIC(3),
+    UNDERLINE(4),
 
-    Style BOLD = new SingularCode(1);
-    Style FAINT = new SingularCode(2);
-    Style ITALIC = new SingularCode(3);
-    Style UNDERLINE = new SingularCode(4);
+    BLACK(30),
+    RED(31),
+    GREEN(32),
+    YELLOW(33),
+    BLUE(34),
+    MAGENTA(35),
+    CYAN(36),
+    WHITE(37),
 
-    Style BLACK = new SingularCode(30);
-    Style RED = new SingularCode(31);
-    Style GREEN = new SingularCode(32);
-    Style YELLOW = new SingularCode(33);
-    Style BLUE = new SingularCode(34);
-    Style MAGENTA = new SingularCode(35);
-    Style CYAN = new SingularCode(36);
-    Style WHITE = new SingularCode(37);
+    BRIGHT_BLACK(90),
+    BRIGHT_RED(91),
+    BRIGHT_GREEN(92),
+    BRIGHT_YELLOW(93),
+    BRIGHT_BLUE(94),
+    BRIGHT_MAGENTA(95),
+    BRIGHT_CYAN(96),
+    BRIGHT_WHITE(97),
 
-    Style BRIGHT_BLACK = new SingularCode(90);
-    Style BRIGHT_RED = new SingularCode(91);
-    Style BRIGHT_GREEN = new SingularCode(92);
-    Style BRIGHT_YELLOW = new SingularCode(93);
-    Style BRIGHT_BLUE = new SingularCode(94);
-    Style BRIGHT_MAGENTA = new SingularCode(95);
-    Style BRIGHT_CYAN = new SingularCode(96);
-    Style BRIGHT_WHITE = new SingularCode(97);
+    BG_BLACK(40),
+    BG_RED(41),
+    BG_GREEN(42),
+    BG_YELLOW(43),
+    BG_BLUE(44),
+    BG_MAGENTA(45),
+    BG_CYAN(46),
+    BG_WHITE(47),
 
-    Style BG_BLACK = new SingularCode(40);
-    Style BG_RED = new SingularCode(41);
-    Style BG_GREEN = new SingularCode(42);
-    Style BG_YELLOW = new SingularCode(43);
-    Style BG_BLUE = new SingularCode(44);
-    Style BG_MAGENTA = new SingularCode(45);
-    Style BG_CYAN = new SingularCode(46);
-    Style BG_WHITE = new SingularCode(47);
+    BG_BRIGHT_BLACK(100),
+    BG_BRIGHT_RED(101),
+    BG_BRIGHT_GREEN(102),
+    BG_BRIGHT_YELLOW(103),
+    BG_BRIGHT_BLUE(104),
+    BG_BRIGHT_MAGENTA(105),
+    BG_BRIGHT_CYAN(106),
+    BG_BRIGHT_WHITE(107);
 
-    Style BG_BRIGHT_BLACK = new SingularCode(100);
-    Style BG_BRIGHT_RED = new SingularCode(101);
-    Style BG_BRIGHT_GREEN = new SingularCode(102);
-    Style BG_BRIGHT_YELLOW = new SingularCode(103);
-    Style BG_BRIGHT_BLUE = new SingularCode(104);
-    Style BG_BRIGHT_MAGENTA = new SingularCode(105);
-    Style BG_BRIGHT_CYAN = new SingularCode(106);
-    Style BG_BRIGHT_WHITE = new SingularCode(107);
+    private final String code;
 
-    /**
-     * Pushes one or more ANSI color codes to the consumer.
-     *
-     * <p>Most implementations will push a single code, but multiple
-     * codes are needed to do things like use 8-bit colors
-     * (e.g., 38+5+206 to make pink foreground text).
-     *
-     * @param codeConsumer Consumer to push integers to.
-     */
-    void pushCodes(IntConsumer codeConsumer);
-
-    /**
-     * Formats the given text with ANSI escapes.
-     *
-     * <p>Each {@code styles} is one or more ANSI escape codes in the format of
-     * "1", "38;5;206" to create an 8-bit color, etc.
-     *
-     * @param text Text to format.
-     * @param styles Styles to apply.
-     * @return Returns the formatted text, and then resets the formatting.
-     * @see <a href="https://man7.org/linux/man-pages/man4/console_codes.4.html">ANSI console codes</a>
-     */
-    static String format(String text, Style... styles) {
-        StringBuilder result = new StringBuilder("\033[");
-        IntConsumer consumer = result::append;
-        boolean isAfterFirst = false;
-
-        for (Style style : styles) {
-            if (isAfterFirst) {
-                result.append(';');
-            }
-            style.pushCodes(consumer);
-            isAfterFirst = true;
-        }
-
-        result.append('m');
-        result.append(text);
-        result.append("\033[0m");
-        return result.toString();
+    Style(int code) {
+        this.code = String.valueOf(code);
     }
 
-    /**
-     * A simple implementation of {@code Style} that pushes a single code.
-     */
-    final class SingularCode implements Style {
-        private final int code;
-
-        public SingularCode(int code) {
-            this.code = code;
-        }
-
-        @Override
-        public void pushCodes(IntConsumer codeConsumer) {
-            codeConsumer.accept(code);
-        }
+    @Override
+    public String toString() {
+        return code;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -16,12 +16,10 @@
 package software.amazon.smithy.cli;
 
 import java.util.function.IntConsumer;
-import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Parameters used to change the ANSI public style of text.
  */
-@SmithyUnstableApi
 @FunctionalInterface
 public interface Style {
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -36,7 +36,7 @@ final class AstCommand extends ClasspathCommand {
 
     @Override
     public String getSummary() {
-        return "Reads Smithy models in and writes out a single JSON AST model";
+        return "Reads Smithy models in and writes out a single JSON AST model.";
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -15,20 +15,18 @@
 
 package software.amazon.smithy.cli.commands;
 
-import java.util.Collections;
 import java.util.List;
-import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ModelSerializer;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class AstCommand extends SimpleCommand {
+final class AstCommand extends ClasspathCommand {
 
-    public AstCommand(String parentCommandName) {
-        super(parentCommandName);
+    AstCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -42,13 +40,8 @@ public final class AstCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return Collections.singletonList(new BuildOptions());
-    }
-
-    @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true);
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
         ModelSerializer serializer = ModelSerializer.builder().build();
         env.stdout().println(Node.prettyPrintJson(serializer.serialize(model)));
         return 0;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.cli.commands;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -125,12 +127,12 @@ final class BuildCommand extends ClasspathCommand {
             Style ansiColor = resultConsumer.failedProjections.isEmpty()
                               ? Style.BRIGHT_GREEN
                               : Style.BRIGHT_YELLOW;
-            env.stderr().println(env.stderr().style(
+            env.stderr().println(
                     String.format("Smithy built %s projection(s), %s plugin(s), and %s artifacts",
                                   resultConsumer.projectionCount,
                                   resultConsumer.pluginCount,
                                   resultConsumer.artifactCount),
-                    Style.BOLD, ansiColor));
+                    Style.BOLD, ansiColor);
         }
 
         // Throw an exception if any errors occurred.
@@ -161,33 +163,32 @@ final class BuildCommand extends ClasspathCommand {
         @Override
         public void accept(String name, Throwable exception) {
             failedProjections.add(name);
-            StringBuilder message = new StringBuilder(
-                    String.format("%nProjection %s failed: %s%n", name, exception.toString()));
-
-            for (StackTraceElement element : exception.getStackTrace()) {
-                message.append(element).append(System.lineSeparator());
-            }
-
-            // Always print errors.
-            printer.println(printer.style(message.toString(), Style.RED));
+            StringWriter writer = new StringWriter();
+            writer.write(String.format("%nProjection %s failed: %s%n", name, exception.toString()));
+            exception.printStackTrace(new PrintWriter(writer));
+            printer.println(writer.toString(), Style.RED);
         }
 
         @Override
         public void accept(ProjectionResult result) {
+            try (CliPrinter.Buffer buffer = printer.buffer()) {
+                printProjectionResult(buffer, result);
+            }
+        }
+
+        private void printProjectionResult(CliPrinter.Buffer buffer, ProjectionResult result) {
             if (result.isBroken()) {
                 // Write out validation errors as they occur.
                 failedProjections.add(result.getProjectionName());
-                StringBuilder message = new StringBuilder(System.lineSeparator());
-                message.append(result.getProjectionName())
-                        .append(" has a model that failed validation")
-                        .append(System.lineSeparator());
+                buffer
+                        .println()
+                        .print(result.getProjectionName(), Style.RED)
+                        .println(" has a model that failed validation");
                 result.getEvents().forEach(event -> {
                     if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
-                        message.append(event).append(System.lineSeparator());
+                        buffer.println(event.toString(), Style.RED);
                     }
                 });
-                // Always print errors.
-                printer.println(printer.style(message.toString(), Style.RED));
             } else {
                 // Only increment the projection count if it succeeded.
                 projectionCount.incrementAndGet();
@@ -202,7 +203,7 @@ final class BuildCommand extends ClasspathCommand {
             if (!quiet) {
                 String message = String.format("Completed projection %s (%d shapes): %s",
                                                result.getProjectionName(), result.getModel().toSet().size(), root);
-                printer.println(printer.style(message, Style.GREEN));
+                buffer.println(message, Style.GREEN);
             }
 
             // Increment the total number of artifacts written.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ClasspathCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ClasspathCommand.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.MavenConfig;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.CliError;
+import software.amazon.smithy.cli.EnvironmentVariable;
+import software.amazon.smithy.cli.SmithyCli;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
+import software.amazon.smithy.cli.dependencies.DependencyResolverException;
+import software.amazon.smithy.cli.dependencies.FileCacheResolver;
+import software.amazon.smithy.cli.dependencies.FilterCliVersionResolver;
+import software.amazon.smithy.cli.dependencies.ResolvedArtifact;
+import software.amazon.smithy.utils.SetUtils;
+
+abstract class ClasspathCommand extends SimpleCommand {
+
+    private static final Set<String> PROVIDED_SMITHY_DEPENDENCIES = SetUtils.of(
+            "software.amazon.smithy:smithy-cli:",
+            "software.amazon.smithy:smithy-model:",
+            "software.amazon.smithy:smithy-build:",
+            "software.amazon.smithy:smithy-utils:");
+    private static final Logger LOGGER = Logger.getLogger(ClasspathCommand.class.getName());
+    private static final MavenRepository CENTRAL = MavenRepository.builder()
+            .url("https://repo.maven.apache.org/maven2")
+            .build();
+    private final DependencyResolver.Factory dependencyResolverFactory;
+
+    ClasspathCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName);
+        this.dependencyResolverFactory = dependencyResolverFactory;
+    }
+
+    @Override
+    protected final List<ArgumentReceiver> createArgumentReceivers() {
+        List<ArgumentReceiver> receivers = new ArrayList<>();
+        receivers.add(new ConfigOptions());
+        receivers.add(new BuildOptions());
+        addAdditionalArgumentReceivers(receivers);
+        return receivers;
+    }
+
+    @Override
+    protected final int run(Arguments arguments, Env env, List<String> positional) {
+        BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
+        ThreadResult threadResult = new ThreadResult();
+        ConfigOptions configOptions = arguments.getReceiver(ConfigOptions.class);
+        SmithyBuildConfig config = configOptions.createSmithyBuildConfig();
+
+        runTaskWithClasspath(buildOptions, config, env, classLoader -> {
+            Env updatedEnv = env.withClassLoader(classLoader);
+            threadResult.returnCode = runWithClassLoader(config, arguments, updatedEnv, positional);
+        });
+
+        return threadResult.returnCode;
+    }
+
+    private static final class ThreadResult {
+        int returnCode;
+    }
+
+    protected void addAdditionalArgumentReceivers(List<ArgumentReceiver> receivers) {
+    }
+
+    abstract int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> positional);
+
+    private void runTaskWithClasspath(
+            BuildOptions buildOptions,
+            SmithyBuildConfig smithyBuildConfig,
+            Env env,
+            Consumer<ClassLoader> consumer
+    ) {
+        Set<String> dependencies = smithyBuildConfig.getMaven()
+                .map(MavenConfig::getDependencies)
+                .orElse(Collections.emptySet());
+
+        String dependencyMode = EnvironmentVariable.SMITHY_DEPENDENCY_MODE.get();
+        boolean useIsolation = false;
+        switch (dependencyMode) {
+            case "forbid":
+                if (!dependencies.isEmpty()) {
+                    throw new DependencyResolverException(String.format(
+                            "%s is set to 'forbid', but the following Maven dependencies are defined in "
+                            + "smithy-build.json: %s. Dependencies are forbidden in this configuration.",
+                            EnvironmentVariable.SMITHY_DEPENDENCY_MODE, dependencies));
+                }
+                break;
+            case "ignore":
+                if (!dependencies.isEmpty()) {
+                    LOGGER.warning(() -> String.format(
+                            "%s is set to 'ignore', and the following Maven dependencies are defined in "
+                            + "smithy-build.json: %s. If the build fails, then you may need to manually configure "
+                            + "the classpath.", EnvironmentVariable.SMITHY_DEPENDENCY_MODE, dependencies));
+                }
+                break;
+            case "standard":
+                useIsolation = !dependencies.isEmpty();
+                break;
+            default:
+                throw new CliError(String.format("Unknown %s setting: '%s'",
+                                                 EnvironmentVariable.SMITHY_DEPENDENCY_MODE, dependencyMode));
+        }
+
+        if (useIsolation) {
+            long start = System.nanoTime();
+            List<Path> files = resolveDependencies(buildOptions, smithyBuildConfig, env,
+                                                   smithyBuildConfig.getMaven().get());
+            long end = System.nanoTime();
+            LOGGER.fine(() -> "Dependency resolution time in ms: " + ((end - start) / 1000000));
+            new IsolatedRunnable(files, env.classLoader(), consumer).run();
+            LOGGER.fine(() -> "Command time in ms: " + ((System.nanoTime() - end) / 1000000));
+        } else {
+            consumer.accept(env.classLoader());
+        }
+    }
+
+    private List<Path> resolveDependencies(
+            BuildOptions buildOptions,
+            SmithyBuildConfig smithyBuildConfig,
+            Env env,
+            MavenConfig maven
+    ) {
+        DependencyResolver baseResolver = dependencyResolverFactory.create(smithyBuildConfig, env);
+        long lastModified = smithyBuildConfig.getLastModifiedInMillis();
+        DependencyResolver delegate = new FilterCliVersionResolver(SmithyCli.getVersion(), baseResolver);
+        DependencyResolver resolver = new FileCacheResolver(getCacheFile(buildOptions), lastModified, delegate);
+        addDefaultConfiguration(resolver);
+        addConfiguredMavenRepos(smithyBuildConfig, resolver);
+        maven.getDependencies().forEach(resolver::addDependency);
+        List<ResolvedArtifact> artifacts = resolver.resolve();
+        LOGGER.fine(() -> "Classpath resolved with Maven: " + artifacts);
+
+        List<Path> result = new ArrayList<>(artifacts.size());
+        for (ResolvedArtifact artifact : artifacts) {
+            result.add(artifact.getPath());
+        }
+
+        return result;
+    }
+
+    private static void addDefaultConfiguration(DependencyResolver resolver) {
+        String version = SmithyCli.getVersion();
+        for (String provided : PROVIDED_SMITHY_DEPENDENCIES) {
+            resolver.addDependency(provided + version);
+        }
+    }
+
+    private static void addConfiguredMavenRepos(SmithyBuildConfig config, DependencyResolver resolver) {
+        // Environment variables take precedence over config files.
+        String envRepos = EnvironmentVariable.SMITHY_MAVEN_REPOS.get();
+        if (envRepos != null) {
+            for (String repo : envRepos.split("\\|")) {
+                resolver.addRepository(MavenRepository.builder().url(repo.trim()).build());
+            }
+        }
+
+        Set<MavenRepository> configuredRepos = config.getMaven()
+                .map(MavenConfig::getRepositories)
+                .orElse(Collections.emptySet());
+
+        if (!configuredRepos.isEmpty()) {
+            configuredRepos.forEach(resolver::addRepository);
+        } else if (envRepos == null) {
+            LOGGER.finest(() -> String.format("maven.repositories is not defined in smithy-build.json and the %s "
+                                              + "environment variable is not set. Defaulting to Maven Central.",
+                                              EnvironmentVariable.SMITHY_MAVEN_REPOS));
+            resolver.addRepository(CENTRAL);
+        }
+    }
+
+    private File getCacheFile(BuildOptions buildOptions) {
+        String output = buildOptions.output();
+        Path buildPath = output == null ? SmithyBuild.getDefaultOutputDirectory() : Paths.get(output);
+        return buildPath.resolve("classpath.json").toFile();
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
@@ -46,7 +46,7 @@ final class CleanCommand extends SimpleCommand {
 
     @Override
     public String getSummary() {
-        return "Removes Smithy build artifacts";
+        return "Removes Smithy build artifacts.";
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.ListUtils;
+
+final class CleanCommand extends SimpleCommand {
+
+    private static final Logger LOGGER = Logger.getLogger(CleanCommand.class.getName());
+
+    CleanCommand(String parentCommandName) {
+        super(parentCommandName);
+    }
+
+    @Override
+    protected List<ArgumentReceiver> createArgumentReceivers() {
+        return ListUtils.of(new ConfigOptions());
+    }
+
+    @Override
+    public String getName() {
+        return "clean";
+    }
+
+    @Override
+    public String getSummary() {
+        return "Removes Smithy build artifacts";
+    }
+
+    @Override
+    protected int run(Arguments arguments, Env env, List<String> positional) {
+        ConfigOptions options = arguments.getReceiver(ConfigOptions.class);
+        SmithyBuildConfig config = options.createSmithyBuildConfig();
+        Path dir = config.getOutputDirectory()
+                .map(Paths::get)
+                .orElseGet(SmithyBuild::getDefaultOutputDirectory);
+        LOGGER.fine(() -> "Deleting directory: " + dir);
+        if (!IoUtils.rmdir(dir)) {
+            LOGGER.fine(() -> "Directory does not exist: " + dir);
+        }
+        LOGGER.fine(() -> "Deleted directory " + dir);
+        return 0;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.EnvironmentVariable;
 import software.amazon.smithy.cli.StandardOptions;
@@ -55,6 +56,7 @@ final class CommandUtils {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
         BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
         Severity minSeverity = buildOptions.severity(standardOptions);
+        ColorFormatter colors = env.colors();
 
         assembler.validationEventListener(event -> {
             // Only log events that are >= --severity. Note that setting --quiet inherently
@@ -62,10 +64,10 @@ final class CommandUtils {
             if (event.getSeverity().ordinal() >= minSeverity.ordinal()) {
                 if (event.getSeverity() == Severity.WARNING) {
                     // Only log warnings when not quiet
-                    printer.println(formatter.format(event), Style.YELLOW);
+                    colors.println(printer, formatter.format(event), Style.YELLOW);
                 } else if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
                     // Always output error and danger events, even when quiet.
-                    printer.println(formatter.format(event), Style.RED);
+                    colors.println(printer, formatter.format(event), Style.RED);
                 } else {
                     printer.println(formatter.format(event));
                 }
@@ -79,7 +81,7 @@ final class CommandUtils {
         config.getImports().forEach(assembler::addImport);
 
         ValidatedResult<Model> result = assembler.assemble();
-        Validator.validate(quietValidation, env.stderr(), result);
+        Validator.validate(quietValidation, colors, env.stderr(), result);
         return result.getResult().orElseThrow(() -> new RuntimeException("Expected Validator to throw"));
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -62,10 +62,10 @@ final class CommandUtils {
             if (event.getSeverity().ordinal() >= minSeverity.ordinal()) {
                 if (event.getSeverity() == Severity.WARNING) {
                     // Only log warnings when not quiet
-                    printer.println(printer.style(formatter.format(event), Style.YELLOW));
+                    printer.println(formatter.format(event), Style.YELLOW);
                 } else if (event.getSeverity() == Severity.DANGER || event.getSeverity() == Severity.ERROR) {
                     // Always output error and danger events, even when quiet.
-                    printer.println(printer.style(formatter.format(event), Style.RED));
+                    printer.println(formatter.format(event), Style.RED);
                 } else {
                     printer.println(formatter.format(event));
                 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ConfigOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ConfigOptions.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.cli.HelpPrinter;
+
+final class ConfigOptions implements ArgumentReceiver {
+
+    private static final Logger LOGGER = Logger.getLogger(ConfigOptions.class.getName());
+    private final List<String> config = new ArrayList<>();
+
+    @Override
+    public void registerHelp(HelpPrinter printer) {
+        printer.param("--config", "-c", "CONFIG_PATH...",
+                      "Path to smithy-build.json configuration (defaults to './smithy-build.json'). "
+                      + "This option can be repeated and each configured will be merged.");
+    }
+
+    @Override
+    public Consumer<String> testParameter(String name) {
+        switch (name) {
+            case "--config":
+            case "-c":
+                return config::add;
+            default:
+                return null;
+        }
+    }
+
+    List<String> config() {
+        List<String> config = this.config;
+        if (config.isEmpty()) {
+            Path defaultConfig = Paths.get("smithy-build.json").toAbsolutePath();
+            if (Files.exists(defaultConfig)) {
+                LOGGER.fine("Detected smithy-build.json at " + defaultConfig);
+                config = Collections.singletonList(defaultConfig.toString());
+            }
+        }
+        return config;
+    }
+
+    SmithyBuildConfig createSmithyBuildConfig() {
+        long startTime = System.nanoTime();
+        SmithyBuildConfig smithyBuildConfig;
+        List<String> config = config();
+
+        if (config.isEmpty()) {
+            smithyBuildConfig = SmithyBuildConfig.builder().version(SmithyBuild.VERSION).build();
+        } else {
+            LOGGER.fine(() -> String.format("Loading Smithy configs: [%s]", String.join(" ", config)));
+            SmithyBuildConfig.Builder configBuilder = SmithyBuildConfig.builder();
+            // Set the lastModified time in millis of the builder to the latest modified date of any config.
+            long newestLastModified = 0;
+            for (String configFile : config) {
+                File file = new File(configFile);
+                newestLastModified = Math.max(newestLastModified, file.lastModified());
+                configBuilder.load(file.toPath());
+            }
+            configBuilder.lastModifiedInMillis(newestLastModified);
+            smithyBuildConfig = configBuilder.build();
+        }
+
+        LOGGER.fine(() -> "Smithy config load time in ms: " + ((System.nanoTime() - startTime) / 1000000));
+        return smithyBuildConfig;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -50,7 +50,7 @@ final class DiffCommand extends ClasspathCommand {
 
     @Override
     public String getSummary() {
-        return "Diffs two Smithy models and reports any significant changes";
+        return "Compares two Smithy models and reports any significant changes.";
     }
 
     private static final class Options implements ArgumentReceiver {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -24,7 +24,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
-import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
@@ -122,7 +122,7 @@ final class DiffCommand extends ClasspathCommand {
 
         // Print the "framing" style output to stderr only if !quiet.
         if (!standardOptions.quiet()) {
-            try (CliPrinter.Buffer buffer = env.stderr().buffer()) {
+            try (ColorFormatter.PrinterBuffer buffer = env.colors().printerBuffer(env.stderr())) {
                 if (hasDanger) {
                     buffer.println("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD);
                 } else if (hasWarning) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -122,13 +122,14 @@ final class DiffCommand extends ClasspathCommand {
 
         // Print the "framing" style output to stderr only if !quiet.
         if (!standardOptions.quiet()) {
-            CliPrinter stderr = env.stderr();
-            if (hasDanger) {
-                stderr.println(stderr.style("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD));
-            } else if (hasWarning) {
-                stderr.println(stderr.style("Smithy diff detected warnings", Style.BRIGHT_YELLOW, Style.BOLD));
-            } else {
-                stderr.println(stderr.style("Smithy diff complete", Style.BRIGHT_GREEN, Style.BOLD));
+            try (CliPrinter.Buffer buffer = env.stderr().buffer()) {
+                if (hasDanger) {
+                    buffer.println("Smithy diff detected danger", Style.BRIGHT_RED, Style.BOLD);
+                } else if (hasWarning) {
+                    buffer.println("Smithy diff detected warnings", Style.BRIGHT_YELLOW, Style.BOLD);
+                } else {
+                    buffer.println("Smithy diff complete", Style.BRIGHT_GREEN, Style.BOLD);
+                }
             }
         }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -16,11 +16,11 @@
 package software.amazon.smithy.cli.commands;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
@@ -28,20 +28,19 @@ import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class DiffCommand extends SimpleCommand {
+final class DiffCommand extends ClasspathCommand {
     private static final Logger LOGGER = Logger.getLogger(DiffCommand.class.getName());
 
-    public DiffCommand(String parentCommandName) {
-        super(parentCommandName);
+    DiffCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -88,25 +87,26 @@ public final class DiffCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return Collections.singletonList(new Options());
+    protected void addAdditionalArgumentReceivers(List<ArgumentReceiver> receivers) {
+        receivers.add(new Options());
     }
 
     @Override
-    protected int run(Arguments arguments, Env env, List<String> positional) {
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> positional) {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
         Options options = arguments.getReceiver(Options.class);
+        ClassLoader classLoader = env.classLoader();
 
         List<String> oldModels = options.oldModels;
         List<String> newModels = options.newModels;
         LOGGER.fine(() -> String.format("Setting old models to: %s; new models to: %s", oldModels, newModels));
 
-        ModelAssembler assembler = CommandUtils.createModelAssembler(env.classLoader());
+        ModelAssembler assembler = CommandUtils.createModelAssembler(classLoader);
         Model oldModel = loadModel("old", assembler, oldModels);
         assembler.reset();
         Model newModel = loadModel("new", assembler, newModels);
 
-        List<ValidationEvent> events = ModelDiff.compare(env.classLoader(), oldModel, newModel);
+        List<ValidationEvent> events = ModelDiff.compare(classLoader, oldModel, newModel);
         boolean hasError = events.stream().anyMatch(event -> event.getSeverity() == Severity.ERROR);
         boolean hasDanger = events.stream().anyMatch(event -> event.getSeverity() == Severity.DANGER);
         boolean hasWarning = events.stream().anyMatch(event -> event.getSeverity() == Severity.DANGER);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/IsolatedRunnable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/IsolatedRunnable.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.function.Consumer;
+import software.amazon.smithy.cli.CliError;
+
+final class IsolatedRunnable implements Runnable {
+
+    private final ClassLoader classLoader;
+    private final Consumer<ClassLoader> consumer;
+
+    IsolatedRunnable(Collection<Path> artifacts, ClassLoader parent, Consumer<ClassLoader> consumer) {
+        this(createClassLoaderFromPaths(artifacts, parent), consumer);
+    }
+
+    private IsolatedRunnable(ClassLoader classLoader, Consumer<ClassLoader> consumer) {
+        this.classLoader = classLoader;
+        this.consumer = consumer;
+    }
+
+    private static ClassLoader createClassLoaderFromPaths(Collection<Path> artifacts, ClassLoader parent) {
+        return new URLClassLoader(createUrlsFromPaths(artifacts), parent);
+    }
+
+    private static URL[] createUrlsFromPaths(Collection<Path> paths) {
+        URL[] urls = new URL[paths.size()];
+        int i = 0;
+        for (Path artifact : paths) {
+            try {
+                urls[i++] = artifact.toUri().toURL();
+            } catch (MalformedURLException e) {
+                throw new CliError("Error creating class loader: " + artifact);
+            }
+        }
+
+        return urls;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Thread thread = new Thread(() -> consumer.accept(classLoader));
+            thread.setContextClassLoader(classLoader);
+            ExceptionHandler handler = new ExceptionHandler();
+            thread.setUncaughtExceptionHandler(handler);
+            thread.start();
+            thread.join();
+            if (handler.e != null) {
+                throw new CliError(handler.e.getMessage(), 1, handler.e);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CliError(e.getMessage(), 1, e);
+        }
+    }
+
+    private static final class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+        volatile Throwable e;
+
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            this.e = e;
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
@@ -55,7 +56,7 @@ final class SelectCommand extends ClasspathCommand {
     }
 
     @Override
-    public String getDocumentation(CliPrinter printer) {
+    public String getDocumentation(ColorFormatter colors) {
         return "By default, each matching shape ID is printed to stdout on a new line. Pass --vars to print out a "
                + "JSON array that contains a 'shape' and 'vars' property, where the 'vars' property is a map of "
                + "each variable that was captured when the shape was matched.";

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -52,7 +52,7 @@ final class SelectCommand extends ClasspathCommand {
 
     @Override
     public String getSummary() {
-        return "Queries a model using a selector";
+        return "Queries a model using a selector.";
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -22,10 +22,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.HelpPrinter;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
@@ -35,14 +37,11 @@ import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.IoUtils;
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyInternalApi;
 
-@SmithyInternalApi
-public final class SelectCommand extends SimpleCommand {
+final class SelectCommand extends ClasspathCommand {
 
-    public SelectCommand(String parentCommandName) {
-        super(parentCommandName);
+    SelectCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -104,17 +103,17 @@ public final class SelectCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return ListUtils.of(new BuildOptions(), new Options());
+    protected void addAdditionalArgumentReceivers(List<ArgumentReceiver> receivers) {
+        receivers.add(new Options());
     }
 
     @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         CliPrinter stdout = env.stdout();
         Options options = arguments.getReceiver(Options.class);
 
         // Don't write the summary, but do write danger/errors to STDERR.
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true);
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
         Selector selector = options.selector();
 
         if (!options.vars()) {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
@@ -19,11 +19,11 @@ import java.util.List;
 import java.util.logging.Logger;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
-import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -32,7 +32,6 @@ import software.amazon.smithy.utils.StringUtils;
  * <p>When -h or --help is found, the help for the command is printed
  * to stdout and exits with code 0.
  */
-@SmithyInternalApi
 abstract class SimpleCommand implements Command {
 
     private static final Logger LOGGER = Logger.getLogger(SimpleCommand.class.getName());
@@ -51,7 +50,15 @@ abstract class SimpleCommand implements Command {
 
         List<String> positionalArguments = arguments.finishParsing();
 
-        if (arguments.getReceiver(StandardOptions.class).help()) {
+        StandardOptions options = arguments.getReceiver(StandardOptions.class);
+
+        // Version is only supported on the root-level command, but the argument has
+        // to be available to all commands to make that work.
+        if (arguments.getReceiver(StandardOptions.class).version()) {
+            throw new CliError("Unexpected CLI argument: --version");
+        }
+
+        if (options.help()) {
             printHelp(arguments, env.stdout());
             return 0;
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SimpleCommand.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.StandardOptions;
@@ -59,7 +60,7 @@ abstract class SimpleCommand implements Command {
         }
 
         if (options.help()) {
-            printHelp(arguments, env.stdout());
+            printHelp(arguments, env.colors(), env.stdout());
             return 0;
         }
 
@@ -68,12 +69,12 @@ abstract class SimpleCommand implements Command {
     }
 
     @Override
-    public void printHelp(Arguments arguments, CliPrinter printer) {
+    public void printHelp(Arguments arguments, ColorFormatter colors, CliPrinter printer) {
         String name = StringUtils.isEmpty(parentCommandName) ? getName() : parentCommandName + " " + getName();
         HelpPrinter.fromArguments(name, arguments)
                 .summary(getSummary())
-                .documentation(getDocumentation(printer))
-                .print(printer);
+                .documentation(getDocumentation(colors))
+                .print(colors, printer);
     }
 
     /**

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -17,24 +17,34 @@ package software.amazon.smithy.cli.commands;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Command;
+import software.amazon.smithy.cli.EnvironmentVariable;
+import software.amazon.smithy.cli.SmithyCli;
 import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
-import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 
-@SmithyInternalApi
-public class SmithyCommand implements Command {
+public final class SmithyCommand implements Command {
 
-    private final List<Command> commands = Arrays.asList(
-            new ValidateCommand(getName()),
-            new BuildCommand(getName()),
-            new AstCommand(getName()),
-            new SelectCommand(getName()),
-            new DiffCommand(getName()),
-            new Upgrade1to2Command(getName()));
+    private final List<Command> commands;
+
+    public SmithyCommand(DependencyResolver.Factory dependencyResolverFactory) {
+        Objects.requireNonNull(dependencyResolverFactory);
+        commands = Arrays.asList(
+            new ValidateCommand(getName(), dependencyResolverFactory),
+            new BuildCommand(getName(), dependencyResolverFactory),
+            new DiffCommand(getName(), dependencyResolverFactory),
+            new AstCommand(getName(), dependencyResolverFactory),
+            new SelectCommand(getName(), dependencyResolverFactory),
+            new CleanCommand(getName()),
+            new Upgrade1to2Command(getName()),
+            new WarmupCommand(getName(), dependencyResolverFactory)
+        );
+    }
 
     @Override
     public String getName() {
@@ -48,34 +58,47 @@ public class SmithyCommand implements Command {
 
     @Override
     public void printHelp(Arguments arguments, CliPrinter printer) {
-        printer.println(String.format("Usage: %s [-h | --help] <command> [<args>]",
+        printer.println(String.format("Usage: %s [-h | --help] [--version] <command> [<args>]",
                                       printer.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
         printer.println("");
         printer.println("Available commands:");
 
         int longestName = 0;
         for (Command command : commands) {
-            if (command.getName().length() + 12 > longestName) {
-                longestName = command.getName().length() + 12;
+            if (!command.isHidden()) {
+                if (command.getName().length() + 12 > longestName) {
+                    longestName = command.getName().length() + 12;
+                }
             }
         }
 
         for (Command command : commands) {
-            printer.println(String.format("    %-" + longestName + "s %s",
-                                          printer.style(command.getName(), Style.YELLOW),
-                                          command.getSummary()));
+            if (!command.isHidden()) {
+                printer.println(String.format("    %-" + longestName + "s %s",
+                                              printer.style(command.getName(), Style.YELLOW),
+                                              command.getSummary()));
+            }
         }
     }
 
     @Override
     public int execute(Arguments arguments, Env env) {
+        // Set the current CLI version as a system property, so it can be used in config files.
+        EnvironmentVariable.SMITHY_VERSION.set(SmithyCli.getVersion());
+
         String command = arguments.shift();
 
-        // If no command was given, then finish parsing to check if -h or --help was given.
+        // If no command was given, then finish parsing to check if -h, --help, or --version was given.
         if (command == null) {
             arguments.finishParsing();
-            if (arguments.getReceiver(StandardOptions.class).help()) {
+
+            StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
+
+            if (standardOptions.help()) {
                 printHelp(arguments, env.stdout());
+                return 0;
+            } else if (standardOptions.version()) {
+                env.stdout().println(SmithyCli.getVersion());
                 return 0;
             } else {
                 printHelp(arguments, env.stderr());

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -18,10 +18,10 @@ package software.amazon.smithy.cli.commands;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Command;
 import software.amazon.smithy.cli.EnvironmentVariable;
 import software.amazon.smithy.cli.SmithyCli;
@@ -58,10 +58,9 @@ public final class SmithyCommand implements Command {
     }
 
     @Override
-    public void printHelp(Arguments arguments, CliPrinter printer) {
-        Ansi ansi = printer.ansi();
+    public void printHelp(Arguments arguments, ColorFormatter colors, CliPrinter printer) {
         printer.println(String.format("Usage: %s [-h | --help] [--version] <command> [<args>]",
-                                      ansi.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
+                                      colors.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
         printer.println("");
         printer.println("Available commands:");
 
@@ -77,7 +76,7 @@ public final class SmithyCommand implements Command {
         for (Command command : commands) {
             if (!command.isHidden()) {
                 printer.println(String.format("    %-" + longestName + "s %s",
-                                              ansi.style(command.getName(), Style.YELLOW),
+                                              colors.style(command.getName(), Style.YELLOW),
                                               command.getSummary()));
             }
         }
@@ -99,13 +98,13 @@ public final class SmithyCommand implements Command {
             StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
 
             if (standardOptions.help()) {
-                printHelp(arguments, env.stdout());
+                printHelp(arguments, env.colors(), env.stdout());
                 return 0;
             } else if (standardOptions.version()) {
                 env.stdout().println(SmithyCli.getVersion());
                 return 0;
             } else {
-                printHelp(arguments, env.stderr());
+                printHelp(arguments, env.colors(), env.stderr());
                 return 1;
             }
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.cli.commands;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
@@ -58,8 +59,9 @@ public final class SmithyCommand implements Command {
 
     @Override
     public void printHelp(Arguments arguments, CliPrinter printer) {
+        Ansi ansi = printer.ansi();
         printer.println(String.format("Usage: %s [-h | --help] [--version] <command> [<args>]",
-                                      printer.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
+                                      ansi.style("smithy", Style.BRIGHT_WHITE, Style.UNDERLINE)));
         printer.println("");
         printer.println("Available commands:");
 
@@ -75,10 +77,12 @@ public final class SmithyCommand implements Command {
         for (Command command : commands) {
             if (!command.isHidden()) {
                 printer.println(String.format("    %-" + longestName + "s %s",
-                                              printer.style(command.getName(), Style.YELLOW),
+                                              ansi.style(command.getName(), Style.YELLOW),
                                               command.getSummary()));
             }
         }
+
+        printer.println("");
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -15,21 +15,19 @@
 
 package software.amazon.smithy.cli.commands;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
-import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.StandardOptions;
-import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
 
-@SmithyInternalApi
-public final class ValidateCommand extends SimpleCommand {
+final class ValidateCommand extends ClasspathCommand {
 
     private static final Logger LOGGER = Logger.getLogger(ValidateCommand.class.getName());
 
-    public ValidateCommand(String parentCommandName) {
-        super(parentCommandName);
+    ValidateCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
     }
 
     @Override
@@ -43,15 +41,9 @@ public final class ValidateCommand extends SimpleCommand {
     }
 
     @Override
-    protected List<ArgumentReceiver> createArgumentReceivers() {
-        return Collections.singletonList(new BuildOptions());
-    }
-
-    @Override
-    protected int run(Arguments arguments, Env env, List<String> models) {
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
-        LOGGER.info(() -> "Validating Smithy model sources: " + models);
-        CommandUtils.buildModel(arguments, models, env, env.stdout(), standardOptions.quiet());
+        CommandUtils.buildModel(arguments, models, env, env.stdout(), standardOptions.quiet(), config);
         LOGGER.info("Smithy validation complete");
         return 0;
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -37,7 +37,7 @@ final class ValidateCommand extends ClasspathCommand {
 
     @Override
     public String getSummary() {
-        return "Validates Smithy models";
+        return "Validates Smithy models.";
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -16,9 +16,9 @@
 package software.amazon.smithy.cli.commands;
 
 import java.util.StringJoiner;
-import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
+import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.Severity;
@@ -31,7 +31,7 @@ final class Validator {
 
     private Validator() {}
 
-    static void validate(boolean quiet, CliPrinter printer, ValidatedResult<Model> result) {
+    static void validate(boolean quiet, ColorFormatter colors, CliPrinter printer, ValidatedResult<Model> result) {
         int notes = result.getValidationEvents(Severity.NOTE).size();
         int warnings = result.getValidationEvents(Severity.WARNING).size();
         int errors = result.getValidationEvents(Severity.ERROR).size();
@@ -39,13 +39,12 @@ final class Validator {
         int shapeCount = result.getResult().isPresent() ? result.getResult().get().toSet().size() : 0;
         boolean isFailed = errors > 0 || dangers > 0;
         boolean hasEvents = warnings > 0 || notes > 0 || isFailed;
-        Ansi ansi = printer.ansi();
 
         StringBuilder output = new StringBuilder();
         if (isFailed) {
-            output.append(ansi.style("FAILURE: ", Style.RED, Style.BOLD));
+            output.append(colors.style("FAILURE: ", Style.RED, Style.BOLD));
         } else {
-            output.append(ansi.style("SUCCESS: ", Style.GREEN, Style.BOLD));
+            output.append(colors.style("SUCCESS: ", Style.GREEN, Style.BOLD));
         }
         output.append("Validated ").append(shapeCount).append(" shapes");
 
@@ -53,19 +52,19 @@ final class Validator {
             output.append(' ').append('(');
             StringJoiner joiner = new StringJoiner(", ");
             if (errors > 0) {
-                appendSummaryCount(joiner, ansi, "ERROR", errors, Style.BRIGHT_RED);
+                appendSummaryCount(joiner, colors, "ERROR", errors, Style.BRIGHT_RED);
             }
 
             if (dangers > 0) {
-                appendSummaryCount(joiner, ansi, "DANGER", dangers, Style.RED);
+                appendSummaryCount(joiner, colors, "DANGER", dangers, Style.RED);
             }
 
             if (warnings > 0) {
-                appendSummaryCount(joiner, ansi, "WARNING", warnings, Style.YELLOW);
+                appendSummaryCount(joiner, colors, "WARNING", warnings, Style.YELLOW);
             }
 
             if (notes > 0) {
-                appendSummaryCount(joiner, ansi, "NOTE", notes, Style.WHITE);
+                appendSummaryCount(joiner, colors, "NOTE", notes, Style.WHITE);
             }
             output.append(joiner);
             output.append(')');
@@ -78,7 +77,12 @@ final class Validator {
         }
     }
 
-    private static void appendSummaryCount(StringJoiner joiner, Ansi ansi, String label, int count, Style color) {
-        joiner.add(ansi.style(label, color) + ": " + count);
+    private static void appendSummaryCount(
+            StringJoiner joiner,
+            ColorFormatter colors,
+            String label,
+            int count,
+            Style color) {
+        joiner.add(colors.style(label, color) + ": " + count);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.cli.commands;
 
 import java.util.StringJoiner;
+import software.amazon.smithy.cli.Ansi;
 import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.Style;
@@ -38,12 +39,13 @@ final class Validator {
         int shapeCount = result.getResult().isPresent() ? result.getResult().get().toSet().size() : 0;
         boolean isFailed = errors > 0 || dangers > 0;
         boolean hasEvents = warnings > 0 || notes > 0 || isFailed;
+        Ansi ansi = printer.ansi();
 
         StringBuilder output = new StringBuilder();
         if (isFailed) {
-            output.append(printer.style("FAILURE: ", Style.RED, Style.BOLD));
+            output.append(ansi.style("FAILURE: ", Style.RED, Style.BOLD));
         } else {
-            output.append(printer.style("SUCCESS: ", Style.GREEN, Style.BOLD));
+            output.append(ansi.style("SUCCESS: ", Style.GREEN, Style.BOLD));
         }
         output.append("Validated ").append(shapeCount).append(" shapes");
 
@@ -51,21 +53,21 @@ final class Validator {
             output.append(' ').append('(');
             StringJoiner joiner = new StringJoiner(", ");
             if (errors > 0) {
-                appendSummaryCount(joiner, printer, "ERROR", errors, Style.BRIGHT_RED);
+                appendSummaryCount(joiner, ansi, "ERROR", errors, Style.BRIGHT_RED);
             }
 
             if (dangers > 0) {
-                appendSummaryCount(joiner, printer, "DANGER", dangers, Style.RED);
+                appendSummaryCount(joiner, ansi, "DANGER", dangers, Style.RED);
             }
 
             if (warnings > 0) {
-                appendSummaryCount(joiner, printer, "WARNING", warnings, Style.YELLOW);
+                appendSummaryCount(joiner, ansi, "WARNING", warnings, Style.YELLOW);
             }
 
             if (notes > 0) {
-                appendSummaryCount(joiner, printer, "NOTE", notes, Style.WHITE);
+                appendSummaryCount(joiner, ansi, "NOTE", notes, Style.WHITE);
             }
-            output.append(joiner.toString());
+            output.append(joiner);
             output.append(')');
         }
 
@@ -76,13 +78,7 @@ final class Validator {
         }
     }
 
-    private static void appendSummaryCount(
-            StringJoiner joiner,
-            CliPrinter printer,
-            String label,
-            int count,
-            Style color
-    ) {
-        joiner.add(printer.style(label, color) + ": " + count);
+    private static void appendSummaryCount(StringJoiner joiner, Ansi ansi, String label, int count, Style color) {
+        joiner.add(ansi.style(label, color) + ": " + count);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
@@ -45,7 +45,7 @@ final class WarmupCommand extends ClasspathCommand {
 
     @Override
     public String getSummary() {
-        return "Creates caches for faster subsequent executions";
+        return "Creates caches for faster subsequent executions.";
     }
 
     @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/WarmupCommand.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.EnvironmentVariable;
+import software.amazon.smithy.cli.SmithyCli;
+import software.amazon.smithy.cli.dependencies.DependencyResolver;
+import software.amazon.smithy.cli.dependencies.MavenDependencyResolver;
+
+final class WarmupCommand extends ClasspathCommand {
+
+    private static final Logger LOGGER = Logger.getLogger(WarmupCommand.class.getName());
+
+    WarmupCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
+        super(parentCommandName, dependencyResolverFactory);
+    }
+
+    @Override
+    public String getName() {
+        return "warmup";
+    }
+
+    @Override
+    public String getSummary() {
+        return "Creates caches for faster subsequent executions";
+    }
+
+    @Override
+    public boolean isHidden() {
+        return true;
+    }
+
+    @Override
+    int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
+        if (EnvironmentVariable.getByName("SMITHY_WARMUP_INTERNAL_ONLY") == null) {
+            throw new UnsupportedOperationException("The warmup command is for internal use only and may "
+                                                    + "be removed in the future");
+        }
+
+        LOGGER.info(() -> "Warming up Smithy CLI");
+
+        try {
+            Path tempDirWithPrefix = Files.createTempDirectory("smithy-warmup");
+            DependencyResolver resolver = new MavenDependencyResolver(tempDirWithPrefix.toString());
+
+            resolve(resolver);
+            // Resolve again, but find it in the cache.
+            resolve(resolver);
+
+            // Create and load SmithyBuild files.
+            File buildFile = tempDirWithPrefix.resolve("smithy-build.json").toFile();
+            try (FileWriter writer = new FileWriter(buildFile)) {
+                writer.write("{\n"
+                             + "  \"version\": \"1.0\",\n"
+                             + "  \"maven\": {\"dependencies\": [\"software.amazon.smithy:smithy-model:"
+                             + SmithyCli.getVersion() + "\"]}\n"
+                             + "}");
+            }
+
+            SmithyBuildConfig.builder().load(buildFile.toPath()).build();
+
+            new ValidateCommand("a", (c, e) -> resolver).execute(arguments, env);
+            new BuildCommand("a", (c, e) -> resolver).execute(arguments, env);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return 0;
+    }
+
+    private void resolve(DependencyResolver resolver) {
+        resolver.addRepository(MavenRepository.builder().url("https://repo.maven.apache.org/maven2").build());
+        resolver.addDependency("software.amazon.smithy:smithy-model:" + SmithyCli.getVersion());
+        resolver.resolve();
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.util.List;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.Command;
+
+/**
+ * Resolves Maven dependencies for the Smithy CLI.
+ */
+public interface DependencyResolver {
+    /**
+     * Add a Maven repository.
+     *
+     * @param repository Repository to add.
+     * @throws DependencyResolverException When the repository is invalid.
+     */
+    void addRepository(MavenRepository repository);
+
+    /**
+     * Add a dependency.
+     *
+     * <p>Coordinates must be given a group ID, artifact ID, and version in the form
+     * of "groupId:artifactId:version". Coordinates support Maven dependency ranges.
+     * Coordinates do not support LATEST, SNAPSHOT, latest-release, latest.*, or
+     * Gradle style "+" syntax.
+     *
+     * @param coordinates Dependency coordinates to add.
+     * @throws DependencyResolverException When the dependency is invalid.
+     */
+    void addDependency(String coordinates);
+
+    /**
+     * Resolves artifacts for the configured dependencies.
+     *
+     * @return Returns the resolved artifacts, including file on disk and coordinates.
+     * @throws DependencyResolverException If dependency resolution fails.
+     */
+    List<ResolvedArtifact> resolve();
+
+    /**
+     * Responsible for creating a {@link DependencyResolver} for the CLI,
+     * optionally based on configuration.
+     */
+    @FunctionalInterface
+    interface Factory {
+        /**
+         * Creates a {@link DependencyResolver}.
+         *
+         * @param config smithy-build.json configuration that can be used to configure the resolver.
+         * @param env Command environment, including stderr and stdout printers.
+         * @return Returns the created resolver.
+         */
+        DependencyResolver create(SmithyBuildConfig config, Command.Env env);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolverException.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/DependencyResolverException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+/**
+ * Exception encountered while attempting to resolve dependencies.
+ */
+public final class DependencyResolverException extends RuntimeException {
+    public DependencyResolverException(String message) {
+        super(message);
+    }
+
+    public DependencyResolverException(Throwable previous) {
+        this(previous.getMessage(), previous);
+    }
+
+    public DependencyResolverException(String message, Throwable previous) {
+        super(message, previous);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.model.loader.ModelSyntaxException;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+
+/**
+ * A resolver that loads and caches resolved artifacts to a JSON file if
+ * the cache is fresh and resolved artifacts haven't been updated after a
+ * given reference point in time.
+ */
+public final class FileCacheResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(FileCacheResolver.class.getName());
+    private final DependencyResolver delegate;
+    private final File location;
+    private final long referenceTimeInMillis;
+
+    /**
+     * @param location The location to the cache.
+     * @param referenceTimeInMillis Invalidate cache items if this time is newer than the cache item time.
+     * @param delegate Resolver to delegate to when dependencies aren't cached.
+     */
+    public FileCacheResolver(File location, long referenceTimeInMillis, DependencyResolver delegate) {
+        this.location = location;
+        this.referenceTimeInMillis = referenceTimeInMillis;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void addRepository(MavenRepository repository) {
+        delegate.addRepository(repository);
+    }
+
+    @Override
+    public void addDependency(String coordinates) {
+        delegate.addDependency(coordinates);
+    }
+
+    @Override
+    public List<ResolvedArtifact> resolve() {
+        List<ResolvedArtifact> cachedResult = load();
+
+        if (!cachedResult.isEmpty()) {
+            LOGGER.fine(() -> "Classpath found in cache: " + cachedResult);
+            return cachedResult;
+        }
+
+        List<ResolvedArtifact> result = delegate.resolve();
+        save(result);
+        return result;
+    }
+
+    private List<ResolvedArtifact> load() {
+        // Invalidate the cache if smithy-build.json was updated after the cache was written.
+        Path filePath = location.toPath();
+        if (!Files.exists(filePath)) {
+            return Collections.emptyList();
+        } else if (!isCacheValid(location)) {
+            invalidate(filePath);
+            return Collections.emptyList();
+        }
+
+        ObjectNode node;
+        try (InputStream stream = Files.newInputStream(filePath)) {
+            node = Node.parse(stream, location.toString()).expectObjectNode();
+        } catch (ModelSyntaxException | IOException e) {
+            throw new DependencyResolverException("Error loading dependency cache file from " + filePath, e);
+        }
+
+        List<ResolvedArtifact> result = new ArrayList<>(node.getStringMap().size());
+        for (Map.Entry<String, Node> entry : node.getStringMap().entrySet()) {
+            Path location = Paths.get(entry.getValue().expectStringNode().getValue());
+            // Invalidate the cache if the JAR file was updated after the cache was written.
+            if (isArtifactUpdatedSinceReferenceTime(location)) {
+                invalidate(filePath);
+                return Collections.emptyList();
+            }
+            result.add(ResolvedArtifact.fromCoordinates(location, entry.getKey()));
+        }
+
+        return result;
+    }
+
+    private void save(List<ResolvedArtifact> result) {
+        Path filePath = location.toPath();
+        Path parent = filePath.getParent();
+        if (parent == null) {
+            throw new DependencyResolverException("Invalid classpath cache location: " + location);
+        }
+
+        try {
+            Files.createDirectories(parent);
+            ObjectNode.Builder builder = Node.objectNodeBuilder();
+            for (ResolvedArtifact artifact : result) {
+                builder.withMember(artifact.getCoordinates(), artifact.getPath().toString());
+            }
+            ObjectNode objectNode = builder.build();
+            Files.write(filePath, Node.printJson(objectNode).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new DependencyResolverException("Unable to write classpath cache file: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean isCacheValid(File file) {
+        return referenceTimeInMillis <= file.lastModified() && file.length() > 0;
+    }
+
+    private boolean isArtifactUpdatedSinceReferenceTime(Path path) {
+        File file = path.toFile();
+        return !file.exists() || (referenceTimeInMillis > 0 && file.lastModified() > referenceTimeInMillis);
+    }
+
+    private void invalidate(Path filePath) {
+        try {
+            if (Files.exists(filePath)) {
+                LOGGER.fine("Invalidating dependency cache file: " + location);
+                Files.delete(filePath);
+            }
+        } catch (IOException e) {
+            throw new DependencyResolverException("Unable to delete cache file: " + e.getMessage(), e);
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolver.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionScheme;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.SetUtils;
+
+/**
+ * Removes Smithy CLI dependencies that conflict with the JARs used by the CLI.
+ *
+ * <p>This makes creating a dedicated ClassLoader simpler because Smithy dependencies are provided by the parent
+ * class loader when running the CLI.
+ */
+public final class FilterCliVersionResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(FilterCliVersionResolver.class.getName());
+    private static final String SMITHY_GROUP = "software.amazon.smithy";
+    private static final Set<String> CLI_ARTIFACTS = SetUtils.of(
+            "smithy-utils", "smithy-model", "smithy-build", "smithy-cli", "smithy-diff");
+
+    private final String version;
+    private final DependencyResolver delegate;
+
+    /**
+     * @param version Version of the Smithy CLI.
+     * @param delegate Resolver to resolve dependencies and filter.
+     */
+    public FilterCliVersionResolver(String version, DependencyResolver delegate) {
+        this.version = version;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void addRepository(MavenRepository repository) {
+        delegate.addRepository(repository);
+    }
+
+    @Override
+    public void addDependency(String coordinates) {
+        delegate.addDependency(coordinates);
+    }
+
+    @Override
+    public List<ResolvedArtifact> resolve() {
+        List<ResolvedArtifact> artifacts = delegate.resolve();
+
+        // Don't cache an empty file.
+        if (artifacts.isEmpty()) {
+            return artifacts;
+        }
+
+        VersionScheme versionScheme = new GenericVersionScheme();
+        Version parsedSmithyVersion = getMavenVersion(version, versionScheme);
+        List<String> replacements = new ArrayList<>();
+        List<ResolvedArtifact> filtered = new ArrayList<>();
+
+        for (ResolvedArtifact artifact : artifacts) {
+            if (artifact.getGroupId().equals(SMITHY_GROUP) && CLI_ARTIFACTS.contains(artifact.getArtifactId())) {
+                // The resolved artifact version does not match the version used by the CLI. In this case,
+                // the resolved version must not be newer than that used by the CLI.
+                Version artifactVersion = getMavenVersion(artifact.getVersion(), versionScheme);
+                int compare = artifactVersion.compareTo(parsedSmithyVersion);
+                if (compare > 0) {
+                    throw new DependencyResolverException(
+                            "The Smithy CLI is at version " + parsedSmithyVersion + ", but dependencies resolved to "
+                            + "use a newer, incompatible version of " + artifact.getCoordinates() + ". Please "
+                            + "update the Smithy CLI.");
+                } else if (compare < 0) {
+                    replacements.add("- Replaced " + artifact.getCoordinates());
+                }
+            } else {
+                filtered.add(artifact);
+            }
+        }
+
+        if (!replacements.isEmpty()) {
+            String contents = String.join(System.lineSeparator(), replacements);
+            LOGGER.info("Resolved dependencies were replaced with dependencies used by the Smithy CLI ("
+                        + version + "). If the CLI fails due to issues like unknown classes, methods, missing "
+                        + "traits, etc, then consider upgrading your dependencies to match the version of the CLI "
+                        + "or modifying your declared dependencies."
+                        + System.lineSeparator() + contents);
+        }
+
+        return filtered;
+    }
+
+    private static Version getMavenVersion(String input, VersionScheme versionScheme) {
+        try {
+            return versionScheme.parseVersion(input);
+        } catch (InvalidVersionSpecificationException e) {
+            throw new DependencyResolverException("Unable to parse dependency version: " + input, e);
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import static org.eclipse.aether.util.artifact.JavaScopes.COMPILE;
+import static org.eclipse.aether.util.artifact.JavaScopes.RUNTIME;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.AuthenticationContext;
+import org.eclipse.aether.repository.AuthenticationDigest;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Resolves Maven dependencies for the Smithy CLI using Maven resolvers.
+ */
+public final class MavenDependencyResolver implements DependencyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(DependencyResolver.class.getName());
+
+    private final List<RemoteRepository> remoteRepositories = new ArrayList<>();
+    private final List<Dependency> dependencies = new ArrayList<>();
+    private final DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+    private final DependencyFilter filter = DependencyFilterUtils.classpathFilter(RUNTIME, COMPILE);
+    private final RepositorySystem repositorySystem;
+
+    public MavenDependencyResolver() {
+        this(null);
+    }
+
+    /**
+     * @param cacheLocation Maven local cache location.
+     */
+    public MavenDependencyResolver(String cacheLocation) {
+        final DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
+        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
+        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+        locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
+            @Override
+            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
+                throw new DependencyResolverException(exception);
+            }
+        });
+
+        repositorySystem = locator.getService(RepositorySystem.class);
+
+        // Sets a default maven local to the default local repo of the user.
+        if (cacheLocation == null) {
+            String userHome = System.getProperty("user.home");
+            cacheLocation = Paths.get(userHome, ".m2", "repository").toString();
+            LOGGER.fine("Set default Maven local cache location to ~/.m2/repository");
+        }
+
+        LocalRepository local = new LocalRepository(cacheLocation);
+        session.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(session, local));
+    }
+
+    @Override
+    public void addRepository(MavenRepository repository) {
+        try {
+            URI uri = new URI(repository.getUrl());
+            String name = uri.getHost();
+            String userInfo = uri.getUserInfo();
+            RemoteRepository.Builder builder = new RemoteRepository.Builder(name, "default", repository.getUrl());
+            if (userInfo != null) {
+                LOGGER.finest(() -> "Setting username and password for " + name + " using URI authority");
+                addUserInfoAuth(uri, userInfo, builder);
+            }
+            repository.getHttpCredentials().ifPresent(credentials -> addUserInfoAuth(uri, credentials, builder));
+            remoteRepositories.add(builder.build());
+        } catch (URISyntaxException e) {
+            throw new DependencyResolverException("Invalid Maven repository URL: " + repository.getUrl()
+                                                  + ": " + e.getMessage());
+        }
+    }
+
+    private void addUserInfoAuth(URI uri, String userInfo, RemoteRepository.Builder builder) {
+        String[] parts = userInfo.split(":", 2);
+        if (parts.length != 2) {
+            throw new DependencyResolverException("Invalid credentials provided for " + uri);
+        }
+        builder.setAuthentication(new MavenAuth(parts[0], parts[1]));
+    }
+
+    @Override
+    public void addDependency(String coordinates) {
+        dependencies.add(createDependency(coordinates, "compile"));
+    }
+
+    @Override
+    public List<ResolvedArtifact> resolve() {
+        if (remoteRepositories.isEmpty()) {
+            LOGGER.warning("No Maven repositories are configured, so only the local repository cache is being used");
+        }
+
+        final List<ArtifactResult> results = resolveMavenArtifacts();
+        final List<ResolvedArtifact> artifacts = new ArrayList<>(results.size());
+        for (ArtifactResult result : results) {
+            Artifact artifact = result.getArtifact();
+            artifacts.add(new ResolvedArtifact(artifact.getFile().toPath(), artifact.getGroupId(),
+                                               artifact.getArtifactId(), artifact.getVersion()));
+        }
+        return artifacts;
+    }
+
+    private static Dependency createDependency(String coordinates, String scope) {
+        Artifact artifact;
+        try {
+            artifact = new DefaultArtifact(coordinates);
+        } catch (IllegalArgumentException e) {
+            throw new DependencyResolverException("Invalid dependency: " + e.getMessage());
+        }
+        if (artifact.isSnapshot()) {
+            throw new DependencyResolverException("Snapshot dependencies are not supported: " + artifact);
+        }
+        validateDependencyVersion(artifact);
+        return new Dependency(artifact, scope);
+    }
+
+    private static void validateDependencyVersion(Artifact artifact) {
+        String version = artifact.getVersion();
+        if (version.equals("LATEST")) {
+            throw new DependencyResolverException("LATEST dependencies are not supported: " + artifact);
+        } else if (version.equals("latest-status") || version.startsWith("latest.")) {
+            throw new DependencyResolverException("Gradle style latest dependencies are not supported: " + artifact);
+        } else if (version.equals("RELEASE")) {
+            throw new DependencyResolverException("RELEASE dependencies are not supported: " + artifact);
+        } else if (version.contains("+")) {
+            throw new DependencyResolverException("'+' dependencies are not supported: " + artifact);
+        }
+    }
+
+    private List<ArtifactResult> resolveMavenArtifacts() {
+        LOGGER.fine(() -> "Resolving Maven dependencies for Smithy CLI; repos: "
+                          + remoteRepositories + "; dependencies: " + dependencies);
+        CollectRequest collectRequest = new CollectRequest();
+        collectRequest.setRepositories(remoteRepositories);
+        collectRequest.setDependencies(dependencies);
+        DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, filter);
+
+        try {
+            List<ArtifactResult> results = repositorySystem
+                    .resolveDependencies(session, dependencyRequest)
+                    .getArtifactResults();
+            LOGGER.fine(() -> "Resolved Maven dependencies: " + results);
+            return results;
+        } catch (DependencyResolutionException e) {
+            throw new DependencyResolverException(e);
+        }
+    }
+
+    /**
+     * Based on Maven's StringAuthentication. There doesn't appear to be another way to do this.
+     */
+    private static final class MavenAuth implements Authentication {
+        private final String key;
+        private final String value;
+
+        private MavenAuth(String key, String value) {
+            if (StringUtils.isEmpty(key)) {
+                throw new IllegalArgumentException("Authentication key must be provided");
+            }
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public void fill(AuthenticationContext context, String key, Map<String, String> data) {
+            context.put(this.key, value);
+        }
+
+        @Override
+        public void digest(AuthenticationDigest digest) {
+            digest.update(key, value);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj == null || !getClass().equals(obj.getClass())) {
+                return false;
+            }
+            MavenAuth that = (MavenAuth) obj;
+            return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return key + "=****";
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.dependencies;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * An artifact resolved from a repository that provides the path on disk where the artifact
+ * was downloaded, and the coordinates of the artifact.
+ */
+public final class ResolvedArtifact {
+    private final Path path;
+    private final String coordinates;
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    public ResolvedArtifact(Path path, String groupId, String artifactId, String version) {
+        this(path, groupId + ':' + artifactId + ':' + version, groupId, artifactId, version);
+    }
+
+    private ResolvedArtifact(Path path, String coordinates, String groupId, String artifactId, String version) {
+        this.coordinates = Objects.requireNonNull(coordinates);
+        this.path = Objects.requireNonNull(path);
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    /**
+     * Creates a resolved artifact from a file path and Maven coordinates string.
+     *
+     * @param location    Location of the artifact.
+     * @param coordinates Maven coordinates (e.g., group:artifact:version).
+     * @return Returns the created artifact.
+     * @throws DependencyResolverException if the provided coordinates are invalid.
+     */
+    public static ResolvedArtifact fromCoordinates(Path location, String coordinates) {
+        String[] parts = coordinates.split(":");
+        if (parts.length != 3) {
+            throw new DependencyResolverException("Invalid Maven coordinates: " + coordinates);
+        }
+        return new ResolvedArtifact(location, coordinates, parts[0], parts[1], parts[2]);
+    }
+
+    /**
+     * Get the path to the artifact on disk.
+     *
+     * @return Returns the location of the downloaded artifact.
+     */
+    public Path getPath() {
+        return path;
+    }
+
+    /**
+     * Get the resolved coordinates (e.g., group:artifact:version).
+     *
+     * @return Returns the resolved coordinates.
+     */
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    /**
+     * @return Get the group ID of the artifact.
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return Get the artifact ID of the artifact.
+     */
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @return Get the version of the artifact.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "{path=" + path + ", coordinates='" + coordinates + "'}";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(coordinates, path);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof ResolvedArtifact)) {
+            return false;
+        }
+        ResolvedArtifact artifact = (ResolvedArtifact) o;
+        return path.equals(artifact.path) && coordinates.equals(artifact.coordinates);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/package-info.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * Everything in this package should be considered an implementation detail;
+ * the only stable interface of the Smithy CLI is passing in a list of
+ * arguments from the command line.
+ */
+@SmithyUnstableApi
+package software.amazon.smithy.cli;
+
+import software.amazon.smithy.utils.SmithyUnstableApi;

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.cli;
+
+final class BufferPrinter implements CliPrinter {
+
+    private final StringBuilder builder = new StringBuilder();
+
+    @Override
+    public void println(String text) {
+        synchronized (this) {
+            builder.append(text + "\n");
+        }
+    }
+
+    @Override
+    public Ansi ansi() {
+        return Ansi.NO_COLOR;
+    }
+
+    @Override
+    public String toString() {
+        // normalize line endings for tests.
+        return builder.toString().replace("\r\n", "\n").replace("\r", "\n");
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
@@ -12,11 +12,6 @@ final class BufferPrinter implements CliPrinter {
     }
 
     @Override
-    public Ansi ansi() {
-        return Ansi.NO_COLOR;
-    }
-
-    @Override
     public String toString() {
         // normalize line endings for tests.
         return builder.toString().replace("\r\n", "\n").replace("\r", "\n");

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliTest.java
@@ -63,4 +63,18 @@ public class CliTest {
         assertThat(result.code(), equalTo(0));
         assertThat(result.stderr(), containsString("Running CLI command"));
     }
+
+    @Test
+    public void canForceColors() {
+        CliUtils.Result result = CliUtils.runSmithyWithAutoColors("--force-color", "--help");
+
+        assertThat(result.stdout(), containsString("[0m"));
+    }
+
+    @Test
+    public void canForceDisableColors() {
+        CliUtils.Result result = CliUtils.runSmithyWithAutoColors("--no-color", "--help");
+
+        assertThat(result.stdout(), not(containsString("[0m")));
+    }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliUtils.java
@@ -27,6 +27,10 @@ public final class CliUtils {
         }
     }
 
+    public static Result runSmithyWithAutoColors(String... args) {
+        return run(SmithyCli.create().createCli(), args);
+    }
+
     private static Result run(Cli cli, String... args) {
         CliPrinter stdout = new BufferPrinter();
         CliPrinter stderr = new BufferPrinter();

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/ColorFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/ColorFormatterTest.java
@@ -1,0 +1,49 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+public class ColorFormatterTest {
+    @Test
+    public void writesToPrinterWhenClosed() {
+        BufferPrinter printer = new BufferPrinter();
+        ColorFormatter formatter = AnsiColorFormatter.FORCE_COLOR;
+        String expected = String.format("abc\nHello\n\n\033[31mRed\033[0m\n\n\n0\n");
+
+        try (ColorFormatter.PrinterBuffer buffer = formatter.printerBuffer(printer)) {
+            buffer.append('a');
+            buffer.append("bc");
+            buffer.println();
+            buffer.println("Hello");
+            buffer.println();
+            buffer.println("Red", Style.RED);
+            buffer.println();
+            buffer.println();
+            buffer.append('0');
+            // ensure that toString does not add the newline.
+            assertThat(normalizeNewlines(buffer.toString()), equalTo(expected.trim()));
+        }
+
+        assertThat(normalizeNewlines(printer.toString()), equalTo(expected));
+    }
+
+    @Test
+    public void appendsNewlineIfNeededInToString() {
+        BufferPrinter printer = new BufferPrinter();
+        ColorFormatter formatter = AnsiColorFormatter.FORCE_COLOR;
+        String expected ="abc\n";
+
+        try (ColorFormatter.PrinterBuffer buffer = formatter.printerBuffer(printer)) {
+            buffer.println("abc");
+            assertThat(normalizeNewlines(buffer.toString()), equalTo(expected));
+        }
+
+        assertThat(normalizeNewlines(printer.toString()), equalTo(expected));
+    }
+
+    private String normalizeNewlines(String str) {
+        return str.replace(System.lineSeparator(), "\n");
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/EnvironmentVariableTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/EnvironmentVariableTest.java
@@ -1,0 +1,38 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+public class EnvironmentVariableTest {
+    @Test
+    public void ignoreDependenciesWhenRunningInGradle() {
+        Object originalValue = System.getProperty("org.gradle.appname");
+
+        try {
+            System.setProperty("org.gradle.appname", "foo");
+            assertThat(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.get(), equalTo("ignore"));
+        } finally {
+            if (originalValue == null) {
+                System.clearProperty("org.gradle.appname");
+            } else {
+                System.setProperty("org.gradle.appname", originalValue.toString());
+            }
+        }
+    }
+
+    @Test
+    public void useStandardDependencyModeWhenRunningInGradle() {
+        Object originalValue = System.getProperty("org.gradle.appname");
+
+        try {
+            System.clearProperty("org.gradle.appname");
+            assertThat(EnvironmentVariable.SMITHY_DEPENDENCY_MODE.get(), equalTo("standard"));
+        } finally {
+            if (originalValue != null) {
+                System.setProperty("org.gradle.appname", originalValue.toString());
+            }
+        }
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
@@ -204,24 +204,4 @@ public class HelpPrinterTest {
                 + "    --foo, -f\n"
                 + "        The foo value\n"));
     }
-
-    private static final class BufferPrinter implements CliPrinter {
-        private final StringBuilder builder = new StringBuilder();
-
-        @Override
-        public void println(String text) {
-            builder.append(text);
-        }
-
-        @Override
-        public String style(String text, Style... styles) {
-            return text;
-        }
-
-        @Override
-        public String toString() {
-            // normalize line endings for tests.
-            return builder.toString().replace("\r\n", "\n").replace("\r", "\n");
-        }
-    }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
@@ -11,7 +11,7 @@ public class HelpPrinterTest {
     public void worksWithNoArguments() {
         BufferPrinter printer = new BufferPrinter();
         HelpPrinter help = new HelpPrinter("foo");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), containsString("Usage: foo"));
     }
@@ -21,7 +21,7 @@ public class HelpPrinterTest {
         BufferPrinter printer = new BufferPrinter();
         HelpPrinter help = new HelpPrinter("foo");
         help.option("--foo", "-f", "The foo value");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -37,7 +37,7 @@ public class HelpPrinterTest {
         help.option("--foo", "-f", "The foo value");
         help.option("--bar", null, "The bar value");
         help.option(null, "-b", "What is this");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] [--bar] [-b] \n"
@@ -58,7 +58,7 @@ public class HelpPrinterTest {
         help.option("--bar", null, "The bar value");
         help.option(null, "-b", "What is this");
         help.param("--baz", "-a", "BAZ", "The baz param");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] [--bar] [-b] [--baz | -a BAZ] \n"
@@ -82,7 +82,7 @@ public class HelpPrinterTest {
         help.option("--bar", null, "The bar value");
         help.option(null, "-b", "What is this");
         help.param("--baz", "-a", "BAZ", "The baz param");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] [--bar] [-b] [--baz | -a BAZ] [FILE...]\n"
@@ -107,7 +107,7 @@ public class HelpPrinterTest {
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -127,7 +127,7 @@ public class HelpPrinterTest {
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -148,7 +148,7 @@ public class HelpPrinterTest {
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo "
                                    + "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -171,7 +171,7 @@ public class HelpPrinterTest {
         help.documentation("Goodbye1 Goodbye2 Goodbye3 Goodbye4 Goodbye5 Goodbye6 Goodbye7 Goodbye8 Goodbye9 "
                            + "Goodbye10 Goodbye11 Goodbye12 Goodbye13 Goodbye14 Goodbye15 Goodbye16 Goodbye17 "
                            + "Goodbye18 Goodbye19 Goodbye20 Goodbye21.");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"
@@ -194,7 +194,7 @@ public class HelpPrinterTest {
         HelpPrinter help = new HelpPrinter("foo");
         help.option("--foo", "-f", "The foo value");
         help.summary("Hello1\r\nHello2\r\rHello3\rHello4.\r");
-        help.print(printer);
+        help.print(AnsiColorFormatter.NO_COLOR, printer);
 
         assertThat(printer.toString(), startsWith(
                 "Usage: foo [--foo | -f] \n"

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/IsolatedRunnableTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/IsolatedRunnableTest.java
@@ -1,0 +1,32 @@
+package software.amazon.smithy.cli.commands;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.cli.CliError;
+
+public class IsolatedRunnableTest {
+    @Test
+    public void runsInThread() {
+        Runnable isolated = new IsolatedRunnable(Collections.emptyList(), getClass().getClassLoader(), cl -> {
+            try {
+                Class<?> c = cl.loadClass("software.amazon.smithy.cli.commands.IsolatedRunnableTest$TestClass");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        isolated.run();
+    }
+
+    @Test
+    public void runsInThreadAndRethrows() {
+        Runnable isolated = new IsolatedRunnable(Collections.emptyList(), getClass().getClassLoader(), cl -> {
+            throw new RuntimeException("Hello from thread");
+        });
+
+        Assertions.assertThrows(CliError.class, isolated::run);
+    }
+
+    public static final class TestClass {}
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
@@ -1,0 +1,107 @@
+package software.amazon.smithy.cli.dependencies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.ListUtils;
+
+public class FileCacheResolverTest {
+    @Test
+    public void proxiesCallsToDelegate() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        Mock mock = new Mock(ListUtils.of());
+        DependencyResolver resolver = new FileCacheResolver(cache, System.currentTimeMillis(), mock);
+        MavenRepository repo = MavenRepository.builder().url("https://example.com").build();
+        resolver.addDependency("com.foo:baz-bar:1.0.0");
+        resolver.addRepository(repo);
+
+        assertThat(mock.repositories, contains(repo));
+        assertThat(mock.coordinates, contains("com.foo:baz-bar:1.0.0"));
+    }
+
+    @Test
+    public void ignoresAndDeletesEmptyCacheFiles() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".json");
+
+        List<ResolvedArtifact> result = ListUtils.of(
+                ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0"));
+        Mock mock = new Mock(result);
+        DependencyResolver resolver = new FileCacheResolver(cache, System.currentTimeMillis(), mock);
+
+        // Delete the cache before resolving to ensure missing files are ignored by the cache.
+        assertThat(cache.delete(), is(true));
+        assertThat(resolver.resolve(), equalTo(result));
+    }
+
+    @Test
+    public void loadsCacheFromDelegateWhenCacheMissingAndSaves() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".json");
+        Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
+
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
+        List<ResolvedArtifact> result = new ArrayList<>();
+        result.add(artifact);
+
+        Mock mock = new Mock(result);
+        DependencyResolver resolver = new FileCacheResolver(cache, jar.lastModified(), mock);
+        List<ResolvedArtifact> resolved = resolver.resolve();
+
+        assertThat(resolved, contains(artifact));
+        assertThat(IoUtils.readUtf8File(cache.toPath()), containsString("com.foo:bar:1.0.0"));
+
+        // Remove the canned entry from the mock to ensure the cache is working before delegating.
+        result.clear();
+
+        // Calling it again will load from the cached file.
+        assertThat(resolver.resolve(), contains(artifact));
+
+        // The cache should still be there.
+        assertThat(IoUtils.readUtf8File(cache.toPath()), containsString("com.foo:bar:1.0.0"));
+
+        // Removing the cache artifact invalidates the cache.
+        assertThat(jar.delete(), is(true));
+
+        assertThat(resolver.resolve(), empty());
+        assertThat(IoUtils.readUtf8File(cache.toPath()), containsString("{}"));
+    }
+
+    private static final class Mock implements DependencyResolver {
+        final List<ResolvedArtifact> artifacts;
+        final List<MavenRepository> repositories = new ArrayList<>();
+        final List<String> coordinates = new ArrayList<>();
+
+        Mock(List<ResolvedArtifact> artifacts) {
+            this.artifacts = artifacts;
+        }
+
+        @Override
+        public void addRepository(MavenRepository repository) {
+            repositories.add(repository);
+        }
+
+        @Override
+        public void addDependency(String coordinates) {
+            this.coordinates.add(coordinates);
+        }
+
+        @Override
+        public List<ResolvedArtifact> resolve() {
+            return artifacts;
+        }
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolverTest.java
@@ -1,0 +1,91 @@
+package software.amazon.smithy.cli.dependencies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.utils.ListUtils;
+
+public class FilterCliVersionResolverTest {
+    @Test
+    public void doesNothingWhenEmpty() {
+        FilterCliVersionResolver filter = new FilterCliVersionResolver("1.26.0", new DependencyResolver() {
+            @Override
+            public void addRepository(MavenRepository repository) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addDependency(String coordinates) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ResolvedArtifact> resolve() {
+                return Collections.emptyList();
+            }
+        });
+
+        assertThat(filter.resolve(), empty());
+    }
+
+    @Test
+    public void filtersMatchingDependencies() {
+        FilterCliVersionResolver filter = new FilterCliVersionResolver("1.26.0", new DependencyResolver() {
+            @Override
+            public void addRepository(MavenRepository repository) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addDependency(String coordinates) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ResolvedArtifact> resolve() {
+                return Arrays.asList(
+                    ResolvedArtifact.fromCoordinates(Paths.get("/a"), "software.amazon.smithy:smithy-model:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/b"), "software.amazon.smithy:smithy-utils:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/c"), "software.amazon.smithy:smithy-other:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/d"), "software.amazon.foo:foo-other:1.0.0")
+                );
+            }
+        });
+
+        assertThat(filter.resolve(), contains(
+            ResolvedArtifact.fromCoordinates(Paths.get("/c"), "software.amazon.smithy:smithy-other:1.25.0"),
+            ResolvedArtifact.fromCoordinates(Paths.get("/d"), "software.amazon.foo:foo-other:1.0.0")
+        ));
+    }
+
+    @Test
+    public void failsWhenResolvedDependenciesGreaterThanCli() {
+        FilterCliVersionResolver filter = new FilterCliVersionResolver("1.26.0", new DependencyResolver() {
+            @Override
+            public void addRepository(MavenRepository repository) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addDependency(String coordinates) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<ResolvedArtifact> resolve() {
+                return ListUtils.of(ResolvedArtifact.fromCoordinates(Paths.get("/a"),
+                                                                     "software.amazon.smithy:smithy-model:1.27.0"));
+            }
+        });
+
+        Assertions.assertThrows(DependencyResolverException.class, filter::resolve);
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolverTest.java
@@ -1,0 +1,61 @@
+package software.amazon.smithy.cli.dependencies;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.build.model.MavenRepository;
+
+// This test does some light validation checks. Actual resolution is tested through integ tests.
+public class MavenDependencyResolverTest {
+    @Test
+    public void allowsValidDependenciesAndRepos() {
+        DependencyResolver resolver = new MavenDependencyResolver();
+        resolver.addRepository(MavenRepository.builder().url("https://example.com").build());
+        resolver.addRepository(MavenRepository.builder()
+                .url("https://mvn.example.com")
+                .httpCredentials("user:pass")
+                .build());
+        resolver.addDependency("com.foo:baz1:1.0.0");
+        resolver.addDependency("com.foo:baz2:[1.0.0]");
+        resolver.addDependency("com.foo:baz3:[1.0.0,]");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidDependencies")
+    public void validatesDependencies(String value) {
+        DependencyResolver resolver = new MavenDependencyResolver();
+
+        DependencyResolverException e = Assertions.assertThrows(DependencyResolverException.class, () -> {
+            resolver.addDependency(value);
+        });
+    }
+
+    public static Stream<Arguments> invalidDependencies() {
+        return Stream.of(
+            Arguments.of("X"),
+            Arguments.of("smithy.foo:bar:1.25.0-SNAPSHOT"),
+            Arguments.of("smithy.foo:bar:RELEASE"),
+            Arguments.of("smithy.foo:bar:latest-status"),
+            Arguments.of("smithy.foo:bar:LATEST"),
+            Arguments.of("smithy.foo:bar:1.25.0+"),
+            Arguments.of("a::1.2.0"),
+            Arguments.of(":b:1.2.0"),
+            Arguments.of("a:b:"),
+            Arguments.of("a:b: ")
+        );
+    }
+
+    @Test
+    public void repositoryNeedsValidUrl() {
+        DependencyResolver resolver = new MavenDependencyResolver();
+
+        Assertions.assertThrows(DependencyResolverException.class, () -> {
+            resolver.addRepository(MavenRepository.builder()
+                    .url("!nope://")
+                    .build());
+        });
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/ResolvedArtifactTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/ResolvedArtifactTest.java
@@ -1,0 +1,54 @@
+package software.amazon.smithy.cli.dependencies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ResolvedArtifactTest {
+    @Test
+    public void loadsFromCoordinates() {
+        Path path = Paths.get("/a");
+        String coordinates = "com.foo:baz-bam:1.2.0";
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(path, coordinates);
+
+        assertThat(artifact.getPath(), equalTo(path));
+        assertThat(artifact.getCoordinates(), equalTo(coordinates));
+        assertThat(artifact.getGroupId(), equalTo("com.foo"));
+        assertThat(artifact.getArtifactId(), equalTo("baz-bam"));
+        assertThat(artifact.getVersion(), equalTo("1.2.0"));
+    }
+
+    @Test
+    public void createsCoordinatesStringFromParts() {
+        Path path = Paths.get("/a");
+        ResolvedArtifact artifact = new ResolvedArtifact(path, "com.foo", "baz-bam", "1.2.0");
+
+        assertThat(artifact.getPath(), equalTo(path));
+        assertThat(artifact.getCoordinates(), equalTo("com.foo:baz-bam:1.2.0"));
+        assertThat(artifact.getGroupId(), equalTo("com.foo"));
+        assertThat(artifact.getArtifactId(), equalTo("baz-bam"));
+        assertThat(artifact.getVersion(), equalTo("1.2.0"));
+    }
+
+    @Test
+    public void validatesCoordinatesNotTooManyParts() {
+        Path path = Paths.get("/a");
+        String coordinates = "com.foo:baz-bam:1.2.0:boo";
+
+        Assertions.assertThrows(DependencyResolverException.class,
+                                () -> ResolvedArtifact.fromCoordinates(path, coordinates));
+    }
+
+    @Test
+    public void validatesCoordinatesEnoughParts() {
+        Path path = Paths.get("/a");
+        String coordinates = "com.foo:baz-bam";
+
+        Assertions.assertThrows(DependencyResolverException.class,
+                                () -> ResolvedArtifact.fromCoordinates(path, coordinates));
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -266,7 +266,8 @@ public final class ModelAssembler {
                 throw new ModelImportException("Error loading the contents of " + importPath, e);
             }
         } else if (Files.isRegularFile(importPath)) {
-            inputStreamModels.put(importPath.toString(), () -> {
+            // Use an absolute path for better de-duping of the same file.
+            inputStreamModels.put(importPath.toAbsolutePath().toString(), () -> {
                 try {
                     return Files.newInputStream(importPath);
                 } catch (IOException e) {
@@ -309,8 +310,8 @@ public final class ModelAssembler {
 
         if (key.startsWith("file:")) {
             try {
-                // Paths.get ensures paths are normalized for Windows too.
-                key = Paths.get(url.toURI()).toString();
+                // Use an absolute Path to ensure paths are normalized for Windows too, and better de-duping.
+                key = Paths.get(url.toURI()).toAbsolutePath().toString();
             } catch (URISyntaxException e) {
                 key = key.substring(5);
             }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
@@ -24,10 +24,17 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Utilities for IO operations.
@@ -170,7 +177,7 @@ public final class IoUtils {
 
         if (exitValue != 0) {
             throw new RuntimeException(String.format(
-                    "Command `%s` failed with exit code %d and output:%n%n%s", command, exitValue, sb.toString()));
+                    "Command `%s` failed with exit code %d and output:%n%n%s", command, exitValue, sb));
         }
 
         return sb.toString();
@@ -191,16 +198,57 @@ public final class IoUtils {
      * @return Returns the exit code of the process.
      */
     public static int runCommand(String command, Path directory, Appendable output) {
-        String[] finalizedCommand;
-        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
-            finalizedCommand = new String[]{"cmd.exe", "/c", command};
-        } else {
-            finalizedCommand = new String[]{"sh", "-c", command};
-        }
+        return runCommand(command, directory, output, Collections.emptyMap());
+    }
 
-        ProcessBuilder processBuilder = new ProcessBuilder(finalizedCommand)
+    /**
+     * Runs a process using the given {@code command} relative to the given
+     * {@code directory} and writes stdout and stderr to {@code output}.
+     *
+     * <p>stderr is redirected to stdout when writing to {@code output}.
+     * This method <em>does not</em> throw when a non-zero exit code is
+     * encountered. For any more complex use cases, use {@link ProcessBuilder}
+     * directly.
+     *
+     * @param command Process command to execute.
+     * @param directory Directory to use as the working directory.
+     * @param output Where stdout and stderr is written.
+     * @param env Environment variables to set.
+     * @return Returns the exit code of the process.
+     */
+    public static int runCommand(String command, Path directory, Appendable output, Map<String, String> env) {
+        List<String> finalizedCommand;
+        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
+            finalizedCommand = Arrays.asList("cmd.exe", "/c", command);
+        } else {
+            finalizedCommand = Arrays.asList("sh", "-c", command);
+        }
+        return runCommand(finalizedCommand, directory, output, env);
+    }
+
+    /**
+     * Runs a process using the given {@code command} relative to the given
+     * {@code directory} and writes stdout and stderr to {@code output}.
+     *
+     * <p>stderr is redirected to stdout when writing to {@code output}.
+     * This method <em>does not</em> throw when a non-zero exit code is
+     * encountered. For any more complex use cases, use {@link ProcessBuilder}
+     * directly.
+     *
+     * @param args Array of arguments.
+     * @param directory Directory to use as the working directory.
+     * @param output Where stdout and stderr is written.
+     * @param env Environment variables to set.
+     * @return Returns the exit code of the process.
+     */
+    public static int runCommand(List<String> args, Path directory, Appendable output, Map<String, String> env) {
+        ProcessBuilder processBuilder = new ProcessBuilder(args)
                 .directory(directory.toFile())
                 .redirectErrorStream(true);
+
+        if (!env.isEmpty()) {
+            processBuilder.environment().putAll(env);
+        }
 
         try {
             Process process = processBuilder.start();
@@ -217,5 +265,56 @@ public final class IoUtils {
         } catch (InterruptedException | IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Delete a directory and all files within.
+     *
+     * <p>Any found symlink is deleted, but the contents of a symlink are not deleted.
+     *
+     * @param dir Directory to delete.
+     * @return Returns true if the directory was deleted, or false if the directory does not exist.
+     * @throws IllegalArgumentException if the given path is not a directory.
+     * @throws RuntimeException if unable to delete a file or directory.
+     */
+    public static boolean rmdir(Path dir) {
+        if (!Files.exists(dir)) {
+            return false;
+        }
+
+        if (!Files.isDirectory(dir)) {
+            throw new IllegalArgumentException(dir + " is not a directory");
+        }
+
+        try {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    return Files.isSymbolicLink(dir)
+                           // Don't delete symlink files, just delete the symlink.
+                           ? FileVisitResult.SKIP_SUBTREE
+                           : FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+                    if (e != null) {
+                        throw e;
+                    }
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException("Error deleting directory: " + dir + ": " + e.getMessage(), e);
+        }
+
+        return true;
     }
 }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/IoUtilsTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/IoUtilsTest.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,6 +26,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Random;
 import org.junit.jupiter.api.Assertions;
@@ -109,5 +113,39 @@ public class IoUtilsTest {
 
         assertThat(code, not(0));
         assertThat(sb.toString(), not(emptyString()));
+    }
+
+    @Test
+    public void deletesDirectories() throws IOException {
+        Path path = Files.createTempDirectory("delete_empty_dir");
+        Files.write(path.resolve("foo"), "hello".getBytes(StandardCharsets.UTF_8));
+        Path nested = path.resolve("a").resolve("b");
+        Files.createDirectories(nested);
+        Files.write(nested.resolve("baz"), "hello".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(Files.exists(path), is(true));
+        assertThat(Files.exists(nested), is(true));
+
+        IoUtils.rmdir(path);
+
+        assertThat(Files.exists(path), is(false));
+        assertThat(Files.exists(nested), is(false));
+    }
+
+    @Test
+    public void rmDirIgnoresIfNotExists() throws IOException {
+        Path path = Files.createTempDirectory("delete_empty_dir");
+        Files.delete(path);
+
+        assertThat(IoUtils.rmdir(path), is(false));
+    }
+
+    @Test
+    public void rmDirFailsWhenNotDir() throws IOException {
+        Path path = Files.createTempFile("foo", ".baz");
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> IoUtils.rmdir(path));
+
+        Files.delete(path);
     }
 }

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -25,5 +25,5 @@ ext {
 }
 
 dependencies {
-    implementation project(":smithy-cli")
+    implementation project(path: ":smithy-cli", configuration: "shadow")
 }


### PR DESCRIPTION
This commit adds the ability to resolve dependencies in the Smithy CLI. This allows end users to author models, generate code, and other activities from the Smithy CLI without needing to use tools like Gradle or Maven. This lowers the up-front learning curve of most Smithy use cases to author models and generate code.

Writing Java library code, model build plugins, or transforms is out of scope of the Smithy CLI. Such use cases require the use of tools like Gradle or Maven.

To support dependency resolution in the CLI, this commit also introduces the ``--version`` option to display the current version.

The ``smithy clean`` command was added since it was very useful to test dependency resolution by removing the classpath-cache file to force them to be re-resolved.

Using the Smithy CLI directly means that tools like Gradle aren't automatically detecting the model directory and adding sources. To account for this, the `sources` property was added to smithy-build.json. It acts like `imports`, but the models contained in `sources` are considered part of the model being built rather than just a dependeny (i.e., the sources plugin will contain these models).

To actually test maven resolution, this commit also adds integration tests for the CLI (./gradlew :smithy-cli:integ).

Other changes:

1. The use of @SmithyUnstableApi and @SmithyInternalApi was removed from all smithy-cli classes because there is a blanket @SmithyUnstableApi annotation on the entire package, making the individual usage unnecessary.
2. Moved --severity setting from StandardOptions to BuildOptions. This setting is only needed when building Smithy models.
3. Made Smithy CLI commands and related options classes package-private since they aren't referenced outside of the commands package.
4. This commit also prints out more useful exceptions when --stacktrace is on since wrapping things in a DependencyRunnably obscured the underlying issue.
5. Command line options related to model discovery and discovery classpath are now hidden from help output. They are much less relevant now that dependency resolution is baked into the CLI, and may not even be necessary if Smithy's Ant and Gradle integration aren't using it (need to verify).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
