### PR TITLE
Fix datetime offset restXml payload

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/datetime-offsets.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/datetime-offsets.smithy
@@ -23,9 +23,9 @@ apply DatetimeOffsets @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-            <DateTime>
+            <DatetimeOffsetsOutput>
                 <datetime>2019-12-16T22:48:18-01:00</datetime>
-            </DateTime>
+            </DatetimeOffsetsOutput>
             """,
         bodyMediaType: "application/xml",
         headers: {
@@ -40,9 +40,9 @@ apply DatetimeOffsets @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-            <DateTime>
+            <DatetimeOffsetsOutput>
                 <datetime>2019-12-17T00:48:18+01:00</datetime>
-            </DateTime>
+            </DatetimeOffsetsOutput>
             """,
         bodyMediaType: "application/xml",
         headers: {


### PR DESCRIPTION
Fixes restXml payload output for datetime offset tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
