### PR TITLE
Fix casing of "passthroughBehavior" property

### DIFF
--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddCorsPreflightIntegration.java
@@ -238,7 +238,7 @@ final class AddCorsPreflightIntegration implements ApiGatewayMapper {
             }
         }
 
-        // Ensure that the mock integration include the "type" = "mock" property.
-        return integration.build().toNode().expectObjectNode().withMember("type", "mock");
+        // Use createIntegration to fix the casing of the passThroughBehavior property.
+        return AddIntegrations.createIntegration(integration.build());
     }
 }

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddIntegrations.java
@@ -65,7 +65,13 @@ final class AddIntegrations implements ApiGatewayMapper {
                 });
     }
 
-    private ObjectNode createIntegration(
+    static ObjectNode createIntegration(MockIntegrationTrait integration) {
+        // The MockIntegrationTrait path doesn't use the context or shape,
+        // so it's safe to pass null here for those.
+        return createIntegration(null, null, integration);
+    }
+
+    private static ObjectNode createIntegration(
             Context<? extends Trait> context,
             OperationShape shape,
             Trait integration

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-model.openapi.json
@@ -84,7 +84,7 @@
           "CORS"
         ],
         "x-amazon-apigateway-integration": {
-          "passThroughBehavior": "when_no_match",
+          "passthroughBehavior": "when_no_match",
           "contentHandling": "CONVERT_TO_TEXT",
           "requestTemplates": {
             "application/json": "{\"statusCode\":200}"
@@ -254,7 +254,7 @@
           "CORS"
         ],
         "x-amazon-apigateway-integration": {
-          "passThroughBehavior": "when_no_match",
+          "passthroughBehavior": "when_no_match",
           "contentHandling": "CONVERT_TO_TEXT",
           "requestTemplates": {
             "application/json": "{\"statusCode\":200}",

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cors-with-additional-headers.openapi.json
@@ -84,7 +84,7 @@
           "CORS"
         ],
         "x-amazon-apigateway-integration": {
-          "passThroughBehavior": "when_no_match",
+          "passthroughBehavior": "when_no_match",
           "contentHandling": "CONVERT_TO_TEXT",
           "requestTemplates": {
             "application/json": "{\"statusCode\":200}"
@@ -254,7 +254,7 @@
           "CORS"
         ],
         "x-amazon-apigateway-integration": {
-          "passThroughBehavior": "when_no_match",
+          "passthroughBehavior": "when_no_match",
           "contentHandling": "CONVERT_TO_TEXT",
           "requestTemplates": {
             "application/json": "{\"statusCode\":200}",


### PR DESCRIPTION
The "passthroughBehavior" property of the x-amzn-apigateway-integration option was incorrectly cased as "passThroughBehavior" when added via the `@cors` trait, when an integration trait was not present.

A couple test cases for CORS were using the incorrect casing, which have been fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
