### PR TITLE
Fix typo in example of codegen plugin name

### DIFF
--- a/docs/source-2.0/guides/building-codegen/configuring-the-generator.rst
+++ b/docs/source-2.0/guides/building-codegen/configuring-the-generator.rst
@@ -38,8 +38,8 @@ Smithy code generation plugins should use a naming pattern of
 
 Examples:
 
-* ``foo-service-codegen``: generate a hypothetical Foo language service
 * ``foo-client-codegen``: generate a hypothetical Foo language client
+* ``foo-server-codegen``: generate a hypothetical Foo language server
 
 
 Recommended properties


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
