### PR TITLE
fix referenced components removed in openapi schema

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java
@@ -122,7 +122,7 @@ public final class RemoveUnusedComponents implements OpenApiMapper {
             public Set<String> objectNode(ObjectNode node) {
                 Set<String> result = new HashSet<>();
 
-                if (node.size() == 1 && node.getMember("$ref").isPresent()) {
+                if (node.getMember("$ref").isPresent()) {
                     node.getMember("$ref")
                             .flatMap(Node::asStringNode)
                             .map(StringNode::getValue)

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponentsTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponentsTest.java
@@ -36,7 +36,10 @@ public class RemoveUnusedComponentsTest {
         config.setService(ShapeId.from("smithy.example#Small"));
         OpenApi result = OpenApiConverter.create().config(config).convert(model);
 
-        Assertions.assertTrue(result.getComponents().getSchemas().isEmpty());
+        Assertions.assertFalse(result.getComponents().getSchemas().isEmpty());
+        Assertions.assertTrue(result.getComponents().getSchemas().containsKey("SmallOperationRequestContent"));
+        Assertions.assertTrue(result.getComponents().getSchemas().containsKey("StringMap"));
+        Assertions.assertFalse(result.getComponents().getSchemas().containsKey("SmallOperationExceptionResponseContent"));
     }
 
     @Test

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/small-service.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/mappers/small-service.smithy
@@ -9,9 +9,23 @@ service Small {
   operations: [SmallOperation]
 }
 
-@http(method: "GET", uri: "/")
+@http(method: "POST", uri: "/")
 operation SmallOperation {
     input: SmallOperationInput
 }
 
-structure SmallOperationInput {}
+structure SmallOperationInput {
+    @default({})
+    payload: StringMap
+}
+
+map StringMap {
+    key: String
+    value: String
+}
+
+@error("server")
+@httpError(500)
+structure SmallOperationException {
+    message: String = null
+}


### PR DESCRIPTION
*Issue #, if available:*

Customer reported referenced component being removed in openapi schema. 

In [RemoveUnusedComponents](https://github.com/awslabs/smithy/blob/main/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/mappers/RemoveUnusedComponents.java#L125), it only keeps referenced components if the field object size is 1.

However there are cases where the field object size is greater than 1.

For example:

__smithy:__
```
structure OperationInput {
    @default({})
    payload: StringMap
}

map StringMap {
    key: String
    value: String
}
```
__openapi:__

(`StringMap` is removed in the `schemas` object.)

```
    "schemas": {
        "OperationRequestContent": {
            "properties": {
                "payload": {
                    "$ref": "#/components/schemas/StringMap",
                    "default": {}
                }
            }
        }
    }
```

*Description of changes:*

Remove the field object size check when removing unused components

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
