### PR TITLE
Preserve tag order in generated OpenAPI specification

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OpenApi.java
@@ -133,7 +133,7 @@ public final class OpenApi extends Component implements ToSmithyBuilder<OpenApi>
         }
 
         if (!tags.isEmpty()) {
-            builder.withMember("tags", tags.stream().sorted().collect(ArrayNode.collect()));
+            builder.withMember("tags", tags.stream().collect(ArrayNode.collect()));
         }
 
         return builder;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OperationObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/OperationObject.java
@@ -161,7 +161,7 @@ public final class OperationObject extends Component implements ToSmithyBuilder<
         }
 
         if (!tags.isEmpty()) {
-            builder.withMember("tags", getTags().stream().sorted().map(Node::from).collect(ArrayNode.collect()));
+            builder.withMember("tags", getTags().stream().map(Node::from).collect(ArrayNode.collect()));
         }
 
         return builder;

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -131,6 +131,45 @@ public class OpenApiConverterTest {
     }
 
     @Test
+    public void preservesUserSpecifiedOrderOfTags() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("tagged-service-order.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        config.setTags(true);
+        OpenApi result = OpenApiConverter.create()
+                .config(config)
+                .convert(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("tagged-service-order.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+
+    @Test
+    public void preservesUserSpecifiedOrderOfTagsWhenFilteringSupportedTags() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("tagged-service-order.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        config.setTags(true);
+        config.setSupportedTags(ListUtils.of("one", "two", "three", "four"));
+        OpenApi result = OpenApiConverter.create()
+                .config(config)
+                .convert(model);
+        Node expectedNode = Node.parse(IoUtils.toUtf8String(
+                getClass().getResourceAsStream("tagged-service-order-supported-tags.openapi.json")));
+
+        Node.assertEquals(result, expectedNode);
+    }
+
+    @Test
     public void usesOpenApiIntegers() {
         OpenApiConfig config = new OpenApiConfig();
         config.setService(ShapeId.from("example.rest#RestService"));

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service-order-supported-tags.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service-order-supported-tags.openapi.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/operation1": {
+      "get": {
+        "operationId": "Operation1",
+        "tags": ["one", "two", "three", "four"],
+        "responses": {
+          "200": {
+            "description": "Operation1 200 response"
+          }
+        }
+      }
+    },
+    "/operation2": {
+      "get": {
+        "operationId": "Operation2",
+        "tags": ["one", "three"],
+        "responses": {
+          "200": {
+            "description": "Operation2 200 response"
+          }
+        }
+      }
+    }
+  },
+  "components": { },
+  "tags": [
+    {
+      "name": "two"
+    },
+    {
+      "name": "four"
+    }
+  ]
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service-order.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service-order.json
@@ -1,0 +1,60 @@
+{
+  "smithy": "2.0",
+  "shapes": {
+    "smithy.example#Service": {
+      "type": "service",
+      "version": "2006-03-01",
+      "operations": [
+        {
+          "target": "smithy.example#Operation1"
+        },
+        {
+          "target": "smithy.example#Operation2"
+        }
+      ],
+      "traits": {
+        "smithy.api#tags": [
+          "two",
+          "four",
+          "six",
+          "eight"
+        ],
+        "aws.protocols#restJson1": {}
+      }
+    },
+    "smithy.example#Operation1": {
+      "type": "operation",
+      "traits": {
+        "smithy.api#tags": [
+          "one",
+          "two",
+          "three",
+          "four",
+          "five",
+          "six",
+          "seven",
+          "eight"
+        ],
+        "smithy.api#http": {
+          "uri": "/operation1",
+          "method": "GET"
+        }
+      }
+    },
+    "smithy.example#Operation2": {
+      "type": "operation",
+      "traits": {
+        "smithy.api#tags": [
+          "one",
+          "three",
+          "five",
+          "seven"
+        ],
+        "smithy.api#http": {
+          "uri": "/operation2",
+          "method": "GET"
+        }
+      }
+    }
+  }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service-order.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/tagged-service-order.openapi.json
@@ -1,0 +1,46 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Service",
+    "version": "2006-03-01"
+  },
+  "paths": {
+    "/operation1": {
+      "get": {
+        "operationId": "Operation1",
+        "tags": ["one", "two", "three", "four", "five", "six", "seven", "eight"],
+        "responses": {
+          "200": {
+            "description": "Operation1 200 response"
+          }
+        }
+      }
+    },
+    "/operation2": {
+      "get": {
+        "operationId": "Operation2",
+        "tags": ["one", "three", "five", "seven"],
+        "responses": {
+          "200": {
+            "description": "Operation2 200 response"
+          }
+        }
+      }
+    }
+  },
+  "components": { },
+  "tags": [
+    {
+      "name": "two"
+    },
+    {
+      "name": "four"
+    },
+    {
+      "name": "six"
+    },
+    {
+      "name": "eight"
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1603

*Description of changes:*

Instead of sorting them lexicographically, preserve the user-specified order of tags.

eg.

`@tags(["one", "two", "three", "four"])`

becomes:

`"tags": ["one", "two", "three", "four"]`

instead of:

`"tags": ["four", "one", "three", "two"]`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
