### PR TITLE
Remove reflected values from validation tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/validation/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/main.smithy
@@ -20,6 +20,7 @@ service RestJsonValidation {
         MalformedRange,
         MalformedRangeOverride,
         MalformedRequired,
+        MalformedUniqueItems,
         RecursiveStructures,
         SensitiveValidation
     ]

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-enum.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-enum.smithy
@@ -38,8 +38,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value $value:L at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/string"}]}"""
                 }
             }
         },
@@ -71,8 +71,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value $value:L at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/list/0"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
+                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/list/0"}]}"""
                 }
             }
         },
@@ -104,8 +104,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value $value:L at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/map"}]}"""
                 }
             }
         },
@@ -137,8 +137,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value $value:L at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/map/abc"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
+                      "fieldList" : [{"message": "Value at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/map/abc"}]}"""
                 }
             }
         },
@@ -170,8 +170,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value $value:L at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/union/first"}]}"""
+                    { "message" : "1 validation error detected. Value at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
+                      "fieldList" : [{"message": "Value at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/union/first"}]}"""
                 }
             }
         },

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
@@ -52,8 +52,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/blob"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/blob"}]}"""
                 }
             }
         },
@@ -86,8 +86,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
                 }
             }
         },
@@ -120,8 +120,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2",
-                      "fieldList" : [{"message": "Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2", "path": "/minString"}]}"""
+                    { "message" : "1 validation error detected. Value with length 1 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2",
+                      "fieldList" : [{"message": "Value with length 1 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2", "path": "/minString"}]}"""
                 }
             }
         }
@@ -150,8 +150,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8",
-                      "fieldList" : [{"message": "Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8", "path": "/maxString"}]}"""
+                    { "message" : "1 validation error detected. Value with length 26 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8",
+                      "fieldList" : [{"message": "Value with length 26 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8", "path": "/maxString"}]}"""
                 }
             }
         }
@@ -180,8 +180,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list"}]}"""
                 }
             }
         },
@@ -215,8 +215,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list/0"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list/0"}]}"""
                 }
             }
         },
@@ -252,8 +252,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
                 }
             }
         },
@@ -292,8 +292,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
                 }
             }
         },
@@ -327,8 +327,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map/abc"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map/abc"}]}"""
                 }
             }
         },
@@ -369,8 +369,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/blob"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/blob"}]}"""
                 }
             }
         },
@@ -403,8 +403,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/string"}]}"""
                 }
             }
         },
@@ -437,8 +437,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4",
-                      "fieldList" : [{"message": "Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4", "path": "/minString"}]}"""
+                    { "message" : "1 validation error detected. Value with length 3 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4",
+                      "fieldList" : [{"message": "Value with length 3 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4", "path": "/minString"}]}"""
                 }
             }
         }
@@ -467,8 +467,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6",
-                      "fieldList" : [{"message": "Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6", "path": "/maxString"}]}"""
+                    { "message" : "1 validation error detected. Value with length 7 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6",
+                      "fieldList" : [{"message": "Value with length 7 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6", "path": "/maxString"}]}"""
                 }
             }
         }
@@ -497,8 +497,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/list"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/list"}]}"""
                 }
             }
         },
@@ -534,8 +534,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/map"}]}"""
                 }
             }
         },
@@ -580,8 +580,8 @@ apply MalformedLengthQueryString @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value with length 0 at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value with length 0 at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
                 }
             }
         }

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
@@ -52,8 +52,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/blob"}]}"""
+                    { "message" : "1 validation error detected. Value at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/blob' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/blob"}]}"""
                 }
             }
         },
@@ -86,8 +86,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
                 }
             }
         },
@@ -120,8 +120,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length 1 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2",
-                      "fieldList" : [{"message": "Value with length 1 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2", "path": "/minString"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2",
+                      "fieldList" : [{"message": "Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 2", "path": "/minString"}]}"""
                 }
             }
         }
@@ -150,8 +150,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length 26 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8",
-                      "fieldList" : [{"message": "Value with length 26 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8", "path": "/maxString"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8",
+                      "fieldList" : [{"message": "Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 8", "path": "/maxString"}]}"""
                 }
             }
         }
@@ -180,8 +180,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/list' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list"}]}"""
                 }
             }
         },
