### PR TITLE
Fix FilterSuppressions to match on hierarchy

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FilterSuppressions.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/FilterSuppressions.java
@@ -287,11 +287,10 @@ public final class FilterSuppressions extends ConfigurableProjectionTransformer<
 
             // Only keep IDs that actually acted to suppress an event.
             if (config.getRemoveUnused()) {
-                Set<String> matched = suppressedEvents.stream()
+                Set<ValidationEvent> matchedEvents = suppressedEvents.stream()
                         .filter(event -> Objects.equals(shape.getId(), event.getShapeId().orElse(null)))
-                        .map(ValidationEvent::getId)
                         .collect(Collectors.toSet());
-                allowed.removeIf(value -> !matched.contains(value));
+                allowed.removeIf(value -> matchedEvents.stream().noneMatch(event -> event.containsId(value)));
             }
 
             if (allowed.isEmpty()) {

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/FilterSuppressionsTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/FilterSuppressionsTest.java
@@ -66,7 +66,8 @@ public class FilterSuppressionsTest {
         "namespaces,filterWithProjectionImports",
         "namespaces,detectsValidatorRemoval",
         "namespaces,unchanged",
-        "noSuppressions,removeUnused"
+        "noSuppressions,removeUnused",
+        "eventHierarchy,removeUnused"
     })
     public void runTransformTests(String modelFile, String testName) throws Exception {
         Model model = Model.assembler()

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/eventHierarchy.removeUnused.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/eventHierarchy.removeUnused.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0",
+    "projections": {
+        "foo": {
+            "transforms": [
+                {
+                    "name": "filterSuppressions",
+                    "args": {
+                        "removeUnused": true
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/eventHierarchy.removeUnused.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/eventHierarchy.removeUnused.smithy
@@ -1,0 +1,28 @@
+$version: "2.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "A.B",
+        severity: "WARNING",
+        configuration: {
+            selector: ":not([id='smithy.example#NoMatches'])"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "B.C.D",
+        severity: "WARNING",
+        configuration: {
+            selector: ":not([id='smithy.example#NoMatches'])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["A", "B.C"])
+structure Foo {
+    @suppress(["A", "B.C"])
+    foo: String
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/eventHierarchy.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/transforms/filtersuppressions/eventHierarchy.smithy
@@ -1,0 +1,28 @@
+$version: "2.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector",
+        id: "A.B",
+        severity: "WARNING",
+        configuration: {
+            selector: ":not([id='smithy.example#NoMatches'])"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "B.C.D",
+        severity: "WARNING",
+        configuration: {
+            selector: ":not([id='smithy.example#NoMatches'])"
+        }
+    }
+]
+
+namespace smithy.example
+
+@suppress(["A", "B.C"])
+structure Foo {
+    @suppress(["A", "B.C"])
+    foo: String
+}


### PR DESCRIPTION
Hierarchical eventIds were added in https://github.com/awslabs/smithy/pull/1527.

This PR fixes the FilterSuppressions transform to keep suppressions that match a prefix when using the `removeUnused` transform configuration.

Currently, `@suppress(['A'])` will be removed as unused if a validation event does not match `A` exactly.

This PR updates the transform retain `@suppress(['A'])` when a validation event for `A.B` has been emitted for the shape where the suppression was applied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
