### PR TITLE
Fix ec2Query fractional seconds response

### DIFF
--- a/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
@@ -22,10 +22,10 @@ apply FractionalSeconds @httpResponseTests([
         protocol: ec2Query,
         code: 200,
         body: """
-              <FractionalSecondsOutput xmlns="https://example.com/">
+              <FractionalSecondsResponse xmlns="https://example.com/">
                   <datetime>2000-01-02T20:34:56.123Z</datetime>
                   <RequestId>requestid</RequestId>
-              </FractionalSecondsOutput>
+              </FractionalSecondsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -40,10 +40,10 @@ apply FractionalSeconds @httpResponseTests([
         protocol: ec2Query,
         code: 200,
         body: """
-              <FractionalSecondsOutput xmlns="https://example.com/">
+              <FractionalSecondsResponse xmlns="https://example.com/">
                   <httpdate>Sun, 02 Jan 2000 20:34:56.456 GMT</httpdate>
                   <RequestId>requestid</RequestId>
-              </FractionalSecondsOutput>
+              </FractionalSecondsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {


### PR DESCRIPTION
Fixes the ec2Query fractional seconds tests to comply with the [response serialization](https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html#response-serialization) specification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
