### PR TITLE
Fix ec2Query fractional seconds value

### DIFF
--- a/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
@@ -31,7 +31,7 @@ apply FractionalSeconds @httpResponseTests([
         headers: {
             "Content-Type": "text/xml;charset=UTF-8"
         },
-        params: { datetime: 1398796238.789 }
+        params: { datetime: 946845296.123 }
     },
     {
         id: "Ec2QueryHttpDateWithFractionalSeconds",


### PR DESCRIPTION
Fixes the ec2Query fractional seconds value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
