### PR TITLE
Make empty map HTTP header tests client-only

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
@@ -53,7 +53,8 @@ apply HttpPrefixHeaders @httpRequestTests([
         params: {
             foo: "Foo",
             fooMap: {}
-        }
+        },
+        appliesTo: "client"
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
@@ -52,7 +52,8 @@ apply HttpPrefixHeaders @httpRequestTests([
         params: {
             foo: "Foo",
             fooMap: {}
-        }
+        },
+        appliesTo: "client"
     },
 ])
 


### PR DESCRIPTION
Fixes https://github.com/awslabs/smithy/issues/1633.

This PR makes HTTP request protocol tests for serializing empty maps client-only.

Clients should omit the empty map when serializing the request. Servers however should not instantiate an optional parameter when it is not set as a header.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
