### PR TITLE
Fix Upgrade1to2Command for Set shape

### DIFF
--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/box.v2.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/box.v2.smithy
@@ -24,7 +24,8 @@ list BadSparseList {
     member: NonBoxedInteger,
 }
 
-set BadSparseSet {
+@uniqueItems
+list BadSparseSet {
     member: NonBoxedInteger,
 }
 

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/list.v1.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/list.v1.smithy
@@ -1,0 +1,27 @@
+$version: "1.0"
+
+namespace com.example
+
+integer NonBoxedInteger
+
+list SparseList {
+    @box
+    member: NonBoxedInteger,
+}
+
+set SparseSet {
+    @box
+    member: NonBoxedInteger,
+}
+
+list SingleLineList { member: NonBoxedInteger, }
+
+set SingleLineSet { member: NonBoxedInteger }
+
+  set SetWithIndentation { member: NonBoxedInteger }
+
+set SetWithComment { // This comment is here
+    member: NonBoxedInteger,
+}
+
+@tags(["set"]) set MultipleSetCharacters { member: NonBoxedInteger, }

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/list.v2.smithy
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/cases/list.v2.smithy
@@ -1,0 +1,31 @@
+$version: "2.0"
+
+namespace com.example
+
+@default(0)
+integer NonBoxedInteger
+
+list SparseList {
+    member: NonBoxedInteger,
+}
+
+@uniqueItems
+list SparseSet {
+    member: NonBoxedInteger,
+}
+
+list SingleLineList { member: NonBoxedInteger, }
+
+@uniqueItems
+list SingleLineSet { member: NonBoxedInteger }
+
+  @uniqueItems
+list SetWithIndentation { member: NonBoxedInteger }
+
+@uniqueItems
+list SetWithComment { // This comment is here
+    member: NonBoxedInteger,
+}
+
+@tags(["set"]) @uniqueItems
+list MultipleSetCharacters { member: NonBoxedInteger, }


### PR DESCRIPTION
*Description of changes:*
Smithy IDL 1 contains set shapes, but IDL 2 does not. When upgrading from IDL 1, set shapes should be converted to list shapes. The upgrade command currently does not perform this conversion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
