### PR TITLE
Add :root and :in selectors, fix variable bug

### DIFF
--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -1401,6 +1401,88 @@ trait applied to it:
     service :not(-[trait]-> [trait|protocolDefinition])
 
 
+.. _selector-in-function:
+
+``:in``
+-------
+
+The ``:in`` function is used to test if a shape is contained within the
+result of an expression. This function is most useful when testing if a
+:ref:`variable <selector-variables>` or the result of a
+:ref:`root <selector-root-function>` function contains a shape. The ``:in``
+function requires exactly one selector. If a shape is contained in the
+result of evaluating the selector, the shape is yielded from the function.
+
+The following example finds all numbers that are used in service operation
+inputs and not used in service operation outputs:
+
+.. code-block:: none
+    :caption: :in example using variables
+    :name: in-variable-input-output-example
+
+    service
+    $outputs(~> operation -[output]-> ~> number)
+    ~> operation -[input]-> ~> number
+    :not(:in(${outputs}))
+
+.. note::
+
+    The above example returns the aggregate results of applying the selector
+    to every shape: if a model contains multiple services, and one of the
+    services uses a number 'X' in input and not output, but another service
+    uses 'X' in both input and output, 'X' is part of the matched shapes.
+    Use the :ref:`:root function <selector-root-function>` to match shapes
+    globally.
+
+
+.. _selector-root-function:
+
+``:root``
+---------
+
+The ``:root`` function evaluates a subexpression against *all* shapes in the
+model and yields all matches. The ``:root`` function is useful for breaking
+a selector down into smaller operations, and it works best when used with
+:ref:`variables <selector-variables>` or the :ref:`:in function <selector-in-function>`.
+The ``:root`` function requires exactly one selector.
+
+The following example finds all numbers that are used in any operation inputs
+and not used in any operation outputs:
+
+.. code-block:: none
+
+    number
+    :in(:root(service ~> operation -[input]-> ~> number))
+    :not(:in(:root(service ~> operation -[output]-> ~> number)))
+
+.. note::
+
+    The above example is similar to ":ref:`in-variable-input-output-example`"
+    but works independent of services. That is, if a model contains multiple
+    services, and one of the services uses a number 'X' in input and not
+    output, but another service uses 'X' in both input and output, 'X'
+    *is not* part of the matched shapes.
+
+
+:root functions are isolated subexpressions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The expression evaluated by a ``:root`` expression is evaluated in an isolated
+context from the rest of the expression. The selector provided to a ``:root``
+function cannot access variables defined outside the function, and variables
+defined in the selector do not persist outside the selector.
+
+
+:root functions are evaluated at most once
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is no need to store the result of a ``:root`` function in a variable
+because ``:root`` selector functions are considered global common
+subexpressions and are evaluated at most once during the selection process.
+Implementations MAY choose to evaluate ``:root`` expressions eagerly or
+lazily, though they MUST evaluate ``:root`` expressions no more than once.
+
+
 ``:topdown``
 ------------
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
@@ -40,6 +41,8 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.IoUtils;
 
 final class SelectCommand extends ClasspathCommand {
+
+    private static final Logger LOGGER = Logger.getLogger(SelectCommand.class.getName());
 
     SelectCommand(String parentCommandName, DependencyResolver.Factory dependencyResolverFactory) {
         super(parentCommandName, dependencyResolverFactory);
@@ -117,6 +120,7 @@ final class SelectCommand extends ClasspathCommand {
         Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
         Selector selector = options.selector();
 
+        long startTime = System.nanoTime();
         if (!options.vars()) {
             sortShapeIds(selector.select(model)).forEach(stdout::println);
         } else {
@@ -130,6 +134,8 @@ final class SelectCommand extends ClasspathCommand {
             });
             stdout.println(Node.prettyPrintJson(new ArrayNode(result, SourceLocation.NONE)));
         }
+        long endTime = System.nanoTime();
+        LOGGER.fine(() -> "Select time: " + ((endTime - startTime) / 1000000) + "ms");
 
         return 0;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -802,6 +802,16 @@ public final class Model implements ToSmithyBuilder<Model> {
             public Iterator<Shape> iterator() {
                 return shapeMap.values().iterator();
             }
+
+            @Override
+            public Stream<Shape> stream() {
+                return shapes();
+            }
+
+            @Override
+            public Stream<Shape> parallelStream() {
+                return shapes().parallel();
+            }
         };
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AbstractNeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AbstractNeighborSelector.java
@@ -32,23 +32,23 @@ abstract class AbstractNeighborSelector implements InternalSelector {
     }
 
     @Override
-    public final boolean push(Context context, Shape shape, Receiver next) {
+    public final Response push(Context context, Shape shape, Receiver next) {
         NeighborProvider resolvedProvider = getNeighborProvider(context, includeTraits);
         for (Relationship rel : resolvedProvider.getNeighbors(shape)) {
             if (matches(rel)) {
-                if (!emitMatchingRel(context, rel, next)) {
+                if (emitMatchingRel(context, rel, next) == Response.STOP) {
                     // Stop pushing shapes upstream and propagate the signal to stop.
-                    return false;
+                    return Response.STOP;
                 }
             }
         }
 
-        return true;
+        return Response.CONTINUE;
     }
 
     abstract NeighborProvider getNeighborProvider(Context context, boolean includeTraits);
 
-    abstract boolean emitMatchingRel(Context context, Relationship rel, Receiver next);
+    abstract Response emitMatchingRel(Context context, Relationship rel, Receiver next);
 
     private boolean matches(Relationship rel) {
         return rel.getNeighborShape().isPresent()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
@@ -15,7 +15,9 @@
 
 package software.amazon.smithy.model.selector;
 
+import java.util.Collection;
 import java.util.List;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
@@ -33,122 +35,38 @@ final class AndSelector {
     static InternalSelector of(List<InternalSelector> selectors) {
         switch (selectors.size()) {
             case 0:
-                // This happens when selectors are optimized (i.e., the first internal
-                // selector is a shape type and it gets applied in Model.shape() before
-                // pushing shapes through the selector.
                 return InternalSelector.IDENTITY;
             case 1:
                 // If there's only a single selector, then no need to wrap.
                 return selectors.get(0);
             case 2:
-                // Cases 2-7 are optimizations that make selectors about
-                // 40% faster based on JMH benchmarks (at least on my machine,
-                // JDK 11.0.5, Java HotSpot(TM) 64-Bit Server VM, 11.0.5+10-LTS).
-                // I stopped at 7 because, it needs to stop somewhere, and it's lucky.
-                return (c, s, n) -> {
-                    return selectors.get(0).push(c, s, (c2, s2) -> {
-                        return selectors.get(1).push(c2, s2, n);
-                    });
-                };
-            case 3:
-                return (c, s, n) -> {
-                    return selectors.get(0).push(c, s, (c2, s2) -> {
-                        return selectors.get(1).push(c2, s2, (c3, s3) -> {
-                            return selectors.get(2).push(c3, s3, n);
-                        });
-                    });
-                };
-            case 4:
-                return (c, s, n) -> {
-                    return selectors.get(0).push(c, s, (c2, s2) -> {
-                        return selectors.get(1).push(c2, s2, (c3, s3) -> {
-                            return selectors.get(2).push(c3, s3, (c4, s4) -> {
-                                return selectors.get(3).push(c4, s4, n);
-                            });
-                        });
-                    });
-                };
-            case 5:
-                return (c, s, n) -> {
-                    return selectors.get(0).push(c, s, (c2, s2) -> {
-                        return selectors.get(1).push(c2, s2, (c3, s3) -> {
-                            return selectors.get(2).push(c3, s3, (c4, s4) -> {
-                                return selectors.get(3).push(c4, s4, (c5, s5) -> {
-                                    return selectors.get(4).push(c5, s5, n);
-                                });
-                            });
-                        });
-                    });
-                };
-            case 6:
-                return (c, s, n) -> {
-                    return selectors.get(0).push(c, s, (c2, s2) -> {
-                        return selectors.get(1).push(c2, s2, (c3, s3) -> {
-                            return selectors.get(2).push(c3, s3, (c4, s4) -> {
-                                return selectors.get(3).push(c4, s4, (c5, s5) -> {
-                                    return selectors.get(4).push(c5, s5, (c6, s6) -> {
-                                        return selectors.get(5).push(c6, s6, n);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                };
-            case 7:
-                return (c, s, n) -> {
-                    return selectors.get(0).push(c, s, (c2, s2) -> {
-                        return selectors.get(1).push(c2, s2, (c3, s3) -> {
-                            return selectors.get(2).push(c3, s3, (c4, s4) -> {
-                                return selectors.get(3).push(c4, s4, (c5, s5) -> {
-                                    return selectors.get(4).push(c5, s5, (c6, s6) -> {
-                                        return selectors.get(5).push(c6, s6, (c7, s7) -> {
-                                            return selectors.get(6).push(c7, s7, n);
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                };
+                return new IntermediateAndSelector(selectors.get(0), selectors.get(1));
             default:
-                return new RecursiveAndSelector(selectors);
+                InternalSelector result = selectors.get(selectors.size() - 1);
+                for (int i = selectors.size() - 2; i >= 0; i--) {
+                    result = new IntermediateAndSelector(selectors.get(i), result);
+                }
+                return result;
         }
     }
 
-    static final class RecursiveAndSelector implements InternalSelector {
+    static final class IntermediateAndSelector implements InternalSelector {
+        private final InternalSelector leftSelector;
+        private final InternalSelector rightSelector;
 
-        private final List<InternalSelector> selectors;
-        private final int terminalSelectorIndex;
-
-        private RecursiveAndSelector(List<InternalSelector> selectors) {
-            this.selectors = selectors;
-            this.terminalSelectorIndex = this.selectors.size() - 1;
+        IntermediateAndSelector(InternalSelector leftSelector, InternalSelector rightSelector) {
+            this.leftSelector = leftSelector;
+            this.rightSelector = rightSelector;
         }
 
         @Override
-        public boolean push(Context context, Shape shape, Receiver next) {
-            // This is safe since the number of selectors is always >= 2.
-            return selectors.get(0).push(context, shape, new State(1, next));
+        public Response push(Context ctx, Shape shape, Receiver next) {
+            return leftSelector.push(ctx, shape, (c, s) -> rightSelector.push(c, s, next));
         }
 
-        private final class State implements Receiver {
-
-            private final int position;
-            private final Receiver downstream;
-
-            private State(int position, Receiver downstream) {
-                this.position = position;
-                this.downstream = downstream;
-            }
-
-            @Override
-            public boolean apply(Context context, Shape shape) {
-                if (position == terminalSelectorIndex) {
-                    return selectors.get(position).push(context, shape, downstream);
-                } else {
-                    return selectors.get(position).push(context, shape, new State(position + 1, downstream));
-                }
-            }
+        @Override
+        public Collection<? extends Shape> getStartingShapes(Model model) {
+            return leftSelector.getStartingShapes(model);
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -16,8 +16,10 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.shapes.Shape;
 
@@ -27,43 +29,31 @@ import software.amazon.smithy.model.shapes.Shape;
 final class Context {
 
     NeighborProviderIndex neighborIndex;
-    private final Map<String, Set<Shape>> variables;
+    private final Model model;
+    private final Map<String, Set<Shape>> variables = new HashMap<>();
+    private final List<Set<Shape>> roots;
 
-    Context(NeighborProviderIndex neighborIndex) {
+    Context(Model model, NeighborProviderIndex neighborIndex, List<Set<Shape>> roots) {
+        this.model = model;
         this.neighborIndex = neighborIndex;
-        this.variables = new HashMap<>();
+        this.roots = roots;
     }
 
     /**
-     * Clears the variables stored in the context.
+     * Gets the mutable map of captured variables.
      *
-     * @return Returns the current context.
-     */
-    Context clearVars() {
-        variables.clear();
-        return this;
-    }
-
-    /**
-     * Gets the currently set variables.
-     *
-     * <p>Note that this is a mutable array and needs to be copied to
-     * get a persistent snapshot of the variables.
-     *
-     * @return Returns the currently set variables.
+     * @return Returns the captured variables.
      */
     Map<String, Set<Shape>> getVars() {
         return variables;
     }
 
-    /**
-     * Puts a variable into the context using a variable name.
-     *
-     * @param variable Variable to set.
-     * @param shapes Shapes to associate with the variable.
-     */
-    void putVar(String variable, Set<Shape> shapes) {
-        variables.put(variable, shapes);
+    Set<Shape> getRootResult(int index) {
+        return roots.get(index);
+    }
+
+    Model getModel() {
+        return model;
     }
 
     /**
@@ -73,10 +63,10 @@ final class Context {
         boolean set;
 
         @Override
-        public boolean apply(Context context, Shape shape) {
+        public InternalSelector.Response apply(Context context, Shape shape) {
             set = true;
             // Stop receiving shapes once the first value is seen.
-            return false;
+            return InternalSelector.Response.STOP;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ForwardNeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ForwardNeighborSelector.java
@@ -37,7 +37,7 @@ final class ForwardNeighborSelector extends AbstractNeighborSelector {
     }
 
     @Override
-    boolean emitMatchingRel(Context context, Relationship rel, Receiver next) {
+    Response emitMatchingRel(Context context, Relationship rel, Receiver next) {
         return next.apply(context, rel.getNeighborShape().get());
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InSelector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.selector;
+
+import software.amazon.smithy.model.shapes.Shape;
+
+/**
+ * Checks if the given value is in the result of a selector.
+ */
+final class InSelector implements InternalSelector {
+
+    private final InternalSelector selector;
+
+    InSelector(InternalSelector selector) {
+        this.selector = selector;
+    }
+
+    @Override
+    public Response push(Context context, Shape shape, Receiver next) {
+        // Some internal selectors provide optimizations for quickly checking if they contain a shape.
+        switch (selector.containsShapeOptimization(context, shape)) {
+            case YES:
+                return next.apply(context, shape);
+            case NO:
+                return Response.CONTINUE;
+            case MAYBE:
+            default:
+                // Unable to use the optimization, so emit each shape until a match is found.
+                FilteredHolder holder = new FilteredHolder(shape);
+                selector.push(context, shape, holder);
+
+                if (holder.matched) {
+                    return next.apply(context, shape);
+                }
+
+                return Response.CONTINUE;
+        }
+    }
+
+    private static final class FilteredHolder implements InternalSelector.Receiver {
+        private final Shape shapeToMatch;
+        private boolean matched;
+
+        FilteredHolder(Shape shapeToMatch) {
+            this.shapeToMatch = shapeToMatch;
+        }
+
+        @Override
+        public Response apply(Context context, Shape shape) {
+            if (shape.equals(shapeToMatch)) {
+                matched = true;
+                return Response.STOP;
+            }
+
+            return Response.CONTINUE;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.Collection;
-import java.util.function.Function;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 
@@ -53,21 +52,73 @@ interface InternalSelector {
      * @param next Receiver to call 0 or more times.
      * @return Returns true to continue sending shapes to the selector.
      */
-    boolean push(Context ctx, Shape shape, Receiver next);
+    Response push(Context ctx, Shape shape, Receiver next);
+
+    /** Tells shape emitters whether to continue to send shapes to an InternalSelector or Receiver. */
+    enum Response {
+        CONTINUE,
+        STOP
+    }
 
     /**
-     * Returns a function that is used to optimize which shapes in a model
-     * need to be evaluated.
+     * Pushes {@code shape} through the selector and adds all results to {@code captures}.
      *
-     * <p>For example, when selecting "structure", it is far less work
+     * <p>This method exists because we've messed this up multiple times. When buffering values sent to a receiver,
+     * you have to return true to keep getting results. It's easy to make a closure that just uses
+     * {@link Collection#add(Object)}, but that will return false if the shape was already in the collection, which
+     * isn't the desired behavior.
+     *
+     * @param context Context being evaluated.
+     * @param shape Shape being pushed through the selector.
+     * @param captures Where to buffer all results.
+     * @param <C> Collection type that is given and returned.
+     * @return Returns the given {@code captures} collection.
+     */
+    default <C extends Collection<Shape>> C pushResultsToCollection(Context context, Shape shape, C captures) {
+        push(context, shape, (c, s) -> {
+            captures.add(s);
+            return Response.CONTINUE;
+        });
+        return captures;
+    }
+
+    /**
+     * Returns the set of shapes to pump through the selector.
+     *
+     * <p>This method returns all shapes in the model by default. Some selectors can return a subset of shapes if
+     * the selector can filter shapes more efficiently. For example, when selecting "structure", it is far less work
      * to leverage {@link Model#toSet(Class)} than it is to send every shape
      * through every selector.
      *
-     * @return Returns a function that returns null if no optimization can
-     *   be made, or a Collection of Shapes if an optimization was made.
+     * @return Returns the starting shapes to push through the selector.
      */
-    default Function<Model, Collection<? extends Shape>> optimize() {
-        return null;
+    default Collection<? extends Shape> getStartingShapes(Model model) {
+        return model.toSet();
+    }
+
+    /**
+     * The result of determining if a presence optimization can be made to find a shape.
+     */
+    enum ContainsShape {
+        /** The shape is definitely in the selector. */
+        YES,
+
+        /** The shape is definitely not in the selector. */
+        NO,
+
+        /** No optimization could be made, so send every shape through to determine if the shape is present. */
+        MAYBE
+    }
+
+    /**
+     * Checks if the internal selector can quickly detect if it contains the given shape.
+     *
+     * @param context Evaluation context.
+     * @param shape Shape to check.
+     * @return Returns YES if the selector knows the shape is in the selector, NO if it isn't, and MAYBE if unknown.
+     */
+    default ContainsShape containsShapeOptimization(Context context, Shape shape) {
+        return ContainsShape.MAYBE;
     }
 
     /**
@@ -82,6 +133,6 @@ interface InternalSelector {
          * @param shape Shape that is received.
          * @return Returns true to continue receiving shapes.
          */
-        boolean apply(Context context, Shape shape);
+        Response apply(Context context, Shape shape);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/IsSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/IsSelector.java
@@ -33,13 +33,13 @@ final class IsSelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context context, Shape shape, Receiver next) {
+    public Response push(Context context, Shape shape, Receiver next) {
         for (InternalSelector selector : selectors) {
-            if (!selector.push(context, shape, next)) {
-                return false;
+            if (selector.push(context, shape, next) == Response.STOP) {
+                return Response.STOP;
             }
         }
 
-        return true;
+        return Response.CONTINUE;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/NotSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/NotSelector.java
@@ -29,11 +29,11 @@ final class NotSelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context context, Shape shape, Receiver next) {
+    public Response push(Context context, Shape shape, Receiver next) {
         if (!context.receivedShapes(shape, selector)) {
             return next.apply(context, shape);
         } else {
-            return true;
+            return Response.CONTINUE;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/RecursiveNeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/RecursiveNeighborSelector.java
@@ -25,7 +25,7 @@ import software.amazon.smithy.model.shapes.Shape;
  */
 final class RecursiveNeighborSelector implements InternalSelector {
     @Override
-    public boolean push(Context context, Shape shape, Receiver next) {
+    public Response push(Context context, Shape shape, Receiver next) {
         Walker walker = new Walker(context.neighborIndex.getProvider());
         Iterator<Shape> shapeIterator = walker.iterateShapes(shape);
 
@@ -33,13 +33,13 @@ final class RecursiveNeighborSelector implements InternalSelector {
             Shape nextShape = shapeIterator.next();
             // Don't include the shape being visited.
             if (!nextShape.equals(shape)) {
-                if (!next.apply(context, nextShape)) {
+                if (next.apply(context, nextShape) == Response.STOP) {
                     // Stop sending recursive neighbors when told to stop and propagate.
-                    return false;
+                    return Response.STOP;
                 }
             }
         }
 
-        return true;
+        return Response.CONTINUE;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ReverseNeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ReverseNeighborSelector.java
@@ -37,7 +37,7 @@ final class ReverseNeighborSelector extends AbstractNeighborSelector {
     }
 
     @Override
-    boolean emitMatchingRel(Context context, Relationship rel, Receiver next) {
+    Response emitMatchingRel(Context context, Relationship rel, Receiver next) {
         return next.apply(context, rel.getShape());
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/RootSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/RootSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,26 +15,30 @@
 
 package software.amazon.smithy.model.selector;
 
-import java.util.Collections;
-import java.util.Set;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
- * Pushes the shapes stored in a specific variable to the next selector.
+ * Root expressions are rooted common subexpressions.
+ *
+ * <p>Roots are evaluated eagerly and then the result is retrieved by ID. This prevents needing to evaluate a root
+ * expression over and over for each shape given the result does not vary based on the current shape.
+ * Roots are evaluated in an isolated context, meaning it can't use variables defined outside the root, nor can it
+ * set variables that can be used outside the root.
  */
-final class VariableGetSelector implements InternalSelector {
-    private final String variableName;
+final class RootSelector implements InternalSelector {
 
-    VariableGetSelector(String variableName) {
-        this.variableName = variableName;
+    private final InternalSelector selector;
+    private final int id;
+
+    RootSelector(InternalSelector selector, int id) {
+        this.selector = selector;
+        this.id = id;
     }
 
     @Override
     public Response push(Context context, Shape shape, Receiver next) {
-        // Do not fail on invalid variable access.
-        for (Shape v : getShapes(context)) {
+        for (Shape v : context.getRootResult(id)) {
             if (next.apply(context, v) == Response.STOP) {
-                // Propagate the signal to stop upstream.
                 return Response.STOP;
             }
         }
@@ -42,12 +46,8 @@ final class VariableGetSelector implements InternalSelector {
         return Response.CONTINUE;
     }
 
-    private Set<Shape> getShapes(Context context) {
-        return context.getVars().getOrDefault(variableName, Collections.emptySet());
-    }
-
     @Override
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
-        return getShapes(context).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
+        return context.getRootResult(id).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
@@ -64,11 +64,11 @@ final class ScopedAttributeSelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context context, Shape shape, Receiver next) {
+    public Response push(Context context, Shape shape, Receiver next) {
         if (matchesAssertions(shape, context.getVars())) {
             return next.apply(context, shape);
         } else {
-            return true;
+            return Response.CONTINUE;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelector.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.model.selector;
 
+import java.util.Collection;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 
 final class ShapeTypeCategorySelector implements InternalSelector {
@@ -25,11 +27,21 @@ final class ShapeTypeCategorySelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context ctx, Shape shape, Receiver next) {
+    public Response push(Context ctx, Shape shape, Receiver next) {
         if (shapeCategory.isInstance(shape)) {
             return next.apply(ctx, shape);
         }
 
-        return true;
+        return Response.CONTINUE;
+    }
+
+    @Override
+    public Collection<? extends Shape> getStartingShapes(Model model) {
+        return model.toSet(shapeCategory);
+    }
+
+    @Override
+    public ContainsShape containsShapeOptimization(Context context, Shape shape) {
+        return getStartingShapes(context.getModel()).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.Collection;
-import java.util.function.Function;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -30,16 +29,23 @@ final class ShapeTypeSelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context ctx, Shape shape, Receiver next) {
+    public Response push(Context ctx, Shape shape, Receiver next) {
         if (shape.getType().isShapeType(shapeType)) {
             return next.apply(ctx, shape);
         }
 
-        return true;
+        return Response.CONTINUE;
     }
 
     @Override
-    public Function<Model, Collection<? extends Shape>> optimize() {
-        return model -> model.toSet(shapeType.getShapeClass());
+    public Collection<? extends Shape> getStartingShapes(Model model) {
+        return model.toSet(shapeType.getShapeClass());
+    }
+
+    @Override
+    public ContainsShape containsShapeOptimization(Context context, Shape shape) {
+        return context.getModel().toSet(shapeType.getShapeClass()).contains(shape)
+               ? ContainsShape.YES
+               : ContainsShape.NO;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TestSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TestSelector.java
@@ -32,7 +32,7 @@ final class TestSelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context context, Shape shape, Receiver next) {
+    public Response push(Context context, Shape shape, Receiver next) {
         for (InternalSelector predicate : selectors) {
             if (context.receivedShapes(shape, predicate)) {
                 // The instant something matches, stop testing selectors.
@@ -40,8 +40,7 @@ final class TestSelector implements InternalSelector {
             }
         }
 
-        // Note that this does not return false when there is not a match,
-        // since it should to continue to receive shapes to test.
-        return true;
+        // Continue to receive shapes because other shapes could match.
+        return Response.CONTINUE;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableStoreSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableStoreSelector.java
@@ -38,12 +38,11 @@ final class VariableStoreSelector implements InternalSelector {
     }
 
     @Override
-    public boolean push(Context context, Shape shape, Receiver next) {
+    public Response push(Context context, Shape shape, Receiver next) {
         // Buffer the result of piping the shape through the selector
         // so that it can be retrieved through context vars.
-        Set<Shape> captures = new HashSet<>();
-        selector.push(context, shape, (c, s) -> captures.add(s));
-        context.putVar(variableName, captures);
+        Set<Shape> captures = selector.pushResultsToCollection(context, shape, new HashSet<>());
+        context.getVars().put(variableName, captures);
 
         // Now send the received shape to the next receiver.
         return next.apply(context, shape);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,16 +16,14 @@
 package software.amazon.smithy.model.selector;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.in;
 
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.Shape;
 
-public class ShapeTypeSelectorTest {
+public class ShapeTypeCategorySelectorTest {
 
     private static Model model;
 
@@ -38,23 +36,11 @@ public class ShapeTypeSelectorTest {
     }
 
     @Test
-    public void stringSelectsEnum() {
-        Set<String> ids = SelectorTest.ids(model, "string");
-        assertThat("smithy.example#String", in(ids));
-        assertThat("smithy.example#Enum", in(ids));
-    }
-
-    @Test
-    public void integerSelectsIntEnum() {
-        Set<String> ids = SelectorTest.ids(model, "integer");
-        assertThat("smithy.example#Integer", in(ids));
-        assertThat("smithy.example#IntEnum", in(ids));
-    }
-
-    @Test
     public void hasContainsOptimization() {
-        Set<String> ids = SelectorTest.ids(model, ":in(enum) [id|namespace = smithy.example]");
+        // "number" is a category. intEnum is considered a number, so it is returned. This example triggers the
+        // :in function optimization of the selector.
+        Set<String> ids = SelectorTest.ids(model, ":in(number) [id|namespace = smithy.example]");
 
-        assertThat("smithy.example#Enum", in(ids));
+        assertThat("smithy.example#IntEnum", in(ids));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/in-function.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/in-function.smithy
@@ -1,0 +1,75 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    // Find numbers that are used in input but are not used in output.
+    {
+        selector: """
+            service
+            $output(~> operation -[output]-> ~> number)
+            ~> operation -[input]-> ~> number
+            :not(:in(${output}))"""
+        matches: [
+            smithy.api#Integer
+            smithy.api#Double
+        ]
+    }
+    // This is not how you should write this expression, but it does test that :in can be used with variables.
+    // This should instead be written as:
+    //     operation ~> number
+    {
+        selector: """
+            $usedNumbers(operation ~> number)
+            operation ~> *
+            :in(${usedNumbers})"""
+        matches: [
+            smithy.api#Integer
+            smithy.api#Float
+            smithy.api#Double
+            smithy.api#Short
+            smithy.api#Long
+            smithy.api#Byte
+        ]
+    }
+    // This is also not how you'd write this, but it is valid.
+    // This should be written more directly as:
+    //     member [id|namespace = smithy.example] > number
+    {
+        selector: ":in(number :test(< member [id|namespace = smithy.example]))"
+        matches: [
+            smithy.api#Integer
+            smithy.api#Float
+            smithy.api#Double
+            smithy.api#Short
+            smithy.api#Long
+            smithy.api#Byte
+        ]
+    }
+]
+
+namespace smithy.example
+
+service MyService {
+    operations: [A, B]
+}
+
+operation A {
+    input:= {
+        a: Integer
+        b: Float
+        c: Double
+    }
+    output:= {
+        a: Short
+        b: Long
+        c: Float
+    }
+}
+
+operation B {
+    input:= {
+        a: Byte
+    }
+    output:= {
+        b: Byte
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/root-function.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/root-function.smithy
@@ -1,0 +1,61 @@
+$version: "2.0"
+
+metadata selectorTests = [
+    // Find shapes used in service operation inputs but not operation outputs.
+    {
+        selector: """
+            number
+            :in(:root(service ~> operation -[input]-> * ~> number))
+            :not(:in(:root(service ~> operation -[output]-> * ~> number)))"""
+        matches: [
+            smithy.api#Integer
+        ]
+    }
+    // This is similar to the above :root example, but also returns smithy.api#Double because each capture
+    // of service operations is isolated to a single service and not global across all services.
+    // * When MyService1 is evaluated, Double is only used in input and not output.
+    // * The usage of Double in the output of MyService2 is not taken into account when evaluating MyService1.
+    {
+        selector: """
+            service
+            $outputs(~> operation -[output]-> ~> number)
+            ~> operation -[input]-> ~> number
+            :not(:in(${outputs}))"""
+        matches: [
+            smithy.api#Integer
+            smithy.api#Double
+        ]
+    }
+]
+
+namespace smithy.example
+
+service MyService1 {
+    operations: [A]
+}
+
+operation A {
+    input:= {
+        a: Integer
+        b: Float
+        c: Double
+    }
+    output:= {
+        d: Float
+        e: Short
+        f: Long
+    }
+}
+
+service MyService2 {
+    operations: [B]
+}
+
+operation B {
+    input:= {
+        a: Double
+    }
+    output:= {
+        a: Double
+    }
+}


### PR DESCRIPTION
This commit adds support for the `:in` and `:root` functions. The `:in` function is a simpler way to check if a shape is in an expression, typically used to test if a variable contains a shape or if a root expression contains a shape. `:root` is used to create rooted common subexpressions that are evaluated once against every shape in the model. `:root` expressions are evaluate in an isolated context, so any variables used or stored by them are not accessible outside the root selector. `:root` selectors allows selection to be broken into multiple steps and evaluate globally.

Let's say you want all number shapes that are used in operation inputs, but not used in operation outputs. This can be done today using the following expression:

```
service
$outputs(~> operation -[output]-> ~> number)
~> operation -[input]-> ~> number
:not([@: @{id} = @{var|outputs|id}])
```

With the addition of the ``:in` selector, this gets easier because we can avoid using a scoped attribute selector:

```
service
$outputs(~> operation -[output]-> ~> number)
~> operation -[input]-> ~> number
:not(:in(${outputs}))
```

(Note: to make this work, I had to uncover and fix a bug in the implementation of how we store variables. We previously used `Collection#add` as a `Receiver`, but that method will return false if it's already seen a shape, which is wrong.)

With the addition of `:root`, you can use a much simpler expression:

```
number
:in(:root(service ~> operation -[input]-> ~> number))
:not(:in(:root(service ~> operation -[output]-> ~> number)))
```

(Note: the result of root expressions are run once and cached. No need to store them in a variable)

These expressions _seem_ to be exactly the same, however, the `:root` expression gives a different result when working with models that contain multiple services. In the first two expressions, if any service uses shape X in input and not output, then X is a result. However, in the `:root` expression, X is only part of the result if no service uses it in their output shape closures.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
