### PR TITLE
Clarify rules for escaping shapes bound to URIs

### DIFF
--- a/docs/source-1.0/spec/core/http-traits.rst
+++ b/docs/source-1.0/spec/core/http-traits.rst
@@ -682,8 +682,9 @@ structure with the ``httpLabel`` trait MUST have a corresponding
   (for example, ``1985-04-12T23:20:50.52Z``, and with percent-encoding,
   ``1985-04-12T23%3A20%3A50.52Z``). The :ref:`timestampFormat-trait`
   MAY be used to use a custom serialization format.
-- Reserved characters defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>`
-  and the `%` itself MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
+- Characters not defined as unreserved by :rfc:`RFC 3986 section 2.3 <3986#section-2.3>`
+  MUST be :rfc:`percent-encoded <3986#section-2.1>`. That is, all characters except for
+  alphanumerics and ``-._~``.
 - However, if the label is greedy, then "/" MUST NOT be percent-encoded
   because greedy labels are meant to span multiple path segments.
 
@@ -918,8 +919,9 @@ request:
 
 * "&" is used to separate query string parameter key-value pairs.
 * "=" is used to separate query string parameter names from values.
-* Reserved characters in keys and values as defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>` and `%`
-  MUST be percent-encoded_ (that is, ``:/?#[]@!$&'()*+,;=%``).
+* Characters not defined as unreserved by :rfc:`RFC 3986 section 2.3 <3986#section-2.3>`
+  MUST be :rfc:`percent-encoded <3986#section-2.1>`. That is, all characters except for
+  alphanumerics and ``-._~``.
 * ``boolean`` values are serialized as ``true`` or ``false``.
 * ``timestamp`` values are serialized as an :rfc:`3339`
   ``date-time`` string by default (for example, ``1985-04-12T23:20:50.52Z``,

--- a/docs/source-2.0/spec/http-bindings.rst
+++ b/docs/source-2.0/spec/http-bindings.rst
@@ -684,9 +684,9 @@ structure with the ``httpLabel`` trait MUST have a corresponding
   (for example, ``1985-04-12T23:20:50.52Z``, and with percent-encoding,
   ``1985-04-12T23%3A20%3A50.52Z``). The :ref:`timestampFormat-trait`
   MAY be used to use a custom serialization format.
-- Reserved characters defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>`
-  and the `%` itself MUST be :rfc:`percent-encoded <3986#section-2.1>` (that is,
-  ``:/?#[]@!$&'()*+,;=%``).
+- Characters not defined as unreserved by :rfc:`RFC 3986 section 2.3 <3986#section-2.3>`
+  MUST be :rfc:`percent-encoded <3986#section-2.1>`. That is, all characters except for
+  alphanumerics and ``-._~``.
 - However, if the label is greedy, then "/" MUST NOT be percent-encoded
   because greedy labels are meant to span multiple path segments.
 
@@ -923,9 +923,9 @@ request:
 
 * "&" is used to separate query string parameter key-value pairs.
 * "=" is used to separate query string parameter names from values.
-* Reserved characters in keys and values as defined in :rfc:`section 2.2 of RFC3986 <3986#section-2.2>` and `%`
-  MUST be :rfc:`percent-encoded <3986#section-2.1>` (that is,
-  ``:/?#[]@!$&'()*+,;=%``).
+* Characters not defined as unreserved by :rfc:`RFC 3986 section 2.3 <3986#section-2.3>`
+  MUST be :rfc:`percent-encoded <3986#section-2.1>`. That is, all characters except for
+  alphanumerics and ``-._~``.
 * ``boolean`` values are serialized as ``true`` or ``false``.
 * ``timestamp`` values are serialized as an :rfc:`3339`
   ``date-time`` string by default (for example, ``1985-04-12T23:20:50.52Z``,
@@ -1367,4 +1367,3 @@ marked with the ``httpPayload`` trait:
     structure Message {
         message: String
     }
-


### PR DESCRIPTION
This updates the rules for escaping values of shapes bound to the HTTP URI according to the rules of RFC3986. The list of characters to escape was replaced with a list of safe characters. Initially that was created by subtracting the reserved characters in section 2.2 from the relevant valid characters defined in the productions for the particular binding locations, but those all ended up being equivalent to the unreserved characters production in section 2.3.

closes #1011


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
