### PR TITLE
Fix params in `Ec2ComplexError` test

### DIFF
--- a/smithy-aws-protocol-tests/model/ec2Query/xml-errors.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-errors.smithy
@@ -107,6 +107,7 @@ apply ComplexError @httpResponseTests([
         id: "Ec2ComplexError",
         protocol: ec2Query,
         params: {
+            Message: "Hi",
             TopLevel: "Top level",
             Nested: {
                 Foo: "bar"


### PR DESCRIPTION
The expected error body has a message, but the params did not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
