### PR TITLE
Skip enum members when looking for potentially sensitive shapes/data

### DIFF
--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingSensitiveTraitValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingSensitiveTraitValidator.java
@@ -143,7 +143,9 @@ public final class MissingSensitiveTraitValidator extends AbstractValidator {
                 Shape containingShape = model.expectShape(memberShape.getContainer());
                 Shape targetShape = model.expectShape(memberShape.getTarget());
 
-                if (!containingShape.hasTrait(SensitiveTrait.class) && !targetShape.hasTrait(SensitiveTrait.class)) {
+                if (!containingShape.hasTrait(SensitiveTrait.class)
+                        && !containingShape.isEnumShape()
+                        && !targetShape.hasTrait(SensitiveTrait.class)) {
                     Optional<ValidationEvent> optionalValidationEvent =
                             detectSensitiveTerms(memberShape.getMemberName(), memberShape);
                     optionalValidationEvent.ifPresent(validationEvents::add);

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/missing-sensitive-trait-defaults.smithy
@@ -41,7 +41,8 @@ structure BillingAddress {
     safeBank: MySensitiveString,
     // should get flagged
     firstName: FirstName,
-    lastName: LastName
+    lastName: LastName,
+    someEnum: MyEnum
 }
 
 @sensitive
@@ -51,6 +52,11 @@ structure SafeBillingAddress {
     safeBank: MySensitiveString,
     firstName: MyString,
     lastName: MySensitiveString
+}
+
+enum MyEnum {
+    // should not be flagged
+    IP_ADDRESS
 }
 
 string MyString


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enum members do not need to be marked sensitive, so we can exclude them from this validator.
Ex: 
https://github.com/awslabs/smithy/blob/30201cb49e9017d4ef7e3622d3e46aec12a0c60e/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json#L211


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
