### PR TITLE
Move CDS warmup to the CLI directly

### DIFF
--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -159,4 +159,11 @@
     <Match>
         <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
     </Match>
+
+    <!-- We don't care if files.delete() returns true or false -->
+    <Match>
+        <Class name="software.amazon.smithy.cli.commands.WarmupCommand"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+    </Match>
+
 </FindBugsFilter>

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -187,26 +187,10 @@ runtime {
     }
 }
 
-// First, call validate with no args and create a class list to use application class data sharing.
-tasks.register("_createClassList", Exec) {
-    environment("SMITHY_OPTS", "-XX:DumpLoadedClassList=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.lst")
-    environment("SMITHY_WARMUP_INTERNAL_ONLY", "true")
-    commandLine("$smithyBinary", "warmup", "--discover")
+tasks.register("optimize", Exec) {
+    commandLine("$smithyBinary", "warmup")
 }
-
-// Next, actually dump out the archive of the collected classes. This is platform specific,
-// so it can only be done for the current OS+architecture.
-tasks.register("_dumpArchive", Exec) {
-    environment("SMITHY_OPTS", "-Xshare:dump -XX:SharedArchiveFile=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.jsa -XX:SharedClassListFile=${project.buildDir}/image/smithy-cli-${imageOs}/lib/smithy.lst")
-    environment("SMITHY_WARMUP_INTERNAL_ONLY", "true")
-    commandLine("$smithyBinary", "warmup", "--discover")
-}
-
-// Can't do CDS if the OS and architecture is not one of our targets.
-if (!imageOs.isEmpty()) {
-    tasks["_dumpArchive"].dependsOn("_createClassList")
-    tasks["runtime"].finalizedBy("_dumpArchive")
-}
+tasks["optimize"].dependsOn("runtime")
 
 // Always shadow the JAR and replace the JAR by the shadowed JAR.
 tasks['jar'].finalizedBy("shadowJar")

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/WarmupTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/WarmupTest.java
@@ -3,8 +3,12 @@ package software.amazon.smithy.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -17,9 +21,17 @@ public class WarmupTest {
     }
 
     @Test
-    public void warmupDoesNotWorkWithoutEnvvar() {
-        IntegUtils.run("simple-config-sources", ListUtils.of("warmup"), result -> {
-            assertThat(result.getExitCode(), equalTo(1));
+    public void canCallHelpForCommand() {
+        IntegUtils.run("simple-config-sources", ListUtils.of("warmup", "--help"), result -> {
+            assertThat(result.getExitCode(), is(0));
         });
+    }
+
+    @Test
+    public void canWarmupTheCli() throws IOException {
+        Path tempDir = Files.createTempDirectory("smithy-warmup-integ");
+        RunResult result = IntegUtils.run(tempDir, ListUtils.of("warmup"));
+
+        assertThat(result.getExitCode(), equalTo(0));
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/LoggingUtil.java
@@ -145,6 +145,8 @@ final class LoggingUtil {
                 } else {
                     printer.println(formatted);
                 }
+                // We want to see log messages right away, so flush the printer.
+                printer.flush();
             }
         }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SmithyCommand.java
@@ -43,7 +43,7 @@ public final class SmithyCommand implements Command {
             new SelectCommand(getName(), dependencyResolverFactory),
             new CleanCommand(getName()),
             new Upgrade1to2Command(getName()),
-            new WarmupCommand(getName(), dependencyResolverFactory)
+            new WarmupCommand(getName())
         );
     }
 


### PR DESCRIPTION
The Java class data sharing archive can now be created by the CLI using the warmup command. This makes it possible to build the CDS archive during an install step so that the archive uses the right paths. Creating the archive before distributing the CLI results in the archive using absolute paths pointing to the where the CLI was built rather than where it is installed on end user machines.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
