### PR TITLE
Fix typo in class cache tweak PR

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/IdentityClassCacheTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/IdentityClassCacheTest.java
@@ -43,7 +43,7 @@ public class IdentityClassCacheTest {
         String key = "key";
         Type associatedClass = new Type() {};
         String storedInstance = "value";
-        cache.getForClass("key", associatedClass, () -> storedInstance);
+        cache.getForClass(key, associatedClass, () -> storedInstance);
 
         Type newAssociatedClass = new Type() {};
         String newStoredInstance = "newValue";


### PR DESCRIPTION
Fixes a typo in https://github.com/awslabs/smithy/pull/1518.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
