### PR TITLE
implement Comparable interface for TagObject and ExternalDocumentation

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ExternalDocumentation.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ExternalDocumentation.java
@@ -15,13 +15,19 @@
 
 package software.amazon.smithy.openapi.model;
 
+import java.util.Comparator;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
-public final class ExternalDocumentation extends Component implements ToSmithyBuilder<ExternalDocumentation> {
+public final class ExternalDocumentation extends Component
+        implements ToSmithyBuilder<ExternalDocumentation>, Comparable<ExternalDocumentation> {
+
+    private static final Comparator<String> STRING_COMPARATOR = Comparator
+            .nullsFirst(String::compareTo);
+
     private final String description;
     private final String url;
 
@@ -56,6 +62,13 @@ public final class ExternalDocumentation extends Component implements ToSmithyBu
         return Node.objectNodeBuilder()
                 .withOptionalMember("description", getDescription().map(Node::from))
                 .withMember("url", url);
+    }
+
+    @Override
+    public int compareTo(ExternalDocumentation that) {
+        return Comparator.comparing(ExternalDocumentation::getUrl, STRING_COMPARATOR)
+            .thenComparing(ed -> ed.description, STRING_COMPARATOR)
+            .compare(this, that);
     }
 
     public static final class Builder extends Component.Builder<Builder, ExternalDocumentation> {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/TagObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/TagObject.java
@@ -15,13 +15,20 @@
 
 package software.amazon.smithy.openapi.model;
 
+import java.util.Comparator;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
-public final class TagObject extends Component implements ToSmithyBuilder<TagObject> {
+public final class TagObject extends Component implements ToSmithyBuilder<TagObject>, Comparable<TagObject> {
+    private static final Comparator<String> STRING_COMPARATOR = Comparator
+            .nullsFirst(String::compareToIgnoreCase);
+
+    private static final Comparator<ExternalDocumentation> EXTERNAL_DOCUMENTATION_COMPARATOR = Comparator
+            .nullsFirst(ExternalDocumentation::compareTo);
+
     private final String name;
     private final String description;
     private final ExternalDocumentation externalDocs;
@@ -64,6 +71,14 @@ public final class TagObject extends Component implements ToSmithyBuilder<TagObj
                 .withMember("name", Node.from(getName()))
                 .withOptionalMember("description", getDescription().map(Node::from))
                 .withOptionalMember("externalDocs", getExternalDocs().map(ExternalDocumentation::toNode));
+    }
+
+    @Override
+    public int compareTo(TagObject that) {
+        return Comparator.comparing(TagObject::getName, STRING_COMPARATOR)
+            .thenComparing(to -> to.description, STRING_COMPARATOR)
+            .thenComparing(to -> to.externalDocs, EXTERNAL_DOCUMENTATION_COMPARATOR)
+            .compare(this, that);
     }
 
     public static final class Builder extends Component.Builder<Builder, TagObject> {

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/model/ExternalDocumentationTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/model/ExternalDocumentationTest.java
@@ -1,0 +1,35 @@
+package software.amazon.smithy.openapi.model;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ExternalDocumentationTest {
+    private static final ExternalDocumentation DOC_1 =
+        ExternalDocumentation.builder()
+            .url("url1")
+            .description("description1")
+            .build();
+
+    private static Stream<Arguments> testData() {
+        return Stream.of(
+            Arguments.of(ExternalDocumentation.builder().url("url1").description("description1").build(), 0),
+            Arguments.of(ExternalDocumentation.builder().url("url1").description("description0").build(), 1),
+            Arguments.of(ExternalDocumentation.builder().url("url1").description("description2").build(), -1),
+            Arguments.of(ExternalDocumentation.builder().url("url0").description("description1").build(), 1),
+            Arguments.of(ExternalDocumentation.builder().url("url2").description("description1").build(), -1),
+            Arguments.of(ExternalDocumentation.builder().url("url1").build(), 1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void testCompareTo(ExternalDocumentation doc2, int expected) {
+        assertThat(DOC_1.compareTo(doc2), equalTo(expected));
+    }
+}

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/model/TagObjectTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/model/TagObjectTest.java
@@ -1,0 +1,38 @@
+package software.amazon.smithy.openapi.model;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class TagObjectTest {
+    private static final TagObject TAG_OBJECT_1 =
+        TagObject.builder()
+            .name("tag1")
+            .description("description1")
+            .externalDocs(ExternalDocumentation.builder().url("url1").build())
+            .build();
+
+    private static Stream<Arguments> testData() {
+        return Stream.of(
+            Arguments.of("tag1", "description1", ExternalDocumentation.builder().url("url1").build(), 0),
+            Arguments.of("tag0", "description1", ExternalDocumentation.builder().url("url1").build(), 1),
+            Arguments.of("tag1", "description1", ExternalDocumentation.builder().url("url2").build(), -1),
+            Arguments.of("tag2", "description1", ExternalDocumentation.builder().url("url1").build(), -1),
+            Arguments.of("tag1", "description2", ExternalDocumentation.builder().url("url1").build(), -1),
+            Arguments.of("tag1", null, ExternalDocumentation.builder().url("url1").build(), 1),
+            Arguments.of("tag1", "description1", null, 1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void testCompareTo(String name, String description, ExternalDocumentation doc, int expected) {
+        TagObject tagObject2 = TagObject.builder().name(name).description(description).externalDocs(doc).build();
+        assertThat(TAG_OBJECT_1.compareTo(tagObject2), equalTo(expected));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
The `OpenAPI` class sorts `TagObject`s [here](https://github.com/awslabs/smithy/blob/main/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java#L136)  but `TagObject` is not comparable.

*Description of changes:*
Implement `Comparable` inteface for `TagObject` and  `ExternalDocumentation`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
