### PR TITLE
Add --show-traits to select command

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
@@ -3,6 +3,7 @@ package software.amazon.smithy.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,45 @@ public class SelectTest {
             // Ensure it's valid JSON
             Node.parse(content);
             assertThat(content, containsString("\"shape\": \"smithy.api#String\""));
+        });
+    }
+
+    @Test
+    public void selectsTraits() {
+        List<String> args = Arrays.asList("select",
+                                          // Can use just shape names, or an absolute shape ID. Including a trait
+                                          // here doesn't mean a shape in the result is required to have the trait.
+                                          "--show-traits", "length, range, smithy.api#documentation",
+                                          // Every match has to have length or range, but documentation is optional.
+                                          "--selector", ":is([trait|length], [trait|range])");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"shape\": \""));
+            assertThat(content, containsString("\"traits\": {"));
+            assertThat(content, containsString("\"smithy.api#length\": {"));
+            assertThat(content, containsString("\"smithy.api#range\": {"));
+            assertThat(content, containsString("\"min\": "));
+            assertThat(content, containsString("\"max\": "));
+            assertThat(content, containsString("\"smithy.api#documentation\": "));
+        });
+    }
+
+    @Test
+    public void showTraitsCannotBeEmpty() {
+        List<String> args = Arrays.asList("select", "--show-traits", "", "--selector", "service");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), not(equalTo(0)));
+        });
+    }
+
+    @Test
+    public void showTraitsCannotHaveEmptyValues() {
+        List<String> args = Arrays.asList("select", "--show-traits", "documentation,", "--selector", "service");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), not(equalTo(0)));
         });
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -20,21 +20,27 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
+import software.amazon.smithy.cli.CliError;
 import software.amazon.smithy.cli.CliPrinter;
 import software.amazon.smithy.cli.ColorFormatter;
 import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.selector.Selector;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -68,6 +74,7 @@ final class SelectCommand extends ClasspathCommand {
     private static final class Options implements ArgumentReceiver {
         private boolean vars;
         private Selector selector;
+        private final List<ShapeId> showTraits = new ArrayList<>();
 
         @Override
         public boolean testOption(String name) {
@@ -80,18 +87,37 @@ final class SelectCommand extends ClasspathCommand {
 
         @Override
         public Consumer<String> testParameter(String name) {
-            if (name.equals("--selector")) {
-                return value -> selector = Selector.parse(value);
+            switch (name) {
+                case "--selector":
+                    return value -> selector = Selector.parse(value);
+                case "--show-traits":
+                    return value -> {
+                        for (String trait : value.split(",", -1)) {
+                            trait = trait.trim();
+                            if (trait.isEmpty()) {
+                                throw new CliError("--show-traits cannot contain empty trait values");
+                            }
+                            showTraits.add(ShapeId.fromOptionalNamespace(Prelude.NAMESPACE, trait));
+                        }
+                        if (showTraits.isEmpty()) {
+                            throw new CliError("--show-traits must contain traits");
+                        }
+                    };
+                default:
+                    return null;
             }
-            return null;
         }
 
         @Override
         public void registerHelp(HelpPrinter printer) {
-            printer.option("--vars", null, "Include the variables that were captured when the shape was matched. "
-                                           + "The output of the command is JSON when --vars is passed.");
             printer.param("--selector", null, "SELECTOR",
                           "The Smithy selector to execute. Reads from STDIN when not provided.");
+            printer.param("--show-traits", null, "TRAITS",
+                          "Returns JSON output that includes the values of specific traits applied to matched shapes, "
+                          + "stored in a 'traits' property. Provide a comma-separated list of trait shape IDs. "
+                          + "Prelude traits may omit a namespace (e.g., 'required' or 'smithy.api#required').");
+            printer.option("--vars", null, "Returns JSON output that includes the variables that were captured when "
+                                           + "a shape was matched, stored in a 'vars' property.");
         }
 
         public boolean vars() {
@@ -113,43 +139,79 @@ final class SelectCommand extends ClasspathCommand {
 
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
-        CliPrinter stdout = env.stdout();
-        Options options = arguments.getReceiver(Options.class);
-
         // Don't write the summary, but do write danger/errors to STDERR.
         Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
+
+        Options options = arguments.getReceiver(Options.class);
         Selector selector = options.selector();
+        OutputFormat outputFormat = OutputFormat.determineFormat(options);
 
         long startTime = System.nanoTime();
-        if (!options.vars()) {
-            sortShapeIds(selector.select(model)).forEach(stdout::println);
-        } else {
-            // Show the JSON output for writing with --vars.
-            List<Node> result = new ArrayList<>();
-            selector.consumeMatches(model, match -> {
-                result.add(Node.objectNodeBuilder()
-                        .withMember("shape", Node.from(match.getShape().getId().toString()))
-                        .withMember("vars", collectVars(match))
-                        .build());
-            });
-            stdout.println(Node.prettyPrintJson(new ArrayNode(result, SourceLocation.NONE)));
-        }
+        outputFormat.dumpResults(selector, model, options, env.stdout());
         long endTime = System.nanoTime();
-        LOGGER.fine(() -> "Select time: " + ((endTime - startTime) / 1000000) + "ms");
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            // Ensure that the log statement isn't interlaced in the JSON output.
+            env.stdout().flush();
+            LOGGER.fine("Select time: " + ((endTime - startTime) / 1000000) + "ms");
+        }
 
         return 0;
     }
 
-    private Stream<String> sortShapeIds(Collection<Shape> shapes) {
-        return shapes.stream().map(Shape::getId).map(ShapeId::toString).sorted();
-    }
+    enum OutputFormat {
+        SHAPE_ID_LINES {
+            @Override
+            void dumpResults(Selector selector, Model model, Options options, CliPrinter stdout) {
+                sortShapeIds(selector.select(model)).forEach(stdout::println);
+            }
+        },
+        JSON {
+            @Override
+            void dumpResults(Selector selector, Model model, Options options, CliPrinter stdout) {
+                List<Node> result = selector.matches(model).map(match -> {
+                    ObjectNode.Builder builder = Node.objectNodeBuilder()
+                            .withMember("shape", Node.from(match.getShape().getId().toString()));
 
-    private ObjectNode collectVars(Map<String, Set<Shape>> vars) {
-        ObjectNode.Builder varBuilder = Node.objectNodeBuilder();
-        for (Map.Entry<String, Set<Shape>> varEntry : vars.entrySet()) {
-            ArrayNode value = sortShapeIds(varEntry.getValue()).map(Node::from).collect(ArrayNode.collect());
-            varBuilder.withMember(varEntry.getKey(), value);
+                    if (!match.isEmpty()) {
+                        builder.withMember("vars", collectVars(match));
+                    }
+
+                    if (!options.showTraits.isEmpty()) {
+                        Map<StringNode, Node> values = new TreeMap<>();
+                        for (ShapeId trait : options.showTraits) {
+                            match.getShape()
+                                    .findTrait(trait)
+                                    .ifPresent(found -> values.put(Node.from(trait.toString()), found.toNode()));
+                        }
+                        builder.withMember("traits", Node.objectNode(values));
+                    }
+
+                    return builder.build();
+                }).collect(Collectors.toList());
+
+                stdout.println(Node.prettyPrintJson(new ArrayNode(result, SourceLocation.NONE)));
+            }
+        };
+
+        abstract void dumpResults(Selector selector, Model model, Options options, CliPrinter stdout);
+
+        static OutputFormat determineFormat(Options options) {
+            // If --var isn't provided and --show-traits is empty, then use the SHAPE_ID_LINES output.
+            return !options.vars() && options.showTraits.isEmpty() ? SHAPE_ID_LINES : JSON;
         }
-        return varBuilder.build();
+
+        private static Stream<String> sortShapeIds(Collection<Shape> shapes) {
+            return shapes.stream().map(Shape::getId).map(ShapeId::toString).sorted();
+        }
+
+        private static ObjectNode collectVars(Map<String, Set<Shape>> vars) {
+            ObjectNode.Builder varBuilder = Node.objectNodeBuilder();
+            for (Map.Entry<String, Set<Shape>> varEntry : vars.entrySet()) {
+                ArrayNode value = sortShapeIds(varEntry.getValue()).map(Node::from).collect(ArrayNode.collect());
+                varBuilder.withMember(varEntry.getKey(), value);
+            }
+            return varBuilder.build();
+        }
     }
 }


### PR DESCRIPTION
The --show-traits option will include the serialize value of specific traits for each shape matched by the --select command. The output format is the same as the format used with --vars, but also included in the output is a 'traits' property that contains a map of trait shape IDs to trait values. --show-traits is a comma separated list of trait shape IDs, where omitting a namespace assumes the trait is in the prelude (e.g., 'required' is the same as 'smithy.api#required'). Matches are not required to have the traits defined in --show-traits, so if that is the desired filtering, the selector provided in --selector needs to ensure each shape has the required traits.

This option can be useful to answer questions like: "what are all the HTTP headers used in my service?" or "what are the default values of every shape?"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
