### PR TITLE
Disable validation for select command

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
@@ -21,6 +21,15 @@ public class SelectTest {
     }
 
     @Test
+    public void doesNotShowWarnings() {
+        List<String> args = Arrays.asList("select", "--selector", "string [id|namespace=smithy.example]");
+        IntegUtils.run("model-with-warning", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput().trim(), equalTo("smithy.example#MyString"));
+        });
+    }
+
+    @Test
     public void selectsVariables() {
         List<String> args = Arrays.asList("select", "--vars", "--selector", "list $list(*) > member > string");
         IntegUtils.run("simple-config-sources", args, result -> {

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/model/main.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+namespace smithy.example
+
+@unstable
+structure exampleUnstable {}
+
+@exampleUnstable
+string MyString

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-warning/smithy-build.json
@@ -1,0 +1,4 @@
+{
+    "version": "1.0",
+    "sources": ["model"]
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -41,7 +41,7 @@ final class AstCommand extends ClasspathCommand {
 
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, config);
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), ValidationFlag.QUIET, config);
         ModelSerializer serializer = ModelSerializer.builder().build();
         env.stdout().println(Node.prettyPrintJson(serializer.serialize(model)));
         return 0;

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -102,7 +102,8 @@ final class BuildCommand extends ClasspathCommand {
 
         // Build the model and fail if there are errors. Prints errors to stdout.
         // Configure whether the build is quiet or not based on the --quiet option.
-        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), standardOptions.quiet(), config);
+        ValidationFlag flag = ValidationFlag.from(standardOptions);
+        Model model = CommandUtils.buildModel(arguments, models, env, env.stderr(), flag, config);
 
         Supplier<ModelAssembler> modelAssemblerSupplier = () -> {
             ModelAssembler assembler = Model.assembler(classLoader);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -77,9 +77,9 @@ final class BuildOptions implements ArgumentReceiver {
                 return value -> discoverClasspath = value;
             case SEVERITY:
                 return value -> {
-                    severity = Severity.fromString(value).orElseThrow(() -> {
+                    severity(Severity.fromString(value).orElseThrow(() -> {
                         return new CliError("Invalid severity level: " + value);
-                    });
+                    }));
                 };
             default:
                 return null;
@@ -100,6 +100,10 @@ final class BuildOptions implements ArgumentReceiver {
 
     String output() {
         return output;
+    }
+
+    void severity(Severity severity) {
+        this.severity = severity;
     }
 
     /**

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CommandUtils.java
@@ -53,7 +53,7 @@ final class CommandUtils {
             List<String> models,
             Command.Env env,
             CliPrinter printer,
-            boolean quietValidation,
+            ValidationFlag validationFlag,
             SmithyBuildConfig config
     ) {
         ClassLoader classLoader = env.classLoader();
@@ -63,6 +63,10 @@ final class CommandUtils {
         BuildOptions buildOptions = arguments.getReceiver(BuildOptions.class);
         Severity minSeverity = buildOptions.severity(standardOptions);
         CliPrinter stderr = env.stderr();
+
+        if (validationFlag == ValidationFlag.DISABLE) {
+            assembler.disableValidation();
+        }
 
         // Emit status updates.
         AtomicInteger issueCount = new AtomicInteger();
@@ -94,7 +98,8 @@ final class CommandUtils {
             }
         }
 
-        Validator.validate(quietValidation, colors, stderr, result);
+        // Note: disabling validation will still show a summary of failures if the model can't be loaded.
+        Validator.validate(validationFlag != ValidationFlag.ENABLE, colors, stderr, result);
         return result.getResult().orElseThrow(() -> new RuntimeException("Expected Validator to throw"));
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
+import software.amazon.smithy.cli.StandardOptions;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelAssembler;
@@ -104,7 +105,8 @@ final class Upgrade1to2Command extends SimpleCommand {
         configBuilder.outputDirectory(tempDir.toString());
         SmithyBuildConfig temporaryConfig = configBuilder.build();
 
-        Model initialModel = CommandUtils.buildModel(arguments, models, env, env.stderr(), true, smithyBuildConfig);
+        ValidationFlag flag = ValidationFlag.from(arguments.getReceiver(StandardOptions.class));
+        Model initialModel = CommandUtils.buildModel(arguments, models, env, env.stderr(), flag, smithyBuildConfig);
 
         SmithyBuild smithyBuild = SmithyBuild.create(classLoader)
                 .config(temporaryConfig)

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidateCommand.java
@@ -43,7 +43,8 @@ final class ValidateCommand extends ClasspathCommand {
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> models) {
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
-        CommandUtils.buildModel(arguments, models, env, env.stdout(), standardOptions.quiet(), config);
+        ValidationFlag flag = ValidationFlag.from(standardOptions);
+        CommandUtils.buildModel(arguments, models, env, env.stdout(), flag, config);
         LOGGER.info("Smithy validation complete");
         return 0;
     }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidationFlag.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidationFlag.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import software.amazon.smithy.cli.StandardOptions;
+
+enum ValidationFlag {
+    QUIET, DISABLE, ENABLE;
+
+    static ValidationFlag from(StandardOptions standardOptions) {
+        return standardOptions.quiet()
+               ? ValidationFlag.QUIET
+               : ValidationFlag.ENABLE;
+    }
+}


### PR DESCRIPTION
The select command doesn't need to perform validation or show validation summary information. This commit updates the select command to only show validation information if the model can't be loaded.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
