### PR TITLE
feat: add endpoint ruleset trait validator

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidator.java
@@ -66,9 +66,7 @@ public final class EndpointRuleSetTraitValidator extends AbstractValidator {
             validateRuleSet(value);
             value.typecheck();
             return Optional.empty();
-        } catch (RuleError e) {
-            return Optional.of(error(service, trait, e.getMessage()));
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | RuleError e) {
             return Optional.of(error(service, trait, e.getMessage()));
         }
     }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidator.java
@@ -62,8 +62,9 @@ public final class EndpointRuleSetTraitValidator extends AbstractValidator {
 
     private Optional<ValidationEvent> validateService(ServiceShape service, EndpointRuleSetTrait trait) {
         try {
-            EndpointRuleSet value = EndpointRuleSet.fromNode(trait.getRuleSet());
+            EndpointRuleSet value = EndpointRuleSet.fromNode(trait.getRuleSet(), false);
             validateRuleSet(value);
+            value.typecheck();
             return Optional.empty();
         } catch (RuleError e) {
             return Optional.of(error(service, trait, e.getMessage()));

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.rulesengine.traits;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.language.error.RuleError;
+import software.amazon.smithy.rulesengine.validators.StandaloneRulesetValidator;
+import software.amazon.smithy.rulesengine.validators.ValidationError;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Validates that the Endpoints 2.0 {@link EndpointRuleSetTrait} are correct and
+ * do not match any prohibited patterns.
+ */
+@SmithyInternalApi
+public final class EndpointRuleSetTraitValidator extends AbstractValidator {
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        for (ServiceShape service : model.getServiceShapesWithTrait(EndpointRuleSetTrait.class)) {
+            validateService(service, service.expectTrait(EndpointRuleSetTrait.class)).ifPresent(events::add);
+        }
+        return events;
+    }
+
+    /**
+     * Validates an Endpoint rule set.
+     *
+     * @param ruleset Endpoint rule set to validate.
+     * @throws IllegalArgumentException if the endpoint rule set is invalid.
+     */
+    public static void validateRuleSet(EndpointRuleSet ruleset) {
+        List<ValidationError> messages = StandaloneRulesetValidator.validate(ruleset, null)
+                .collect(Collectors.toList());
+
+        if (!messages.isEmpty()) {
+            throw new IllegalArgumentException(String.format(
+                    "Invalid Endpoint rule set: %s", messages.toString()));
+        }
+    }
+
+    private Optional<ValidationEvent> validateService(ServiceShape service, EndpointRuleSetTrait trait) {
+        try {
+            EndpointRuleSet value = EndpointRuleSet.fromNode(trait.getRuleSet());
+            validateRuleSet(value);
+            return Optional.empty();
+        } catch (RuleError e) {
+            return Optional.of(error(service, trait, e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return Optional.of(error(service, trait, e.getMessage()));
+        }
+    }
+}

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/IntegrationTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/language/IntegrationTest.java
@@ -94,7 +94,7 @@ public class IntegrationTest {
     @ParameterizedTest
     @MethodSource("validTestcases")
     void checkValidRules(ValidationTestCase validationTestCase) {
-        EndpointRuleSet ruleset = EndpointRuleSet.fromNode(validationTestCase.contents());
+        EndpointRuleSet ruleset = EndpointRuleSet.fromNode(validationTestCase.contents(), false);
         List<ValidationError> errors = StandaloneRulesetValidator.validate(ruleset, null).collect(Collectors.toList());
         assertEquals(Collections.emptyList(), errors);
         ruleset.typeCheck(new Scope<>());
@@ -143,7 +143,7 @@ public class IntegrationTest {
     @ParameterizedTest
     @MethodSource("invalidStandaloneValidationTestCases")
     void checkInvalidStandaloneValidationRules(ValidationTestCase validationTestCase) throws IOException {
-        EndpointRuleSet ruleset = EndpointRuleSet.fromNode(validationTestCase.contents());
+        EndpointRuleSet ruleset = EndpointRuleSet.fromNode(validationTestCase.contents(), false);
         List<ValidationError> errors = StandaloneRulesetValidator.validate(ruleset, null)
                 .collect(Collectors.toList());
         assertFalse(errors.isEmpty());

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidatorTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidatorTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.rulesengine.traits;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidatorTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTraitValidatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.rulesengine.traits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class EndpointRuleSetTraitValidatorTest {
+    @Test
+    public void validEndpointRuleSetInModel() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("traits-test-model.smithy"))
+                .assemble()
+                .unwrap();
+
+        EndpointRuleSetTraitValidator validator = new EndpointRuleSetTraitValidator();
+        List<ValidationEvent> events = validator.validate(model);
+        assertThat(events, empty());
+    }
+
+    @Test
+    public void invalidEndpointRuleSet() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("invalid-test-model.smithy"))
+                .assemble()
+                .unwrap();
+        EndpointRuleSetTraitValidator validator = new EndpointRuleSetTraitValidator();
+        List<ValidationEvent> events = validator.validate(model);
+        assertThat(events.get(0).getMessage(),
+                containsString("Expected String but found Option<String>"));
+    }
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/invalid-test-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/invalid-test-model.smithy
@@ -1,0 +1,106 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.rules#clientContextParams
+use smithy.rules#endpointRuleSet
+
+@endpointRuleSet({
+    "version": "1.3",
+    "parameters": {
+        "Region": {
+            "builtIn": "AWS::Region",
+            "type": "String",
+            "required": true,
+            "default": "us-east-1",
+            "documentation": "The region to dispatch this request, eg. `us-east-1`."
+        },
+        "Stage": {
+            "type": "String",
+            "required": false
+        },
+        "Endpoint": {
+            "builtIn": "SDK::Endpoint",
+            "type": "String",
+            "required": false,
+            "documentation": "Override the endpoint used to send this request"
+        }
+    },
+    "rules": [
+        {
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Endpoint"
+                        }
+                    ]
+                },
+                {
+                    "fn": "parseURL",
+                    "argv": [
+                        {
+                            "ref": "Endpoint"
+                        }
+                    ],
+                    "assign": "url"
+                }
+            ],
+            "endpoint": {
+                "url": {
+                    "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        },
+        {
+            "conditions": [
+                {
+                    "fn": "stringEquals",
+                    "argv": [
+                        {
+                            "ref": "Stage"
+                        },
+                        "staging"
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://exampleservice.{Region}.staging.example.com/2023-01-01",
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Fallback to production endpoint and default region",
+            "conditions": [],
+            "endpoint": {
+                "url": "https://exampleservice.{Region}.example.com/2023-01-01",
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        }
+    ]
+})
+@clientContextParams(
+    Stage: {type: "string", documentation: "The endpoint stage used to contruct the hostname."}
+)
+service ExampleService {
+    version: "2023-01-01"
+    operations: [GetThing]
+}
+
+@readonly
+operation GetThing {
+    input: GetThingInput
+}
+
+@input
+structure GetThingInput {
+    fizz: String
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This will add a validator for the `EndpointRuleSetTrait` so that we can check the Endpoint rule sets when running Smithy build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
