### PR TITLE
Fix allowUnknownTraits for projection with import

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -70,23 +70,7 @@ public final class SmithyBuild {
      * @return Returns the created {@code SmithyBuild} object.
      */
     public static SmithyBuild create(ClassLoader classLoader) {
-        return create(classLoader, false);
-    }
-
-    /**
-     * Creates a {@code SmithyBuild} implementation that is configured to
-     * discover various Smithy service providers using the given
-     * {@code ClassLoader}.
-     *
-     * @param classLoader ClassLoader used to discover service providers.
-     * @param allowUnknownTraits Set to true to allow unknown traits.
-     * @return Returns the created {@code SmithyBuild} object.
-     */
-    public static SmithyBuild create(ClassLoader classLoader, boolean allowUnknownTraits) {
         ModelAssembler assembler = Model.assembler(classLoader);
-        if (allowUnknownTraits) {
-            assembler.putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
-        }
         return create(classLoader, assembler::copy);
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -70,7 +70,23 @@ public final class SmithyBuild {
      * @return Returns the created {@code SmithyBuild} object.
      */
     public static SmithyBuild create(ClassLoader classLoader) {
+        return create(classLoader, false);
+    }
+
+    /**
+     * Creates a {@code SmithyBuild} implementation that is configured to
+     * discover various Smithy service providers using the given
+     * {@code ClassLoader}.
+     *
+     * @param classLoader ClassLoader used to discover service providers.
+     * @param allowUnknownTraits Set to true to allow unknown traits.
+     * @return Returns the created {@code SmithyBuild} object.
+     */
+    public static SmithyBuild create(ClassLoader classLoader, boolean allowUnknownTraits) {
         ModelAssembler assembler = Model.assembler(classLoader);
+        if (allowUnknownTraits) {
+            assembler.putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
+        }
         return create(classLoader, assembler::copy);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -102,7 +102,7 @@ final class BuildCommand extends ClasspathCommand {
         // Configure whether the build is quiet or not based on the --quiet option.
         Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), standardOptions.quiet(), config);
 
-        SmithyBuild smithyBuild = SmithyBuild.create(classLoader)
+        SmithyBuild smithyBuild = SmithyBuild.create(classLoader, buildOptions.allowUnknownTraits())
                 .config(config)
                 .model(model);
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.ProjectionResult;
 import software.amazon.smithy.build.SmithyBuild;
@@ -40,6 +41,7 @@ import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.validation.Severity;
 
 final class BuildCommand extends ClasspathCommand {
@@ -102,7 +104,14 @@ final class BuildCommand extends ClasspathCommand {
         // Configure whether the build is quiet or not based on the --quiet option.
         Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), standardOptions.quiet(), config);
 
-        SmithyBuild smithyBuild = SmithyBuild.create(classLoader, buildOptions.allowUnknownTraits())
+        Supplier<ModelAssembler> modelAssemblerSupplier = () -> {
+            ModelAssembler assembler = Model.assembler(classLoader);
+            if (buildOptions.allowUnknownTraits()) {
+                assembler.putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
+            }
+            return assembler;
+        };
+        SmithyBuild smithyBuild = SmithyBuild.create(classLoader, modelAssemblerSupplier)
                 .config(config)
                 .model(model);
 

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
@@ -53,6 +53,16 @@ public class BuildCommandTest {
     }
 
     @Test
+    public void allowsUnknownTraitWithFlag() throws Exception {
+        String model = Paths.get(getClass().getResource("unknown-trait.smithy").toURI()).toString();
+        CliUtils.Result result = CliUtils.runSmithy("build", "--allow-unknown-traits", model);
+
+        assertThat(result.code(), equalTo(0));
+        assertThat(result.stderr(), containsString("Completed projection source"));
+        assertThat(result.stderr(), containsString("Smithy built "));
+    }
+
+    @Test
     public void printsSuccessfulProjections() throws Exception {
         String model = Paths.get(getClass().getResource("valid-model.smithy").toURI()).toString();
         CliUtils.Result result = CliUtils.runSmithy("build", model);
@@ -72,6 +82,26 @@ public class BuildCommandTest {
         assertThat(result.stderr(), containsString("ResourceLifecycle"));
         assertThat(result.stderr(),
                    containsString("The following 1 Smithy build projection(s) failed: [exampleProjection]"));
+    }
+
+    @Test
+    public void projectionUnknownTraitsAreDisallowed() throws Exception {
+        String config = Paths.get(getClass().getResource("projection-model-import.json").toURI()).toString();
+        CliUtils.Result result = CliUtils.runSmithy("build", "--config", config);
+
+        assertThat(result.code(), not(0));
+        assertThat(result.stderr(), containsString("Unable to resolve trait `some.unknown#trait`"));
+        assertThat(result.stderr(), containsString("Smithy build projection(s) failed: [exampleProjection]\n"));
+    }
+
+    @Test
+    public void projectionUnknownTraitsAreAllowedWithFlag() throws Exception {
+        String config = Paths.get(getClass().getResource("projection-model-import.json").toURI()).toString();
+        CliUtils.Result result = CliUtils.runSmithy("build", "--allow-unknown-traits",  "--config", config);
+
+        assertThat(result.code(), equalTo(0));
+        assertThat(result.stderr(), containsString("Completed projection exampleProjection"));
+        assertThat(result.stderr(), containsString("Smithy built "));
     }
 
     @Test

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/projection-model-import.json
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/projection-model-import.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "projections": {
+    "exampleProjection": {
+      "imports": ["unknown-trait.smithy"]
+    }
+  }
+}


### PR DESCRIPTION
Previously if SmithyBuild had a projection that imported a model that had an unknown trait, the allowUnknownTraits option wasn't allowing it.

Added BuildCommand unit tests to show the broken behavior and fix working. Previously, the test case `projectionUnknownTraitsAreAllowedWithFlag` did not work without the code changes in this PR. Note, the test case `allowsUnknownTraitWithFlag` (not using import) worked even before this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
