### PR TITLE
Fix typos for "ignore"

### DIFF
--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/CfnConfig.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/CfnConfig.java
@@ -324,7 +324,7 @@ public final class CfnConfig extends JsonSchemaConfig {
     public static CfnConfig fromNode(Node settings) {
         NodeMapper mapper = new NodeMapper();
 
-        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
+        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.IGNORE);
 
         ObjectNode node = settings.expectObjectNode();
         CfnConfig config = new CfnConfig();

--- a/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/xml-structs.smithy
@@ -639,7 +639,7 @@ structure XmlNamespacesOutput {
     nested: XmlNamespaceNested
 }
 
-// Ingored since it's not at the top-level
+// Ignored since it's not at the top-level
 @xmlNamespace(uri: "http://boo.com")
 structure XmlNamespaceNested {
     @xmlNamespace(uri: "http://baz.com", prefix: "baz")

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -622,7 +622,7 @@ structure XmlNamespacesOutput {
     nested: XmlNamespaceNested
 }
 
-// Ingored since it's not at the top-level
+// Ignored since it's not at the top-level
 @xmlNamespace(uri: "http://foo.com")
 structure XmlNamespaceNested {
     @xmlNamespace(uri: "http://baz.com", prefix: "baz")

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -1317,7 +1317,7 @@ structure XmlNamespacesInputOutput {
     nested: XmlNamespaceNested
 }
 
-// Ingored since it's not at the top-level
+// Ignored since it's not at the top-level
 @xmlNamespace(uri: "http://foo.com")
 structure XmlNamespaceNested {
     @xmlNamespace(uri: "http://baz.com", prefix: "baz")

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -114,7 +114,7 @@ public class JsonSchemaConfig {
     private boolean useIntegerType;
 
     public JsonSchemaConfig() {
-        nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
+        nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.IGNORE);
     }
 
     public boolean getAlphanumericOnlyRefs() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeMapper.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/NodeMapper.java
@@ -78,7 +78,7 @@ public final class NodeMapper {
         /**
          * Ignores unknown properties.
          */
-        INGORE {
+        IGNORE {
             public void handle(Type into, String pointer, String property, Node value) {
             }
         };

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/suppression-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/loader/suppression-test.smithy
@@ -54,7 +54,7 @@ metadata suppressions = [
 
 namespace smithy.example
 
-@suppress(["IngoreMe"])
+@suppress(["IgnoreMe"])
 service MyService {
     version: "XYZ",
     operations: [GetFoo],

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -342,7 +342,7 @@ public class OpenApiConfig extends JsonSchemaConfig {
         // warning on something intentional is just noise. It sucks
         // that this can't tell us when keys are misspelled, but it
         // does allow for a flat key-space for all extensions.
-        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
+        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.IGNORE);
 
         // Fix and remap deprecated keys to newly supported keys.
         ObjectNode node = fixDeprecatedKeys(input.expectObjectNode());

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ExampleObject.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/model/ExampleObject.java
@@ -80,7 +80,7 @@ public final class ExampleObject extends Component implements ToSmithyBuilder<Ex
             return null;
         }
         NodeMapper mapper = new NodeMapper();
-        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.INGORE);
+        mapper.setWhenMissingSetter(NodeMapper.WhenMissing.IGNORE);
         ObjectNode node = exampleObject.expectObjectNode();
         ExampleObject.Builder result = new ExampleObject.Builder();
         mapper.deserializeInto(node, result);


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Fix typos around "ignore":

- Fix typos on "Ignored" in smithy-aws-protocol-tests
- Fix typos on "IgnoreMe" in smithy-model
- Fix typos for NodeMapper.WhenMissing.IGNORE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
