### PR TITLE
Add unix install script for smithy-cli

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -187,6 +187,18 @@ runtime {
     }
 }
 
+// Add finishing touches to the distributables, such as an install script
+tasks.runtime.doLast {
+    targetPlatforms.each { targetPlatform ->
+        copy {
+            from "config"
+            include targetPlatform.value.name.contains("windows") ? "install.bat" : "install"
+            into Paths.get(
+                    "${project.buildDir}", "image", "smithy-cli-${targetPlatform.value.name}").toString()
+        }
+    }
+}
+
 tasks.register("optimize", Exec) {
     commandLine("$smithyBinary", "warmup")
 }

--- a/smithy-cli/config/README.md
+++ b/smithy-cli/config/README.md
@@ -1,0 +1,42 @@
+# Overview
+This document describes how to test and lint the ``install`` scripts used
+to install the Smithy CLI distributables.
+
+These installers get packaged with the respective distributable (`install` for linux/mac, `install.bat` for windows).
+
+## Shell installer (`install`)
+
+### Running the tests
+The test suite utilizes [`bats-core`](https://github.com/bats-core/bats-core) to run
+the tests. To run the tests, first make sure you first install `bats-core`:
+
+     $ brew install bats-core
+
+
+And then run bats-core from within this `config` directory:
+
+     $ bats .
+
+
+### Linting
+To help catch potential issues in the shell scripts, you should lint the scripts.
+To lint the shell scripts, use [`shellcheck`](https://github.com/koalaman/shellcheck).
+It can be installed with `brew`:
+
+     $ brew install shellcheck
+
+
+Then can be ran on both the ``install`` shell script and the ``install.bats``
+test file::
+
+    $ shellcheck install install.bats
+
+
+## Batch installer (`install.bat`)
+Unfortunately, it's not exactly straightforward to test batch (`.bat`) files on linux or mac.
+
+If you do find yourself on a windows machine, you can bootstrap an test installation environment
+by creating a folder, which contains `install.bat` and a dummy executable, `bin/smithy`.
+
+Running the installer will perform the installation as if you were installing the real
+distributable (which is exactly what `bats` does above).

--- a/smithy-cli/config/install
+++ b/smithy-cli/config/install
@@ -1,0 +1,133 @@
+#!/bin/sh
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+  cat 1>&2 <<EOF
+Installs the Smithy CLI
+
+USAGE:
+    install [FLAGS] [OPTIONS]
+
+FLAGS:
+    -u, --update              Updates the Smithy CLI if a different version
+                              is previously installed. By default, this script
+                              will not update the Smithy CLI if a previous
+                              installation is detected.
+
+    -h, --help                Prints help information
+
+OPTIONS:
+    -i, --install-dir <path>  The directory to install the Smithy CLI. By
+                              default, this directory is: /usr/local/smithy
+
+    -b, --bin-dir <path>      The directory to store symlinks to executables
+                              for the Smithy CLI. By default, the directory
+                              used is: /usr/local/bin
+EOF
+}
+
+parse_commandline() {
+  while test $# -gt 0
+  do
+    key="$1"
+  case "$key" in
+    -i|--install-dir)
+      PARSED_INSTALL_DIR="$2"
+      shift
+      ;;
+    -b|--bin-dir)
+      PARSED_BIN_DIR="$2"
+      shift
+      ;;
+    -u|--update)
+      PARSED_UPGRADE="yes"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      quit "Got an unexpected argument: $1"
+      ;;
+    esac
+      shift
+  done
+}
+
+set_global_vars() {
+  ROOT_INSTALL_DIR=${PARSED_INSTALL_DIR:-/usr/local/smithy}
+  BIN_DIR=${PARSED_BIN_DIR:-/usr/local/bin}
+  UPGRADE=${PARSED_UPGRADE:-no}
+
+  EXE_NAME="smithy"
+  INSTALLER_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+  INSTALLER_EXE="$INSTALLER_DIR/bin/$EXE_NAME"
+  SMITHY_VERSION=$($INSTALLER_EXE --version)
+
+  INSTALL_DIR="$ROOT_INSTALL_DIR/$SMITHY_VERSION"
+#  INSTALL_DIR="$INSTALL_DIR"
+
+  CURRENT_INSTALL_DIR="$ROOT_INSTALL_DIR/current"
+  CURRENT_SMITHY_EXE="$CURRENT_INSTALL_DIR/bin/$EXE_NAME"
+
+  BIN_SMITHY_EXE="$BIN_DIR/$EXE_NAME"
+}
+
+create_install_dir() {
+  echo "Installing Smithy CLI to '$INSTALL_DIR'..."
+  mkdir -p "$INSTALL_DIR" || exit 1
+  {
+    cp -R "$INSTALLER_DIR/" "$INSTALL_DIR" &&
+    ln -snf "$INSTALL_DIR" "$CURRENT_INSTALL_DIR"
+  } || {
+    rm -rf "$INSTALL_DIR"
+    exit 1
+  }
+}
+
+check_preexisting_install() {
+    echo "Checking for existing installations of Smithy CLI..."
+  if [ -L "$CURRENT_INSTALL_DIR" ] && [ "$UPGRADE" = "no" ]
+  then
+    quit "Found preexisting Smithy CLI installation: $CURRENT_INSTALL_DIR. Please rerun install script with --update flag."
+  fi
+  if [ -d "$INSTALL_DIR" ]
+  then
+    echo "Found same Smithy CLI version: $INSTALL_DIR. Skipping install."
+    exit 0
+  fi
+}
+
+create_bin_symlinks() {
+  echo "Setting up links..."
+  mkdir -p "$BIN_DIR"
+  ln -sf "$CURRENT_SMITHY_EXE" "$BIN_SMITHY_EXE"
+}
+
+quit() {
+  err_msg="$1"
+  echo "$err_msg" >&2
+  exit 1
+}
+
+main() {
+  parse_commandline "$@"
+  set_global_vars
+  check_preexisting_install
+  create_install_dir
+  create_bin_symlinks
+  $BIN_SMITHY_EXE warmup
+  echo "You can now run: '$BIN_SMITHY_EXE --version' or '$EXE_NAME --version'"
+  case :$PATH: in
+    *:$BIN_DIR:*)
+    ;;
+    *)
+      echo "$BIN_DIR not detected in \$PATH, you will be unable to use '$EXE_NAME --version'"
+    ;;
+  esac
+  exit 0
+}
+
+main "$@"

