### PR TITLE
Adding IAM Action name trait to override using the API operation name

### DIFF
--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -392,6 +392,45 @@ deviates from the :ref:`shape name of the shape ID <shape-id>` of the resource.
         }
     }
 
+.. smithy-trait:: aws.iam#actionName
+.. _aws.iam#actionName-trait:
+
+-------------------------------
+``aws.iam#actionName`` trait
+-------------------------------
+
+Summary
+    Provides the ability to override the default action name for the operation. By convention, the action name is the same as the operation name.
+Trait selector
+    ``:test(operation)``
+Value type
+    ``string``
+
+Operations not annotated with the ``actionName`` trait use the operation name as the action name.
+
+The following example defines two operations:
+
+* OperationA is not annoated with the ``actionName`` trait, so has the action name ``OperationA`` which is the same as the operation name.
+* OperationB has the ``actionName`` trait, so has the action name ``OverridingActionName``.
+
+.. code-block:: smithy
+
+    $version: "2"
+
+    namespace smithy.example
+
+    use aws.iam#actionName
+
+    service MyService {
+        version: "2020-07-02"
+        operations: [OperationA, OperationB]
+    }
+
+    operation OperationA {}
+
+    @actionName("OverridingActionName")
+    operation OperationB {}
+
 
 .. _deriving-condition-keys:
 

--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -395,9 +395,9 @@ deviates from the :ref:`shape name of the shape ID <shape-id>` of the resource.
 .. smithy-trait:: aws.iam#actionName
 .. _aws.iam#actionName-trait:
 
--------------------------------
+----------------------------
 ``aws.iam#actionName`` trait
--------------------------------
+----------------------------
 
 Summary
     Provides a custom IAM action name.

--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -411,8 +411,10 @@ Operations not annotated with the ``actionName`` trait, default to the
 
 The following example defines two operations:
 
-* ``OperationA`` is not annotated with the ``actionName`` trait, and resolves the action name of ``OperationA``.
-* ``OperationB`` has the ``actionName`` trait, so has the action name ``OverridingActionName``.
+* ``OperationA`` is not annotated with the ``actionName`` trait, and
+  resolves the action name of ``OperationA``.
+* ``OperationB`` has the ``actionName`` trait, so has the action
+  name ``OverridingActionName``.
 
 .. code-block:: smithy
 

--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -400,18 +400,19 @@ deviates from the :ref:`shape name of the shape ID <shape-id>` of the resource.
 -------------------------------
 
 Summary
-    Provides the ability to override the default action name for the operation. By convention, the action name is the same as the operation name.
+    Provides a custom IAM action name.
 Trait selector
-    ``:test(operation)``
+    ``operation``
 Value type
     ``string``
 
-Operations not annotated with the ``actionName`` trait use the operation name as the action name.
+Operations not annotated with the ``actionName`` trait, default to the
+:ref:`shape name of the shape ID <shape-id>` of the targeted operation.
 
 The following example defines two operations:
 
-* OperationA is not annoated with the ``actionName`` trait, so has the action name ``OperationA`` which is the same as the operation name.
-* OperationB has the ``actionName`` trait, so has the action name ``OverridingActionName``.
+* ``OperationA`` is not annotated with the ``actionName`` trait, and resolves the action name of ``OperationA``.
+* ``OperationB`` has the ``actionName`` trait, so has the action name ``OverridingActionName``.
 
 .. code-block:: smithy
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionNameTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionNameTrait.java
@@ -1,16 +1,6 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package software.amazon.smithy.aws.iam.traits;

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionNameTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionNameTrait.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.iam.traits;
+
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.StringTrait;
+
+public final class ActionNameTrait extends StringTrait {
+
+    public static final ShapeId ID = ShapeId.from("aws.iam#actionName");
+
+    private ActionNameTrait(String action) {
+        super(ID, action, SourceLocation.NONE);
+    }
+
+    private ActionNameTrait(String action, FromSourceLocation sourceLocation) {
+        super(ID, action, sourceLocation);
+    }
+
+    public static final class Provider extends StringTrait.Provider<ActionNameTrait> {
+        public Provider() {
+            super(ID, ActionNameTrait::new);
+        }
+    }
+}

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -5,3 +5,4 @@ software.amazon.smithy.aws.iam.traits.DisableConditionKeyInferenceTrait$Provider
 software.amazon.smithy.aws.iam.traits.RequiredActionsTrait$Provider
 software.amazon.smithy.aws.iam.traits.SupportedPrincipalTypesTrait$Provider
 software.amazon.smithy.aws.iam.traits.IamResourceTrait$Provider
+software.amazon.smithy.aws.iam.traits.ActionNameTrait$Provider

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
@@ -274,7 +274,7 @@
                 "smithy.api#trait": {
                     "selector": "operation"
                 },
-                "smithy.api#documentation": "Provides the ability to override the default action name for the operation. By convention, the action name is the same as the operation name."
+                "smithy.api#documentation": "Provides a custom IAM action name. By default, the action name is the same as the operation name."
             }
         }
     }

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
@@ -264,6 +264,18 @@
                 "smithy.api#private": {},
                 "smithy.api#documentation": "An IAM policy principal type."
             }
+        },
+        "aws.iam#actionName": {
+            "type": "string",
+            "member": {
+                "target": "aws.iam#IamIdentifier"
+            },
+            "traits": {
+                "smithy.api#trait": {
+                    "selector": "operation"
+                },
+                "smithy.api#documentation": "Provides the ability to override the default action name for the operation. By convention, the action name is the same as the operation name."
+            }
         }
     }
 }

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ActionNameTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ActionNameTraitTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.iam.traits;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ActionNameTraitTest {
+    @Test
+    public void loadsFromModel() {
+        Model result = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("actionname-override.smithy"))
+                .assemble()
+                .unwrap();
+
+        Shape shape = result.expectShape(ShapeId.from("smithy.example#Echo"));
+        ActionNameTrait trait = shape.expectTrait(ActionNameTrait.class);
+        assertThat(trait.getValue(), equalTo("overridingActionName"));
+    }
+}

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ActionNameTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ActionNameTraitTest.java
@@ -1,16 +1,6 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package software.amazon.smithy.aws.iam.traits;

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/actionname-override.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/actionname-override.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+namespace smithy.example
+
+@aws.iam#actionName("overridingActionName")
+operation Echo {}
+
+operation GetResource2 {
+    input: GetResource2Input
+}
+
+structure GetResource2Input {
+    id1: String,
+
+    @required
+    id2: String
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds the ActionName trait to override using the API operation name as the IAM action name. Also, allows adding additional actions using the input member field if the value is not null in the request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