@@ -215,8 +215,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list/0"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/list/0"}]}"""
                 }
             }
         },
@@ -252,8 +252,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
                 }
             }
         },
@@ -292,8 +292,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map"}]}"""
                 }
             }
         },
@@ -327,8 +327,8 @@ apply MalformedLength @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map/abc"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/map/abc' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/map/abc"}]}"""
                 }
             }
         },
@@ -369,8 +369,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/blob"}]}"""
+                    { "message" : "1 validation error detected. Value at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/blob' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/blob"}]}"""
                 }
             }
         },
@@ -403,8 +403,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/string"}]}"""
                 }
             }
         },
@@ -437,8 +437,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length 3 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4",
-                      "fieldList" : [{"message": "Value with length 3 at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4", "path": "/minString"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4",
+                      "fieldList" : [{"message": "Value at '/minString' failed to satisfy constraint: Member must have length greater than or equal to 4", "path": "/minString"}]}"""
                 }
             }
         }
@@ -467,8 +467,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length 7 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6",
-                      "fieldList" : [{"message": "Value with length 7 at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6", "path": "/maxString"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6",
+                      "fieldList" : [{"message": "Value at '/maxString' failed to satisfy constraint: Member must have length less than or equal to 6", "path": "/maxString"}]}"""
                 }
             }
         }
@@ -497,8 +497,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/list"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/list' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/list"}]}"""
                 }
             }
         },
@@ -534,8 +534,8 @@ apply MalformedLengthOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value with length $inputLength:L at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must have length between 4 and 6, inclusive", "path": "/map"}]}"""
                 }
             }
         },
@@ -580,8 +580,8 @@ apply MalformedLengthQueryString @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value with length 0 at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value with length 0 at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must have length between 2 and 8, inclusive", "path": "/string"}]}"""
                 }
             }
         }

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-pattern.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-pattern.smithy
@@ -45,8 +45,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/string"}]}"""
                 }
             }
         },
@@ -78,8 +78,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/string"}]}"""
                 }
             }
         }
@@ -108,8 +108,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/list/0"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
+                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/list/0"}]}"""
                 }
             }
         },
@@ -141,8 +141,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/map"}]}"""
                 }
             }
         },
@@ -174,8 +174,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/map/abc' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/map/abc' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/map/abc"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map/abc' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
+                      "fieldList" : [{"message": "Value at '/map/abc' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/map/abc"}]}"""
                 }
             }
         },
@@ -207,8 +207,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/union/first"}]}"""
+                    { "message" : "1 validation error detected. Value at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$",
+                      "fieldList" : [{"message": "Value at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-m]+$$", "path": "/union/first"}]}"""
                 }
             }
         },
@@ -245,8 +245,8 @@ apply MalformedPatternOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/string"}]}"""
                 }
             }
         },
@@ -278,8 +278,8 @@ apply MalformedPatternOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/list/0"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
+                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/list/0"}]}"""
                 }
             }
         },
@@ -311,8 +311,8 @@ apply MalformedPatternOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/map"}]}"""
                 }
             }
         },
@@ -344,8 +344,8 @@ apply MalformedPatternOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/map/ghi' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/map/ghi' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/map/ghi"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map/ghi' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
+                      "fieldList" : [{"message": "Value at '/map/ghi' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/map/ghi"}]}"""
                 }
             }
         },
@@ -377,8 +377,8 @@ apply MalformedPatternOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
-                      "fieldList" : [{"message": "Value $value:L at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/union/first"}]}"""
+                    { "message" : "1 validation error detected. Value at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$",
+                      "fieldList" : [{"message": "Value at '/union/first' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[g-m]+$$", "path": "/union/first"}]}"""
                 }
             }
         },

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-range.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-range.smithy
@@ -45,8 +45,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/byte' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/byte' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/byte"}]}"""
+                    { "message" : "1 validation error detected. Value at '/byte' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/byte' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/byte"}]}"""
                 }
             }
         },
@@ -78,8 +78,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 1 at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 2",
-                      "fieldList" : [{"message": "Value 1 at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minByte"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 2",
+                      "fieldList" : [{"message": "Value at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minByte"}]}"""
                 }
             }
         }
