### PR TITLE
Directed codegen builder

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -85,17 +85,16 @@ public final class CodegenDirector<
     }
 
     private CodegenDirector(Builder<W, I, C, S> builder) {
-        System.out.println("BuILDER " +  builder);
-        System.out.println("VALUE " +  builder.integrationClass);
-        integrationClass = SmithyBuilder.requiredState("integrationClass", builder.integrationClass);
-        service = SmithyBuilder.requiredState("service", builder.service);
-        model = SmithyBuilder.requiredState("model", builder.model);
-        settings = SmithyBuilder.requiredState("settings", builder.settings);
-        fileManifest = SmithyBuilder.requiredState("fileManifest", builder.fileManifest);
-        directedCodegen = SmithyBuilder.requiredState("directedCodegen", builder.directedCodegen);
-        shapeGenerationOrder = SmithyBuilder.requiredState("shapeGenerationOrder", builder.shapeGenerationOrder);
+        integrationClass = builder.integrationClass;
+        service = builder.service;
+        model = builder.model;
+        settings = builder.settings;
+        fileManifest = builder.fileManifest;
+        directedCodegen = builder.directedCodegen;
+        shapeGenerationOrder = builder.shapeGenerationOrder;
         integrationFinder = builder.integrationFinder;
         transforms.addAll(builder.transforms);
+        validateState();
     }
 
 
@@ -224,12 +223,11 @@ public final class CodegenDirector<
      * Set to true to apply {@link CodegenDirector#simplifyModelForServiceCodegen}
      * prior to code generation.
      */
-    public CodegenDirector<W, I, C, S> performDefaultCodegenTransforms() {
+    public void performDefaultCodegenTransforms() {
         transforms.add((model, transformer) -> {
             LOGGER.finest("Performing default codegen model transforms for directed codegen");
             return simplifyModelForServiceCodegen(model, Objects.requireNonNull(service), transformer);
         });
-        return this;
     }
 
     /**
@@ -242,9 +240,8 @@ public final class CodegenDirector<
      *
      * @see ModelTransformer#createDedicatedInputAndOutput(Model, String, String)
      */
-    public CodegenDirector<W, I, C, S> createDedicatedInputsAndOutputs() {
+    public void createDedicatedInputsAndOutputs() {
         createDedicatedInputsAndOutputs("Input", "Output");
-        return this;
     }
 
     /**
@@ -269,12 +266,11 @@ public final class CodegenDirector<
      * @param synthesizeEnumNames Whether enums without names should have names synthesized if possible.
      * @see ModelTransformer#changeStringEnumsToEnumShapes(Model, boolean)
      */
-    public CodegenDirector<W, I, C, S> changeStringEnumsToEnumShapes(boolean synthesizeEnumNames) {
+    public void changeStringEnumsToEnumShapes(boolean synthesizeEnumNames) {
         transforms.add((model, transformer) -> {
             LOGGER.finest("Creating dedicated input and output shapes for directed codegen");
             return transformer.changeStringEnumsToEnumShapes(model, synthesizeEnumNames);
         });
-        return this;
     }
 
     /**
@@ -297,12 +293,11 @@ public final class CodegenDirector<
      * Once this is performed, there's no need to ever explicitly sort members
      * throughout the rest of code generation.
      */
-    public CodegenDirector<W, I, C, S> sortMembers() {
+    public void sortMembers() {
         transforms.add((model, transformer) -> {
             LOGGER.finest("Sorting model members for directed codegen");
             return transformer.sortMembers(model, Shape::compareTo);
         });
-        return this;
     }
 
     /**
@@ -498,6 +493,14 @@ public final class CodegenDirector<
         return new Builder<>();
     }
 
+    /**
+     * Builder used to create a {@link CodegenDirector}.
+     *
+     * @param <W> Type of {@link SymbolWriter} used to generate code.
+     * @param <I> Type of {@link SmithyIntegration} to apply.
+     * @param <C> Type of {@link CodegenContext} to create and use.
+     * @param <S> Type of settings object to pass to directed methods.
+     */
     public static final class Builder<
         W extends SymbolWriter<W, ? extends ImportContainer>,
         I extends SmithyIntegration<S, W, C>,

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -354,8 +354,8 @@ public class CodegenDirectorTest {
             .shapeGenerationOrder(ShapeGenerationOrder.NONE)
             .build();
 
-        runner.performDefaultCodegenTransforms()
-            .run();
+        runner.performDefaultCodegenTransforms();
+        runner.run();
 
         assertThat(testDirected.generatedShapes, contains(
             ShapeId.from("smithy.example#FooOperationOutput"),

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.empty;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sun.tools.javac.jvm.Code;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.FileManifest;
@@ -36,7 +35,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.SmithyBuilder;
 
 public class CodegenDirectorTest {
 

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -347,7 +347,6 @@ public class CodegenDirectorTest {
             CodegenDirector.<TestWriter, TestIntegration, TestContext, TestSettings>builder()
             .settings(new TestSettings())
             .directedCodegen(testDirected)
-            .directedCodegen(testDirected)
             .fileManifest(manifest)
             .service(ShapeId.from("smithy.example#Foo"))
             .model(model)


### PR DESCRIPTION
**Description of changes:**
Adds a static builder class for the CodeGen Director

**Usage**
Usage is shown in the unit test added for this PR and duplicated here for clarity: 

```java 
CodegenDirector<TestWriter, TestIntegration, TestContext, TestSettings> runner =
            CodegenDirector.<TestWriter, TestIntegration, TestContext, TestSettings>builder()
            .settings(new TestSettings())
            .directedCodegen(testDirected)
            .fileManifest(manifest)
            .service(ShapeId.from("smithy.example#Foo"))
            .model(model)
            .integrationClass(TestIntegration.class)
            .shapeGenerationOrder(ShapeGenerationOrder.NONE)
            .build();
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
