### PR TITLE
Reduce IDL ambiguity by replacing `*WS` with `[WS]`

### DIFF
--- a/docs/source-1.0/spec/core/idl.rst
+++ b/docs/source-1.0/spec/core/idl.rst
@@ -86,7 +86,7 @@ The Smithy IDL is defined by the following ABNF which uses case-sensitive
 string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
 
 .. productionlist:: smithy
-    idl:*`WS` `ControlSection` `MetadataSection` `ShapeSection`
+    idl:[`WS`] `ControlSection` `MetadataSection` `ShapeSection`
 
 .. rubric:: Whitespace
 
@@ -95,7 +95,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     SP           :1*(%x20 / %x09) ; one or more spaces or tabs
     NL           :%x0A / %x0D.0A ; Newline: \n and \r\n
     NotNL        :%x09 / %x20-10FFFF ; Any character except newline
-    BR           :*`SP` 1*(`Comment` / `NL`) *`WS`; line break followed by whitespace
+    BR           :*`SP` 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
 
 .. rubric:: Comments
 
@@ -124,19 +124,19 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                         :/ `Number`
                         :/ `NodeKeywords`
                         :/ `NodeStringValue`
-    NodeArray           :"[" *`WS`
-                        :      [`NodeValue` *`WS`
-                        :          *(`Comma` `NodeValue` *`WS`)
+    NodeArray           :"[" [`WS`]
+                        :      [`NodeValue` [`WS`]
+                        :          *(`Comma` `NodeValue` [`WS`])
                         :      `TrailingComma`]
                         :  "]"
-    Comma               :"," *`WS`
+    Comma               :"," [`WS`]
     TrailingComma       :[`Comma`]
-    NodeObject          :"{" *`WS`
-                        :      [`NodeObjectKvp` *`WS`
-                        :          *(`Comma` `NodeObjectKvp` *`WS`)
+    NodeObject          :"{" [`WS`]
+                        :      [`NodeObjectKvp` [`WS`]
+                        :          *(`Comma` `NodeObjectKvp` [`WS`])
                         :      `TrailingComma`]
                         :  "}"
-    NodeObjectKvp       :`NodeObjectKey` *`WS` ":" *`WS` `NodeValue`
+    NodeObjectKvp       :`NodeObjectKey` [`WS`] ":" [`WS`] `NodeValue`
     NodeObjectKey       :`QuotedText` / `Identifier`
     Number              :[`Minus`] `Int` [`Frac`] [`Exp`]
     DecimalPoint        :%x2E ; .
@@ -190,51 +190,51 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                             :/ %s"byte" / %s"short" / %s"integer" / %s"long"
                             :/ %s"float" / %s"double" / %s"bigInteger"
                             :/ %s"bigDecimal" / %s"timestamp"
-    ListStatement           :%s"list" `SP` `Identifier` *`WS` `ListMembers`
-    ListMembers             :"{" *`WS` `ListMember` *`WS` "}"
+    ListStatement           :%s"list" `SP` `Identifier` [`WS`] `ListMembers`
+    ListMembers             :"{" [`WS`] `ListMember` [`WS`] "}"
     ListMember              :`TraitStatements` `ExplicitListMember`
     ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
-    SetStatement            :%s"set" `SP` `Identifier` *`WS` `SetMembers`
-    SetMembers              :"{" *`WS` `SetMember` *`WS` "}"
+    SetStatement            :%s"set" `SP` `Identifier` [`WS`] `SetMembers`
+    SetMembers              :"{" [`WS`] `SetMember` [`WS`] "}"
     SetMember               :`TraitStatements` `ExplicitSetMember`
     ExplicitSetMember       :%s"member" *`SP` ":" *`SP` `ShapeId`
-    MapStatement            :%s"map" `SP` `Identifier` *`WS` `MapMembers`
-    MapMembers              :"{" *`WS` `MapKey` `WS` `MapValue` *`WS` "}"
+    MapStatement            :%s"map" `SP` `Identifier` [`WS`] `MapMembers`
+    MapMembers              :"{" [`WS`] `MapKey` `WS` `MapValue` [`WS`] "}"
     MapKey                  :`TraitStatements` `ExplicitMapKey`
     ExplicitMapKey          :%s"key" *`SP` ":" *`SP` `ShapeId`
     MapValue                :`TraitStatements` `ExplicitMapValue`
     ExplicitMapValue        :%s"value" *`SP` ":" *`SP` `ShapeId`
-    StructureStatement      :%s"structure" `SP` `Identifier` *`WS` `StructureMembers`
-    StructureMembers        :"{" *`WS`
-                            :      [`StructureMember` *`WS`
-                            :          *(`Comma` `StructureMember` *`WS`)
+    StructureStatement      :%s"structure" `SP` `Identifier` [`WS`] `StructureMembers`
+    StructureMembers        :"{" [`WS`]
+                            :      [`StructureMember` [`WS`]
+                            :          *(`Comma` `StructureMember` [`WS`])
                             :      `TrailingComma`]
                             :  "}"
     StructureMember         :`TraitStatements` `ExplicitStructureMember`                        
     ExplicitStructureMember :`Identifier` *`SP` ":" *`SP` `ShapeId`
-    UnionStatement          :%s"union" `SP` `Identifier` *`WS` `UnionMembers`
-    UnionMembers            :"{" *`WS`
-                            :      `UnionMember` *`WS`
-                            :          *(`Comma` `UnionMember` *`WS`)
+    UnionStatement          :%s"union" `SP` `Identifier` [`WS`] `UnionMembers`
+    UnionMembers            :"{" [`WS`]
+                            :      `UnionMember` [`WS`]
+                            :          *(`Comma` `UnionMember` [`WS`])
                             :      `TrailingComma`
                             :  "}"
     UnionMember             :`TraitStatements` `ExplicitUnionMember`
     ExplicitUnionMember     :`Identifier` *`SP` ":" *`SP` `ShapeId`
-    ServiceStatement        :%s"service" `SP` `Identifier` *`WS` `NodeObject`
-    ResourceStatement       :%s"resource" `SP` `Identifier` *`WS` `NodeObject`
-    OperationStatement      :%s"operation" `SP` `Identifier` *`WS` `NodeObject`
+    ServiceStatement        :%s"service" `SP` `Identifier` [`WS`] `NodeObject`
+    ResourceStatement       :%s"resource" `SP` `Identifier` [`WS`] `NodeObject`
+    OperationStatement      :%s"operation" `SP` `Identifier` [`WS`] `NodeObject`
 
 .. rubric:: Traits
 
 .. productionlist:: smithy
-    TraitStatements         :*(*`WS` `Trait`) *`WS`
+    TraitStatements         :*([`WS`] `Trait`) [`WS`]
     Trait                   :"@" `ShapeId` [`TraitBody`]
-    TraitBody               :"(" *`WS` [`TraitBodyValue`] *`WS` ")"
+    TraitBody               :"(" [`WS`] [`TraitBodyValue`] [`WS`] ")"
     TraitBodyValue          :`TraitStructure` / `NodeValue`
-    TraitStructure          :`TraitStructureKvp` *`WS`
-                            :      *(`Comma` `TraitStructureKvp` *`WS`)
+    TraitStructure          :`TraitStructureKvp` [`WS`]
+                            :      *(`Comma` `TraitStructureKvp` [`WS`])
                             :  `TrailingComma`
-    TraitStructureKvp       :`NodeObjectKey` *`WS` ":" *`WS` `NodeValue`
+    TraitStructureKvp       :`NodeObjectKey` [`WS`] ":" [`WS`] `NodeValue`
     ApplyStatement          :%s"apply" `SP` `ShapeId` `WS` `Trait` `BR`
 
 .. rubric:: Shape ID

--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -93,7 +93,7 @@ The Smithy IDL is defined by the following ABNF which uses case-sensitive
 string support defined in :rfc:`7405`.
 
 .. productionlist:: smithy
-    idl:*`WS` `ControlSection` `MetadataSection` `ShapeSection`
+    idl:[`WS`] `ControlSection` `MetadataSection` `ShapeSection`
 
 .. rubric:: Whitespace
 
@@ -102,7 +102,7 @@ string support defined in :rfc:`7405`.
     SP   :1*(%x20 / %x09) ; one or more spaces or tabs
     NL   :%x0A / %x0D.0A ; Newline: \n and \r\n
     NotNL:%x09 / %x20-10FFFF ; Any character except newline
-    BR   :*`SP` 1*(`Comment` / `NL`) *`WS`; line break followed by whitespace
+    BR   :*`SP` 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
 
 .. rubric:: Comments
 
@@ -131,9 +131,9 @@ string support defined in :rfc:`7405`.
                         :/ `Number`
                         :/ `NodeKeywords`
                         :/ `NodeStringValue`
-    NodeArray           :"[" *`WS` *(`NodeValue` *`WS`) "]"
-    NodeObject          :"{" *`WS` [`NodeObjectKvp` *(`WS` `NodeObjectKvp`)] *`WS` "}"
-    NodeObjectKvp       :`NodeObjectKey` *`WS` ":" *`WS` `NodeValue`
+    NodeArray           :"[" [`WS`] *(`NodeValue` [`WS`]) "]"
+    NodeObject          :"{" [`WS`] [`NodeObjectKvp` *(`WS` `NodeObjectKvp`)] [`WS`] "}"
+    NodeObjectKvp       :`NodeObjectKey` [`WS`] ":" [`WS`] `NodeValue`
     NodeObjectKey       :`QuotedText` / `Identifier`
     Number              :[`Minus`] `Int` [`Frac`] [`Exp`]
     DecimalPoint        :%x2E ; .
@@ -188,18 +188,18 @@ string support defined in :rfc:`7405`.
                             :/ %s"byte" / %s"short" / %s"integer" / %s"long"
                             :/ %s"float" / %s"double" / %s"bigInteger"
                             :/ %s"bigDecimal" / %s"timestamp"
-    Mixins                  :*`SP` %s"with" *`WS` "[" 1*(*`WS` `ShapeId`) *`WS` "]"
-    EnumShapeStatement      :`EnumTypeName` `SP` `Identifier` [`Mixins`] *`WS` `EnumShapeMembers`
+    Mixins                  :*`SP` %s"with" [`WS`] "[" 1*([`WS`] `ShapeId`) [`WS`] "]"
+    EnumShapeStatement      :`EnumTypeName` `SP` `Identifier` [`Mixins`] [`WS`] `EnumShapeMembers`
     EnumTypeName            :%s"enum" / %s"intEnum"
-    EnumShapeMembers        :"{" *`WS` 1*(`TraitStatements` `Identifier` [`ValueAssignment`] `*WS`) "}"
+    EnumShapeMembers        :"{" [`WS`] 1*(`TraitStatements` `Identifier` [`ValueAssignment`] [`WS`]) "}"
     ValueAssignment         :*`SP` "=" *`SP` `NodeValue` `BR`
-    ListStatement           :%s"list" `SP` `Identifier` [`Mixins`] *`WS` `ListMembers`
-    ListMembers             :"{" *`WS` [`ListMember`] *`WS` "}"
+    ListStatement           :%s"list" `SP` `Identifier` [`Mixins`] [`WS`] `ListMembers`
+    ListMembers             :"{" [`WS`] [`ListMember`] [`WS`] "}"
     ListMember              :`TraitStatements` (`ElidedListMember` / `ExplicitListMember`)
     ElidedListMember        :%s"$member"
     ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
-    MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] *`WS` `MapMembers`
-    MapMembers              :"{" *`WS` [`MapKey` / `MapValue` / (`MapKey` `WS` `MapValue`)] *`WS` "}"
+    MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] [`WS`] `MapMembers`
+    MapMembers              :"{" [`WS`] [`MapKey` / `MapValue` / (`MapKey` `WS` `MapValue`)] [`WS`] "}"
     MapKey                  :`TraitStatements` (`ElidedMapKey` / `ExplicitMapKey`)
     MapValue                :`TraitStatements` (`ElidedMapValue` / `ExplicitMapValue`)
     ElidedMapKey            :%s"$key"
@@ -207,37 +207,37 @@ string support defined in :rfc:`7405`.
     ElidedMapValue          :%s"$value"
     ExplicitMapValue        :%s"value" *`SP` ":" *`SP` `ShapeId`
     StructureStatement      :%s"structure" `SP` `Identifier` [`StructureResource`]
-                            :        [`Mixins`] *`WS` `StructureMembers`
+                            :        [`Mixins`] [`WS`] `StructureMembers`
     StructureResource       :`SP` %s"for" `SP` `ShapeId`
-    StructureMembers        :"{" *`WS` *(`TraitStatements` `StructureMember` *`WS`) "}"
+    StructureMembers        :"{" [`WS`] *(`TraitStatements` `StructureMember` [`WS`]) "}"
     StructureMember         :(`ExplicitStructureMember` / `ElidedStructureMember`) [`ValueAssignment`]
     ExplicitStructureMember :`Identifier` *`SP` ":" *`SP` `ShapeId`
     ElidedStructureMember   :"$" `Identifier`
-    UnionStatement          :%s"union" `SP` `Identifier` [`Mixins`] *`WS` `UnionMembers`
-    UnionMembers            :"{" *`WS` *(`TraitStatements` `UnionMember` *`WS`) "}"
+    UnionStatement          :%s"union" `SP` `Identifier` [`Mixins`] [`WS`] `UnionMembers`
+    UnionMembers            :"{" [`WS`] *(`TraitStatements` `UnionMember` [`WS`]) "}"
     UnionMember             :(`ExplicitStructureMember` / `ElidedStructureMember`)
-    ServiceStatement        :%s"service" `SP` `Identifier` [`Mixins`] *`WS` `NodeObject`
-    ResourceStatement       :%s"resource" `SP` `Identifier` [`Mixins`] *`WS` `NodeObject`
-    OperationStatement      :%s"operation" `SP` `Identifier` [`Mixins`] *`WS` `OperationBody`
-    OperationBody           :"{" *`WS`
+    ServiceStatement        :%s"service" `SP` `Identifier` [`Mixins`] [`WS`] `NodeObject`
+    ResourceStatement       :%s"resource" `SP` `Identifier` [`Mixins`] [`WS`] `NodeObject`
+    OperationStatement      :%s"operation" `SP` `Identifier` [`Mixins`] [`WS`] `OperationBody`
+    OperationBody           :"{" [`WS`]
                             :    *([`OperationInput`] / [`OperationOutput`] / [`OperationErrors`])
-                            :    *`WS` "}"
+                            :    [`WS`] "}"
                             :    ; only one of each property can be specified.
-    OperationInput          :%s"input" *WS (`InlineStructure` / (":" *`WS` `ShapeId`)) `WS`
-    OperationOutput         :%s"output" *WS (`InlineStructure` / (":" *`WS` `ShapeId`)) `WS`
-    OperationErrors         :%s"errors" *WS ":" *WS "[" *(*`WS` `Identifier`) *`WS` "]" `WS`
-    InlineStructure         :":=" *`WS` `TraitStatements` [`StructureResource`]
-                            :        [`Mixins`] *`WS` `StructureMembers`
+    OperationInput          :%s"input" [`WS`] (`InlineStructure` / (":" [`WS`] `ShapeId`)) `WS`
+    OperationOutput         :%s"output" [`WS`] (`InlineStructure` / (":" [`WS`] `ShapeId`)) `WS`
+    OperationErrors         :%s"errors" [`WS`] ":" [`WS`] "[" *([`WS`] `Identifier`) [`WS`] "]" `WS`
+    InlineStructure         :":=" [`WS`] `TraitStatements` [`StructureResource`]
+                            :        [`Mixins`] [`WS`] `StructureMembers`
 
 .. rubric:: Traits
 
 .. productionlist:: smithy
-    TraitStatements         :*(*`WS` `Trait`) *`WS`
+    TraitStatements         :*([`WS`] `Trait`) [`WS`]
     Trait                   :"@" `ShapeId` [`TraitBody`]
-    TraitBody               :"(" *`WS` [`TraitBodyValue`] *`WS` ")"
+    TraitBody               :"(" [`WS`] [`TraitBodyValue`] [`WS`] ")"
     TraitBodyValue          :`TraitStructure` / `NodeValue`
-    TraitStructure          :`TraitStructureKvp` *(*`WS` `TraitStructureKvp`)
-    TraitStructureKvp       :`NodeObjectKey` *`WS` ":" *`WS` `NodeValue`
+    TraitStructure          :`TraitStructureKvp` *([`WS`] `TraitStructureKvp`)
+    TraitStructureKvp       :`NodeObjectKey` [`WS`] ":" [`WS`] `NodeValue`
     ApplyStatement          :`ApplyStatementSingular` / `ApplyStatementBlock`
     ApplyStatementSingular  :%s"apply" `SP` `ShapeId` `WS` `Trait`
     ApplyStatementBlock     :%s"apply" `SP` `ShapeId` `WS` "{" `TraitStatements` "}"


### PR DESCRIPTION
https://github.com/awslabs/smithy/issues/1249

A grammar containing

```
WS = *1{ ... }
... = ... *WS ...
```

defines multiple parse trees.

We can eliminate the ambiguity by replacing `*WS` with `[WS]`.