@@ -108,8 +108,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 9 at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 8",
-                      "fieldList" : [{"message": "Value 9 at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxByte"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 8",
+                      "fieldList" : [{"message": "Value at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxByte"}]}"""
                 }
             }
         }
@@ -138,8 +138,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/float' failed to satisfy constraint: Member must be between 2.2 and 8.8, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/float' failed to satisfy constraint: Member must be between 2.2 and 8.8, inclusive", "path": "/float"}]}"""
+                    { "message" : "1 validation error detected. Value at '/float' failed to satisfy constraint: Member must be between 2.2 and 8.8, inclusive",
+                      "fieldList" : [{"message": "Value at '/float' failed to satisfy constraint: Member must be between 2.2 and 8.8, inclusive", "path": "/float"}]}"""
                 }
             }
         },
@@ -171,8 +171,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 2.1 at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 2.2",
-                      "fieldList" : [{"message": "Value 2.1 at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 2.2", "path": "/minFloat"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 2.2",
+                      "fieldList" : [{"message": "Value at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 2.2", "path": "/minFloat"}]}"""
                 }
             }
         }
@@ -201,8 +201,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 8.9 at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 8.8",
-                      "fieldList" : [{"message": "Value 8.9 at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 8.8", "path": "/maxFloat"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 8.8",
+                      "fieldList" : [{"message": "Value at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 8.8", "path": "/maxFloat"}]}"""
                 }
             }
         }
@@ -231,8 +231,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/short' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/short' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/short"}]}"""
+                    { "message" : "1 validation error detected. Value at '/short' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/short' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/short"}]}"""
                 }
             }
         },
@@ -264,8 +264,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 1 at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 2",
-                      "fieldList" : [{"message": "Value 1 at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minShort"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 2",
+                      "fieldList" : [{"message": "Value at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minShort"}]}"""
                 }
             }
         }
@@ -294,8 +294,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 9 at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 8",
-                      "fieldList" : [{"message": "Value 9 at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxShort"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 8",
+                      "fieldList" : [{"message": "Value at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxShort"}]}"""
                 }
             }
         }
@@ -324,8 +324,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/integer' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/integer' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/integer"}]}"""
+                    { "message" : "1 validation error detected. Value at '/integer' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/integer' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/integer"}]}"""
                 }
             }
         },
@@ -357,8 +357,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 1 at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 2",
-                      "fieldList" : [{"message": "Value 1 at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minInteger"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 2",
+                      "fieldList" : [{"message": "Value at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minInteger"}]}"""
                 }
             }
         }
@@ -387,8 +387,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 9 at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 8",
-                      "fieldList" : [{"message": "Value 9 at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxInteger"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 8",
+                      "fieldList" : [{"message": "Value at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxInteger"}]}"""
                 }
             }
         }
@@ -417,8 +417,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/long' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/long' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/long"}]}"""
+                    { "message" : "1 validation error detected. Value at '/long' failed to satisfy constraint: Member must be between 2 and 8, inclusive",
+                      "fieldList" : [{"message": "Value at '/long' failed to satisfy constraint: Member must be between 2 and 8, inclusive", "path": "/long"}]}"""
                 }
             }
         },
@@ -450,8 +450,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 1 at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 2",
-                      "fieldList" : [{"message": "Value 1 at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minLong"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 2",
+                      "fieldList" : [{"message": "Value at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 2", "path": "/minLong"}]}"""
                 }
             }
         }
@@ -480,8 +480,8 @@ apply MalformedRange @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 9 at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 8",
-                      "fieldList" : [{"message": "Value 9 at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxLong"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 8",
+                      "fieldList" : [{"message": "Value at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 8", "path": "/maxLong"}]}"""
                 }
             }
         }
@@ -514,8 +514,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/byte' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/byte' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/byte"}]}"""
+                    { "message" : "1 validation error detected. Value at '/byte' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/byte' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/byte"}]}"""
                 }
             }
         },
@@ -547,8 +547,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 3 at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 4",
-                      "fieldList" : [{"message": "Value 3 at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minByte"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 4",
+                      "fieldList" : [{"message": "Value at '/minByte' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minByte"}]}"""
                 }
             }
         }
