### PR TITLE
Clarify handling of date-time offsets

### DIFF
--- a/docs/source-1.0/spec/core/protocol-traits.rst
+++ b/docs/source-1.0/spec/core/protocol-traits.rst
@@ -305,6 +305,8 @@ Smithy defines the following built-in timestamp formats:
         `RFC3339 section 5.6 <https://www.rfc-editor.org/rfc/rfc3339#section-5.6>`_
         with no UTC offset and optional fractional precision (for example,
         ``1985-04-12T23:20:50.52Z``).
+        *However*, offsets are parsed gracefully, but the datetime is normalized
+        to an offset of zero by converting to UTC.
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,

--- a/docs/source-2.0/spec/protocol-traits.rst
+++ b/docs/source-2.0/spec/protocol-traits.rst
@@ -221,8 +221,8 @@ Smithy defines the following built-in timestamp formats:
         :rfc:`3339#section-5.6`
         with no UTC offset and optional fractional precision (for example,
         ``1985-04-12T23:20:50.52Z``).
-        *However*, offsets will still be parsed gracefully, but the datetime
-        will be normalized to an offset of zero (i.e. converted to UTC)
+        *However*, offsets are parsed gracefully, but the datetime is normalized
+        to an offset of zero by converting to UTC.
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,


### PR DESCRIPTION
This PR clarifies the `timestampFormat` trait documentation concerning UTC offsets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
