### PR TITLE
Add Tree Sitter to implementations docs

### DIFF
--- a/docs/source-2.0/implementations.rst
+++ b/docs/source-2.0/implementations.rst
@@ -75,6 +75,11 @@ IDE Support
       - Java
       - WIP
       - A Language Server Protocol implementation for the Smithy IDL.
+    * - `Tree Sitter grammar for Smithy <https://github.com/indoorvivants/tree-sitter-smithy>`_
+      - C
+      - GA
+      - Included in `nvim-treesitter <https://github.com/nvim-treesitter/nvim-treesitter>`_
+        to provide syntax highlighting in Neovim.
 
 
 -------------

--- a/docs/source-2.0/implementations.rst
+++ b/docs/source-2.0/implementations.rst
@@ -76,7 +76,7 @@ IDE Support
       - WIP
       - A Language Server Protocol implementation for the Smithy IDL.
     * - `Tree Sitter grammar for Smithy <https://github.com/indoorvivants/tree-sitter-smithy>`_
-      - C
+      - JavaScript, C
       - GA
       - Included in `nvim-treesitter <https://github.com/nvim-treesitter/nvim-treesitter>`_
         to provide syntax highlighting in Neovim.


### PR DESCRIPTION
Lists the [Tree Sitter grammar for Smithy](https://github.com/indoorvivants/tree-sitter-smithy) and notes its inclusion in [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) on the implementations doc page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
