### PR TITLE
Remove CDS from integ test and runtime by default

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -202,11 +202,7 @@ tasks.register("_dumpArchive", Exec) {
     commandLine("$smithyBinary", "warmup", "--discover")
 }
 
-// Can't do CDS if the OS and architecture is not one of our targets.
-if (!imageOs.isEmpty()) {
-    tasks["_dumpArchive"].dependsOn("_createClassList")
-    tasks["runtime"].finalizedBy("_dumpArchive")
-}
+tasks["_dumpArchive"].dependsOn("_createClassList")
 
 // Always shadow the JAR and replace the JAR by the shadowed JAR.
 tasks['jar'].finalizedBy("shadowJar")


### PR DESCRIPTION
Building the CDS archive automatically seems to cause intermittent timeout issues on GitHub actions. It also makes it take much longer to run integ tests.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
