### PR TITLE
Fix NodeMapper handling of lists with generic types

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/DefaultNodeDeserializers.java
@@ -186,6 +186,13 @@ final class DefaultNodeDeserializers {
 
                 // Extract out the expected generic type of the collection.
                 Type memberType = Object.class;
+
+                // If given a Class, then attempt to find the generic superclass (e.g., extending ArrayList with a
+                // concrete generic type).
+                if (targetType instanceof Class) {
+                    targetType = ((Class<?>) target).getGenericSuperclass();
+                }
+
                 if (targetType instanceof ParameterizedType) {
                     Type[] genericTypes = ((ParameterizedType) targetType).getActualTypeArguments();
                     if (genericTypes.length > 0) {


### PR DESCRIPTION
We previously deserialized lists with generic types incorrectly, causing the list to be created, but storing invalid types in the list. This caused the use of the list at runtime to fail due to a ClassCastException.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
