### PR TITLE
Add smithy-utils ShellUtils

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/ShellUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/ShellUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Utility methods likely to be needed across packages.
+ */
+public final class ShellUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(ShellUtils.class.getName());
+
+    private ShellUtils() {
+    }
+
+    /**
+     * Executes a given shell command in a given directory.
+     *
+     * @param command   The string command to execute, e.g. "go fmt".
+     * @param directory The directory to run the command in.
+     * @return Returns the console output of the command.
+     */
+    public static String runCommand(String command, Path directory) {
+        String[] finalizedCommand;
+        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            finalizedCommand = new String[] {
+                    "cmd.exe",
+                    "/c",
+                    command
+            };
+        } else {
+            finalizedCommand = new String[] {
+                    "sh",
+                    "-c",
+                    command
+            };
+        }
+
+        ProcessBuilder processBuilder = new ProcessBuilder(finalizedCommand)
+                .redirectErrorStream(true)
+                .directory(directory.toFile());
+
+        try {
+            Process process = processBuilder.start();
+            List<String> output = new ArrayList<>();
+
+            // Capture output for reporting.
+            try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(
+                    process.getInputStream(), Charset.defaultCharset()))) {
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    LOGGER.finest(line);
+                    output.add(line);
+                }
+            }
+
+            process.waitFor();
+            process.destroy();
+
+            String joinedOutput = String.join(System.lineSeparator(), output);
+            if (process.exitValue() != 0) {
+                throw new RuntimeException(String.format(
+                        "Command `%s` failed with output:%n%n%s", command, joinedOutput));
+            }
+            return joinedOutput;
+        } catch (InterruptedException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add a way to run shell command through `ShellUtils.runCommand()`.

Used smithy-go `CodegenUtils.runCommand()` as a base.

https://github.com/aws/smithy-go/blob/08fe458a10dbfc9f6c544cc2cf4b8fea2e89ecb2/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java#L57-L102

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
