### PR TITLE
Add selector compliance tests

### DIFF
--- a/docs/source-1.0/spec/core/selectors.rst
+++ b/docs/source-1.0/spec/core/selectors.rst
@@ -1646,5 +1646,75 @@ Selectors are defined by the following ABNF_ grammar.
     SelectorVariableSet                :"$" `smithy:Identifier` "(" `Selector` ")"
     SelectorVariableGet                :"${" `smithy:Identifier` "}"
 
+
+Compliance Tests
+================
+
+Selector compliance tests are used to verify the behavior of selectors. Each compliance test is written as a Smithy file
+and includes a :ref:`metadata <metadata>` called ``selectorTests``. This metadata contains a list of test cases, each including a selector,
+the expected matched shapes, and additional configuration options. The test case contains the following properties:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - selector
+      - ``string``
+      - **REQUIRED** The selector to match shapes within the smithy model
+    * - matches
+      - ``list<shape ID>``
+      - **REQUIRED** The expected shapes ID of the matched shapes
+    * - skipPreludeShapes
+      - ``boolean``
+      - Skip :ref:`prelude shapes <prelude>` when comparing the expected shapes and the actual shapes returned from the selector. Default value is ``false``
+
+Below is an example selector compliance test:
+
+.. code-block:: smithy
+
+    $version: "1.0"
+
+    metadata selectorTests = [
+        {
+            selector: "[trait|length|min > 1]"
+            matches: [
+                smithy.example#AtLeastTen
+            ]
+        }
+        {
+            selector: "[trait|length|min >= 1]"
+            skipPreludeShapes: true
+            matches: [
+                smithy.example#AtLeastOne
+                smithy.example#AtLeastTen
+            ]
+        }
+        {
+            selector: "[trait|length|min < 2]"
+            skipPreludeShapes: true
+            matches: [
+                smithy.example#AtLeastOne
+            ]
+        }
+    ]
+
+    namespace smithy.example
+
+    @length(min: 1)
+    string AtLeastOne
+
+    @length(max: 5)
+    string AtMostFive
+
+    @length(min: 10)
+    string AtLeastTen
+
+The compliance tests can also be accessed in this
+`directory <https://github.com/awslabs/smithy/tree/main/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases>`__
+of the Smithy Github repository.
+
 .. _ABNF: https://tools.ietf.org/html/rfc5234
 .. _set: https://en.wikipedia.org/wiki/Set_(abstract_data_type)

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -1663,4 +1663,75 @@ Selectors are defined by the following :rfc:`ABNF <5234>` grammar.
     SelectorVariableSet                :"$" `smithy:Identifier` "(" `Selector` ")"
     SelectorVariableGet                :"${" `smithy:Identifier` "}"
 