@@ -577,8 +577,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 7 at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 6",
-                      "fieldList" : [{"message": "Value 7 at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxByte"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 6",
+                      "fieldList" : [{"message": "Value at '/maxByte' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxByte"}]}"""
                 }
             }
         }
@@ -607,8 +607,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/float' failed to satisfy constraint: Member must be between 4.4 and 6.6, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/float' failed to satisfy constraint: Member must be between 4.4 and 6.6, inclusive", "path": "/float"}]}"""
+                    { "message" : "1 validation error detected. Value at '/float' failed to satisfy constraint: Member must be between 4.4 and 6.6, inclusive",
+                      "fieldList" : [{"message": "Value at '/float' failed to satisfy constraint: Member must be between 4.4 and 6.6, inclusive", "path": "/float"}]}"""
                 }
             }
         },
@@ -640,8 +640,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 4.3 at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 4.4",
-                      "fieldList" : [{"message": "Value 4.3 at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 4.4", "path": "/minFloat"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 4.4",
+                      "fieldList" : [{"message": "Value at '/minFloat' failed to satisfy constraint: Member must be greater than or equal to 4.4", "path": "/minFloat"}]}"""
                 }
             }
         }
@@ -670,8 +670,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 6.7 at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 6.6",
-                      "fieldList" : [{"message": "Value 6.7 at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 6.6", "path": "/maxFloat"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 6.6",
+                      "fieldList" : [{"message": "Value at '/maxFloat' failed to satisfy constraint: Member must be less than or equal to 6.6", "path": "/maxFloat"}]}"""
                 }
             }
         }
@@ -700,8 +700,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/short' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/short' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/short"}]}"""
+                    { "message" : "1 validation error detected. Value at '/short' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/short' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/short"}]}"""
                 }
             }
         },
@@ -733,8 +733,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 3 at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 4",
-                      "fieldList" : [{"message": "Value 3 at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minShort"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 4",
+                      "fieldList" : [{"message": "Value at '/minShort' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minShort"}]}"""
                 }
             }
         }
@@ -763,8 +763,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 7 at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 6",
-                      "fieldList" : [{"message": "Value 7 at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxShort"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 6",
+                      "fieldList" : [{"message": "Value at '/maxShort' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxShort"}]}"""
                 }
             }
         }
@@ -793,8 +793,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/integer' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/integer' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/integer"}]}"""
+                    { "message" : "1 validation error detected. Value at '/integer' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/integer' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/integer"}]}"""
                 }
             }
         },
@@ -826,8 +826,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 3 at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 4",
-                      "fieldList" : [{"message": "Value 3 at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minInteger"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 4",
+                      "fieldList" : [{"message": "Value at '/minInteger' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minInteger"}]}"""
                 }
             }
         }
@@ -856,8 +856,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 7 at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 6",
-                      "fieldList" : [{"message": "Value 7 at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxInteger"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 6",
+                      "fieldList" : [{"message": "Value at '/maxInteger' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxInteger"}]}"""
                 }
             }
         }
@@ -886,8 +886,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value $value:L at '/long' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
-                      "fieldList" : [{"message": "Value $value:L at '/long' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/long"}]}"""
+                    { "message" : "1 validation error detected. Value at '/long' failed to satisfy constraint: Member must be between 4 and 6, inclusive",
+                      "fieldList" : [{"message": "Value at '/long' failed to satisfy constraint: Member must be between 4 and 6, inclusive", "path": "/long"}]}"""
                 }
             }
         },
@@ -919,8 +919,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 3 at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 4",
-                      "fieldList" : [{"message": "Value 3 at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minLong"}]}"""
+                    { "message" : "1 validation error detected. Value at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 4",
+                      "fieldList" : [{"message": "Value at '/minLong' failed to satisfy constraint: Member must be greater than or equal to 4", "path": "/minLong"}]}"""
                 }
             }
         }
@@ -949,8 +949,8 @@ apply MalformedRangeOverride @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 7 at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 6",
-                      "fieldList" : [{"message": "Value 7 at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxLong"}]}"""
+                    { "message" : "1 validation error detected. Value at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 6",
+                      "fieldList" : [{"message": "Value at '/maxLong' failed to satisfy constraint: Member must be less than or equal to 6", "path": "/maxLong"}]}"""
                 }
             }
         }

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-required.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-required.smithy
@@ -43,8 +43,8 @@ apply MalformedRequired @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value null at '/string' failed to satisfy constraint: Member must not be null",
-                      "fieldList" : [{"message": "Value null at '/string' failed to satisfy constraint: Member must not be null", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must not be null",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must not be null", "path": "/string"}]}"""
                 }
             }
         }
