### PR TITLE
docs: type correction in primitive root-level example

### DIFF
--- a/docs/source-2.0/guides/migrating-idl-1-to-2.rst
+++ b/docs/source-2.0/guides/migrating-idl-1-to-2.rst
@@ -105,7 +105,7 @@ This 1.0 model:
 
     boolean MyPrimitiveBoolean
 
-    boolean MyPrimitiveInteger
+    integer MyPrimitiveInteger
 
     structure Foo {
         myBoolean: MyPrimitiveBoolean,
@@ -123,7 +123,7 @@ Becomes this 2.0 model:
     boolean MyPrimitiveBoolean
 
     @default(0)
-    boolean MyPrimitiveInteger
+    integer MyPrimitiveInteger
 
     structure Foo {
         myBoolean: MyPrimitiveBoolean = false


### PR DESCRIPTION
*Description of changes:*

Minor correction in an example provided in documentation for migration from Smithy v1 to v2

`MyPrimitiveInteger` was typed as `boolean`, it should be `integer`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
