### PR TITLE
Validate upgraded models in Upgrade1to2Command

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
@@ -128,6 +128,9 @@ final class Upgrade1to2Command extends SimpleCommand {
             writeUpgradedFile(finalizedModel, modelFile);
         }
 
+        // Validate upgraded models
+        CommandUtils.buildModel(arguments, models, env, env.stderr(), true, smithyBuildConfig);
+
         return 0;
     }
 


### PR DESCRIPTION
*Issue:*
> The Smithy CLI has a command that allows you to update IDL 1 models to IDL 2 models in place, overwriting the IDL 1 files. However, the resulting IDL 2 model isn't guaranteed to be valid, because no validation is done on the upgraded model within the CLI. The upgrade command needs to be updated to always produce valid IDL 2 models, by building and validating the upgraded model before writing out the files.

*Description of changes:*
Validate upgraded models in Upgrade1to2Command

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