@@ -77,8 +77,8 @@ apply MalformedRequired @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value null at '/string' failed to satisfy constraint: Member must not be null",
-                      "fieldList" : [{"message": "Value null at '/string' failed to satisfy constraint: Member must not be null", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must not be null",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must not be null", "path": "/string"}]}"""
                 }
             }
         }
@@ -110,8 +110,8 @@ apply MalformedRequired @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value null at '/stringInHeader' failed to satisfy constraint: Member must not be null",
-                      "fieldList" : [{"message": "Value null at '/stringInHeader' failed to satisfy constraint: Member must not be null", "path": "/stringInHeader"}]}"""
+                    { "message" : "1 validation error detected. Value at '/stringInHeader' failed to satisfy constraint: Member must not be null",
+                      "fieldList" : [{"message": "Value at '/stringInHeader' failed to satisfy constraint: Member must not be null", "path": "/stringInHeader"}]}"""
                 }
             }
         }

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-uniqueItems.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-uniqueItems.smithy
@@ -13,7 +13,6 @@ use aws.protocoltests.shared#IntegerSet
 use aws.protocoltests.shared#IntegerEnumSet
 use aws.protocoltests.shared#ListSet
 use aws.protocoltests.shared#LongSet
-use aws.protocoltests.shared#MapSet
 use aws.protocoltests.shared#ShortSet
 use aws.protocoltests.shared#StringSet
 use aws.protocoltests.shared#StructureSet
@@ -428,36 +427,6 @@ apply MalformedUniqueItems @httpMalformedRequestTests([
         }
     },
     {
-        id: "RestJsonMalformedUniqueItemsMapList",
-        documentation: """
-        When an list of maps contains non-unique values,
-        the response should be a 400 ValidationException.""",
-        protocol: restJson1,
-        request: {
-            method: "POST",
-            uri: "/MalformedUniqueItems",
-            body: """
-            { "mapList" : [{"foo": "bar"}, {"foo": "bar"}] }""",
-            headers: {
-                "content-type": "application/json"
-            }
-        },
-        response: {
-            code: 400,
-            headers: {
-                "x-amzn-errortype": "ValidationException"
-            },
-            body: {
-                mediaType: "application/json",
-                assertion: {
-                    contents: """
-                    { "message" : "1 validation error detected. Value with repeated values at '/mapList' failed to satisfy constraint: Member must have unique values",
-                      "fieldList" : [{"message": "Value with repeated values at '/mapList' failed to satisfy constraint: Member must have unique values", "path": "/mapList"}]}"""
-                }
-            }
-        }
-    },
-    {
         id: "RestJsonMalformedUniqueItemsStructureList",
         documentation: """
         When an list of structures contains non-unique values,
