### PR TITLE
Omit serializing empty http-query lists

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -476,6 +476,59 @@ structure OmitsNullSerializesEmptyStringInput {
     emptyString: String,
 }
 
+/// Omits serializing empty lists. Because empty strings are serilized as
+/// `Foo=`, empty lists cannot also be serialized as `Foo=` and instead
+/// must be omitted.
+@http(uri: "/OmitsSerializingEmptyLists", method: "POST")
+@tags(["client-only"])
+operation OmitsSerializingEmptyLists {
+    input: OmitsSerializingEmptyListsInput
+}
+
+apply OmitsSerializingEmptyLists @httpRequestTests([
+    {
+        id: "RestJsonOmitsEmptyListQueryValues",
+        documentation: "Supports omitting empty lists.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/OmitsSerializingEmptyLists",
+        body: "",
+        queryParams: [],
+        params: {
+            queryStringList: [],
+            queryIntegerList: [],
+            queryDoubleList: [],
+            queryBooleanList: [],
+            queryTimestampList: [],
+            queryEnumList: [],
+            queryIntegerEnumList: [],
+        }
+    }
+])
+
+structure OmitsSerializingEmptyListsInput {
+    @httpQuery("StringList")
+    queryStringList: StringList,
+
+    @httpQuery("IntegerList")
+    queryIntegerList: IntegerList,
+
+    @httpQuery("DoubleList")
+    queryDoubleList: DoubleList,
+
+    @httpQuery("BooleanList")
+    queryBooleanList: BooleanList,
+
+    @httpQuery("TimestampList")
+    queryTimestampList: TimestampList,
+
+    @httpQuery("EnumList")
+    queryEnumList: FooEnumList,
+
+    @httpQuery("IntegerEnumList")
+    queryIntegerEnumList: IntegerEnumList,
+}
+
 /// Automatically adds idempotency tokens.
 @http(uri: "/QueryIdempotencyTokenAutoFill", method: "POST")
 @tags(["client-only"])

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -43,6 +43,7 @@ service RestJson {
         ConstantAndVariableQueryString,
         IgnoreQueryParamsInResponse,
         OmitsNullSerializesEmptyString,
+        OmitsSerializingEmptyLists,
         QueryIdempotencyTokenAutoFill,
         QueryPrecedence,
         QueryParamsAsStringListMap,


### PR DESCRIPTION
This PR adds a protocol test to clarify clients should omit empty lists when serializing a query string.

When serializing an empty string for param `Foo`, `Foo=` is serialized in the query string. An empty list for param `Foo` cannot also be serialized as `Foo=` as one might expect. Instead, it is omitted to clearly differentiate between an empty string, and an empty list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
