### PR TITLE
Improve CLI validation output

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
@@ -21,6 +21,15 @@ public class SelectTest {
     }
 
     @Test
+    public void doesNotShowWarnings() {
+        List<String> args = Arrays.asList("select", "--selector", "string [id|namespace=smithy.example]");
+        IntegUtils.run("model-with-warning", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), equalTo("smithy.example#MyString"));
+        });
+    }
+
+    @Test
     public void selectsVariables() {
         List<String> args = Arrays.asList("select", "--vars", "--selector", "list $list(*) > member > string");
         IntegUtils.run("simple-config-sources", args, result -> {

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SmithyValidateTest.java
@@ -31,7 +31,9 @@ public class SmithyValidateTest {
     public void validatesModelFailure() {
         IntegUtils.run("invalid-model", ListUtils.of("validate", "model"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
-            assertThat(result.getOutput(), containsString("ERROR: smithy.example#MyString (TraitTarget)"));
+            assertThat(result.getOutput(), containsString("ERROR"));
+            assertThat(result.getOutput(), containsString("smithy.example#MyString"));
+            assertThat(result.getOutput(), containsString("TraitTarget"));
             assertThat(result.getOutput(), containsString("invalid.smithy"));
             assertThat(result.getOutput(), containsString("@range(min: 10, max: 100) // not valid for strings!"));
             assertThat(result.getOutput(), containsString("ERROR: 1"));

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/model/main.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+namespace smithy.example
+
+@unstable
+structure exampleUnstable {}
+
+@exampleUnstable
+string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/smithy-build.json
@@ -1,0 +1,4 @@
+{
+    "version": "1.0",
+    "sources": ["model"]
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Cli.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.cli;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
@@ -141,6 +142,16 @@ public final class Cli {
             @Override
             public void style(Appendable appendable, String text, Style... styles) {
                 delegateSupplier.get().style(appendable, text, styles);
+            }
+
+            @Override
+            public boolean isColorEnabled() {
+                return delegateSupplier.get().isColorEnabled();
+            }
+
+            @Override
+            public <T extends Appendable> void style(T appendable, Consumer<T> consumer, Style... styles) {
+                delegateSupplier.get().style(appendable, consumer, styles);
             }
         };
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/CliPrinter.java
@@ -30,11 +30,20 @@ import java.nio.charset.StandardCharsets;
 public interface CliPrinter extends Flushable {
 
     /**
+     * Prints text to the writer.
+     *
+     * @param text Text to write.
+     */
+    void print(String text);
+
+    /**
      * Prints text to the writer and appends a new line.
      *
      * @param text Text to print.
      */
-    void println(String text);
+    default void println(String text) {
+        print(text + System.lineSeparator());
+    }
 
     /**
      * Flushes any buffers in the printer.
@@ -52,6 +61,11 @@ public interface CliPrinter extends Flushable {
             @Override
             public void println(String text) {
                 printWriter.println(text);
+            }
+
+            @Override
+            public void print(String text) {
+                printWriter.print(text);
             }
 
             @Override

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorFormatter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorFormatter.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.cli;
 
+import java.util.function.Consumer;
+
 /**
  * Styles text using color codes.
  *
@@ -38,6 +40,21 @@ public interface ColorFormatter {
      * @param styles Styles to apply.
      */
     void style(Appendable appendable, String text, Style... styles);
+
+    /**
+     * Adds styles around text written to an appendable by a consumer.
+     *
+     * @param appendable Appendable to write to.
+     * @param consumer   Consumer to write to the appendable using style.
+     * @param styles     Styles to apply to the text written by the consumer.
+     * @param <T>        Appendable type.
+     */
+    <T extends Appendable> void style(T appendable, Consumer<T> consumer, Style... styles);
+
+    /**
+     * @return Returns true if this formatter supports color output.
+     */
+    boolean isColorEnabled();
 
     /**
      * Print a styled line of text to the given {@code printer}.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/Style.java
@@ -17,56 +17,65 @@ package software.amazon.smithy.cli;
 
 /**
  * Colors and styles for use with {@link AnsiColorFormatter} or {@link CliPrinter}.
+ *
+ * <p>ANSI codes returned by this interface should not include the opening {@code \033[}, the final {@code ;m} when
+ * opening styles, or the closing {@code [0m}. These escapes are added automatically when multiple styles are
+ * applied.
  */
-public enum Style {
-    BOLD(1),
-    FAINT(2),
-    ITALIC(3),
-    UNDERLINE(4),
+public interface Style {
 
-    BLACK(30),
-    RED(31),
-    GREEN(32),
-    YELLOW(33),
-    BLUE(34),
-    MAGENTA(35),
-    CYAN(36),
-    WHITE(37),
+    Style BOLD = new Constant("1");
+    Style FAINT = new Constant("2");
+    Style ITALIC = new Constant("3");
+    Style UNDERLINE = new Constant("4");
 
-    BRIGHT_BLACK(90),
-    BRIGHT_RED(91),
-    BRIGHT_GREEN(92),
-    BRIGHT_YELLOW(93),
-    BRIGHT_BLUE(94),
-    BRIGHT_MAGENTA(95),
-    BRIGHT_CYAN(96),
-    BRIGHT_WHITE(97),
+    Style BLACK = new Constant("30");
+    Style RED = new Constant("31");
+    Style GREEN = new Constant("32");
+    Style YELLOW = new Constant("33");
+    Style BLUE = new Constant("34");
+    Style MAGENTA = new Constant("35");
+    Style CYAN = new Constant("36");
+    Style WHITE = new Constant("37");
 
-    BG_BLACK(40),
-    BG_RED(41),
-    BG_GREEN(42),
-    BG_YELLOW(43),
-    BG_BLUE(44),
-    BG_MAGENTA(45),
-    BG_CYAN(46),
-    BG_WHITE(47),
+    Style BRIGHT_BLACK = new Constant("90");
+    Style BRIGHT_RED = new Constant("91");
+    Style BRIGHT_GREEN = new Constant("92");
+    Style BRIGHT_YELLOW = new Constant("93");
+    Style BRIGHT_BLUE = new Constant("94");
+    Style BRIGHT_MAGENTA = new Constant("95");
+    Style BRIGHT_CYAN = new Constant("96");
+    Style BRIGHT_WHITE = new Constant("97");
 
-    BG_BRIGHT_BLACK(100),
-    BG_BRIGHT_RED(101),
-    BG_BRIGHT_GREEN(102),
-    BG_BRIGHT_YELLOW(103),
-    BG_BRIGHT_BLUE(104),
-    BG_BRIGHT_MAGENTA(105),
-    BG_BRIGHT_CYAN(106),
-    BG_BRIGHT_WHITE(107);
+    Style BG_BLACK = new Constant("40");
+    Style BG_RED = new Constant("41");
+    Style BG_GREEN = new Constant("42");
+    Style BG_YELLOW = new Constant("43");
+    Style BG_BLUE = new Constant("44");
+    Style BG_MAGENTA = new Constant("45");
+    Style BG_CYAN = new Constant("46");
+    Style BG_WHITE = new Constant("47");
 
-    private final String ansiColorCode;
+    Style BG_BRIGHT_BLACK = new Constant("100");
+    Style BG_BRIGHT_RED = new Constant("101");
+    Style BG_BRIGHT_GREEN = new Constant("102");
+    Style BG_BRIGHT_YELLOW = new Constant("103");
+    Style BG_BRIGHT_BLUE = new Constant("104");
+    Style BG_BRIGHT_MAGENTA = new Constant("105");
+    Style BG_BRIGHT_CYAN = new Constant("106");
+    Style BG_BRIGHT_WHITE = new Constant("107");
 
-    Style(int ansiColorCode) {
-        this.ansiColorCode = String.valueOf(ansiColorCode);
-    }
+    String getAnsiColorCode();
 
-    public String getAnsiColorCode() {
-        return ansiColorCode;
+    final class Constant implements Style {
+        private final String ansiColorCode;
+
+        public Constant(String ansiColorCode) {
+            this.ansiColorCode = ansiColorCode;
+        }
+
+        public String getAnsiColorCode() {
+            return ansiColorCode;
+        }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -41,7 +41,7 @@ final class AstCommand extends ClasspathCommand {
 
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), ValidationFlag.QUIET, config);
         ModelSerializer serializer = ModelSerializer.builder().build();
         env.stdout().println(Node.prettyPrintJson(serializer.serialize(model)));
         return 0;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -102,7 +102,8 @@ final class BuildCommand extends ClasspathCommand {
 
         // Build the model and fail if there are errors. Prints errors to stdout.
         // Configure whether the build is quiet or not based on the --quiet option.
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), standardOptions.quiet(), config);
+        ValidationFlag flag = ValidationFlag.from(standardOptions);
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), flag, config);
 
         Supplier<ModelAssembler> modelAssemblerSupplier = () -> {
             ModelAssembler assembler = Model.assembler(classLoader);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -77,9 +77,9 @@ final class BuildOptions implements ArgumentReceiver {
                 return value -> discoverClasspath = value;
             case SEVERITY:
                 return value -> {
-                    severity = Severity.fromString(value).orElseThrow(() -> {
+                    severity(Severity.fromString(value).orElseThrow(() -> {
                         return new CliError("Invalid severity level: " + value);
-                    });
+                    }));
                 };
             default:
                 return null;
@@ -100,6 +100,10 @@ final class BuildOptions implements ArgumentReceiver {
 
     String output() {
         return output;
+    }
+
+    void severity(Severity severity) {
+        this.severity = severity;
     }
 
     /**

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CodeFormatter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CodeFormatter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Iterator;
+import software.amazon.smithy.cli.ColorFormatter;
+import software.amazon.smithy.cli.Style;
+import software.amazon.smithy.model.loader.sourcecontext.SourceContextLoader;
+
+/**
+ * Formats source {@link SourceContextLoader.Line} values and writes them to an {@link Appendable}.
+ */
+final class CodeFormatter {
+
+    private final Appendable writer;
+    private final ColorFormatter colors;
+    private final int maxWidth;
+
+    CodeFormatter(Appendable writer, ColorFormatter colors, int maxWidth) {
+        this.writer = writer;
+        this.colors = colors;
+        this.maxWidth = maxWidth;
+    }
+
+    void writeCode(int cursorLine, int cursorColumn, Collection<SourceContextLoader.Line> lines) {
+        if (lines.isEmpty()) {
+            return;
+        }
+
+        int numberLength = findLongestNumber(lines);
+
+        try {
+            Iterator<SourceContextLoader.Line> lineIterator = lines.iterator();
+            int lastLine = -1;
+
+            while (lineIterator.hasNext()) {
+                SourceContextLoader.Line line = lineIterator.next();
+
+                if (line.getLineNumber() != lastLine + 1 && lastLine != -1) {
+                    writeColumnAndContent(numberLength, -1, "");
+                }
+
+                writeColumnAndContent(numberLength, line.getLineNumber(), line.getContent());
+
+                if (line.getLineNumber() == cursorLine) {
+                    writePointer(numberLength, cursorColumn);
+                }
+
+                lastLine = line.getLineNumber();
+            }
+
+            writer.append(System.lineSeparator());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error write source code: " + e.getMessage(), e);
+        }
+    }
+
+    private void writeColumnAndContent(int numberLength, int lineNumber, CharSequence content) throws IOException {
+        if (lineNumber == -1) {
+            colors.style(writer, w -> {
+                try {
+                    for (int i = 0; i < numberLength; i++) {
+                        w.append("·");
+                    }
+                    w.append("|");
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }, Style.BRIGHT_BLACK);
+        } else {
+            colors.style(writer, w -> {
+                try {
+                    String lineString = String.valueOf(lineNumber);
+                    int thisLineLength = lineString.length();
+                    writer.append(lineString);
+                    // Write the appropriate amount of padding.
+                    for (int i = 0; i < numberLength - thisLineLength; i++) {
+                        writer.append(' ');
+                    }
+                    colors.style(writer, "| ", Style.BRIGHT_BLACK);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }, Style.BRIGHT_BLACK);
+        }
+
+        if (content.length() > 0) {
+            writeStringWithMaxWidth(content, numberLength);
+        }
+
+        writer.append(System.lineSeparator());
+    }
+
+    private void writePointer(int numberLength, int cursorColumn) {
+        colors.style(writer, w -> {
+            try {
+                for (int j = 0; j < numberLength; j++) {
+                    writer.append(' ');
+                }
+                writer.append("|");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }, Style.BRIGHT_BLACK);
+
+        try {
+            for (int j = 0; j < cursorColumn; j++) {
+                writer.append(' ');
+            }
+            colors.style(writer, "^", Style.RED);
+            writer.append(System.lineSeparator());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private int findLongestNumber(Collection<SourceContextLoader.Line> lines) {
+        int maxLineNumber = 1;
+        for (SourceContextLoader.Line line : lines) {
+            maxLineNumber = line.getLineNumber();
+        }
+        return String.valueOf(maxLineNumber).length();
+    }
+
+    private void writeStringWithMaxWidth(CharSequence line, int offsetSize) throws IOException {
+        int allowedSize = maxWidth - offsetSize;
+        writer.append(line, 0, Math.min(line.length(), allowedSize));
+        if (line.length() >= allowedSize) {
+            writer.append("…");
+        }
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CodeFormatter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CodeFormatter.java
@@ -43,6 +43,7 @@ final class CodeFormatter {
             return;
         }
 
+        // Determine the string length of the biggest number to pad the line gutter correctly.
         int numberLength = findLongestNumber(lines);
 
         try {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -53,7 +53,7 @@ final class CommandUtils {
             List<String> models,
             Command.Env env,
             CliPrinter printer,
-            boolean quietValidation,
+            ValidationFlag validationFlag,
             SmithyBuildConfig config
     ) {
         ClassLoader classLoader = env.classLoader();
@@ -63,6 +63,10 @@ final class CommandUtils {
         BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
         Severity minSeverity = buildOptions.severity(standardOptions);
         CliPrinter stderr = env.stderr();
+
+        if (validationFlag == ValidationFlag.DISABLE) {
+            assembler.disableValidation();
+        }
 
         // Emit status updates.
         AtomicInteger issueCount = new AtomicInteger();
@@ -94,7 +98,8 @@ final class CommandUtils {
             }
         }
 
-        Validator.validate(quietValidation, colors, stderr, result);
+        // Note: disabling validation will still show a summary of failures if the model can't be loaded.
+        Validator.validate(validationFlag != ValidationFlag.ENABLE, colors, stderr, result);
         return result.getResult().orElseThrow(() -> new RuntimeException("Expected Validator to throw"));
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/PrettyAnsiValidationFormatter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/PrettyAnsiValidationFormatter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import software.amazon.smithy.cli.ColorFormatter;
+import software.amazon.smithy.cli.Style;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.loader.sourcecontext.SourceContextLoader;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationEventFormatter;
+import software.amazon.smithy.utils.StringUtils;
+
+final class PrettyAnsiValidationFormatter implements ValidationEventFormatter {
+
+    private static final int LINE_LENGTH = 80;
+    private static final Pattern TICK_PATTERN = Pattern.compile("`(.*?)`");
+    private final SourceContextLoader sourceContextLoader;
+    private final ColorFormatter colors;
+    private final String rootPath = Paths.get("").normalize().toAbsolutePath().toString();
+
+    PrettyAnsiValidationFormatter(SourceContextLoader loader, ColorFormatter colors) {
+        this.sourceContextLoader = loader;
+        this.colors = colors;
+    }
+
+    @Override
+    public String format(ValidationEvent event) {
+        String ls = System.lineSeparator();
+        StringBuilder writer = new StringBuilder();
+        writer.append(ls);
+
+        switch (event.getSeverity()) {
+            case WARNING:
+                printTitle(writer, event, Style.YELLOW, Style.BG_YELLOW, Style.BLACK);
+                break;
+            case ERROR:
+                printTitle(writer, event, Style.RED, Style.BG_RED, Style.BLACK);
+                break;
+            case DANGER:
+                printTitle(writer, event, Style.MAGENTA, Style.BG_MAGENTA, Style.BLACK);
+                break;
+            case NOTE:
+                printTitle(writer, event, Style.CYAN, Style.BG_CYAN, Style.BLACK);
+                break;
+            case SUPPRESSED:
+            default:
+                printTitle(writer, event, Style.GREEN, Style.BG_GREEN, Style.BLACK);
+        }
+
+        // Only write an event ID if there is an associated ID.
+        event.getShapeId().ifPresent(id -> {
+            colors.style(writer, "Shape: ", Style.BRIGHT_BLACK);
+            colors.style(writer, id.toString(), Style.BLUE);
+            writer.append(ls);
+        });
+
+        if (event.getSourceLocation() == SourceLocation.NONE) {
+            writer.append(ls);
+        } else {
+            String humanReadableFilename = getHumanReadableFilename(event.getSourceLocation().getFilename());
+            int line = event.getSourceLocation().getLine();
+            int column = event.getSourceLocation().getColumn();
+            colors.style(writer, "File:  ", Style.BRIGHT_BLACK);
+            colors.style(writer, humanReadableFilename + ':' + line + ':' + column, Style.BLUE);
+            writer.append(ls).append(ls);
+
+            Collection<SourceContextLoader.Line> lines = sourceContextLoader.loadContext(event);
+            if (!lines.isEmpty()) {
+                new CodeFormatter(writer, colors, LINE_LENGTH).writeCode(line, column, lines);
+            }
+        }
+
+        writeMessage(writer, event);
+        writer.append(ls);
+
+        return writer.toString();
+    }
+
+    private void printTitle(StringBuilder writer, ValidationEvent event, Style borderColor, Style... styles) {
+        colors.style(writer, "── ", borderColor);
+        String severity = ' ' + event.getSeverity().toString() + ' ';
+        colors.style(writer, severity, styles);
+
+        colors.style(writer, w -> {
+            w.append(" ──");
+
+            int currentLength = severity.length() + 3 + 3 + 1; // severity, dash+padding, padding+dash, padding.
+            int remainingLength = LINE_LENGTH - currentLength;
+            int padding = remainingLength - event.getId().length();
+
+            for (int i = 0; i < padding; i++) {
+                w.append("─");
+            }
+
+            w.append(' ');
+        }, borderColor);
+
+        writer.append(event.getId()).append(System.lineSeparator());
+    }
+
+    // Converts Markdown style ticks to use color highlights if colors are enabled.
+    private void writeMessage(StringBuilder writer, ValidationEvent event) {
+        String content = StringUtils.wrap(event.getMessage(), 80, System.lineSeparator(), false);
+
+        if (colors.isColorEnabled()) {
+            content = TICK_PATTERN.matcher(content).replaceAll(colors.style("$1", Style.CYAN));
+        }
+
+        writer.append(content);
+    }
+
+    private String getHumanReadableFilename(String filename) {
+        if (filename.startsWith("jar:")) {
+            filename = filename.substring(4);
+        }
+
+        if (filename.startsWith("file:")) {
+            filename = filename.substring(5);
+        }
+
+        if (filename.startsWith(rootPath)) {
+            filename = filename.substring(rootPath.length() + 1);
+        }
+
+        return filename;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
+import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelAssembler;
@@ -104,7 +105,8 @@ final class Upgrade1to2Command extends SimpleCommand {
         configBuilder.outputDirectory(tempDir.toString());
         SmithyBuildConfig temporaryConfig = configBuilder.build();
 
-        Model initialModel = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, smithyBuildConfig);
+        ValidationFlag flag = ValidationFlag.from(arguments.getReceiver(StandardOptions.class));
+        Model initialModel = CommandUtils.buildModel(arguments, models, env, env.stderr(), flag, smithyBuildConfig);
 
         SmithyBuild smithyBuild = SmithyBuild.create(classLoader)
                 .config(temporaryConfig)

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -43,7 +43,8 @@ final class ValidateCommand extends ClasspathCommand {
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
-        CommandUtils.buildModel(arguments, models, env, env.stdout(), standardOptions.quiet(), config);
+        ValidationFlag flag = ValidationFlag.from(standardOptions);
+        CommandUtils.buildModel(arguments, models, env, env.stdout(), flag, config);
         LOGGER.info("Smithy validation complete");
         return 0;
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidationFlag.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidationFlag.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import software.amazon.smithy.cli.StandardOptions;
+
+enum ValidationFlag {
+    QUIET, DISABLE, ENABLE;
+
+    static ValidationFlag from(StandardOptions standardOptions) {
+        return standardOptions.quiet()
+               ? ValidationFlag.QUIET
+               : ValidationFlag.ENABLE;
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Validator.java
@@ -52,23 +52,25 @@ final class Validator {
             output.append(' ').append('(');
             StringJoiner joiner = new StringJoiner(", ");
             if (errors > 0) {
-                appendSummaryCount(joiner, colors, "ERROR", errors, Style.BRIGHT_RED);
+                appendSummaryCount(joiner, "ERROR", errors);
             }
 
             if (dangers > 0) {
-                appendSummaryCount(joiner, colors, "DANGER", dangers, Style.RED);
+                appendSummaryCount(joiner, "DANGER", dangers);
             }
 
             if (warnings > 0) {
-                appendSummaryCount(joiner, colors, "WARNING", warnings, Style.YELLOW);
+                appendSummaryCount(joiner, "WARNING", warnings);
             }
 
             if (notes > 0) {
-                appendSummaryCount(joiner, colors, "NOTE", notes, Style.WHITE);
+                appendSummaryCount(joiner, "NOTE", notes);
             }
             output.append(joiner);
             output.append(')');
         }
+
+        output.append(System.lineSeparator());
 
         if (!result.getResult().isPresent() || errors + dangers > 0) {
             throw new CliError(output.toString());
@@ -77,12 +79,7 @@ final class Validator {
         }
     }
 
-    private static void appendSummaryCount(
-            StringJoiner joiner,
-            ColorFormatter colors,
-            String label,
-            int count,
-            Style color) {
-        joiner.add(colors.style(label, color) + ": " + count);
+    private static void appendSummaryCount(StringJoiner joiner, String label, int count) {
+        joiner.add(label + ": " + count);
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/AnsiColorFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/AnsiColorFormatterTest.java
@@ -1,0 +1,47 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AnsiColorFormatterTest {
+    @Test
+    public void detectsIfColorIsEnabled() {
+        assertThat(AnsiColorFormatter.NO_COLOR.isColorEnabled(), is(false));
+        assertThat(AnsiColorFormatter.FORCE_COLOR.isColorEnabled(), is(true));
+    }
+
+    @Test
+    public void wrapsConsumerWithColor() {
+        ColorFormatter formatter = AnsiColorFormatter.FORCE_COLOR;
+        StringBuilder builder = new StringBuilder();
+
+        formatter.style(builder, b -> {
+            b.append("Hello");
+        }, Style.RED);
+
+        String result = builder.toString();
+
+        assertThat(result, equalTo("\033[31mHello\033[0m"));
+    }
+
+    @Test
+    public void wrapsConsumerWithColorAndClosesColorIfThrows() {
+        ColorFormatter formatter = AnsiColorFormatter.FORCE_COLOR;
+        StringBuilder builder = new StringBuilder();
+
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            formatter.style(builder, b -> {
+                b.append("Hello");
+                throw new RuntimeException("A");
+            }, Style.RED);
+        });
+
+        String result = builder.toString();
+
+        assertThat(result, equalTo("\033[31mHello\033[0m"));
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/AnsiColorFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/AnsiColorFormatterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/BufferPrinter.java
@@ -6,8 +6,13 @@ final class BufferPrinter implements CliPrinter {
 
     @Override
     public void println(String text) {
+        print(text + "\n");
+    }
+
+    @Override
+    public void print(String text) {
         synchronized (this) {
-            builder.append(text + "\n");
+            builder.append(text);
         }
     }
 

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliPrinterTest.java
@@ -1,0 +1,17 @@
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+public class CliPrinterTest {
+    @Test
+    public void printsWithNewlineByDefault() {
+        StringBuilder builder = new StringBuilder();
+        CliPrinter printer = builder::append;
+        printer.println("Hi");
+
+        assertThat(builder.toString(), equalTo("Hi" + System.lineSeparator()));
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/CliPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/CliPrinterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/CodeFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/CodeFormatterTest.java
@@ -1,0 +1,104 @@
+package software.amazon.smithy.cli.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.cli.AnsiColorFormatter;
+import software.amazon.smithy.cli.ColorFormatter;
+import software.amazon.smithy.model.loader.sourcecontext.SourceContextLoader;
+
+public class CodeFormatterTest {
+
+    private final String ls = System.lineSeparator();
+    private final String ls2 = ls + ls;
+
+    @Test
+    public void outputsSequentialLinesWithNoCursor() {
+        StringBuilder builder = new StringBuilder();
+        ColorFormatter colors = AnsiColorFormatter.NO_COLOR;
+        CodeFormatter formatter = new CodeFormatter(builder, colors, 80);
+        List<SourceContextLoader.Line> lines = Arrays.asList(
+            new SourceContextLoader.Line(2, "A"),
+            new SourceContextLoader.Line(3, "B"),
+            new SourceContextLoader.Line(4, "C"),
+            new SourceContextLoader.Line(5, "D"));
+
+        formatter.writeCode(0, 0, lines);
+
+        assertThat(builder.toString(), equalTo("2| A" + ls
+                                               + "3| B" + ls
+                                               + "4| C" + ls
+                                               + "5| D" + ls2));
+    }
+
+    @Test
+    public void outputsSequentialLinesWithCursor() {
+        StringBuilder builder = new StringBuilder();
+        ColorFormatter colors = AnsiColorFormatter.NO_COLOR;
+        CodeFormatter formatter = new CodeFormatter(builder, colors, 80);
+        List<SourceContextLoader.Line> lines = Arrays.asList(
+                new SourceContextLoader.Line(2, "Aa"),
+                new SourceContextLoader.Line(3, "Bb"),
+                new SourceContextLoader.Line(4, "Cc"),
+                new SourceContextLoader.Line(5, "Dd"));
+
+        formatter.writeCode(3, 2, lines);
+
+        assertThat(builder.toString(), equalTo("2| Aa" + ls
+                                               + "3| Bb" + ls
+                                               + " |  ^" + ls
+                                               + "4| Cc" + ls
+                                               + "5| Dd" + ls2));
+    }
+
+    @Test
+    public void detectsLineSkips() {
+        StringBuilder builder = new StringBuilder();
+        ColorFormatter colors = AnsiColorFormatter.NO_COLOR;
+        CodeFormatter formatter = new CodeFormatter(builder, colors, 80);
+        List<SourceContextLoader.Line> lines = Arrays.asList(
+                new SourceContextLoader.Line(2, "Aa"),
+                new SourceContextLoader.Line(8, "Bb"),
+                new SourceContextLoader.Line(9, "Cc"),
+                new SourceContextLoader.Line(12, "Dd"));
+
+        formatter.writeCode(8, 2, lines);
+
+        assertThat(builder.toString(), equalTo("2 | Aa" + ls
+                                               + "··|" + ls
+                                               + "8 | Bb" + ls
+                                               + "  |  ^" + ls
+                                               + "9 | Cc" + ls
+                                               + "··|" + ls
+                                               + "12| Dd" + ls2));
+    }
+
+    @Test
+    public void truncatesLongLines() {
+        StringBuilder builder = new StringBuilder();
+        ColorFormatter colors = AnsiColorFormatter.NO_COLOR;
+        CodeFormatter formatter = new CodeFormatter(builder, colors, 10);
+        List<SourceContextLoader.Line> lines = Collections.singletonList(
+                new SourceContextLoader.Line(1, "abcdefghijklmnopqrstuvwxyz"));
+
+        formatter.writeCode(0, 0, lines);
+
+        assertThat(builder.toString(), equalTo("1| abcdefghi…" + ls2));
+    }
+
+    @Test
+    public void ignoresEmptyLines() {
+        StringBuilder builder = new StringBuilder();
+        ColorFormatter colors = AnsiColorFormatter.NO_COLOR;
+        CodeFormatter formatter = new CodeFormatter(builder, colors, 80);
+        List<SourceContextLoader.Line> lines = Collections.emptyList();
+
+        formatter.writeCode(0, 0, lines);
+
+        assertThat(builder.toString(), equalTo(""));
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/CodeFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/CodeFormatterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.cli.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/PrettyAnsiValidationFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/PrettyAnsiValidationFormatterTest.java
@@ -1,0 +1,113 @@
+package software.amazon.smithy.cli.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.cli.AnsiColorFormatter;
+import software.amazon.smithy.cli.ColorFormatter;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.sourcecontext.SourceContextLoader;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class PrettyAnsiValidationFormatterTest {
+    @Test
+    public void formatsEventsWithNoColors() {
+        PrettyAnsiValidationFormatter pretty = createFormatter(AnsiColorFormatter.NO_COLOR);
+        String formatted = formatTestEventWithSeverity(pretty, Severity.ERROR);
+
+        assertThat(formatted, equalTo(
+                "\n"
+                + "──  ERROR  ───────────────────────────────────────────────────────────────── Foo\n"
+                + "Shape: smithy.example#Foo\n"
+                + "File:  build/resources/test/software/amazon/smithy/cli/commands/valid-model.smithy:5:1\n"
+                + "\n"
+                + "4| \n"
+                + "5| resource Foo {\n"
+                + " | ^\n"
+                + "\n"
+                + "Hello, `there`\n")); // keeps ticks because formatting is disabled.
+    }
+
+    @Test
+    public void formatsEventsWithColors() {
+        PrettyAnsiValidationFormatter pretty = createFormatter(AnsiColorFormatter.FORCE_COLOR);
+        String formatted = formatTestEventWithSeverity(pretty, Severity.ERROR);
+
+        assertThat(formatted, equalTo(
+                "\n"
+                + "\u001B[31m── \u001B[0m\u001B[41;30m ERROR \u001B[0m\u001B[31m ───────────────────────────────────────────────────────────────── \u001B[0mFoo\n"
+                + "\u001B[90mShape: \u001B[0m\u001B[34msmithy.example#Foo\u001B[0m\n"
+                + "\u001B[90mFile:  \u001B[0m\u001B[34mbuild/resources/test/software/amazon/smithy/cli/commands/valid-model.smithy:5:1\u001B[0m\n"
+                + "\n"
+                + "\u001B[90m4\u001B[90m| \u001B[0m\u001B[0m\n"
+                + "\u001B[90m5\u001B[90m| \u001B[0m\u001B[0mresource Foo {\n"
+                + "\u001B[90m |\u001B[0m \u001B[31m^\u001B[0m\n"
+                + "\n"
+                + "Hello, \u001B[36mthere\u001B[0m\n"));
+    }
+
+    @Test
+    public void doesNotIncludeSourceLocationNoneInOutput() {
+        PrettyAnsiValidationFormatter pretty = createFormatter(AnsiColorFormatter.NO_COLOR);
+        ValidationEvent event = ValidationEvent.builder()
+                .id("Hello")
+                .severity(Severity.WARNING)
+                .shapeId(ShapeId.from("smithy.example#Foo"))
+                .message("Hi")
+                .build();
+
+        String formatted =  normalizeLinesAndFiles(pretty.format(event));
+
+        assertThat(formatted, equalTo(
+                "\n"
+                + "──  WARNING  ───────────────────────────────────────────────────────────── Hello\n"
+                + "Shape: smithy.example#Foo\n"
+                + "\n"
+                + "Hi\n"));
+    }
+
+    @Test
+    public void wrapsLongLines() {
+        PrettyAnsiValidationFormatter pretty = createFormatter(AnsiColorFormatter.NO_COLOR);
+        ValidationEvent event = ValidationEvent.builder()
+                .id("Hello")
+                .severity(Severity.WARNING)
+                .shapeId(ShapeId.from("smithy.example#Foo"))
+                .message("abcdefghijklmnopqrstuvwxyz 1234567890 abcdefghijklmnopqrstuvwxyz 1234567890 "
+                         + "abcdefghijklmnopqrstuvwxyz 1234567890 abcdefghijklmnopqrstuvwxyz 1234567890")
+                .build();
+
+        String formatted =  normalizeLinesAndFiles(pretty.format(event));
+
+        assertThat(formatted, equalTo(
+                "\n"
+                + "──  WARNING  ───────────────────────────────────────────────────────────── Hello\n"
+                + "Shape: smithy.example#Foo\n"
+                + "\n"
+                + "abcdefghijklmnopqrstuvwxyz 1234567890 abcdefghijklmnopqrstuvwxyz 1234567890\n"
+                + "abcdefghijklmnopqrstuvwxyz 1234567890 abcdefghijklmnopqrstuvwxyz 1234567890\n"));
+    }
+
+    private PrettyAnsiValidationFormatter createFormatter(ColorFormatter colors) {
+        SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(2);
+        return new PrettyAnsiValidationFormatter(loader, colors);
+    }
+
+    private String formatTestEventWithSeverity(PrettyAnsiValidationFormatter pretty, Severity severity) {
+        Model model = Model.assembler().addImport(getClass().getResource("valid-model.smithy")).assemble().unwrap();
+        ValidationEvent event = ValidationEvent.builder()
+                .id("Foo")
+                .severity(severity)
+                .shape(model.expectShape(ShapeId.from("smithy.example#Foo")))
+                .message("Hello, `there`")
+                .build();
+        return normalizeLinesAndFiles(pretty.format(event));
+    }
+
+    private String normalizeLinesAndFiles(String output) {
+        return output.replace("\r\n", "\n").replace("\r", "\n").replace("\\", "/");
+    }
+}

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/ValidateCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/ValidateCommandTest.java
@@ -95,11 +95,11 @@ public class ValidateCommandTest {
         CliUtils.Result cliResult = runValidationEventsTest(Severity.NOTE);
         String result = cliResult.stdout();
 
-        assertThat(result, not(containsString("EmitSuppressed")));
-        assertThat(result, containsString("EmitNotes"));
-        assertThat(result, containsString("EmitWarnings"));
-        assertThat(result, containsString("EmitDangers"));
-        assertThat(result, containsString("TraitTarget"));
+        assertThat(result, not(containsString("─ EmitSuppressed")));
+        assertThat(result, containsString("─ EmitNotes"));
+        assertThat(result, containsString("─ EmitWarnings"));
+        assertThat(result, containsString("─ EmitDangers"));
+        assertThat(result, containsString("─ TraitTarget"));
     }
 
     @Test

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoader.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader.sourcecontext;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * This class loads model files into memory, one at a time, and either shows leading lines up to a source location or
+ * shows lines that are relevant to a source location use context from a {@link Model}.
+ *
+ * <p>Sort sequences of {@link SourceLocation}s before calling {@link #loadContext(FromSourceLocation)} to avoid
+ * needing to open and parse the same file more than once.
+ *
+ * @see SourceContextLoader#createLineBasedLoader
+ * @see SourceContextLoader#createModelAwareLoader
+ */
+final class DefaultSourceLoader implements SourceContextLoader {
+
+    private static final Logger LOGGER = Logger.getLogger(DefaultSourceLoader.class.getName());
+    private final List<Line> lines = new ArrayList<>();
+    private final Model model;
+    private final int defaultCodeLines;
+    private SourceLocation lastLoadedLocation;
+    private Collection<Line> lastLoadedLocationLines;
+
+    DefaultSourceLoader(int defaultCodeLines, Model model) {
+        if (defaultCodeLines < 1) {
+            throw new IllegalArgumentException("Must allow at least one code hint line: " + defaultCodeLines);
+        }
+
+        this.defaultCodeLines = defaultCodeLines;
+        this.model = model;
+    }
+
+    @Override
+    public Collection<Line> loadContext(FromSourceLocation source) {
+        SourceLocation location = source.getSourceLocation();
+
+        // Ignore the components that were generated and have no location.
+        if (location == SourceLocation.NONE) {
+            return Collections.emptyList();
+        }
+
+        // Use the cache if possible (e.g., multiple validation events for the same shape).
+        if (location.equals(lastLoadedLocation)) {
+            return lastLoadedLocationLines;
+        }
+
+        // Open a new file if no file is open, or it differs from the source location file.
+        if (lastLoadedLocation == null || !lastLoadedLocation.getFilename().equals(location.getFilename())) {
+            loadNextFile(location);
+        }
+
+        int line = location.getLine();
+
+        if (!isValidLine(line)) {
+            LOGGER.finer(() -> "Attempted to load context for an invalid source location: " + location);
+            lastLoadedLocationLines = Collections.emptyList();
+        } else if (model == null) {
+            int start = Math.max(0, line - defaultCodeLines);
+            lastLoadedLocationLines = lines.subList(start, line);
+        } else {
+            lastLoadedLocationLines = parseLines(source);
+        }
+
+        return lastLoadedLocationLines;
+    }
+
+    private void loadNextFile(SourceLocation source) {
+        lines.clear();
+        lastLoadedLocation = source;
+        LOGGER.finer(() -> "Opening source location file for " + source);
+
+        try (LineNumberReader reader = openSourceLocation(source)) {
+            String lineString;
+            while ((lineString = reader.readLine()) != null) {
+                lines.add(new Line(reader.getLineNumber(), lineString));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private LineNumberReader openSourceLocation(FromSourceLocation source) {
+        try {
+            // Ensure that there's a scheme.
+            SourceLocation location = source.getSourceLocation();
+            String normalizedFile = location.getFilename();
+
+            // Refuse to open URLs that are not files or JARs by forcing the file protocol.
+            if (!location.getFilename().startsWith("file:") && !location.getFilename().startsWith("jar:")) {
+                normalizedFile = "file:" + normalizedFile;
+            }
+
+            // Loading from a JAR needs special treatment, but this can
+            // all actually be handled in a uniform way using URLs.
+            URL url = new URL(normalizedFile);
+            URLConnection connection = url.openConnection();
+            connection.setUseCaches(false);
+
+            return new LineNumberReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to load source location context for " + source, e);
+        }
+    }
+
+    private boolean isValidLine(int line) {
+        line--;
+        return line >= 0 && line < lines.size();
+    }
+
+    private void addLineIfValid(int line, List<Line> mutate) {
+        if (isValidLine(line)) {
+            mutate.add(lines.get(line - 1));
+        }
+    }
+
+    private List<Line> parseLines(FromSourceLocation source) {
+        SourceLocation location = source.getSourceLocation();
+        int line = location.getLine();
+
+        if (source instanceof ValidationEvent) {
+            ValidationEvent event = (ValidationEvent) source;
+            Shape targetShape = event.getShapeId().flatMap(model::getShape).orElse(null);
+            if (targetShape != null) {
+                if (targetShape.getSourceLocation().equals(location)) {
+                    // The validation event is on a shape since the location is equal to the shape location.
+                    source = targetShape;
+                } else if (targetShape.getSourceLocation().getLine() > location.getLine()) {
+                    // Assume it's a trait in the Smithy IDL. Show the trait definition followed by shape definition.
+                    return parseTraitBeforeShape(location, targetShape);
+                } else if (location.getFilename().endsWith(".json")) {
+                    // Assume it's a trait defined in JSON. Show the trait definition followed by shape definition.
+                    return parseTraitAfterShape(location, targetShape);
+                } else {
+                    // It's a trait that uses "apply" or the location is invalid, so just show the trait line.
+                    return Collections.singletonList(lines.get(line - 1));
+                }
+            }
+        }
+
+        if (source instanceof MemberShape) {
+            return parseMemberShape(location, (MemberShape) source);
+        }
+
+        return parseOtherComponents(location);
+    }
+
+    private List<Line> parseTraitBeforeShape(SourceLocation location, Shape targetShape) {
+        List<Line> result = new ArrayList<>(2);
+        addLineIfValid(location.getLine(), result);
+        addLineIfValid(targetShape.getSourceLocation().getLine(), result);
+        return result;
+    }
+
+    private List<Line> parseTraitAfterShape(SourceLocation location, Shape targetShape) {
+        List<Line> result = new ArrayList<>(2);
+        addLineIfValid(targetShape.getSourceLocation().getLine(), result);
+        addLineIfValid(location.getLine(), result);
+        return result;
+    }
+
+    private List<Line> parseMemberShape(SourceLocation location, MemberShape member) {
+        // Members should always crawl up to the defining shape in both the IDL and JSON.
+        Shape container = model.getShape(member.getContainer()).orElse(null);
+
+        if (container != null) {
+            SourceLocation containerLocation = container.getSourceLocation();
+            // Some basic checking to ensure the member after the container in the same file.
+            if (containerLocation.getFilename().equals(location.getFilename())
+                    && containerLocation.getLine() < location.getLine()) {
+                List<Line> result = new ArrayList<>(2);
+                addLineIfValid(containerLocation.getLine(), result);
+                addLineIfValid(location.getLine(), result);
+                return result;
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<Line> parseOtherComponents(SourceLocation location) {
+        // Show context lines up from the shape until maxCode or until an empty line is encountered.
+        int line = location.getLine();
+        int lowestPossibleLine = Math.max(0, line - 1 - defaultCodeLines);
+        int foundStart = line - 1;
+
+        for (int i = line - 1; i > lowestPossibleLine; i--) {
+            Line foundLine = lines.get(i);
+            if (foundLine.getContent().length() > 0) {
+                foundStart = i;
+            } else {
+                break;
+            }
+        }
+
+        return lines.subList(foundStart, line);
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoader.java
@@ -194,7 +194,10 @@ final class DefaultSourceLoader implements SourceContextLoader {
         // Members should always crawl up to the defining shape in both the IDL and JSON.
         Shape container = model.getShape(member.getContainer()).orElse(null);
 
-        if (container != null) {
+        // This should never be null, but guard here just in case.
+        if (container == null) {
+            LOGGER.warning(() -> "Member container not found: " + member.getId() + " -> " + member.getTarget());
+        } else {
             SourceLocation containerLocation = container.getSourceLocation();
             // Some basic checking to ensure the member after the container in the same file.
             if (containerLocation.getFilename().equals(location.getFilename())

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/sourcecontext/SourceContextLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/sourcecontext/SourceContextLoader.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.loader.sourcecontext;
+
+import java.util.Collection;
+import java.util.Objects;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Loads lines of text from source location files to display in things like error messages.
+ */
+@SmithyUnstableApi
+public interface SourceContextLoader {
+    /**
+     * Attempts to load a file and return contextual source lines for the given source location.
+     *
+     * @param location Source location to load.
+     * @return Returns the loaded source lines.
+     */
+    Collection<Line> loadContext(FromSourceLocation location);
+
+    /**
+     * Load context and include {@code defaultCodeLines} lines leading up to the target line.
+     *
+     * @param defaultCodeLines Number of leading lines to include leading up to the target. Must be greater than 0.
+     * @return Returns the loader.
+     * @throws IllegalArgumentException if {@code defaultCodeLines} is less than 1.
+     */
+    static SourceContextLoader createLineBasedLoader(int defaultCodeLines) {
+        return new DefaultSourceLoader(defaultCodeLines, null);
+    }
+
+    /**
+     * Load context and include the most relevant information possible based on the kind of {@link FromSourceLocation}.
+     *
+     * @param defaultCodeLinesHint Limits the number of context lines in some cases. Must be greater than 0.
+     * @return Returns the loader.
+     * @throws IllegalArgumentException if {@code defaultCodeLinesHint} is less than 1.
+     */
+    static SourceContextLoader createModelAwareLoader(Model model, int defaultCodeLinesHint) {
+        return new DefaultSourceLoader(defaultCodeLinesHint, model);
+    }
+
+    /**
+     * A pair of line numbers to the contents of lines.
+     */
+    final class Line {
+
+        private final int lineNumber;
+        private final CharSequence content;
+
+        public Line(int lineNumber, CharSequence content) {
+            this.lineNumber = lineNumber;
+            this.content = content;
+        }
+
+        /**
+         * Get the line number of the line, starting at 1.
+         *
+         * @return Returns the 1-based line number.
+         */
+        public int getLineNumber() {
+            return lineNumber;
+        }
+
+        /**
+         * Returns the content as a CharSequence.
+         *
+         * <p>CharSequence is used here to allow implementations to potentially use things like CharBuffer slices.
+         *
+         * @return The content of the line.
+         */
+        public CharSequence getContent() {
+            return content;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(lineNumber, content);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            } else if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Line line = (Line) o;
+            return lineNumber == line.lineNumber && Objects.equals(content, line.content);
+        }
+
+        @Override
+        public String toString() {
+            return lineNumber + " | " + content;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationEvent.java
@@ -39,7 +39,8 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * Events with a severity less than ERROR can be suppressed. All events contain
  * a message, severity, and eventId.
  */
-public final class ValidationEvent implements Comparable<ValidationEvent>, ToNode, ToSmithyBuilder<ValidationEvent> {
+public final class ValidationEvent
+        implements FromSourceLocation, Comparable<ValidationEvent>, ToNode, ToSmithyBuilder<ValidationEvent> {
     private static final ValidationEventFormatter DEFAULT_FORMATTER = new LineValidationEventFormatter();
     private final SourceLocation sourceLocation;
     private final String message;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DeprecatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DeprecatedTraitValidator.java
@@ -60,7 +60,7 @@ public final class DeprecatedTraitValidator extends AbstractValidator {
                     for (Shape shape : shapesWithTrait) {
                         // Ignore the use of @box on prelude shapes.
                         if (!Prelude.isPreludeShape(shape)) {
-                            events.add(warning(shape, trait, format(
+                            events.add(warning(shape, shape.findTrait(trait.getId()).get(), format(
                                     "This shape applies a trait that is deprecated: %s", traitMessage)));
                         }
                     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnstableTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnstableTraitValidator.java
@@ -37,7 +37,7 @@ public final class UnstableTraitValidator extends AbstractValidator {
             for (Shape appliedTo : model.getShapesWithTrait(trait)) {
                 events.add(warning(
                         appliedTo,
-                        trait,
+                        appliedTo.findTrait(trait.getId()).get(), // point to the applied trait which for sure exists.
                         format("This shape applies a trait that is unstable: %s", trait.toShapeId()),
                         trait.toShapeId().toString())
                 );

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoaderTest.java
@@ -1,0 +1,223 @@
+package software.amazon.smithy.model.loader.sourcecontext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class DefaultSourceLoaderTest {
+
+    @Test
+    public void requiresAtLeastOneLine() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            SourceContextLoader.createLineBasedLoader(0);
+        });
+    }
+
+    @Test
+    public void ignoresSourceLocationNone() {
+        assertThat(SourceContextLoader.createLineBasedLoader(4).loadContext(SourceLocation.NONE), empty());
+    }
+
+    @Test
+    public void ignoresInvalidSourceLocations() {
+        String file = getClass().getResource("context.smithy").getFile();
+
+        assertThat(SourceContextLoader.createLineBasedLoader(4).loadContext(new SourceLocation(file, -1, -1)),
+                   empty());
+        assertThat(SourceContextLoader.createLineBasedLoader(4).loadContext(new SourceLocation(file, 9999, -1)),
+                   empty());
+    }
+
+    @Test
+    public void doesNotLoadHttp() {
+        SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(1);
+        SourceLocation location = new SourceLocation("http://test.com", 1, 1);
+
+        Assertions.assertThrows(UncheckedIOException.class, () -> loader.loadContext(location));
+    }
+
+    @Test
+    public void doesNotLoadHttps() {
+        SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(1);
+        SourceLocation location = new SourceLocation("https://test.com", 1, 1);
+
+        Assertions.assertThrows(UncheckedIOException.class, () -> loader.loadContext(location));
+    }
+
+    @Test
+    public void loadsSingleLineContextFromFile() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(1);
+        SourceLocation location = model.expectShape(ShapeId.from("example.smithy#Foo$bar")).getSourceLocation();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(location);
+
+        assertThat(context, hasSize(1));
+        assertThat(context.iterator().next().toString(), containsString("  bar: String,"));
+    }
+
+    @Test
+    public void loadsMultipleLineContextFromFile() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(4);
+        SourceLocation location = model.expectShape(ShapeId.from("example.smithy#Foo$bar")).getSourceLocation();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(location);
+        Iterator<SourceContextLoader.Line> iter = context.iterator();
+
+        assertThat(context, hasSize(4));
+        assertThat(iter.next().toString(), containsString("namespace example.smithy"));
+        assertThat(iter.next().toString(), endsWith("| "));
+        assertThat(iter.next().toString(), containsString("structure Foo {"));
+        assertThat(iter.next().toString(), containsString("  bar: String,"));
+    }
+
+    @Test
+    public void loadsContextFromJar() {
+        Model model = Model.assembler().addImport(getClass().getResource("../jar-import.jar")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(1);
+        SourceLocation location = model.expectShape(ShapeId.from("foo.baz#A")).getSourceLocation();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(location);
+
+        assertThat(context, not(empty()));
+        assertThat(context.iterator().next().toString(), containsString("string A"));
+    }
+
+    @Test
+    public void modelLoadsLeadingLinesUpToShape() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createModelAwareLoader(model, 4);
+        Shape shape = model.expectShape(ShapeId.from("example.smithy#Baz"));
+        ValidationEvent event = ValidationEvent.builder()
+                .severity(Severity.ERROR)
+                .id("Foo")
+                .shape(shape)
+                .message("Test")
+                .build();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(event);
+        Iterator<SourceContextLoader.Line> iter = context.iterator();
+
+        assertThat(context, hasSize(3));
+        assertThat(iter.next().toString(), containsString("/// Docs"));
+        assertThat(iter.next().toString(), containsString("@deprecated"));
+        assertThat(iter.next().toString(), containsString("structure Baz {"));
+    }
+
+    @Test
+    public void showsContainerAndMember() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createModelAwareLoader(model, 4);
+        Shape shape = model.expectShape(ShapeId.from("example.smithy#Baz$bam"));
+        ValidationEvent event = ValidationEvent.builder()
+                .severity(Severity.ERROR)
+                .id("Foo")
+                .shape(shape)
+                .message("Test")
+                .build();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(event);
+        Iterator<SourceContextLoader.Line> iter = context.iterator();
+
+        assertThat(context, hasSize(2));
+        assertThat(iter.next().toString(), containsString("structure Baz {"));
+        assertThat(iter.next().toString(), containsString("  bam: String,"));
+    }
+
+    @Test
+    public void ignoresInvalidMembersThatAreAboveContainers() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        MemberShape member = model.expectShape(ShapeId.from("example.smithy#Baz$bam"), MemberShape.class);
+        // Create a modified member that is incorrectly above the container shape.
+        MemberShape modified = member.toBuilder()
+                .addTrait(new SensitiveTrait()) // change it so the change takes effect
+                .source(new SourceLocation(member.getSourceLocation().getFilename(), 1, 1))
+                .build();
+        Model updated = ModelTransformer.create().replaceShapes(model, Collections.singleton(modified));
+        SourceContextLoader loader = SourceContextLoader.createModelAwareLoader(updated, 4);
+        ValidationEvent event = ValidationEvent.builder()
+                .severity(Severity.ERROR)
+                .id("Foo")
+                .shape(modified)
+                .message("Test")
+                .build();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(event);
+
+        assertThat(context, empty());
+    }
+
+    @Test
+    public void showsMemberAfterTrait() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createModelAwareLoader(model, 4);
+        Shape shape = model.expectShape(ShapeId.from("example.smithy#Baz$bam"));
+        ValidationEvent event = ValidationEvent.builder()
+                .severity(Severity.ERROR)
+                .id("Foo")
+                .shape(shape)
+                .sourceLocation(shape.expectTrait(DocumentationTrait.class))
+                .message("Test")
+                .build();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(event);
+        Iterator<SourceContextLoader.Line> iter = context.iterator();
+
+        assertThat(context, hasSize(2));
+        assertThat(iter.next().toString(), containsString("/// Hello!"));
+        assertThat(iter.next().toString(), containsString("bam: String,"));
+    }
+
+    @Test
+    public void applyStatementsJustShowTheStatement() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.smithy")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createModelAwareLoader(model, 4);
+        Shape shape = model.expectShape(ShapeId.from("example.smithy#Foo"));
+        ValidationEvent event = ValidationEvent.builder()
+                .severity(Severity.ERROR)
+                .id("Foo")
+                .shape(shape)
+                .sourceLocation(shape.expectTrait(DocumentationTrait.class))
+                .message("Test")
+                .build();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(event);
+        Iterator<SourceContextLoader.Line> iter = context.iterator();
+
+        assertThat(context, hasSize(1));
+        assertThat(iter.next().toString(), containsString("apply Foo @documentation(\"applied\")"));
+    }
+
+    @Test
+    public void showsJsonModelTraits() {
+        Model model = Model.assembler().addImport(getClass().getResource("context.json")).assemble().unwrap();
+        SourceContextLoader loader = SourceContextLoader.createModelAwareLoader(model, 4);
+        Shape shape = model.expectShape(ShapeId.from("example.smithy#Foo"));
+        ValidationEvent event = ValidationEvent.builder()
+                .severity(Severity.ERROR)
+                .id("Foo")
+                .shape(shape)
+                .sourceLocation(shape.expectTrait(SensitiveTrait.class))
+                .message("Test")
+                .build();
+        Collection<SourceContextLoader.Line> context = loader.loadContext(event);
+        Iterator<SourceContextLoader.Line> iter = context.iterator();
+
+        assertThat(context, hasSize(2));
+        assertThat(iter.next().toString(), containsString("\"example.smithy#Foo\": {"));
+        assertThat(iter.next().toString(), containsString("\"smithy.api#sensitive\": {}"));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/sourcecontext/DefaultSourceLoaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.model.loader.sourcecontext;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatterTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatterTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.startsWith;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.loader.sourcecontext.SourceContextLoader;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
@@ -16,7 +17,8 @@ public class ContextualValidationEventFormatterTest {
     @Test
     public void loadsContext() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("context.smithy"))
+                // Use the shared context file.
+                .addImport(SourceContextLoader.class.getResource("context.smithy"))
                 .assemble()
                 .unwrap();
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/sourcecontext/context.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/sourcecontext/context.json
@@ -1,0 +1,11 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "example.smithy#Foo": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/sourcecontext/context.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/sourcecontext/context.smithy
@@ -4,6 +4,12 @@ structure Foo {
   bar: String,
 }
 
+/// Docs
+@deprecated
 structure Baz {
+  /// Hello!
+  @recommended
   bam: String,
 }
+
+apply Foo @documentation("applied")


### PR DESCRIPTION
This commit adds more colorful and easier to scan validation output for the CLI.

To support this change, I needed to introduce a new validation event formatter that uses ANSI codes. Updating the existing formatter would have added a ton of composition to it, making it hard to understand.

When breaking out a new validation event formatter, I noticed some duplicate code in handling: 1) creating a human-readable filename 2) loading a line of text from a source location.

To account for (1), I added getHumanReadableFilename() to ValidationEvent.

To account for (2), I created a new abstraction for grabbing source context from a SourceLocation.

I ended up needing an abstraction for emitting lots of content that's wrapped in ANSI color escapes, and I didn't want to add escapes over and over or have to buffer intermediate output to a string, so I added a method for wrapping a Consumer<Appendable> that handles adding ANSI styles before and after the consumer is called.

Style was updated to an interface in case we ever want to support theming and use HEX code colors.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