@@ -536,7 +505,6 @@ structure MalformedUniqueItemsInput {
     enumList: FooEnumSet
     intEnumList: IntegerEnumSet
     listList: ListSet,
-    mapList: MapSet,
     structureList: StructureSet
     unionList: UnionSet
 }

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-uniqueItems.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-uniqueItems.smithy
@@ -1,0 +1,542 @@
+$version: "2.0"
+
+namespace aws.protocoltests.restjson.validation
+
+use aws.protocols#restJson1
+use aws.protocoltests.shared#BlobSet
+use aws.protocoltests.shared#BooleanSet
+use aws.protocoltests.shared#ByteSet
+use aws.protocoltests.shared#DateTimeSet
+use aws.protocoltests.shared#FooEnumSet
+use aws.protocoltests.shared#HttpDateSet
+use aws.protocoltests.shared#IntegerSet
+use aws.protocoltests.shared#IntegerEnumSet
+use aws.protocoltests.shared#ListSet
+use aws.protocoltests.shared#LongSet
+use aws.protocoltests.shared#MapSet
+use aws.protocoltests.shared#ShortSet
+use aws.protocoltests.shared#StringSet
+use aws.protocoltests.shared#StructureSet
+use aws.protocoltests.shared#TimestampSet
+use aws.protocoltests.shared#UnionSet
+use smithy.test#httpMalformedRequestTests
+use smithy.framework#ValidationException
+
+@suppress(["UnstableTrait"])
+@http(uri: "/MalformedUniqueItems", method: "POST")
+operation MalformedUniqueItems {
+    input: MalformedUniqueItemsInput,
+    errors: [ValidationException]
+}
+
+apply MalformedUniqueItems @httpMalformedRequestTests([
+    {
+        id: "RestJsonMalformedUniqueItemsBlobList",
+        documentation: """
+        When a blob list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "blobList" : ["YQ==", "YQ=="] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/blobList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/blobList' failed to satisfy constraint: Member must have unique values", "path": "/blobList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsBooleanList",
+        documentation: """
+        When a boolean list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "booleanList" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/booleanList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/booleanList' failed to satisfy constraint: Member must have unique values", "path": "/booleanList"}]}"""
+                }
+            }
+        },
+        testParameters: {
+            value: ["[true, true]", "[false, false]"]
+        }
+
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsStringList",
+        documentation: """
+        When a string list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "stringList" : ["abc", "abc"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/stringList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/stringList' failed to satisfy constraint: Member must have unique values", "path": "/stringList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsByteList",
+        documentation: """
+        When a byte list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "byteList" : [1, 1] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/byteList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/byteList' failed to satisfy constraint: Member must have unique values", "path": "/byteList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsShortList",
+        documentation: """
+        When a short list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "shortList" : [2, 2] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/shortList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/shortList' failed to satisfy constraint: Member must have unique values", "path": "/shortList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsIntegerList",
+        documentation: """
+        When an integer list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "integerList" : [3, 3] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/integerList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/integerList' failed to satisfy constraint: Member must have unique values", "path": "/integerList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsLongList",
+        documentation: """
+        When an integer list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "longList" : [4, 4] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/longList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/longList' failed to satisfy constraint: Member must have unique values", "path": "/longList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsTimestampList",
+        documentation: """
+        When a timestamp list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "timestampList" : [1676660607, 1676660607] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/timestampList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/timestampList' failed to satisfy constraint: Member must have unique values", "path": "/timestampList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsDateTimeList",
+        documentation: """
+        When a date-time timestamp list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "dateTimeList" : ["1985-04-12T23:20:50.52Z", "1985-04-12T23:20:50.52Z"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/dateTimeList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/dateTimeList' failed to satisfy constraint: Member must have unique values", "path": "/dateTimeList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsHttpDateList",
+        documentation: """
+        When a http-date timestamp list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "httpDateList" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/httpDateList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/httpDateList' failed to satisfy constraint: Member must have unique values", "path": "/httpDateList"}]}"""
+                }
+            }
+        },
+        testParameters: {
+            value: ["[\"Tue, 29 Apr 2014 18:30:38 GMT\", \"Tue, 29 Apr 2014 18:30:38 GMT\"]", "[\"Sun, 02 Jan 2000 20:34:56.000 GMT\", \"Sun, 02 Jan 2000 20:34:56.000 GMT\"]"]
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsEnumList",
+        documentation: """
+        When an enum list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "enumList" : ["Foo", "Foo"] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/enumList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/enumList' failed to satisfy constraint: Member must have unique values", "path": "/enumList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsIntEnumList",
+        documentation: """
+        When an intEnum list contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "intEnumList" : [3, 3] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/intEnumList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/intEnumList' failed to satisfy constraint: Member must have unique values", "path": "/intEnumList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsListList",
+        documentation: """
+        When an list of lists contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "listList" : [["foo","bar"], ["foo","bar"]] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/listList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/listList' failed to satisfy constraint: Member must have unique values", "path": "/listList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsMapList",
+        documentation: """
+        When an list of maps contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "mapList" : [{"foo": "bar"}, {"foo": "bar"}] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/mapList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/mapList' failed to satisfy constraint: Member must have unique values", "path": "/mapList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsStructureList",
+        documentation: """
+        When an list of structures contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "structureList" : [{"hi": "hello"}, {"hi": "hello"}] }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/structureList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/structureList' failed to satisfy constraint: Member must have unique values", "path": "/structureList"}]}"""
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonMalformedUniqueItemsUnionList",
+        documentation: """
+        When an list of unions contains non-unique values,
+        the response should be a 400 ValidationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUniqueItems",
+            body: """
+            { "unionList" : $value:L }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "ValidationException"
+            },
+            body: {
+                mediaType: "application/json",
+                assertion: {
+                    contents: """
+                    { "message" : "1 validation error detected. Value with repeated values at '/unionList' failed to satisfy constraint: Member must have unique values",
+                      "fieldList" : [{"message": "Value with repeated values at '/unionList' failed to satisfy constraint: Member must have unique values", "path": "/unionList"}]}"""
+                }
+            }
+        },
+        testParameters: {
+            value: ["[{\"string\": \"foo\"}, {\"string\": \"foo\"}]", "[{\"integer\": 1}, {\"integer\": 1}]"]
+        }
+    },
+])
+
+structure MalformedUniqueItemsInput {
+    blobList: BlobSet
+    booleanList: BooleanSet
+    stringList: StringSet
+    byteList: ByteSet
+    shortList: ShortSet
+    integerList: IntegerSet
+    longList: LongSet
+    timestampList: TimestampSet
+    dateTimeList: DateTimeSet
+    httpDateList: HttpDateSet
+    enumList: FooEnumSet
+    intEnumList: IntegerEnumSet
+    listList: ListSet,
+    mapList: MapSet,
+    structureList: StructureSet
+    unionList: UnionSet
+}

