### PR TITLE
Fix diff message for RemovedOperationError

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedOperationError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedOperationError.java
@@ -46,7 +46,7 @@ public final class RemovedOperationError extends AbstractDiffEvaluator {
             if (!change.getNewShape().getErrors().contains(id)) {
                 events.add(warning(change.getNewShape(), String.format(
                         "The `%s` error was removed from the `%s` operation.",
-                        change.getShapeId(), id)));
+                        id, change.getShapeId())));
             }
         }
 

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedOperationErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedOperationErrorTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.diff.evaluators;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -51,5 +52,11 @@ public class RemovedOperationErrorTest {
 
         // Emits an event for each removal.
         assertThat(TestHelper.findEvents(events, "RemovedOperationError").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationError").get(0).toString(),
+                startsWith("[WARNING] foo.baz#Operation: The `foo.baz#E1` error was removed " +
+                        "from the `foo.baz#Operation` operation. | RemovedOperationError"));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationError").get(1).toString(),
+                startsWith("[WARNING] foo.baz#Operation: The `foo.baz#E2` error was removed " +
+                        "from the `foo.baz#Operation` operation. | RemovedOperationError"));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Arguments were reversed, resulting in nonsense such as:

[In com.amazonaws.servicediscovery#ListOperations] The com.amazonaws.servicediscovery#ListOperations error was removed from the com.amazonaws.servicediscovery#RequestLimitExceeded operation.


*Description of changes:*
Swapped the argument order to fix


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
