### PR TITLE
Fix javadoc with cli shadowing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,9 @@ project.afterEvaluate {
         source(project.subprojects.stream().map({
             project(it.path).sourceSets.main.allJava
         }).collect(Collectors.toList()))
+        classpath = files(project.subprojects.stream()
+                .map({project(it.path).sourceSets.main.compileClasspath})
+                .collect(Collectors.toList()))
     }
 }
 


### PR DESCRIPTION
After the addition of jar shadowing for the CLI in https://github.com/awslabs/smithy/pull/1526, javadoc fails to find packages and symbols, causing it to fail:

```
> Task :javadoc
/Volumes/workplace/smithy/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java:18: error: package org.eclipse.aether.util.artifact does not exist
import static org.eclipse.aether.util.artifact.JavaScopes.COMPILE;
```

This PR sets the javadoc classpath to the compileClasspath from each of the subprojects, including smithy-cli, so that javadoc can find the appropriate packages.

After this fix, javadoc can run successfully and the output is copied to `build/docs/javadoc/latest`. Cli docs are successfully written to `build/docs/javadoc/latest/software/amazon/smithy/cli`:

```
╰─⠠⠵ tree build/docs/javadoc/latest/software/amazon/smithy/cli
build/docs/javadoc/latest/software/amazon/smithy/cli
├── AnsiColorFormatter.html
├── ArgumentReceiver.html
├── Arguments.html
├── BuildParameterBuilder.ClassPathTagMatcher.html
├── BuildParameterBuilder.JarFileClassPathTagMatcher.html
├── BuildParameterBuilder.Result.html
├── BuildParameterBuilder.html
├── Cli.html
├── CliError.html
├── CliPrinter.html
├── ColorFormatter.PrinterBuffer.html
├── ColorFormatter.html
├── Command.Env.html
├── Command.html
├── EnvironmentVariable.html
├── HelpPrinter.html
├── SmithyCli.html
├── StandardOptions.html
├── Style.html
├── commands
│   ├── SmithyCommand.html
│   ├── package-summary.html
│   └── package-tree.html
├── dependencies
│   ├── DependencyResolver.Factory.html
│   ├── DependencyResolver.html
│   ├── DependencyResolverException.html
│   ├── FileCacheResolver.html
│   ├── FilterCliVersionResolver.html
│   ├── MavenDependencyResolver.html
│   ├── ResolvedArtifact.html
│   ├── package-summary.html
│   └── package-tree.html
├── package-summary.html
└── package-tree.html
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
