### PR TITLE
Fix quoted text grammar and parsing

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -148,20 +148,20 @@ string support defined in :rfc:`7405`.
     NodeKeywords        :%s"true" / %s"false" / %s"null"
     NodeStringValue     :`ShapeId` / `TextBlock` / `QuotedText`
     QuotedText          :DQUOTE *`QuotedChar` DQUOTE
-    QuotedChar          :%x20-21     ; space - "!"
+    QuotedChar          :%x09        ; tab
+                        :/ %x20-21     ; space - "!"
                         :/ %x23-5B     ; "#" - "["
                         :/ %x5D-10FFFF ; "]"+
                         :/ `EscapedChar`
-                        :/ `PreservedDouble`
                         :/ `NL`
-    EscapedChar         :`Escape` (`Escape` / "'" / DQUOTE / %s"b"
-                        :          / %s"f" / %s"n" / %s"r" / %s"t"
-                        :          / "/" / `UnicodeEscape`)
+    EscapedChar         :`Escape` (`Escape` / DQUOTE / %s"b" / %s"f"
+                        :           / %s"n" / %s"r" / %s"t" / "/"
+                        :           / `UnicodeEscape`)
     UnicodeEscape       :%s"u" `Hex` `Hex` `Hex` `Hex`
     Hex                 :DIGIT / %x41-46 / %x61-66
-    PreservedDouble     :`Escape` (%x20-21 / %x23-5B / %x5D-10FFFF)
     Escape              :%x5C ; backslash
-    TextBlock           :`ThreeDquotes` *`SP` `NL` *`QuotedChar` `ThreeDquotes`
+    TextBlock           :`ThreeDquotes` *`SP` `NL` *`TextBlockContent` `ThreeDquotes`
+    TextBlockContent    :`QuotedChar` / (1*2DQUOTE 1*`QuotedChar`)
     ThreeDquotes        :DQUOTE DQUOTE DQUOTE
 
 .. rubric:: Shapes


### PR DESCRIPTION
Updates Smithy ABNF for QuotedChar and TextBlock, and updates IdlTextParser to properly parse QuotedChar and TextBlock. Previously, IdlTextParser was allowing any character to be used as a QuotedChar, despite QuotedChar having certain restrictions in the grammar. IdlTextParser was updated to follow the grammar's restrictions properly. The grammar restrictions were also loosened to allow tab characters in QuotedChar and double quotes in TextBlock, both of which were already in use. Specifically for double quotes in a TextBlock, one or two are allowed in a row, and must be followed by a QuotedChar.

*Issue #, if available:*
https://github.com/awslabs/smithy/issues/1491

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
