### PR TITLE
Handle nested properties in cfn schema generation

### DIFF
--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
@@ -28,9 +28,9 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.BottomUpIndex;
 import software.amazon.smithy.model.knowledge.IdentifierBindingIndex;
 import software.amazon.smithy.model.knowledge.KnowledgeIndex;
-import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.PropertyBindingIndex;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -89,7 +89,7 @@ public final class CfnResourceIndex implements KnowledgeIndex {
     }
 
     public CfnResourceIndex(Model model) {
-        OperationIndex operationIndex = OperationIndex.of(model);
+        PropertyBindingIndex propertyIndex = PropertyBindingIndex.of(model);
         BottomUpIndex bottomUpIndex = BottomUpIndex.of(model);
         model.shapes(ResourceShape.class)
                 .filter(shape -> shape.hasTrait(CfnResourceTrait.ID))
@@ -110,37 +110,37 @@ public final class CfnResourceIndex implements KnowledgeIndex {
                     // Use the read lifecycle's input to collect the additional identifiers
                     // and its output to collect readable properties.
                     resource.getRead().ifPresent(operationId -> {
-                        operationIndex.getInputShape(operationId).ifPresent(input -> {
-                            addAdditionalIdentifiers(builder, computeResourceAdditionalIdentifiers(input));
-                        });
-                        operationIndex.getOutputShape(operationId).ifPresent(output -> {
-                            updatePropertyMutabilities(builder, model, resourceId, operationId, output,
-                                    SetUtils.of(Mutability.READ), this::addReadMutability);
-                        });
+                        OperationShape operation = model.expectShape(operationId, OperationShape.class);
+                        StructureShape input = model.expectShape(operation.getInputShape(), StructureShape.class);
+                        addAdditionalIdentifiers(builder, computeResourceAdditionalIdentifiers(input));
+
+                        StructureShape output = propertyIndex.getOutputPropertiesShape(operation);
+                        updatePropertyMutabilities(builder, model, resourceId, operationId, output,
+                                SetUtils.of(Mutability.READ), this::addReadMutability);
                     });
 
                     // Use the put lifecycle's input to collect put-able properties.
                     resource.getPut().ifPresent(operationId -> {
-                        operationIndex.getInputShape(operationId).ifPresent(input -> {
-                            updatePropertyMutabilities(builder, model, resourceId, operationId, input,
-                                    SetUtils.of(Mutability.CREATE, Mutability.WRITE), this::addPutMutability);
-                        });
+                        OperationShape operation = model.expectShape(operationId, OperationShape.class);
+                        StructureShape input = propertyIndex.getInputPropertiesShape(operation);
+                        updatePropertyMutabilities(builder, model, resourceId, operationId, input,
+                                SetUtils.of(Mutability.CREATE, Mutability.WRITE), this::addPutMutability);
                     });
 
                     // Use the create lifecycle's input to collect creatable properties.
                     resource.getCreate().ifPresent(operationId -> {
-                        operationIndex.getInputShape(operationId).ifPresent(input -> {
-                            updatePropertyMutabilities(builder, model, resourceId, operationId, input,
-                                    SetUtils.of(Mutability.CREATE), this::addCreateMutability);
-                        });
+                        OperationShape operation = model.expectShape(operationId, OperationShape.class);
+                        StructureShape input = propertyIndex.getInputPropertiesShape(operation);
+                        updatePropertyMutabilities(builder, model, resourceId, operationId, input,
+                                SetUtils.of(Mutability.CREATE), this::addCreateMutability);
                     });
 
                     // Use the update lifecycle's input to collect writeable properties.
                     resource.getUpdate().ifPresent(operationId -> {
-                        operationIndex.getInputShape(operationId).ifPresent(input -> {
-                            updatePropertyMutabilities(builder, model, resourceId, operationId, input,
-                                    SetUtils.of(Mutability.WRITE), this::addWriteMutability);
-                        });
+                        OperationShape operation = model.expectShape(operationId, OperationShape.class);
+                        StructureShape input = propertyIndex.getInputPropertiesShape(operation);
+                        updatePropertyMutabilities(builder, model, resourceId, operationId, input,
+                                SetUtils.of(Mutability.WRITE), this::addWriteMutability);
                     });
 
                     // Apply any members found through the trait's additionalSchemas property.

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/nested-properties.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/nested-properties.cfn.json
@@ -1,0 +1,38 @@
+{
+    "typeName": "Smithy::TestService::Forecast",
+    "description": "Definition of Smithy::TestService::Forecast Resource Type",
+    "properties": {
+        "ChanceOfRain": {
+            "type": "number"
+        },
+        "ForecastId": {
+            "type": "string"
+        }
+    },
+    "createOnlyProperties": [
+        "/properties/ForecastId"
+    ],
+    "primaryIdentifier": [
+        "/properties/ForecastId"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "testservice:CreateForecast",
+                "testservice:PutForecast"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "testservice:GetForecast"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "testservice:PutForecast",
+                "testservice:UpdateForecast"
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/nested-properties.smithy
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/integ/nested-properties.smithy
@@ -1,0 +1,67 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use aws.cloudformation#cfnMutability
+use aws.cloudformation#cfnResource
+
+service TestService {
+    version: "2020-07-02",
+    resources: [Forecast]
+}
+
+@cfnResource()
+resource Forecast {
+    identifiers: {
+        forecastId: String
+    }
+    properties: {
+        chanceOfRain: Float
+    }
+    read: GetForecast
+    put: PutForecast
+    create: CreateForecast
+    update: UpdateForecast
+}
+
+@readonly
+operation GetForecast {
+    input := {
+        @required
+        forecastId: String
+    }
+    output := {
+        @nestedProperties
+        forecastData: ForecastData
+    }
+}
+
+@idempotent
+operation PutForecast {
+    input := {
+        @required
+        forecastId: String
+        @nestedProperties
+        forecastData: ForecastData
+    }
+}
+
+operation CreateForecast {
+    input := {
+        @nestedProperties
+        forecastData: ForecastData
+    }
+}
+
+operation UpdateForecast {
+    input := {
+        @required
+        forecastId: String
+        @nestedProperties
+        forecastData: ForecastData
+    }
+}
+
+structure ForecastData for Forecast {
+    $chanceOfRain
+}


### PR DESCRIPTION
Resource properties can be nested if the `nestedProperties` trait is used. This fixes an issue where the cfn resource schema generation wasn't respecting that trait.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
