### PR TITLE
Add intEnum coverage on map of string list

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -117,7 +117,9 @@ apply AllQueryStringTypes @httpRequestTests([
                 "Timestamp": ["1970-01-01T00:00:01Z"],
                 "TimestampList": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1970-01-01T00:00:03Z"],
                 "Enum": ["Foo"],
-                "EnumList": ["Foo", "Baz", "Bar"]
+                "EnumList": ["Foo", "Baz", "Bar"],
+                "IntegerEnum": ["1"],
+                "IntegerEnumList": ["1", "2", "3"]
             },
         }
     },


### PR DESCRIPTION
This PR adds intEnum coverage to the `queryParamsMapOfStringList` that was added in https://github.com/awslabs/smithy/pull/1564/.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
