### PR TITLE
Add labeler workflow for adding github labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: github
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v1
+      -
+        name: Run Labeler
+        if: success()
+        uses: crazy-max/ghaction-github-labeler@v1
+        with:
+          yaml_file: .github/labels.yml
+          skip_delete: true
+          dry_run: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow will add the GitHub issue labels in a .github/labels.yml file. It does not delete our existing labels.

GitHub doesn't seem to have a way to run a workflow on PR merge, so this workflow just runs on pushes to main. After this PR is merged, a commit will have to be made into main with the .github/labels.yml file. After the labeler workflow runs, the workflow file (in this commit) and the labels.yml file should be deleted.

The labels to be added are the standard labels that AWS SDKs use, and having these labels will bring consistency across repos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