--- a/smithy-cli/config/install.bat
+++ b/smithy-cli/config/install.bat
@@ -1,0 +1,60 @@
+@echo off
+
+:: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+:: SPDX-License-Identifier: Apache-2.0
+
+set exe_name=smithy
+set installer_path=%~dp0
+set installer_drive=%~d0
+set installer_exe=%installer_path%bin\%exe_name%
+set install_path=%installer_drive%\Program Files\Smithy
+
+
+:: Set the installation path
+set choice_path=%install_path%
+set /p choice_path=Install path [%install_path%]: 
+echo Installing Smithy to %choice_path%...
+
+
+echo Checking for existing installation...
+if exist "%choice_path%" goto upgrade
+
+
+:start
+:: Create a wrapper bat
+(
+  echo @echo off
+  echo "%choice_path%\bin\smithy" %%*
+) > "%installer_path%\%exe_name%.bat" 
+
+:: Copy the installation
+xcopy /i /h /e "%installer_path%\*" "%choice_path%\"
+setx path "%path%;%choice_path%\;"
+call %exe_name% warmup
+echo You may now run '%exe_name% --version'
+goto done
+
+
+:: Check if upgrade is desired
+:upgrade
+echo Existing Smithy installation found...
+set choice_upgrade=''
+set /p choice_upgrade=Upgrade Smithy? [y/n]:
+if '%choice_upgrade%'=='y' goto yes
+if '%choice_upgrade%'=='n' goto no
+echo "%choice_upgrade%" is not valid
+goto upgrade
+
+
+:no
+echo Not upgrading Smithy...
+goto done
+
+:yes
+echo Upgrading Smithy...
+rmdir "%choice_path%" /s /q
+goto start
+
+:done
+pause
+exit

