### PR TITLE
Fix parameters to builder

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/Parameter.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/Parameter.java
@@ -209,8 +209,12 @@ public final class Parameter implements ToSmithyBuilder<Parameter>, FromSourceLo
                 .type(getType())
                 .name(getName())
                 .builtIn(builtIn)
+                .value(value)
+                .required(required)
+                .sourceLocation(sourceLocation)
+                .deprecated(deprecated)
                 .documentation(documentation)
-                .value(value);
+                .defaultValue(defaultValue);
     }
 
     public String template() {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamsTrait.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.BuilderRef;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -58,7 +57,7 @@ public final class ClientContextParamsTrait extends AbstractTrait implements ToS
     }
 
     @Override
-    public SmithyBuilder<ClientContextParamsTrait> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .sourceLocation(getSourceLocation())
                 .parameters(getParameters());

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/syntax/ParameterTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/syntax/ParameterTest.java
@@ -1,0 +1,23 @@
+package software.amazon.smithy.rulesengine.language.syntax;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.rulesengine.language.eval.Value;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType;
+
+public class ParameterTest {
+    @Test
+    void parameterToBuilderRoundTrips() {
+        Parameter p = Parameter.builder()
+                .name("test")
+                .builtIn("Test::BuiltIn")
+                .required(true)
+                .defaultValue(Value.bool(true))
+                .type(ParameterType.BOOLEAN)
+                .deprecated(new Parameter.Deprecated("message", "I wrote this test"))
+                .build();
+        assertEquals(p, p.toBuilder().build());
+    }
+}

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/syntax/ParameterTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/syntax/ParameterTest.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.rulesengine.language.syntax;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.rulesengine.language.eval.Value;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType;
@@ -17,6 +18,8 @@ public class ParameterTest {
                 .defaultValue(Value.bool(true))
                 .type(ParameterType.BOOLEAN)
                 .deprecated(new Parameter.Deprecated("message", "I wrote this test"))
+                .value(Node.from(true))
+                .documentation("here are some docs")
                 .build();
         assertEquals(p, p.toBuilder().build());
     }


### PR DESCRIPTION
*Description of changes:* Fix two bugs in the `toBuilder` methods.

In `Parameter`, fields were dropped.

In `ClientContextParameter`, `toBuilder` returned an interface which made it impossible to use from calling code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
