### PR TITLE
Minor fix to restJson1 docs

### DIFF
--- a/docs/source-2.0/aws/protocols/aws-restjson1-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-restjson1-protocol.rst
@@ -100,7 +100,7 @@ preferred over ``http/1.1``.
 
     use aws.protocols#restJson1
 
-    @awsJson1_1(
+    @restJson1(
         http: ["h2", "http/1.1"],
         eventStreamHttp: ["h2", "http/1.1"]
     )


### PR DESCRIPTION
One of the code blocks used `awsJson1_1` instead of `restJson`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
