### PR TITLE
Add exclude/include tranforms using selectors

### DIFF
--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -292,6 +292,47 @@ Only the following shape type changes are supported:
     }
 
 
+.. _excludeShapesBySelector-transform:
+
+excludeShapesBySelector
+-----------------------
+
+Removes all shapes matching the given :ref:`selector <selectors>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - selector
+      - ``string``
+      - A valid :ref:`selector <selectors>` used to exclude shapes.
+
+.. code-block:: json
+
+    {
+        "version": "1.0",
+        "projections": {
+            "exampleProjection": {
+                "transforms": [
+                    {
+                        "name": "excludeShapesBySelector",
+                        "args": {
+                            // Excludes all operations that use event streams.
+                            "selector": "[trait|streaming] :test(<) :is(< member < structure <-[input, output]- operation)"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+.. note::
+
+    This transformer does not remove shapes from the prelude.
+
 .. _excludeShapesByTag-transform:
 
 excludeShapesByTag
@@ -373,6 +414,47 @@ Removes shapes if they are marked with one or more specific traits.
         }
     }
 
+
+.. _includeShapesBySelector-transform:
+
+includeShapesBySelector
+-----------------------
+
+Includes only the shapes matching the given :ref:`selector <selectors>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - selector
+      - ``string``
+      - A valid :ref:`selector <selectors>` used to include shapes.
+
+.. code-block:: json
+
+    {
+        "version": "1.0",
+        "projections": {
+            "exampleProjection": {
+                "transforms": [
+                    {
+                        "name": "includeShapesBySelector",
+                        "args": {
+                            // Includes only shapes in the FooService closure.
+                            "selector": "[id=smithy.example#FooService] is(*, ~> *)"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+.. note::
+
+    This transformer does not remove shapes from the prelude.
 
 .. _includeShapesByTag-transform:
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesBySelector.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeShapesBySelector.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.selector.Selector;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.utils.FunctionalUtils;
+
+/**
+ * {@code excludeShapesBySelector} excludes the shapes matching the given selector.
+ *
+ * <p>Prelude shapes are not removed by this transformer.
+ */
+public final class ExcludeShapesBySelector extends ConfigurableProjectionTransformer<ExcludeShapesBySelector.Config> {
+
+    /**
+     * {@code excludeShapesBySelector} configuration.
+     */
+    public static final class Config {
+        private Selector selector = null;
+
+        /**
+         * Gets the selector used to filter the shapes.
+         *
+         * @return The selector used to filter the shapes.
+         */
+        public Selector getSelector() {
+            return selector;
+        }
+
+        /**
+         * Sets the selector used to filter the shapes.
+         *
+         * @param selector The selector used to filter the shapes.
+         */
+        public void setSelector(Selector selector) {
+            this.selector = selector;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    public String getName() {
+        return "excludeShapesBySelector";
+    }
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Selector selector = config.getSelector();
+        ModelTransformer transformer = context.getTransformer();
+        Model model = context.getModel();
+        Set<Shape> selected = selector.select(model);
+        return transformer.filterShapes(model, FunctionalUtils.not(selected::contains));
+    }
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeShapesBySelector.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeShapesBySelector.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import java.util.Set;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.selector.Selector;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.transform.ModelTransformer;
+
+/**
+ * {@code includeShapesBySelector} includes the shapes matching the given selector.
+ *
+ * <p>Prelude shapes are not removed by this transformer.
+ */
+public final class IncludeShapesBySelector extends ConfigurableProjectionTransformer<IncludeShapesBySelector.Config> {
+
+    /**
+     * {@code includeShapesBySelector} configuration.
+     */
+    public static final class Config {
+        private Selector selector = null;
+
+        /**
+         * Gets the selector used to filter the shapes.
+         *
+         * @return The selector used to filter the shapes.
+         */
+        public Selector getSelector() {
+            return selector;
+        }
+
+        /**
+         * Sets the selector used to filter the shapes.
+         *
+         * @param selector The selector used to filter the shapes.
+         */
+        public void setSelector(Selector selector) {
+            this.selector = selector;
+        }
+    }
+
+    @Override
+    public Class<Config> getConfigType() {
+        return Config.class;
+    }
+
+    @Override
+    public String getName() {
+        return "includeShapesBySelector";
+    }
+
+
+    @Override
+    protected Model transformWithConfig(TransformContext context, Config config) {
+        Selector selector = config.getSelector();
+        ModelTransformer transformer = context.getTransformer();
+        Model model = context.getModel();
+        Set<Shape> selected = selector.select(model);
+        return transformer.filterShapes(model, selected::contains);
+    }
+}

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -2,6 +2,7 @@ software.amazon.smithy.build.transforms.Apply
 software.amazon.smithy.build.transforms.ChangeStringEnumsToEnumShapes
 software.amazon.smithy.build.transforms.ChangeTypes
 software.amazon.smithy.build.transforms.ExcludeMetadata
+software.amazon.smithy.build.transforms.ExcludeShapesBySelector
 software.amazon.smithy.build.transforms.ExcludeShapesByTag
 software.amazon.smithy.build.transforms.ExcludeShapesByTrait
 software.amazon.smithy.build.transforms.ExcludeTags
@@ -12,6 +13,7 @@ software.amazon.smithy.build.transforms.FilterSuppressions
 software.amazon.smithy.build.transforms.IncludeMetadata
 software.amazon.smithy.build.transforms.IncludeNamespaces
 software.amazon.smithy.build.transforms.IncludeServices
+software.amazon.smithy.build.transforms.IncludeShapesBySelector
 software.amazon.smithy.build.transforms.IncludeShapesByTag
 software.amazon.smithy.build.transforms.IncludeTags
 software.amazon.smithy.build.transforms.IncludeTraits

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesBySelectorTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ExcludeShapesBySelectorTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.smithy.build.transforms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.Test;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SetUtils;
+
+public class ExcludeShapesBySelectorTest {
+
+    @Test
+    public void excludesByOperationsThatUseEventStreams() {
+        Model model = testModel();
+        String selector = "[trait|streaming] :test(<) :is(< member < structure <-[input, output]- operation)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new ExcludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#BarInteger",
+                "smithy.example#BarService",
+                "smithy.example#BarStruct",
+                "smithy.example#BarStruct$intVal",
+                "smithy.example#BarStruct$stringVal",
+                "smithy.example#BarStruct$unionVal",
+                "smithy.example#BarStructInput",
+                "smithy.example#BarStructInput$intVal",
+                "smithy.example#BarStructInput$stringVal",
+                "smithy.example#BarStructOutput",
+                "smithy.example#BarStructOutput$intVal",
+                "smithy.example#BarStructOutput$stringVal",
+                "smithy.example#BarStructOutput$unionVal",
+                "smithy.example#BarUnion",
+                "smithy.example#BarUnion$fooEnum",
+                "smithy.example#BarUnion$fooInteger",
+                "smithy.example#BarUnion$fooString",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooEnum$FOO",
+                "smithy.example#FooInteger",
+                "smithy.example#FooService",
+                "smithy.example#FooStruct",
+                "smithy.example#FooStruct$intVal",
+                "smithy.example#FooStruct$stringVal",
+                "smithy.example#FooStruct$unionVal",
+                "smithy.example#FooStructInput",
+                "smithy.example#FooStructInput$intVal",
+                "smithy.example#FooStructInput$stringVal",
+                "smithy.example#FooStructOutput",
+                "smithy.example#FooStructOutput$intVal",
+                "smithy.example#FooStructOutput$stringVal",
+                "smithy.example#FooStructOutput$unionVal",
+                "smithy.example#FooUnion",
+                "smithy.example#FooUnion$fooEnum",
+                "smithy.example#FooUnion$fooInteger",
+                "smithy.example#FooUnion$fooString",
+                "smithy.example#GetBar",
+                "smithy.example#GetFoo",
+                "smithy.example#LeaveEvent",
+                "smithy.example#Message",
+                "smithy.example#Message$message",
+                "smithy.example#PublishEvents",
+                "smithy.example#PublishEvents$leave",
+                "smithy.example#PublishEvents$message",
+                "smithy.example#PublishMessagesInput",
+                "smithy.example#PublishMessagesInput$messages",
+                "smithy.example#PublishMessagesInput$room")));
+    }
+
+    @Test
+    public void excludesByServiceFoo() {
+        Model model = testModel();
+        String selector = "[id=smithy.example#FooService] :is(*, ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new ExcludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#BarInteger",
+                "smithy.example#BarService",
+                "smithy.example#BarStruct",
+                "smithy.example#BarStruct$intVal",
+                "smithy.example#BarStruct$stringVal",
+                "smithy.example#BarStruct$unionVal",
+                "smithy.example#BarStructInput",
+                "smithy.example#BarStructInput$intVal",
+                "smithy.example#BarStructInput$stringVal",
+                "smithy.example#BarStructOutput",
+                "smithy.example#BarStructOutput$intVal",
+                "smithy.example#BarStructOutput$stringVal",
+                "smithy.example#BarStructOutput$unionVal",
+                "smithy.example#BarUnion",
+                "smithy.example#BarUnion$fooEnum",
+                "smithy.example#BarUnion$fooInteger",
+                "smithy.example#BarUnion$fooString",
+                "smithy.example#FooStruct",
+                "smithy.example#FooStruct$intVal",
+                "smithy.example#FooStruct$stringVal",
+                "smithy.example#GetBar")));
+    }
+
+    @Test
+    public void excludesByServiceBar() {
+        Model model = testModel();
+        String selector = "[id=smithy.example#BarService] :is(*, ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new ExcludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarStruct",
+                "smithy.example#BarStruct$intVal",
+                "smithy.example#BarStruct$stringVal",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooEnum$FOO",
+                "smithy.example#FooInteger",
+                "smithy.example#FooService",
+                "smithy.example#FooStruct",
+                "smithy.example#FooStruct$intVal",
+                "smithy.example#FooStruct$stringVal",
+                "smithy.example#FooStruct$unionVal",
+                "smithy.example#FooStructInput",
+                "smithy.example#FooStructInput$intVal",
+                "smithy.example#FooStructInput$stringVal",
+                "smithy.example#FooStructOutput",
+                "smithy.example#FooStructOutput$intVal",
+                "smithy.example#FooStructOutput$stringVal",
+                "smithy.example#FooStructOutput$unionVal",
+                "smithy.example#FooUnion",
+                "smithy.example#FooUnion$fooEnum",
+                "smithy.example#FooUnion$fooInteger",
+                "smithy.example#FooUnion$fooString",
+                "smithy.example#GetFoo",
+                "smithy.example#LeaveEvent",
+                "smithy.example#Message",
+                "smithy.example#Message$message",
+                "smithy.example#PublishEvents",
+                "smithy.example#PublishEvents$leave",
+                "smithy.example#PublishEvents$message",
+                "smithy.example#PublishMessages",
+                "smithy.example#PublishMessagesInput",
+                "smithy.example#PublishMessagesInput$messages",
+                "smithy.example#PublishMessagesInput$room")));
+    }
+
+    @Test
+    public void excludesNotByService() {
+        Model model = testModel();
+        String selector = ":not([id=smithy.example#BarService] ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new ExcludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of( "smithy.example#BarService")));
+    }
+
+    @Test
+    public void excludesOnlyEnumMembersWithTags() {
+        Model model = testModel();
+        String selector = ":is(enum > member:test([trait|tags|(values) = \"alpha\",\"beta\"]))";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new ExcludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarInteger",
+                "smithy.example#BarService",
+                "smithy.example#BarStruct",
+                "smithy.example#BarStruct$intVal",
+                "smithy.example#BarStruct$stringVal",
+                "smithy.example#BarStruct$unionVal",
+                "smithy.example#BarStructInput",
+                "smithy.example#BarStructInput$intVal",
+                "smithy.example#BarStructInput$stringVal",
+                "smithy.example#BarStructOutput",
+                "smithy.example#BarStructOutput$intVal",
+                "smithy.example#BarStructOutput$stringVal",
+                "smithy.example#BarStructOutput$unionVal",
+                "smithy.example#BarUnion",
+                "smithy.example#BarUnion$fooEnum",
+                "smithy.example#BarUnion$fooInteger",
+                "smithy.example#BarUnion$fooString",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooInteger",
+                "smithy.example#FooService",
+                "smithy.example#FooStruct",
+                "smithy.example#FooStruct$intVal",
+                "smithy.example#FooStruct$stringVal",
+                "smithy.example#FooStruct$unionVal",
+                "smithy.example#FooStructInput",
+                "smithy.example#FooStructInput$intVal",
+                "smithy.example#FooStructInput$stringVal",
+                "smithy.example#FooStructOutput",
+                "smithy.example#FooStructOutput$intVal",
+                "smithy.example#FooStructOutput$stringVal",
+                "smithy.example#FooStructOutput$unionVal",
+                "smithy.example#FooUnion",
+                "smithy.example#FooUnion$fooEnum",
+                "smithy.example#FooUnion$fooInteger",
+                "smithy.example#FooUnion$fooString",
+                "smithy.example#GetBar",
+                "smithy.example#GetFoo",
+                "smithy.example#LeaveEvent",
+                "smithy.example#Message",
+                "smithy.example#Message$message",
+                "smithy.example#PublishEvents",
+                "smithy.example#PublishEvents$leave",
+                "smithy.example#PublishEvents$message",
+                "smithy.example#PublishMessages",
+                "smithy.example#PublishMessagesInput",
+                "smithy.example#PublishMessagesInput$messages",
+                "smithy.example#PublishMessagesInput$room")));
+    }
+
+    Model testModel() {
+        try {
+            return Model.assembler()
+                    .addImport(Paths.get(getClass().getResource("transform-by-selector.smithy").toURI()))
+                    .assemble()
+                    .unwrap();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Set<String> exampleIds(Model model) {
+        return model.getShapeIds()
+                .stream()
+                .filter(id -> id.getNamespace().equals("smithy.example"))
+                .map(ShapeId::toString)
+                .collect(Collectors.toSet());
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeShapesBySelectorTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/IncludeShapesBySelectorTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.smithy.build.transforms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.Test;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SetUtils;
+
+public class IncludeShapesBySelectorTest {
+
+    @Test
+    public void includesByServiceFoo() {
+        Model model = testModel();
+        String selector = "[id=smithy.example#FooService] :is(*, ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new IncludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooEnum$FOO",
+                "smithy.example#FooInteger",
+                "smithy.example#FooService",
+                "smithy.example#FooStructInput",
+                "smithy.example#FooStructInput$intVal",
+                "smithy.example#FooStructInput$stringVal",
+                "smithy.example#FooStructOutput",
+                "smithy.example#FooStructOutput$intVal",
+                "smithy.example#FooStructOutput$stringVal",
+                "smithy.example#FooStructOutput$unionVal",
+                "smithy.example#FooUnion",
+                "smithy.example#FooUnion$fooEnum",
+                "smithy.example#FooUnion$fooInteger",
+                "smithy.example#FooUnion$fooString",
+                "smithy.example#GetFoo",
+                "smithy.example#LeaveEvent",
+                "smithy.example#Message",
+                "smithy.example#Message$message",
+                "smithy.example#PublishEvents",
+                "smithy.example#PublishEvents$leave",
+                "smithy.example#PublishEvents$message",
+                "smithy.example#PublishMessages",
+                "smithy.example#PublishMessagesInput",
+                "smithy.example#PublishMessagesInput$messages",
+                "smithy.example#PublishMessagesInput$room")));
+    }
+
+    @Test
+    public void includesByServiceBar() {
+        Model model = testModel();
+        String selector = "[id=smithy.example#BarService] :is(*, ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new IncludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#BarInteger",
+                "smithy.example#BarService",
+                "smithy.example#BarStructInput",
+                "smithy.example#BarStructInput$intVal",
+                "smithy.example#BarStructInput$stringVal",
+                "smithy.example#BarStructOutput",
+                "smithy.example#BarStructOutput$intVal",
+                "smithy.example#BarStructOutput$stringVal",
+                "smithy.example#BarStructOutput$unionVal",
+                "smithy.example#BarUnion",
+                "smithy.example#BarUnion$fooEnum",
+                "smithy.example#BarUnion$fooInteger",
+                "smithy.example#BarUnion$fooString",
+                "smithy.example#GetBar")));
+    }
+
+    @Test
+    public void includesNotByService() {
+        Model model = testModel();
+        String selector = ":not([id=smithy.example#BarService] ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new IncludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#BarInteger",
+                "smithy.example#BarStruct",
+                "smithy.example#BarStruct$intVal",
+                "smithy.example#BarStruct$stringVal",
+                "smithy.example#BarStruct$unionVal",
+                "smithy.example#BarStructInput",
+                "smithy.example#BarStructInput$intVal",
+                "smithy.example#BarStructInput$stringVal",
+                "smithy.example#BarStructOutput",
+                "smithy.example#BarStructOutput$intVal",
+                "smithy.example#BarStructOutput$stringVal",
+                "smithy.example#BarStructOutput$unionVal",
+                "smithy.example#BarUnion",
+                "smithy.example#BarUnion$fooEnum",
+                "smithy.example#BarUnion$fooInteger",
+                "smithy.example#BarUnion$fooString",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooEnum$FOO",
+                "smithy.example#FooInteger",
+                "smithy.example#FooService",
+                "smithy.example#FooStruct",
+                "smithy.example#FooStruct$intVal",
+                "smithy.example#FooStruct$stringVal",
+                "smithy.example#FooStruct$unionVal",
+                "smithy.example#FooStructInput",
+                "smithy.example#FooStructInput$intVal",
+                "smithy.example#FooStructInput$stringVal",
+                "smithy.example#FooStructOutput",
+                "smithy.example#FooStructOutput$intVal",
+                "smithy.example#FooStructOutput$stringVal",
+                "smithy.example#FooStructOutput$unionVal",
+                "smithy.example#FooUnion",
+                "smithy.example#FooUnion$fooEnum",
+                "smithy.example#FooUnion$fooInteger",
+                "smithy.example#FooUnion$fooString",
+                "smithy.example#GetBar",
+                "smithy.example#GetFoo",
+                "smithy.example#LeaveEvent",
+                "smithy.example#Message",
+                "smithy.example#Message$message",
+                "smithy.example#PublishEvents",
+                "smithy.example#PublishEvents$leave",
+                "smithy.example#PublishEvents$message",
+                "smithy.example#PublishMessages",
+                "smithy.example#PublishMessagesInput",
+                "smithy.example#PublishMessagesInput$messages",
+                "smithy.example#PublishMessagesInput$room")));
+    }
+
+    @Test
+    public void includesOnlyEnumMembersWithTags() {
+        Model model = testModel();
+        String selector = ":is(enum, enum > member:test([trait|tags|(values) = \"alpha\",\"beta\"]))";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new IncludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$FOO")));
+    }
+
+    @Test
+    public void includesOnlyEnums() {
+        Model model = testModel();
+        String selector = ":is(enum, enum > member)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new IncludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooEnum$FOO")));
+    }
+
+    @Test
+    public void includesStructsAndForwardRecursiveNeighbors() {
+        Model model = testModel();
+        String selector = ":is(structure, structure ~> *)";
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(Node.objectNode().withMember("selector", selector))
+                .build();
+        Model result = new IncludeShapesBySelector().transform(context);
+        assertThat(exampleIds(result), is(SetUtils.of(
+                "smithy.example#BarEnum",
+                "smithy.example#BarEnum$BAR",
+                "smithy.example#BarEnum$BAZ",
+                "smithy.example#BarEnum$FOO",
+                "smithy.example#BarInteger",
+                "smithy.example#BarStruct",
+                "smithy.example#BarStruct$intVal",
+                "smithy.example#BarStruct$stringVal",
+                "smithy.example#BarStruct$unionVal",
+                "smithy.example#BarStructInput",
+                "smithy.example#BarStructInput$intVal",
+                "smithy.example#BarStructInput$stringVal",
+                "smithy.example#BarStructOutput",
+                "smithy.example#BarStructOutput$intVal",
+                "smithy.example#BarStructOutput$stringVal",
+                "smithy.example#BarStructOutput$unionVal",
+                "smithy.example#BarUnion",
+                "smithy.example#BarUnion$fooEnum",
+                "smithy.example#BarUnion$fooInteger",
+                "smithy.example#BarUnion$fooString",
+                "smithy.example#FooEnum",
+                "smithy.example#FooEnum$BAR",
+                "smithy.example#FooEnum$BAZ",
+                "smithy.example#FooEnum$FOO",
+                "smithy.example#FooInteger",
+                "smithy.example#FooStruct",
+                "smithy.example#FooStruct$intVal",
+                "smithy.example#FooStruct$stringVal",
+                "smithy.example#FooStruct$unionVal",
+                "smithy.example#FooStructInput",
+                "smithy.example#FooStructInput$intVal",
+                "smithy.example#FooStructInput$stringVal",
+                "smithy.example#FooStructOutput",
+                "smithy.example#FooStructOutput$intVal",
+                "smithy.example#FooStructOutput$stringVal",
+                "smithy.example#FooStructOutput$unionVal",
+                "smithy.example#FooUnion",
+                "smithy.example#FooUnion$fooEnum",
+                "smithy.example#FooUnion$fooInteger",
+                "smithy.example#FooUnion$fooString",
+                "smithy.example#LeaveEvent",
+                "smithy.example#Message",
+                "smithy.example#Message$message",
+                "smithy.example#PublishEvents",
+                "smithy.example#PublishEvents$leave",
+                "smithy.example#PublishEvents$message",
+                "smithy.example#PublishMessagesInput",
+                "smithy.example#PublishMessagesInput$messages",
+                "smithy.example#PublishMessagesInput$room")));
+    }
+
+
+    Model testModel() {
+        try {
+            return Model.assembler()
+                    .addImport(Paths.get(getClass().getResource("transform-by-selector.smithy").toURI()))
+                    .assemble()
+                    .unwrap();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Set<String> exampleIds(Model model) {
+        return model.getShapeIds()
+                .stream()
+                .filter(id -> id.getNamespace().equals("smithy.example"))
+                .map(ShapeId::toString)
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/transform-by-selector.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/transform-by-selector.smithy
@@ -1,0 +1,116 @@
+$version: "2.0"
+
+namespace smithy.example
+
+service FooService {
+  version: "2017-02-11"
+  operations: [GetFoo PublishMessages ]
+}
+
+operation PublishMessages {
+    input: PublishMessagesInput
+}
+
+@input
+structure PublishMessagesInput {
+    room: String,
+    messages: PublishEvents,
+}
+
+@streaming
+union PublishEvents {
+    message: Message,
+    leave: LeaveEvent,
+}
+
+structure Message {
+    message: String,
+}
+
+structure LeaveEvent {}
+
+
+operation GetFoo {
+  input: FooStructInput
+  output: FooStructOutput
+}
+
+enum FooEnum {
+  @tags(["alpha"])
+  FOO
+  @tags(["beta"])
+  BAR
+  @tags(["gamma"])
+  BAZ
+}
+
+union FooUnion {
+  fooString: String
+  fooInteger: Integer
+  fooEnum: FooEnum
+}
+
+@range(min: 10, max: 30)
+integer FooInteger
+
+structure FooStructInput {
+  stringVal: String
+  intVal: Integer
+}
+
+structure FooStruct {
+  stringVal: String
+  intVal: Integer
+  unionVal: FooUnion
+}
+
+structure FooStructOutput {
+  stringVal: String
+  intVal: FooInteger
+  unionVal: FooUnion
+}
+
+service BarService {
+  version: "2017-02-11"
+  operations: [GetBar]
+}
+
+operation GetBar {
+  input: BarStructInput
+  output: BarStructOutput
+}
+
+enum BarEnum {
+  @tags(["alpha"])
+  FOO
+  @tags(["beta"])
+  BAR
+  @tags(["gamma"])
+  BAZ
+}
+
+union BarUnion {
+  fooString: String
+  fooInteger: Integer
+  fooEnum: BarEnum
+}
+
+@range(min: 10, max: 30)
+integer BarInteger
+
+structure BarStructInput {
+  stringVal: String
+  intVal: Integer
+}
+
+structure BarStruct {
+  stringVal: String
+  intVal: Integer
+  unionVal: BarUnion
+}
+
+structure BarStructOutput {
+  stringVal: String
+  intVal: BarInteger
+  unionVal: BarUnion
+}


### PR DESCRIPTION

*Description of changes:*

Added include/exclude transforms using selectors. Using selectors is a generic way to include or exclude shapes, instead of adding specific transforms such as `byShapeType` (e.g., [this PR](https://github.com/awslabs/smithy/pull/1330)) a selector can be used to replace that and other use cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
