### PR TITLE
Run javadoc on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
 
-      - name: Clean and build
-        run: ./gradlew clean build -Plog-tests --stacktrace
+      - name: Clean, build and javadoc
+        run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
       - name: CLI integration tests
         if: matrix.java >= 17


### PR DESCRIPTION
This PR adds running javadoc on CI. It will not succeed until the fix for javadoc in https://github.com/awslabs/smithy/pull/1556 is merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