--- a/smithy-aws-protocol-tests/model/restJson1/validation/recursive-structures.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/recursive-structures.smithy
@@ -73,8 +73,8 @@ apply RecursiveStructures @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value XYZ at '/union/union/union/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value XYZ at '/union/union/union/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/union/union/union/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/union/union/union/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
+                      "fieldList" : [{"message": "Value at '/union/union/union/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/union/union/union/string"}]}"""
                 }
             }
         }

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -121,16 +121,6 @@ list ListSet {
 }
 
 @uniqueItems
-list MapSet {
-    member: StringMap
-}
-
-map StringMap {
-    key: String,
-    value: String
-}
-
-@uniqueItems
 list StructureSet {
     member: GreetingStruct
 }

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -72,8 +72,77 @@ list BooleanList {
     member: Boolean,
 }
 
+@uniqueItems
+list BooleanSet {
+    member: Boolean,
+}
+
 list TimestampList {
     member: Timestamp,
+}
+
+@uniqueItems
+list BlobSet {
+    member: Blob,
+}
+
+@uniqueItems
+list ByteSet {
+    member: Byte,
+}
+@uniqueItems
+list ShortSet {
+    member: Short,
+}
+
+@uniqueItems
+list LongSet {
+    member: Long,
+}
+
+@uniqueItems
+list TimestampSet {
+    member: Timestamp,
+}
+
+@uniqueItems
+list DateTimeSet {
+    member: DateTime,
+}
+
+@uniqueItems
+list HttpDateSet {
+    member: HttpDate,
+}
+
+@uniqueItems
+list ListSet {
+    member: StringList
+}
+
+@uniqueItems
+list MapSet {
+    member: StringMap
+}
+
+map StringMap {
+    key: String,
+    value: String
+}
+
+@uniqueItems
+list StructureSet {
+    member: GreetingStruct
+}
+
+@uniqueItems
+list UnionSet {
+    member: FooUnion
+}
+
+union FooUnion {
+    string: String
+    integer: Integer
 }
 
 enum FooEnum {
@@ -114,7 +183,7 @@ blob TextPlainBlob
 blob JpegBlob
 
 structure GreetingStruct {
-    hi: String,
+    hi: String
 }
 
 list GreetingList {


### PR DESCRIPTION
This PR updates the validation protocol tests to remove the input value from being returned in the validation message.

It also adds coverage for uniqueItems validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