+
+Compliance Tests
+================
+
+Selector compliance tests are used to verify the behavior of selectors. Each compliance test is written as a Smithy file
+and includes a :ref:`metadata <metadata>` called ``selectorTests``. This metadata contains a list of test cases, each including a selector,
+the expected matched shapes, and additional configuration options. The test case contains the following properties:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - selector
+      - ``string``
+      - **REQUIRED** The selector to match shapes within the smithy model
+    * - matches
+      - ``list<shape ID>``
+      - **REQUIRED** The expected shapes ID of the matched shapes
+    * - skipPreludeShapes
+      - ``boolean``
+      - Skip :ref:`prelude shapes <prelude>` when comparing the expected shapes and the actual shapes returned from the selector. Default value is ``false``
+
+Below is an example selector compliance test:
+
+.. code-block:: smithy
+
+    $version: "2.0"
+
+    metadata selectorTests = [
+        {
+            selector: "[trait|length|min > 1]"
+            matches: [
+                smithy.example#AtLeastTen
+            ]
+        }
+        {
+            selector: "[trait|length|min >= 1]"
+            skipPreludeShapes: true
+            matches: [
+                smithy.example#AtLeastOne
+                smithy.example#AtLeastTen
+            ]
+        }
+        {
+            selector: "[trait|length|min < 2]"
+            skipPreludeShapes: true
+            matches: [
+                smithy.example#AtLeastOne
+            ]
+        }
+    ]
+
+    namespace smithy.example
+
+    @length(min: 1)
+    string AtLeastOne
+
+    @length(max: 5)
+    string AtMostFive
+
+    @length(min: 10)
+    string AtLeastTen
+
+The compliance tests can also be accessed in this
+`directory <https://github.com/awslabs/smithy/tree/main/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases>`__
+of the Smithy Github repository.
+
+
 .. _set: https://en.wikipedia.org/wiki/Set_(abstract_data_type)

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorRunnerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorRunnerTest.java
@@ -1,0 +1,109 @@
+package software.amazon.smithy.model.selector;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class SelectorRunnerTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("source")
+    public void selectorTest(Path filename) {
+        Model model = Model.assembler().addImport(filename).assemble().unwrap();
+        List<ObjectNode> tests = findTestCases(model);
+
+        for (ObjectNode test : tests) {
+            Selector selector = Selector.parse(test.expectStringMember("selector").getValue());
+            boolean skipPrelude = test.getBooleanMemberOrDefault("skipPreludeShapes", false);
+
+            Set<ShapeId> expectedMatches = test.expectArrayMember("matches")
+                    .getElementsAs(n -> n.expectStringNode("Each element of matches must be an ID").expectShapeId())
+                    .stream()
+                    .filter(shapeId -> {
+                        String namespace = shapeId.getNamespace();
+                        return !namespace.contains(Prelude.NAMESPACE)
+                                || (!skipPrelude && namespace.contains(Prelude.NAMESPACE));
+                    })
+                    .collect(Collectors.toSet());
+
+            Set<ShapeId> actualMatches = selector.shapes(model)
+                    .map(Shape::getId)
+                    .filter(shapeId -> {
+                        String namespace = shapeId.getNamespace();
+                        return !namespace.contains(Prelude.NAMESPACE)
+                                || (!skipPrelude && namespace.contains(Prelude.NAMESPACE));
+                    })
+                    .collect(Collectors.toSet());
+
+            if (!expectedMatches.equals(actualMatches)) {
+                failTest(filename, test, expectedMatches, actualMatches);
+            }
+        }
+    }
+
+    private List<ObjectNode> findTestCases(Model model) {
+        return model.getMetadataProperty("selectorTests")
+                .orElseThrow(() -> new IllegalArgumentException("Missing selectorTests metadata key"))
+                .expectArrayNode("selectorTests must be an array")
+                .getElementsAs(ObjectNode.class);
+    }
+
+    private void failTest(Path filename, ObjectNode test, Set<ShapeId> expectedMatches, Set<ShapeId> actualMatches) {
+        String selector = test.expectStringMember("selector").getValue();
+        Set<ShapeId> missing = new TreeSet<>(expectedMatches);
+        missing.removeAll(actualMatches);
+
+        Set<ShapeId> extra = new TreeSet<>(actualMatches);
+        extra.removeAll(expectedMatches);
+
+        StringBuilder error = new StringBuilder("Selector ")
+            .append(selector)
+            .append(" test case failed.\n");
+
+        if (!missing.isEmpty()) {
+            error.append("The following shapes were not matched: ").append(missing).append(".\n");
+        }
+
+        if (!extra.isEmpty()) {
+            error.append("The following shapes were matched unexpectedly: ").append(extra).append(".\n");
+        }
+
+        test.getStringMember("documentation")
+                .ifPresent(docs -> error.append('(').append(docs.getValue()).append(")"));
+
+        Assertions.fail(error.toString());
+    }
+
+    public static List<Path> source() throws Exception {
+        List<Path> paths = new ArrayList<>();
+        try (Stream<Path> files = Files.walk(Paths.get(SelectorRunnerTest.class.getResource("cases").toURI()))) {
+            files
+                .filter(Files::isRegularFile)
+                .filter(file -> {
+                    String filename = file.toString();
+                    return filename.endsWith(".smithy") || filename.endsWith(".json");
+                })
+                .forEach(paths::add);
+        } catch (IOException e) {
+            throw new RuntimeException("Error loading models for selector runner", e);
+        }
+
+        return paths;
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/attribute-existence.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/attribute-existence.smithy
@@ -1,0 +1,35 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[trait|enum]"
+        matches: [
+            smithy.example#SimpleEnum
+            smithy.example#EnumWithTags
+        ]
+    },
+    {
+        selector: "[trait|enum|(values)|tags|(values)]"
+        matches: [
+            smithy.example#EnumWithTags
+        ]
+    }
+]
+
+namespace smithy.example
+
+@deprecated
+string NoMatch
+
+@enum([
+    {name: "foo", value: "foo"}
+    {name: "baz", value: "baz"}
+])
+string SimpleEnum
+
+@enum([
+    {name: "foo", value: "foo", tags: ["a"]}
+    {name: "baz", value: "baz"}
+    {name: "spam", value: "spam", tags: []}
+])
+string EnumWithTags

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/functions.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/functions.smithy
@@ -1,0 +1,118 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "list:test(> member > string)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#StringList
+        ]
+    }
+    {
+        selector: ":is(string, number)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#SimpleString
+            smithy.example#SimpleInteger
+        ]
+    }
+    {
+        selector: "member > :is(string, number)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#SimpleInteger,
+            smithy.example#SimpleString
+        ]
+    }
+    {
+        selector: ":is(list > member > string, map > member > number)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#SimpleString
+            smithy.example#SimpleInteger
+        ]
+    }
+    {
+        selector: ":not(string) :not(number) :not(structure) :not(service) :not(operation) :not(resource)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#IntegerList
+            smithy.example#IntegerList$member
+            smithy.example#SimpleMap
+            smithy.example#SimpleMap$key
+            smithy.example#SimpleMap$value
+            smithy.example#StringList
+            smithy.example#StringList$member
+        ]
+    }
+    {
+        selector: "list :not(> member > string)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#IntegerList
+        ]
+    }
+    {
+        selector: ":topdown([trait|smithy.example#dataPlane])"
+        matches: [
+            smithy.example#OperationA
+            smithy.example#Resource
+            smithy.example#ServiceA
+        ]
+    }
+    {
+        selector: ":topdown([trait|smithy.example#dataPlane], [trait|smithy.example#controlPlane])"
+        matches: [
+            smithy.example#OperationA
+            smithy.example#ServiceA
+        ]
+    }
+]
+
+namespace smithy.example
+
+string SimpleString
+
+integer SimpleInteger
+
+list StringList {
+    member: SimpleString
+}
+
+list IntegerList {
+    member: SimpleInteger
+}
+
+map SimpleMap {
+    key: String,
+    value: SimpleInteger
+}
+
+@trait(selector: ":test(service, resource, operation)")
+structure dataPlane {}
+
+@trait(selector: ":test(service, resource, operation)")
+structure controlPlane {}
+
+@dataPlane
+service ServiceA {
+    version: "2019-06-17",
+    operations: [OperationA]
+    resources: [Resource]
+}
+
+@controlPlane
+service ServiceB {
+    version: "2019-06-17",
+    operations: [OperationB]
+    resources: [Resource]
+}
+
+@dataPlane
+operation OperationA {}
+
+@controlPlane
+operation OperationB {}
+
+@controlPlane
+resource Resource {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/id-attribute.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/id-attribute.smithy
@@ -1,0 +1,37 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[id = smithy.example#Exception]"
+        matches: [
+            smithy.example#Exception
+        ]
+    }
+    {
+        selector: "[id|namespace = 'smithy.example']"
+        matches: [
+            smithy.example#Exception
+            smithy.example#Exception$message
+        ]
+    }
+    {
+        selector: "[id|(length) <= 24]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Exception
+        ]
+    }
+    {
+        selector: "[id|(length) > 24]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Exception$message
+        ]
+    }
+]
+
+namespace smithy.example
+
+structure Exception {
+    message: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/neighbors.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/neighbors.smithy
@@ -1,0 +1,86 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "service ~> operation"
+        matches: [
+            smithy.example#OperationA
+            smithy.example#OperationB
+        ]
+    }
+    {
+        selector: "service[trait|title] ~> operation:not([trait|http])"
+        matches: [
+            smithy.example#OperationB
+        ]
+    }
+    {
+        selector: "string :test(< member < list)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#String
+        ]
+    }
+    {
+        selector: ":not([trait|trait]) :not(< *)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#List
+            smithy.example#Structure
+        ]
+    }
+    {
+        selector: "[trait|streaming] :test(<) :not(< member < structure <-[input, output]- operation)"
+        matches: [
+            smithy.example#StreamBlob
+        ]
+    }
+    {
+        selector: "[trait|trait] :not(<-[trait]-)"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Regex
+        ]
+    }
+]
+
+namespace smithy.example
+
+@title("Service")
+service Service {
+    version: "2019-06-17",
+    operations: [OperationA, OperationB]
+}
+
+// Inherits the authorizer of ServiceA
+@http(method: "GET", uri: "/operationA")
+operation OperationA {}
+
+operation OperationB {
+    input: Input
+}
+
+string String
+
+list List {
+    member: String
+}
+
+structure Input {
+    @required
+    content: StreamFile
+}
+
+structure Structure {
+    @required
+    content: StreamBlob
+}
+
+@streaming
+blob StreamBlob
+
+@streaming
+blob StreamFile
+
+@trait
+string Regex

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/node-attributes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/node-attributes.smithy
@@ -1,0 +1,68 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[trait|externalDocumentation|(keys) = Homepage]"
+        matches: [
+            smithy.example#ServiceA
+        ]
+    }
+    {
+        selector: "[trait|enum|(values)|tags|(values) = internal]"
+        matches: [
+            smithy.example#Ec2Instance
+        ]
+    }
+    {
+        selector: "[trait|documentation|(length) < 3]"
+        matches: [
+            smithy.example#ServiceB
+        ]
+    }
+    {
+        selector: "[trait|externalDocumentation|'API Reference']"
+        matches: [
+            smithy.example#ServiceA
+        ]
+    }
+    {
+        selector: "[trait|documentation|invalid|child = Hi]"
+        matches: [
+        ]
+    }
+]
+
+namespace smithy.example
+
+@documentation("This is ServiceA")
+@externalDocumentation(
+    "Homepage": "https://www.example.com/"
+    "API Reference": "https://www.example.com/api-ref"
+)
+service ServiceA {
+    version: "2019-06-17"
+}
+
+@enum([
+    {
+        value: "t2.nano",
+        name: "T2_NANO",
+        tags: ["internal"]
+    },
+    {
+        value: "t2.micro",
+        name: "T2_MICRO",
+        tags: ["external"]
+    },
+    {
+        value: "m256.mega",
+        name: "M256_MEGA",
+        deprecated: true
+    }
+])
+string Ec2Instance
+
+@documentation("??")
+service ServiceB {
+
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/numeric-comparators.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/numeric-comparators.smithy
@@ -1,0 +1,42 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[trait|length|min > 1]"
+        matches: [
+            smithy.example#AtLeastTen
+        ]
+    },
+    {
+        selector: "[trait|length|min >= 1]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#AtLeastOne
+            smithy.example#AtLeastTen
+        ]
+    },
+    {
+        selector: "[trait|length|min < 2]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#AtLeastOne
+        ]
+    },
+    {
+        selector: "[trait|length|max <= 5]"
+        matches: [
+            smithy.example#AtMostFive
+        ]
+    },
+]
+
+namespace smithy.example
+
+@length(min: 1)
+string AtLeastOne
+
+@length(max: 5)
+string AtMostFive
+
+@length(min: 10)
+string AtLeastTen

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/projection-attributes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/projection-attributes.smithy
@@ -1,0 +1,76 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: """
+        service
+        [trait|smithy.example#allowedTags]
+        $service(*)
+        ~>
+        [trait|tags]
+        :not([@: @{trait|tags|(values)} = @{var|service|trait|smithy.example#allowedTags|(values)}])
+        """
+        matches: [
+            smithy.example#OperationD
+        ]
+    }
+    {
+        selector: """
+        service
+        [trait|smithy.example#allowedTags]
+        $service(*)
+        ~>
+        [trait|enum]
+        :not([@: @{trait|enum|(values)|tags|(values)}
+                 {<} @{var|service|trait|smithy.example#allowedTags|(values)}])
+        """
+        matches: [
+            smithy.example#BadEnum
+        ]
+    }
+]
+
+namespace smithy.example
+
+@trait(selector: "service")
+list allowedTags {
+    member: String
+}
+
+@allowedTags(["internal", "external"])
+service MyService {
+    version: "2020-04-28"
+    operations: [OperationA, OperationB, OperationC, OperationD]
+}
+
+operation OperationA {
+    input: OperationAInput
+}
+
+@tags(["internal"])
+operation OperationB {}
+
+@tags(["internal", "external"])
+operation OperationC {}
+
+@tags(["invalid"])
+operation OperationD {}
+
+@input
+structure OperationAInput {
+    badValue: BadEnum
+    goodValue: GoodEnum
+}
+
+@enum([
+    {value: "a", tags: ["internal"]}
+    {value: "b", tags: ["invalid"]}
+])
+string BadEnum
+
+@enum([
+    {value: "a"}
+    {value: "b", tags: ["internal", "external"]}
+    {value: "c", tags: ["internal"]}
+])
+string GoodEnum

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/scope-attribute.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/scope-attribute.smithy
@@ -1,0 +1,72 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[@trait|range: @{min} = @{max}]"
+        matches: [
+            smithy.example#Ten
+        ]
+    }
+    {
+        selector: "[@trait|enum|(values): @{deprecated} = true && @{tags|(values)} = \"deprecated\"]"
+        matches: [
+            smithy.example#GoodEnum
+        ]
+    }
+    {
+        selector: "[@trait|idRef: @{failWhenMissing} = true && @{errorMessage} ?= false]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#integerRef
+        ]
+    }
+    {
+        selector: "[@trait|httpApiKeyAuth: @{name} = header && @{in} != 'x-api-token', 'authorization']"
+        matches: [
+            smithy.example#WeatherService
+        ]
+    }
+    {
+        selector: "[@trait|deprecated: @{message} = DePrEcAtEd]"
+        matches: [
+        ]
+    }
+    {
+        selector: "[@trait|deprecated: @{message} = DePrEcAtEd i]"
+        matches: [
+            smithy.example#DeprecatedString
+        ]
+    }
+]
+
+namespace smithy.example
+
+@range(min: 1, max: 10)
+integer OneToTen
+
+@range(min: 1)
+integer GreaterThanOne
+
+@range(min: 10, max: 10)
+integer Ten
+
+@enum([
+    {value: "a"}
+    {value: "b", tags: ["deprecated"], deprecated: true}
+    {value: "c", tags: ["internal"]}
+])
+string GoodEnum
+
+@trait
+@idRef(failWhenMissing: true, selector: "integer")
+string integerRef
+
+@httpApiKeyAuth(name: "header", in: "header")
+service WeatherService {
+    version: "2017-02-11"
+}
+
+@deprecated(
+    message: "deprecated"
+)
+string DeprecatedString

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/service-attribute.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/service-attribute.smithy
@@ -1,0 +1,33 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[service]"
+        matches: [
+            smithy.example#ServiceA
+            smithy.example#ServiceB
+        ]
+    }
+    {
+        selector: "[service = smithy.example#ServiceA]"
+        matches: [
+            smithy.example#ServiceA
+        ]
+    }
+    {
+        selector: "[service|version ^= '2018-']"
+        matches: [
+            smithy.example#ServiceB
+        ]
+    }
+]
+
+namespace smithy.example
+
+service ServiceA {
+    version: "2019-06-17"
+}
+
+service ServiceB {
+    version: "2018-06-17"
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/string-comparators.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/string-comparators.smithy
@@ -1,0 +1,54 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[id|name = 'Name']"
+        matches: [
+            smithy.example#Name
+        ]
+    },
+    {
+        selector: "[id|namespace != 'smithy.api']"
+        matches: [
+            smithy.example#Name
+            smithy.example#Age
+            smithy.example#_Boolean
+        ]
+    },
+    {
+        selector: "[id|name ^= '_']"
+        matches: [
+            smithy.example#_Boolean
+        ]
+    },
+    {
+        selector: "[trait|documentation $= 'ge']"
+        matches: [
+            smithy.example#Age
+        ]
+    },
+    {
+        selector: "[id|name *= 'Boo']"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#_Boolean
+        ]
+    },
+    {
+        selector: "[trait|documentation ?= true]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Age
+        ]
+    },
+]
+
+namespace smithy.example
+
+@length(min: 1)
+string Name
+
+@documentation("Age")
+integer Age
+
+boolean _Boolean

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/trait-attributes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/trait-attributes.smithy
@@ -1,0 +1,84 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "[trait|(keys)|namespace = 'smithy.example']"
+        matches: [
+            smithy.example#ServiceA
+        ]
+    }
+    {
+        selector: "[trait|(values)|description]"
+        matches: [
+            smithy.example#ServiceA
+        ]
+    }
+    {
+        selector: "[trait|(length) > 1]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Exception
+            smithy.example#ServiceB
+        ]
+    }
+    {
+        selector: "[trait|smithy.api#deprecated]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Exception
+            smithy.example#ServiceB
+        ]
+    }
+    {
+        selector: "[trait|deprecated]"
+        skipPreludeShapes: true
+        matches: [
+            smithy.example#Exception
+            smithy.example#ServiceB
+        ]
+    }
+    {
+        selector: "[trait|error = client]"
+        matches: [
+            smithy.example#Exception
+        ]
+    }
+    {
+        selector: "[trait|error != client]"
+        matches: [
+        ]
+    }
+    {
+        selector: "[trait|documentation *= TODO, FIXME]"
+        matches: [
+            smithy.example#ServiceB
+            smithy.example#Exception
+        ]
+    }
+]
+
+namespace smithy.example
+
+@deprecated
+@unstable
+@error("client")
+@documentation("FIXME")
+structure Exception {
+    message: String
+}
+
+@ServiceProperty(description: "This is ServiceA")
+service ServiceA {
+    version: "2019-06-17"
+}
+
+@deprecated
+@documentation("TODO")
+service ServiceB {
+    version: "2018-06-17"
+}
+
+@trait(selector: "service")
+structure ServiceProperty {
+    description: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/variables.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/variables.smithy
@@ -1,0 +1,54 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    {
+        selector: "service $authTraits(-[trait]-> [trait|authDefinition])"
+        matches: [
+            smithy.example#MyService
+        ]
+    }
+    {
+        selector: """
+        service
+        $authTraits(-[trait]-> [trait|authDefinition])
+        ~>
+        operation [trait|auth]
+        """
+        matches: [
+            smithy.example#HasBasicAuth
+            smithy.example#HasDigestAuth
+        ]
+    }
+    {
+        selector: """
+        service
+        $authTraits(-[trait]-> [trait|authDefinition])
+        ~>
+        operation
+        [trait|auth]
+        :not([@: @{trait|auth|(values)} {<} @{var|authTraits|id}]))
+        """
+        matches: [
+            smithy.example#HasDigestAuth
+        ]
+    }
+]
+
+namespace smithy.example
+
+
+@httpBasicAuth
+@httpBearerAuth
+service MyService {
+    version: "2020-04-21"
+    operations: [HasDigestAuth, HasBasicAuth, NoAuth]
+}
+
+@suppress(["AuthTrait"])
+@auth([httpDigestAuth])
+operation HasDigestAuth {}
+
+@auth([httpBasicAuth])
+operation HasBasicAuth {}
+
+operation NoAuth {}


### PR DESCRIPTION
*Description of changes:*
Create self-contained compliance tests for selectors to make them safer to evolve and bugfix, and to make it possible for other implementations to just copy/paste our self-contained directory of test cases.

Most of the test cases are based on examples in the [selectors documentation](https://smithy.io/2.0/spec/selectors.html?highlight=selector#)

TODO: Create a follow-up PR for porting existing selector test cases into this format

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
