### PR TITLE
Fix MapMembers grammar and update test

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -199,7 +199,7 @@ string support defined in :rfc:`7405`.
     ElidedListMember        :%s"$member"
     ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] *`WS` `MapMembers`
-    MapMembers              :"{" *`WS` [`MapKey` `WS` `MapValue`] *`WS` "}"
+    MapMembers              :"{" *`WS` [`MapKey` / `MapValue` / (`MapKey` `WS` `MapValue`)] *`WS` "}"
     MapKey                  :`TraitStatements` (`ElidedMapKey` / `ExplicitMapKey`)
     MapValue                :`TraitStatements` (`ElidedMapValue` / `ExplicitMapValue`)
     ElidedMapKey            :%s"$key"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.flattened.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.flattened.smithy
@@ -41,6 +41,11 @@ map MixedMap {
     value: String
 }
 
+map MixedMapRedefineValue {
+    key: String
+    value: String
+}
+
 service MixedService {}
 
 resource MixedResource {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.json
@@ -233,6 +233,15 @@
                 "target": "smithy.example#MixinMap"
             }]
         },
+        "smithy.example#MixedMapRedefineValue": {
+            "type": "map",
+            "value": {
+                "target": "smithy.api#String"
+            },
+            "mixins": [{
+                "target": "smithy.example#MixinMap"
+            }]
+        },
         "smithy.example#MixinService": {
             "type": "service",
             "traits": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/mixins/loads-mixins.smithy
@@ -98,6 +98,10 @@ map MixinMap {
 
 map MixedMap with [MixinMap] {}
 
+map MixedMapRedefineValue with [MixinMap] {
+    value: String
+}
+
 @mixin
 service MixinService {}
 


### PR DESCRIPTION
In IDL 2, map members can be mixed in, so Smithy grammar should reflect their optionality. https://github.com/awslabs/smithy/pull/1533 incorrectly changed MapMembers grammar to make both MapKey and MapValue optional together, when they are optional separately. This PR fixes the MapMembers grammar to allow MapKey and MapValue to be optional separately, and updates a test case to reflect that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
