### PR TITLE
Add check to skip CLI tests for version bump PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
         run: ./gradlew clean build -Plog-tests --stacktrace
 
       - name: CLI integration tests
-        if: matrix.java >= 17
+        # This step will fail if smithy version is not released on Maven Central.
+        # There is a condition to skip on version bump PRs.
+        if: matrix.java >= 17 && !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'bump-'))
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

CLI integration tests if the smithy version in the `VERSION` file is not published to Maven Central.

Is there a way to run CLI integration tests for only published Maven Central versions?

The failures will happen in the period between: bumping the smithy version and the smithy version getting released on Maven Central.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
