### PR TITLE
Fix cp-R for linux, xcopy for windows in installers

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -159,10 +159,10 @@ runtime {
         // startup script is significantly slower than what was used by the plugin.
         unixScriptTemplate = file('config/unixStartScript.txt')
         jvmArgs = [
-                // Disable this when attempting to profile the CLI. In 99% of use cases this isn't not necessary.
-                '-XX:-UsePerfData',
-                '-Xshare:auto',
-                '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
+            // Disable this when attempting to profile the CLI. In 99% of use cases this isn't not necessary.
+            '-XX:-UsePerfData',
+            '-Xshare:auto',
+            '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
         ]
     }
 

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -159,10 +159,10 @@ runtime {
         // startup script is significantly slower than what was used by the plugin.
         unixScriptTemplate = file('config/unixStartScript.txt')
         jvmArgs = [
-            // Disable this when attempting to profile the CLI. In 99% of use cases this isn't not necessary.
-            '-XX:-UsePerfData',
-            '-Xshare:auto',
-            '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
+                // Disable this when attempting to profile the CLI. In 99% of use cases this isn't not necessary.
+                '-XX:-UsePerfData',
+                '-Xshare:auto',
+                '-XX:SharedArchiveFile={{BIN_DIR}}/../lib/smithy.jsa'
         ]
     }
 

--- a/smithy-cli/config/install
+++ b/smithy-cli/config/install
@@ -67,7 +67,6 @@ set_global_vars() {
   SMITHY_VERSION=$($INSTALLER_EXE --version)
 
   INSTALL_DIR="$ROOT_INSTALL_DIR/$SMITHY_VERSION"
-#  INSTALL_DIR="$INSTALL_DIR"
 
   CURRENT_INSTALL_DIR="$ROOT_INSTALL_DIR/current"
   CURRENT_SMITHY_EXE="$CURRENT_INSTALL_DIR/bin/$EXE_NAME"
@@ -79,7 +78,7 @@ create_install_dir() {
   echo "Installing Smithy CLI to '$INSTALL_DIR'..."
   mkdir -p "$INSTALL_DIR" || exit 1
   {
-    cp -R "$INSTALLER_DIR/" "$INSTALL_DIR" &&
+    cp -R "$INSTALLER_DIR/." "$INSTALL_DIR/." &&
     ln -snf "$INSTALL_DIR" "$CURRENT_INSTALL_DIR"
   } || {
     rm -rf "$INSTALL_DIR"

--- a/smithy-cli/config/install.bat
+++ b/smithy-cli/config/install.bat
@@ -28,7 +28,7 @@ if exist "%choice_path%" goto upgrade
 ) > "%installer_path%\%exe_name%.bat" 
 
 :: Copy the installation
-xcopy /i /h /e "%installer_path%\*" "%choice_path%\"
+xcopy /i /h /e /k "%installer_path%*" "%choice_path%\"
 setx path "%path%;%choice_path%\;"
 call %exe_name% warmup
 echo You may now run '%exe_name% --version'


### PR DESCRIPTION
*Description of changes:*
- BSD and GNU `cp` differ slightly in their (implementation of the  `-R` option)[https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00], this change addresses that
- For windows, `xcopy` will succeed with path with double-trailing slashes (`//`) on Windows 11, but not on Windows server, this change addresses that

*Testing:*
- run installer on mac (local machine)
- run installer on linux (ubuntu)
- run installer on windows (11 and server)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
