### PR TITLE
Fix mixins in style guide

### DIFF
--- a/docs/source-2.0/guides/style-guide.rst
+++ b/docs/source-2.0/guides/style-guide.rst
@@ -45,16 +45,16 @@ Smithy models SHOULD resemble the following example:
     structure MyMixin {}
 
     // When using a single mixin, place "with" and the shape on the same line
-    structure UsesMixin with MyMixin {
+    structure UsesMixin with [MyMixin] {
         foo: String
     }
 
     // When using multiple mixins, place each shape ID on its own line,
     // followed by a line that contains the opening brace.
-    structure UsesMixin with
+    structure UsesMixin with [
         MyMixin
         SomeOtherMixin
-    {
+    ] {
         foo: String
     }
 


### PR DESCRIPTION
Adds missing braces to style guide for mixin examples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
