### PR TITLE
Add github action for CI testing with SDK generators.

### DIFF
--- a/.github/workflows/checkout-and-build-smithy/action.yml
+++ b/.github/workflows/checkout-and-build-smithy/action.yml
@@ -1,0 +1,29 @@
+name: 'Checkout and build Smithy repo'
+description: 'Checkout and build Smithy repo'
+outputs:
+  smithy-version:
+    description: "Smithy version"
+    value: ${{ steps.smithy-version.outputs.smithy-version }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-java@v2
+      with:
+        java-version: 17
+        distribution: 'zulu'
+
+    - uses: actions/checkout@v2
+      with:
+        path: main
+
+    - uses: actions/checkout@v2
+      with:
+        repository: awslabs/smithy
+        path: smithy
+
+    - run: cd ./smithy && ./gradlew clean build publishToMavenLocal
+      shell: bash
+
+    - id: smithy-version
+      run: cd ./smithy && echo "smithy-version=$(cat ./VERSION)" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/sdk-codegen-ci.yml
+++ b/.github/workflows/sdk-codegen-ci.yml
@@ -1,0 +1,179 @@
+name: sdk-codegen-ci
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-aws-sdk-js-v3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Increase Node Heap space
+        run: echo "NODE_OPTIONS=--max-old-space-size=16384" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v1
+      - id: smithy-version
+        uses: ./.github/workflows/checkout-and-build-smithy
+
+      - name: Add smithyVersion env variable
+        run: echo "smithyVersion=${{ steps.smithy-version.outputs.smithy-version }}" >> $GITHUB_ENV
+
+      - name: Checkout smithy-typescript
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/smithy-typescript
+          path: smithy-typescript
+
+      - name: Build smithy-typescript
+        run: cd smithy-typescript && ./gradlew -PsmithyVersion=$smithyVersion clean build publishToMavenLocal
+
+      - name: Checkout aws-sdk-js-v3
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-js-v3
+          path: aws-sdk-js-v3
+
+      - name: Build aws-sdk-js-v3
+        run: cd aws-sdk-js-v3/codegen && ./gradlew -PsmithyVersion=$smithyVersion clean build
+
+      - name: Test aws-sdk-js-v3
+        run: cd aws-sdk-js-v3 && yarn && yarn test:all
+
+  build-aws-sdk-go-v2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'zulu'
+
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+
+      - uses: actions/checkout@v1
+      - id: smithy-version
+        uses: ./.github/workflows/checkout-and-build-smithy
+
+      - name: Add smithyVersion env variable
+        run: echo "smithyVersion=${{ steps.smithy-version.outputs.smithy-version }}" >> $GITHUB_ENV
+
+      - name: Checkout smithy-go
+        uses: actions/checkout@v2
+        with:
+          repository: aws/smithy-go
+          path: smithy-go
+
+      - name: Build smithy-go
+        run: cd smithy-go/codegen && ./gradlew -PsmithyVersion=$smithyVersion clean build publishToMavenLocal
+
+      - name: Checkout aws-sdk-go-v2
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-go-v2
+          path: aws-sdk-go-v2
+
+      - name: Build aws-sdk-go-v2
+        run: cd aws-sdk-go-v2/codegen && ./gradlew -PsmithyVersion=$smithyVersion clean build -Plog-tests && ./gradlew clean
+
+      - name: Run aws-sdk-go-v2 protocol tests
+        # This is essentially the `ci-test` command in the Makefile
+        run: |
+          cd aws-sdk-go-v2 && make update-requires gen-repo-mod-replace \
+          update-module-metadata smithy-annotate-stable gen-config-asserts gen-internal-codegen \
+          copy-attributevalue-feature gen-mod-dropreplace-smithy-. min-go-version-. tidy-modules-. \
+          add-module-license-files gen-aws-ptrs format unit-race ci-test-generate-validate
+
+  build-aws-sdk-kotlin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - id: smithy-version
+        uses: ./.github/workflows/checkout-and-build-smithy
+
+      - name: Add smithyVersion env variable
+        run: echo "smithyVersion=${{ steps.smithy-version.outputs.smithy-version }}" >> $GITHUB_ENV
+
+      - name: Checkout smithy-kotlin
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/smithy-kotlin
+          path: smithy-kotlin
+
+      - name: Build smithy-kotlin
+        run: cd smithy-kotlin && ./gradlew -PsmithyVersion=$smithyVersion clean build publishToMavenLocal
+
+      - name: Checkout aws-sdk-kotlin
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/aws-sdk-kotlin
+          path: aws-sdk-kotlin
+
+      - name: Build aws-sdk-kotlin
+        run: cd aws-sdk-kotlin && ./gradlew -PsmithyVersion=$smithyVersion clean build
+
+      - name: Build aws-sdk-kotlin
+        run: cd aws-sdk-kotlin && ./gradlew -PsmithyVersion=$smithyVersion clean build publishToMavenLocal
+
+      - name: Run aws-sdk-kotlin protocol tests
+        run: cd aws-sdk-kotlin && ./gradlew -PsmithyVersion=$smithyVersion -p codegen/protocol-tests testAllProtocols
+
+  build-aws-sdk-swift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: swift-actions/setup-swift@v1
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - uses: actions/checkout@v1
+      - id: smithy-version
+        uses: ./.github/workflows/checkout-and-build-smithy
+
+      - name: Add smithyVersion env variable
+        run: echo "smithyVersion=${{ steps.smithy-version.outputs.smithy-version }}" >> $GITHUB_ENV
+
+      - name: Checkout aws-crt-swift
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/aws-crt-swift
+          path: Sources/SmithySwift/aws-crt-swift
+
+      - name: Checkout smithy-swift
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/smithy-swift
+          path: Sources/SmithySwift/smithy-swift
+
+      - name: Build smithy-swift
+        run: echo $smithyVersion && cd Sources/SmithySwift/smithy-swift && ./gradlew -PsmithyVersion=$smithyVersion clean build publishToMavenLocal
+
+      - name: Checkout aws-sdk-swift
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/aws-sdk-swift
+          path: Sources/SmithySwift/aws-sdk-swift
+
+      - name: Set SMITHY_SWIFT_CI_DIR env variable
+        run: echo "SMITHY_SWIFT_CI_DIR=$GITHUB_WORKSPACE/Sources/SmithySwift/smithy-swift" >> $GITHUB_ENV
+
+      - name: Set AWS_SDK_SWIFT_CI_DIR env variable
+        run: echo "AWS_SDK_SWIFT_CI_DIR=$GITHUB_WORKSPACE/Sources/SmithySwift/aws-sdk-swift" >> $GITHUB_ENV
+
+      - name: Build aws-sdk-swift
+        run: cd Sources/SmithySwift/aws-sdk-swift && ./gradlew -PsmithyVersion=$smithyVersion clean build
+
+      - name: Generate Swift SDKs
+        run: cd Sources/SmithySwift/aws-sdk-swift && ./gradlew -PsmithyVersion=$smithyVersion -p codegen/sdk-codegen build
+
+      - name: Build codegen/protocol-test-codegen-local
+        run: cd Sources/SmithySwift/aws-sdk-swift && ./gradlew -PsmithyVersion=$smithyVersion -p codegen/protocol-test-codegen-local build
+
+      - name: Run local protocol tests
+        run: cd Sources/SmithySwift/aws-sdk-swift/codegen/protocol-test-codegen-local/build && swift test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,18 @@ and [creating a pull request](https://help.github.com/articles/creating-a-pull-r
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/smithy/labels/help%20wanted) issues is a great place to start.
 
 
+## Testing with AWS SDK code generators
+
+> In the past, Smithy changes have been released without integration testing with Smithy-based SDK code generators.
+> In addition, SDK code generators often fall behind in Smithy versions. As a result, we don’t have visibility on code generators’ failures
+> until they are upgraded to the latest smithy version.
+
+The GitHub action `sdk-codegen-ci.yml` builds and test Smithy-based AWS SDKs using the latest Smithy implementation.
+
+The GitHub action can be triggered manually via `Run workflow` in the `Actions` tab of the Smithy repo.
+(See [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) for step-by-step instructions)
+
+
 ## Code of Conduct
 
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).


### PR DESCRIPTION
*Description of changes:*

> In the past, Smithy changes have been released without integration testing with Smithy-based SDK code generators. In addition, SDK code generators often fall behind in Smithy versions. As a result, we don’t have visibility on code generators’ failures until they are upgraded to the latest smithy version. 

> Upgrading versions and building all the code generators manually is also a labor-intensive task. Hence, the goal is to design a continuous integration system for testing the latest Smithy implementation with the SDK code generators.

This PR adds a new Github action for integration testing with Smithy based SDKs. (See [example execution](https://github.com/AndrewFossAWS/smithy/actions/runs/3653031602))

Note:
- Most SDK generators' build or protocol tests are failing with the latest smithy changes. I have skipped github action triggering on push commit or scheduled event for now to reduce noise, and allow manual triggering via `workflow_dispatch`.
- Most SDKs generators' build and test commands are relatively concise. The Go SDK protocol test commands are more verbose/complicated. `smithy-ci` gradle task will be added in the Go SDK repo for running protocol tests.
- Rust SDK to be added in a subsequent PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
