### PR TITLE
Fix OR condition in scoped attribute selector

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
@@ -96,11 +96,17 @@ final class ScopedAttributeSelector implements InternalSelector {
         // Ensure that each assertion matches, and provide them the scope.
         for (Assertion assertion : assertions) {
             AttributeValue lhs = assertion.lhs.create(scope);
+            boolean matchedOneRhs = false;
             for (ScopedFactory factory : assertion.rhs) {
                 AttributeValue rhs = factory.create(scope);
-                if (!assertion.comparator.compare(lhs, rhs, assertion.caseInsensitive)) {
-                    return false;
+                if (assertion.comparator.compare(lhs, rhs, assertion.caseInsensitive)) {
+                    matchedOneRhs = true;
+                    break;
                 }
+            }
+
+            if (!matchedOneRhs) {
+                return false;
             }
         }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -737,6 +737,24 @@ public class SelectorTest {
     }
 
     @Test
+    public void evaluatesScopedAttributesWithOr() {
+        final Model enumModel = Model.assembler()
+                .addImport(SelectorTest.class.getResource("enums.smithy"))
+                .assemble()
+                .unwrap();
+
+        Set<String> shapes = ids(
+            enumModel, "[@trait|enum|(values): @{name} ^= DIA, CLU]");
+
+        assertThat(shapes, containsInAnyOrder("smithy.example#Suit"));
+
+        shapes = ids(
+            enumModel, "[@trait|enum|(values): @{name} ^= DIA, BLA]");
+
+        assertThat(shapes, containsInAnyOrder("smithy.example#Color", "smithy.example#Suit"));
+    }
+
+    @Test
     public void evaluatesScopedAttributesWithProjections() {
         // Note that the projection can be on either side.
         Set<String> shapes1 = ids(traitModel, "[@trait|enum|(values): @{name}=@{value} && @{tags|(values)}=hi]");

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/enums.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/enums.smithy
@@ -1,0 +1,17 @@
+$version: "1.0"
+
+namespace smithy.example
+
+@enum([
+    { name: "DIAMOND", value: "diamond"},
+    { name: "CLUB", value: "club"},
+    { name: "HEART", value: "heart"},
+    { name: "SPADE", value: "spade"},
+])
+string Suit
+
+@enum([
+    { name: "RED", value: "red"}
+    { name: "BLACK", value: "black"}
+])
+string Color


### PR DESCRIPTION
*Issue #, if available:*
A bug was discovered when using `,` (OR condition) in scoped attribute selector

```
enum Suit {
    DIAMOND = "diamond"
    CLUB = "club"
    HEART = "heart"
    SPADE = "spade"
}

enum Color {
    RED
    BLACK
}
```

`[@trait|enum|(values): @{name} ^= DIA, BLA]`  (return enums with names starting with `DIA` or `BLA`

Expected: `smithy.example#Suit`, `smithy.example#Color`

Acutal: `smithy.example#Suit`

*Description of changes:*
Fix OR condition in scoped attribute selector

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