--- a/smithy-cli/config/install.bats
+++ b/smithy-cli/config/install.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+setup() {
+  EXE_BUNDLE_DIR="$BATS_TMPDIR/smithy-image"
+  EXE_NAME="smithy"
+  SMITHY_EXE_VERSION="1.0.0"
+  new_exe_bundle "$SMITHY_EXE_VERSION"
+  INSTALL_DIR="$BATS_TMPDIR/smithy"
+  BIN_DIR="$BATS_TMPDIR/bin"
+  BIN_EXE="$BIN_DIR/$EXE_NAME"
+  PREV_PATH=$PATH
+  PATH=$PATH:$BIN_DIR
+}
+
+teardown() {
+  clear_preexisting_bundle
+  rm -rf "$INSTALL_DIR"
+  rm -rf "$BIN_DIR"
+}
+
+new_exe_bundle() {
+  smithy_version="$1"
+  clear_preexisting_bundle
+  mkdir -p "$EXE_BUNDLE_DIR/bin"
+  cp "${BATS_TEST_DIRNAME}/install" "$EXE_BUNDLE_DIR"
+  create_exes "$smithy_version"
+}
+
+clear_preexisting_bundle() {
+  [ -d "$EXE_BUNDLE_DIR" ] || rm -rf "$EXE_BUNDLE_DIR"
+}
+
+create_exes() {
+  smithy_version="$1"
+  smithy_exe="$EXE_BUNDLE_DIR/bin/$EXE_NAME"
+
+  echo "echo $smithy_version" > "$smithy_exe"
+  chmod +x "$smithy_exe"
+}
+
+run_install() {
+  run "$EXE_BUNDLE_DIR/install" "$@"
+}
+
+assert_expected_installation() {
+  expected_installed_version="$1"
+  expected_current_dir="$INSTALL_DIR/current"
+  expected_install_dir="$INSTALL_DIR/$expected_installed_version"
+
+  # Assert that the installation of the installed version is correct
+  [ -d "$expected_install_dir" ]
+
+  # Assert that current points to the expected installed version
+  readlink "$expected_current_dir"
+  assert_expected_symlink "$expected_current_dir" "$expected_install_dir"
+
+  # Assert the bin symlinks are correct
+  assert_expected_symlink "$BIN_EXE" "$expected_current_dir/bin/smithy"
+
+  # Assert the executable works with the expected output
+  [ "$("$BIN_EXE" --version)" = "$expected_installed_version" ]
+}
+
+assert_expected_symlink() {
+  expected_symlink="$1"
+  expected_target="$2"
+  [ -L "$expected_symlink" ]
+  [ "$(readlink "$expected_symlink")" = "$expected_target" ]
+}
+
+@test "-h prints help" {
+  run_install -h
+  [[ "$output" = *"USAGE"* ]]
+}
+
+@test "--help prints help" {
+  run_install -h
+  [[ "$output" = *"USAGE"* ]]
+}
+
+@test "with unexpected arguments" {
+  run_install --unexpected
+  [ "$status" -eq 1 ]
+  [[ "$output" = *"unexpected argument"* ]]
+}
+
+@test "install" {
+  run_install --install-dir "$INSTALL_DIR" --bin-dir "$BIN_DIR"
+  [ "$status" -eq 0 ]
+  echo $output
+  [[ "$output" == *"You can now run: '$BIN_EXE --version' or '$EXE_NAME --version'"* ]]
+  echo $output
+  assert_expected_installation "$SMITHY_EXE_VERSION"
+}
+
+@test "using shorthand parameters" {
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"You can now run: '$BIN_EXE --version' or '$EXE_NAME --version'"* ]]
+  assert_expected_installation "$SMITHY_EXE_VERSION"
+}
+
+@test "fails when detects preexisting installation" {
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 0 ]
+
+  new_exe_bundle "new-version"
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" = *"Found preexisting"* ]]
+}
+
+@test "--updates updates to new version" {
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 0 ]
+
+  new_exe_bundle "new-version"
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR" --update
+  [ "$status" -eq 0 ]
+  assert_expected_installation "new-version"
+}
+
+@test "-u updates to new version" {
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 0 ]
+
+  new_exe_bundle "new-version"
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR" -u
+  [ "$status" -eq 0 ]
+  assert_expected_installation "new-version"
+}
+
+@test "--update skips for same version" {
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 0 ]
+
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR" -u
+  [ "$status" -eq 0 ]
+  [[ "$output" = *"Found same Smithy CLI version"* ]]
+  assert_expected_installation "$SMITHY_EXE_VERSION"
+}
+
+@test "detects PATH missing BIN_DIR" {
+  PATH=$PREV_PATH
+  run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not detected in \$PATH"* ]]
+  assert_expected_installation "$SMITHY_EXE_VERSION"
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds install scripts to be used to install the smithy-cli distributable (and is included within it)


*Testing*
- Build the smithy-cli distributables via `gradlew :smithy-cli:runtime`, and navigate to the respective image for your machine (`smithy-cli/build/image/smithy-cli-<platfrm>/`)

For the shell script, you can:
- Run the install script via `sudo ./install`
- Optionally, you may configure a custom install and bin directory to use instead of the defaults.
- Run the `bats` tests, according to the README instructions (added in this PR)

For the batch script, you can:
- Generate the windows runtime, `./gradlew :smithy-cli:runtime`, and download it to a windows environment
- Run install.bat as administrator
- Or, you can do a mock installation according to the steps in the README



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.