### PR TITLE
Fix `RestJsonQueryStringEscaping` protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -130,7 +130,10 @@ apply AllQueryStringTypes @httpRequestTests([
 		"String=%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9",
         ],
         params: {
-		queryString: "%:/?#[]@!$&'()*+,;=😹"
+		queryString: "%:/?#[]@!$&'()*+,;=😹",
+		queryParamsMapOfStringList: {
+                    "String": ["%:/?#[]@!$&'()*+,;=😹"]
+                }
         }
     },
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
