### PR TITLE
fix docs for camelCase Validator default behavior

### DIFF
--- a/docs/source-2.0/guides/model-linters.rst
+++ b/docs/source-2.0/guides/model-linters.rst
@@ -87,7 +87,8 @@ CamelCase
 Validates that shape names and member names adhere to a consistent style of
 camel casing. By default, this validator will ensure that shape names use
 UpperCamelCase, trait shape names use lowerCamelCase, and that member names
-use lowerCamelCase.
+use *either* lowerCamelCase or UpperCamelCase (depending on which is currently more
+prevalent in each service closure).
 
 Rationale
     Utilizing a consistent camelCase style makes it easier to understand a
@@ -108,7 +109,7 @@ Configuration
        * - memberNames
          - ``string``
          - Specifies the camelCase style of member names. Can be set to either
-           "upper" or "lower" (the default).
+           "upper", "lower", or "auto" (the default).
 
 Example:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Default behavior for CamelCase Validator is out-of-date and should be updated to explain how member names are treated based on the current service's set of member names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
