### PR TITLE
Allow core validation events to be suppressible

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelValidator.java
@@ -184,8 +184,8 @@ final class ModelValidator {
             // Perform critical validation before other more granular semantic validators.
             // If these validators fail, then many other validators will fail as well,
             // which will only obscure the root cause.
-            coreEvents.addAll(new TargetValidator().validate(model));
-            coreEvents.addAll(new ResourceCycleValidator().validate(model));
+            coreEvents.addAll(suppressEvents(model, new TargetValidator().validate(model), modelSuppressions));
+            coreEvents.addAll(suppressEvents(model, new ResourceCycleValidator().validate(model), modelSuppressions));
             // Emit any events that have already occurred.
             coreEvents.forEach(eventListener);
 
@@ -284,6 +284,13 @@ final class ModelValidator {
                 }
             }
         });
+    }
+
+    private static List<ValidationEvent> suppressEvents(
+            Model model,
+            List<ValidationEvent> events,
+            List<Suppression> suppressions) {
+        return events.stream().map(event -> suppressEvent(model, event, suppressions)).collect(Collectors.toList());
     }
 
     private static ValidationEvent suppressEvent(Model model, ValidationEvent event, List<Suppression> suppressions) {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/core-events.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/core-events.smithy
@@ -1,0 +1,22 @@
+metadata suppressions = [
+    {
+        id: "DeprecatedShape.smithy.example#MyOtherString",
+        namespace: "*",
+        reason: "shhhh"
+    }
+]
+
+namespace smithy.example
+
+structure MyStruct {
+    @suppress(["DeprecatedShape"])
+    myString: MyString
+
+    myOtherString: MyOtherString
+}
+
+@deprecated
+string MyString
+
+@deprecated
+string MyOtherString


### PR DESCRIPTION
Previously, core validation events resulted in errors, which could not be suppressed.

Now, events from the TargetValidator can result in warnings, which could be suppressed.

This PR updates the ModelValidator to check core validation events for matching suppressions with tests covering both metadata suppressions and suppressions through the `@suppress` trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
