### PR TITLE
Ensure that the event listener gets all the events

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoadOperationProcessor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoadOperationProcessor.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.loader;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,15 @@ final class LoadOperationProcessor implements Consumer<LoadOperation> {
             public boolean add(ValidationEvent e) {
                 validationEventListener.accept(e);
                 return super.add(e);
+            }
+
+            @Override
+            public boolean addAll(Collection<? extends ValidationEvent> validationEvents) {
+                for (ValidationEvent e : validationEvents) {
+                    validationEventListener.accept(e);
+
+                }
+                return super.addAll(validationEvents);
             }
         };
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoadOperationProcessor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoadOperationProcessor.java
@@ -61,7 +61,6 @@ final class LoadOperationProcessor implements Consumer<LoadOperation> {
             public boolean addAll(Collection<? extends ValidationEvent> validationEvents) {
                 for (ValidationEvent e : validationEvents) {
                     validationEventListener.accept(e);
-
                 }
                 return super.addAll(validationEvents);
             }


### PR DESCRIPTION
*Description of changes:*

Currently not all events are passed to the listener given the way this is implemented, e.g., if some part of logic add a set of events directly to the list using `addAll`. In particular`LoaderShapeMap` adds all the events to the events list for each `ShapeModifier` [here](https://github.com/awslabs/smithy/blob/1f0da40ff2ee24f863f4895189c4c3ec89d275e2/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderShapeMap.java#L380) which are then not shown in the output. Validation for the following model

```
$version: "2.0"

namespace com.amazon.example
structure Mixin1 {
    a: String
}

structure Valid with [Mixin1] {
    a: Integer
}
```

Will currently output

```
$ smithy validate ~/tmp/test-model5.smithy
FAILURE: Validated 211 shapes (ERROR: 1)
```

After this change it will output

```
ERROR: com.amazon.example#Valid$a (Model)
     @ /Users/sugmanue/tmp/test-model5.smithy
     |
  21 |     a: Integer
     |     ^
     = Member conflicts with an inherited mixin member: com.amazon.example#Mixin1$a

FAILURE: Validated 211 shapes (ERROR: 1)
```

This example shows that we should probably create an abstraction to contains the `ValidationEvents` instead of just using a raw `List`.

**EDIT**

After the recent change made by Michael this error show up in the output since now the validation events are processed in a different way, however we're still not sending those to the listener, so I think is still worth patching.