### PR TITLE
Add shapes generation order in CodegenDirector

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/ShapeGenerationOrder.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/ShapeGenerationOrder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core;
+
+/**
+ * Shapes order for code generation.
+ *
+ * <p>CodegenDirector order the shapes appropriately before feeding them to the code generators. See {@link
+ * software.amazon.smithy.codegen.core.directed.CodegenDirector#shapeGenerationOrder(ShapeGenerationOrder)}
+ */
+public enum ShapeGenerationOrder {
+    /**
+     * Shapes ordered in reverse-topological order. Also see {@link TopologicalIndex}
+     */
+    TOPOLOGICAL,
+
+    /**
+     * Shapes ordered alphabetically by their names.
+     */
+    ALPHABETICAL,
+
+    /**
+     * Shapes without order.
+     */
+    NONE
+}


### PR DESCRIPTION
*Description of changes:*
* Add shapes generation ordering in CodegenDirector
* This allows code generators to decide the ordering of the shapes which get passed to them. 
* E.g. `smithy-ruby` needs the shapes ordered alphabetically by their names because generated ruby code needs to be alphabetic in a ruby file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
