### PR TITLE
Fix `RestJsonAllQueryStringTypes` protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -99,6 +99,26 @@ apply AllQueryStringTypes @httpRequestTests([
             queryEnumList: ["Foo", "Baz", "Bar"],
             queryIntegerEnum: 1,
             queryIntegerEnumList: [1, 2, 3],
+            queryParamsMapOfStringList: {
+                "String": ["Hello there"],
+                "StringList": ["a", "b", "c"],
+                "StringSet": ["a", "b", "c"],
+                "Byte": ["1"],
+                "Short": ["2"],
+                "Integer": ["3"],
+                "IntegerList": ["1", "2", "3"],
+                "IntegerSet": ["1", "2", "3"],
+                "Long": ["4"],
+                "Float": ["1.1"],
+                "Double": ["1.1"],
+                "DoubleList": ["1.1", "2.1", "3.1"],
+                "Boolean": ["true"],
+                "BooleanList": ["true", "false", "true"],
+                "Timestamp": ["1970-01-01T00:00:01Z"],
+                "TimestampList": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1970-01-01T00:00:03Z"],
+                "Enum": ["Foo"],
+                "EnumList": ["Foo", "Baz", "Bar"]
+            },
         }
     },
     {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
