### PR TITLE
Add GenerateOperationDirective

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -38,6 +38,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -476,6 +477,14 @@ public final class CodegenDirector<
             LOGGER.finest(() -> "Generating resource " + shape.getId());
             directedCodegen.generateResource(
                     new GenerateResourceDirective<>(context, serviceShape, shape));
+            return null;
+        }
+
+        @Override
+        public Void operationShape(OperationShape shape) {
+            LOGGER.finest(() -> "Generating operation " + shape.getId());
+            directedCodegen.generateOperation(
+                new GenerateOperationDirective<>(context, serviceShape, shape));
             return null;
         }
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java
@@ -67,6 +67,15 @@ public interface DirectedCodegen<C extends CodegenContext<S, ?, I>, S, I extends
     }
 
     /**
+     * Generates the code needed for an operation shape.
+     *
+     * @param directive Directive to perform.
+     */
+    default void generateOperation(GenerateOperationDirective<C, S> directive) {
+        // Does nothing by default.
+    }
+
+    /**
      * Generates the code needed for a structure shape.
      *
      * <p>This method should not be invoked for structures marked with the

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateOperationDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateOperationDirective.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.codegen.core.directed;
+
+import software.amazon.smithy.codegen.core.CodegenContext;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+
+/**
+ * Directive used to generate an operation.
+ *
+ * @param <C> CodegenContext type.
+ * @param <S> Codegen settings type.
+ * @see DirectedCodegen#generateOperation
+ */
+public class GenerateOperationDirective<C extends CodegenContext<S, ?, ?>, S>
+    extends ShapeDirective<OperationShape, C, S> {
+    GenerateOperationDirective(C context, ServiceShape service, OperationShape shape) {
+        super(context, service, shape);
+    }
+}
+

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -72,6 +72,11 @@ public class CodegenDirectorTest {
         }
 
         @Override
+        public void generateOperation(GenerateOperationDirective<TestContext, TestSettings> directive) {
+            generatedShapes.add(directive.shape().getId());
+        }
+
+        @Override
         public void generateStructure(GenerateStructureDirective<TestContext, TestSettings> directive) {
             generatedShapes.add(directive.shape().getId());
         }
@@ -177,7 +182,8 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#Status"),
                 ShapeId.from("smithy.example#FaceCard"),
                 ShapeId.from("smithy.example#Instruction"),
-                ShapeId.from("smithy.api#Unit")
+                ShapeId.from("smithy.api#Unit"),
+                ShapeId.from("smithy.example#ListFoo")
         ));
 
         assertThat(testDirected.generatedStringTypeEnums, containsInAnyOrder(
@@ -218,7 +224,8 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#Status"),
                 ShapeId.from("smithy.example#FaceCard"),
                 ShapeId.from("smithy.example#Instruction"),
-                ShapeId.from("smithy.api#Unit")
+                ShapeId.from("smithy.api#Unit"),
+                ShapeId.from("smithy.example#ListFoo")
         ));
 
         assertThat(testDirected.generatedEnumTypeEnums, containsInAnyOrder(
@@ -258,6 +265,7 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#RecursiveA"),
                 ShapeId.from("smithy.example#RecursiveB"),
                 ShapeId.from("smithy.example#FooOperationInput"),
+                ShapeId.from("smithy.example#FooOperation"),
                 ShapeId.from("smithy.example#Foo")
         ));
     }
@@ -288,6 +296,7 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#B"),
                 ShapeId.from("smithy.example#C"),
                 ShapeId.from("smithy.example#D"),
+                ShapeId.from("smithy.example#FooOperation"),
                 ShapeId.from("smithy.example#FooOperationInput"),
                 ShapeId.from("smithy.example#FooOperationOutput"),
                 ShapeId.from("smithy.example#RecursiveA"),
@@ -318,6 +327,7 @@ public class CodegenDirectorTest {
         runner.run();
 
         assertThat(testDirected.generatedShapes, contains(
+                ShapeId.from("smithy.example#FooOperation"),
                 ShapeId.from("smithy.example#FooOperationOutput"),
                 ShapeId.from("smithy.example#A"),
                 ShapeId.from("smithy.example#B"),


### PR DESCRIPTION
*Description of changes:*
- Adds an optional (directive defaults to no action) directive to generate operation shapes separate from resources and services

There are use cases where the operation shapes need to be generated separately from the Resource/Service shapes. For example in an SSDKs generator where you might generate an abstract class per operation or in a UML generator where the operation would be generated separately and linked to a service only via a relationship.

In most cases this will go unused, which is why it is set to default to do nothing. However, it would be a nice functionality to provide to users so they can cleanly generate operations separate from Resources or Services when required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
