### PR TITLE
generate unique synthetic names from unnamed enums

### DIFF
--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ChangeStringEnumsToEnumShapesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ChangeStringEnumsToEnumShapesTest.java
@@ -111,7 +111,7 @@ public class ChangeStringEnumsToEnumShapesTest {
         assertThat(result.expectShape(shapeId).getType(), Matchers.is(ShapeType.ENUM));
         assertThat(result.expectShape(shapeId).members(), Matchers.hasSize(1));
         assertThat(result.expectShape(shapeId).members().iterator().next(), Matchers.equalTo(MemberShape.builder()
-                .id(shapeId.withMember("foo_bar"))
+                .id(shapeId.withMember("FOO_BAR"))
                 .target(UnitTypeTrait.UNIT)
                 .addTrait(EnumValueTrait.builder().stringValue("foo:bar").build())
                 .build()));

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ChangeTypesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/ChangeTypesTest.java
@@ -67,7 +67,7 @@ public class ChangeTypesTest {
         assertThat(result.expectShape(shapeId).getType(), Matchers.is(ShapeType.ENUM));
         assertThat(result.expectShape(shapeId).members(), Matchers.hasSize(1));
         assertThat(result.expectShape(shapeId).members().iterator().next(), Matchers.equalTo(MemberShape.builder()
-                .id(shapeId.withMember("foo_bar"))
+                .id(shapeId.withMember("FOO_BAR"))
                 .target(UnitTypeTrait.UNIT)
                 .addTrait(EnumValueTrait.builder().stringValue("foo:bar").build())
                 .build()));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EnumShapeValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EnumShapeValidator.java
@@ -42,7 +42,7 @@ import software.amazon.smithy.model.validation.ValidationEvent;
  * naming convention of all upper case letters separated by underscores.
  */
 public final class EnumShapeValidator extends AbstractValidator {
-    private static final Pattern RECOMMENDED_NAME_PATTERN = Pattern.compile("^[A-Z]+[A-Z_0-9]*$");
+    public static final Pattern RECOMMENDED_NAME_PATTERN = Pattern.compile("^[A-Z]+[A-Z_0-9]*$");
 
     @Override
     public List<ValidationEvent> validate(Model model) {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
@@ -423,7 +423,7 @@ public class ChangeShapeTypeTest {
         assertThat(result.expectShape(shapeId).getType(), Matchers.is(ShapeType.ENUM));
         assertThat(result.expectShape(shapeId).members(), Matchers.hasSize(1));
         assertThat(result.expectShape(shapeId).members().iterator().next(), Matchers.equalTo(MemberShape.builder()
-                .id(shapeId.withMember("foo_bar"))
+                .id(shapeId.withMember("FOO_BAR"))
                 .target(UnitTypeTrait.UNIT)
                 .addTrait(EnumValueTrait.builder().stringValue("foo:bar").build())
                 .build()));


### PR DESCRIPTION
### Context

Smithy 1.0 defined enumerations using an @enum trait on a string shape. Smithy 2.0 introduces the enum and intEnum shapes and deprecates the @enum trait. Enum’s name has also been changed from _optional_ to _required_.

Smithy currently does not convert enum string into enum shape by default; code generators are handling both enum string and enum shape.

Code generators have the option of calling [CodegenDirector.changeStringEnumsToEnumShapes(boolean synthesizeEnumNames)](https://github.com/awslabs/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java#L246) to convert all enum string to enum shape, and generate “synthetic” names from values if names are missing. This feature is currently NOT used by any code generators e.g. Swift, Kotlin, Typescript, Go and Rust.

When generating synthetic enum names, Smithy replaces some characters with underscore i.e. `replaceAll("[-.:/\\s]+", "_")`. However this is not sufficient as the generated names need to match the following regular expression: `^[A-Z]+[A-Z_0-9]*$` (See [enum validation in documentation](https://smithy.io/2.0/spec/simple-types.html?highlight=enum#enum-validation))

For example:
```
Linux/UNIX -> Linux_UNIX
foo:bar -> foo_bar
```
However the convertion fails for the following examples:
```
Linux/UNIX (Amazon VPC)
ns.foo#bar
```

### Description of changes:

* Generate synthetic names that match the following regular expression: `^[A-Z]+[A-Z_0-9]*$` 
* Generate synthetic names by replacing all non-alphabetical and non-numerical characters with `_`
* Generate unique synthetic names by padding a number as suffix to the name.

Examples:

1.
```
Linux/UNIX → LINUX_UNIX
Windows (Amazon VPC) → WINDOWS_AMAZON_VPC_
Linux/UNIX (Amazon VPC) → LINUX_UNIX_AMAZON_VPC_
```

2.
```
a:b → A_B_0
a=b → A_B_1
a_b → A_B_2
```

3.
```
:b → B_0
=b → B_1
_b → B_2
```

4.
```
a:b → A_B_0
a=b  → A_B_1
a_b_0 → A_B_0_2
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
