### PR TITLE
Add examples of validators to documentation

### DIFF
--- a/docs/source-2.0/guides/index.rst
+++ b/docs/source-2.0/guides/index.rst
@@ -14,4 +14,5 @@ Guides
     generating-cloudformation-resources
     migrating-idl-1-to-2
     building-codegen/index
+    model-validation-examples
     glossary

--- a/docs/source-2.0/guides/index.rst
+++ b/docs/source-2.0/guides/index.rst
@@ -8,11 +8,11 @@ Guides
     building-models/index
     using-code-generation/index
     model-linters
+    model-validation-examples
     evolving-models
     style-guide
     converting-to-openapi
     generating-cloudformation-resources
     migrating-idl-1-to-2
     building-codegen/index
-    model-validation-examples
     glossary

--- a/docs/source-2.0/guides/model-validation-examples.rst
+++ b/docs/source-2.0/guides/model-validation-examples.rst
@@ -1,18 +1,21 @@
-========================================
-Smithy Model Validation Examples
-========================================
+=========================
+Model Validation Examples
+=========================
 
-Smithy :ref:`validator-definition` can be used to lint Smithy models to help avoid common pitfalls and bugs as well as
-to enforce a common style for APIs designed with Smithy.
+:ref:`validator-definition` can be used to lint Smithy models to help avoid
+common pitfalls and bugs as well as to enforce a common style for APIs
+designed with Smithy.
 
-This document provides a kind of "cookbook" of examples for using, suppressing, and modifying Smithy Validators.
+This document provides a kind of "cookbook" of examples for using,
+suppressing, and modifying Smithy Validators.
 
 
-Suppress a Validator for a Single Shape or Member
-======================================================
+Suppress a validator for a single shape or member
+=================================================
 
-Use the :ref:`@suppress <suppress-trait>` trait to suppress a validator on a single shape or member.
-The example below shows the use of the suppress trait to suppress the `Foo` and `Bar` validators.
+Use the :ref:`@suppress <suppress-trait>` trait to suppress a validator on
+a single shape or member. The example below shows the use of the suppress
+trait to suppress the ``Foo`` and ``Bar`` validators.
 
 .. code-block:: smithy
 
@@ -23,15 +26,18 @@ The example below shows the use of the suppress trait to suppress the `Foo` and 
         fieldB: Integer
     }
 
-.. note::
-    It is generally recommended to add a comment above the `@suppress` trait to explain the reason for the suppression.
+.. tip::
+    It is generally recommended to add a comment above the ``@suppress``
+    trait to explain the reason for the suppression.
 
 
-Suppress a Validator for a Namespace
-==========================================
+Suppress a validator for a namespace
+====================================
 
-Validators can be suppressed for an entire namespace rather than just for a single shape. The following example
-demonstrates how to suppress the `ShouldHaveUsedTimestamp` validator for all shapes within the `com.example.weather` namespace.
+Validators can be suppressed for an entire namespace rather than just for a
+single shape. The following example demonstrates how to suppress the
+``ShouldHaveUsedTimestamp`` validator for all shapes within the ``com.example
+.weather`` namespace.
 
 .. code-block:: smithy
 
@@ -39,18 +45,19 @@ demonstrates how to suppress the `ShouldHaveUsedTimestamp` validator for all sha
         {
             id: "ShouldHaveUsedTimestamp",
             namespace: "com.example.weather",
-            reason: "Ignore `ShouldHaveUsedTimestamp` validator for com.example.weather namespace."
+            reason: "Ignore `ShouldHaveUsedTimestamp` validator for `com.example.weather` namespace."
         },
     ]
 
 
-Execute Validator for All Shapes Matching Selector
-==============================================================
+Execute validator for all shapes matching selector
+==================================================
 
-We can use selectors to only run a validator for shapes matching that selector. The following example
-demonstrates how to have the `MissingPaginatedTrait` built-in validator ignore any operations with the
-`@internal` trait. The `MissingPaginatedTrait` will run for only shapes that are not operations with the `@internal`
-trait.
+We can use selectors to only run a validator for shapes matching that
+selector. The following example demonstrates how to have the
+``MissingPaginatedTrait`` built-in validator ignore any operations with the
+``@internal`` trait. The ``MissingPaginatedTrait`` will run for only shapes
+that are not operations with the ``@internal`` trait.
 
 .. code-block:: smithy
 
@@ -60,13 +67,14 @@ trait.
     }
 
 
-Ignore Built-in Validator for Multiple Namespaces
-==================================================
+Ignore built-in validator for multiple namespaces
+=================================================
 
-Selectors can be used to ignore a validator for specific namespaces such as the root smithy namespace.
-This can be useful when you want a validator to ignore imported shapes from another smithy package.
-The following example shows how to have the `MissingPaginatedTrait` built-in validator
-ignore any shapes in the `smithy.*` or `com.example.*` namespaces.
+Selectors can be used to ignore a validator for specific namespaces such as
+the root smithy namespace. This can be useful when you want a validator to
+ignore imported shapes from another smithy package. The following example
+shows how to have the ``MissingPaginatedTrait`` built-in validator ignore any
+shapes in the ``smithy.*`` or ``com.example.*`` namespaces.
 
 .. code-block:: smithy
 
@@ -76,11 +84,12 @@ ignore any shapes in the `smithy.*` or `com.example.*` namespaces.
     }
 
 
-Ignore Validator for specific Shape ID
-==========================================
+Ignore validator for specific shape id
+======================================
 
-Selectors can also be used to ignore one or more shapes based on the shape's id. This example uses selectors to
-ignore a validator for a shape with a specific name. In this case the `MissingPaginatedTrait` built-in validator
+Selectors can also be used to ignore one or more shapes based on the shape's
+id. This example uses selectors to ignore a validator for a shape with a
+specific name. In this case the ``MissingPaginatedTrait`` built-in validator
 is set to ignore the shape with the name "IgnorableShape".
 
 .. code-block:: smithy
@@ -91,12 +100,14 @@ is set to ignore the shape with the name "IgnorableShape".
     }
 
 
-Set a Custom Severity for Built-in Validator
-=============================================
+Set a custom severity for built-in validator
+============================================
 
-The following example demonstrates how to update the :ref:`severity <severity-definition>` level of a built-in validator
-to a custom value. The following example will cause validation events emitted by the `MissingPaginatedTrait` validator
-to be emitted at a `WARNING` level instead of at the default `ERROR` severity.
+The following example demonstrates how to update the :ref:`severity
+<severity-definition>` level of a built-in validator to a custom value. The
+following example will cause validation events emitted by the
+``MissingPaginatedTrait`` validator to be emitted at a ``WARNING`` level
+instead of at the default ``ERROR`` severity.
 
 
 .. code-block:: smithy
@@ -107,11 +118,12 @@ to be emitted at a `WARNING` level instead of at the default `ERROR` severity.
     }
 
 
-Common suffix on all Operation Inputs
-============================================
+Common suffix on all operation inputs
+=====================================
 
-You may want to enforce a convention of all operation inputs ending with a specific string such as "Request".
-The following example creates a custom linter that checks that all operation input names end with "Request".
+You may want to enforce a convention of all operation inputs ending with a
+specific string such as "Request". The following example creates a custom
+linter that checks that all operation input names end with "Request".
 
 .. code-block:: smithy
 
@@ -128,11 +140,12 @@ The following example creates a custom linter that checks that all operation inp
     }
 
 
-Common suffix on all Operation Outputs
-============================================
+Common suffix on all operation outputs
+======================================
 
-You may want to enforce a convention of all operation outputs ending with a specific string such as "Response".
-The following example linter checks that all operation output names end with "Response".
+You may want to enforce a convention of all operation outputs ending with a
+specific string such as "Response". The following example linter checks that
+all operation output names end with "Response".
 
 .. code-block:: smithy
 
@@ -149,10 +162,11 @@ The following example linter checks that all operation output names end with "Re
     }
 
 
-Common Suffix on all Error shapes
-============================================
+Common suffix on all error shapes
+=================================
 
-The following example creates a linter that checks that all error shapes end with "Exception".
+The following example creates a linter that checks that all error shapes end
+with "Exception".
 
 .. code-block:: smithy
 
@@ -169,11 +183,12 @@ The following example creates a linter that checks that all error shapes end wit
     }
 
 
-Forbid Prefix on Shape Members
-================================
+Forbid prefix on shape members
+==============================
 
-This example checks that no member names begin with "is" or "Is". This particular case is useful
-to prevent problems when using libraries such as Jackson which changes behavior when object fields have "is" prefixes.
+This example checks that no member names begin with "is" or "Is". This
+particular case is useful to prevent problems when using libraries such as
+Jackson which changes behavior when object fields have "is" prefixes.
 
 .. code-block:: smithy
 
@@ -187,13 +202,15 @@ to prevent problems when using libraries such as Jackson which changes behavior 
     }
 
 
-Require Integers to Have a @range Constraint
-==================================================
+Require integers to have a ``@range`` constraint
+================================================
 
-This example shows how to require all integers used in an operation input have a range constraint with both a minimum and maximum value.
-The first validator checks that the range trait exists on the shape, while the other two validators check that both the
-maximum and minimum values of the range are both filled out. This validation is split across three separate linters to
-have clear, actionable error messages.
+This example shows how to require all integers used in an operation input
+have a range constraint with both a minimum and maximum value. The first
+validator checks that the range trait exists on the shape, while the other
+two validators check that both the maximum and minimum values of the range
+are both filled out. This validation is split across three separate linters
+to have clear, actionable error messages.
 
 .. code-block:: smithy
 
@@ -247,11 +264,13 @@ have clear, actionable error messages.
     }
 
 
-Require Lists to Have an @length Constraint
-============================================
+Require lists to have an ``@length`` constraint
+===============================================
 
-This example shows how to require all List shapes in the `com.example.weather` namespace to apply the @length constraint trait
-with both a minimum and maximum value. This validation is split across three separate linters to have clear, actionable error messages.
+This example shows how to require all List shapes in the ``com.example.weather``
+namespace to apply the ``@length`` constraint trait with both a
+minimum and maximum value. This validation is split across three separate
+linters to have clear, actionable error messages.
 
 .. code-block:: smithy
 
@@ -292,10 +311,11 @@ with both a minimum and maximum value. This validation is split across three sep
     }
 
 
-Require Strings to Have a @pattern Constraint
-==================================================
+Require strings to have a ``@pattern`` constraint
+=================================================
 
-This example shows how to require all integers used in an operation input to have a `@pattern` constraint trait.
+This example shows how to require all integers used in an operation input to
+have a ``@pattern`` constraint trait.
 
 .. code-block:: smithy
 
@@ -318,11 +338,12 @@ This example shows how to require all integers used in an operation input to hav
     }
 
 
-Require @externalDocumentation Trait to Provide a Homepage Entry
-=================================================================
+Require ``@externalDocumentation`` trait to provide a homepage entry
+====================================================================
 
-The following example shows how to enforce that all uses of the :ref:`externaldocumentation-trait` include a
-`Homepage` entry.
+The following example shows how to enforce that all uses of the
+:ref:`@externaldocumentation <externaldocumentation-trait>` include a
+``Homepage`` entry.
 
 .. code-block:: smithy
 
@@ -340,11 +361,11 @@ The following example shows how to enforce that all uses of the :ref:`externaldo
     }
 
 
-Limit Shape name length
-=============================
+Limit shape name length
+=======================
 
-The following example limits the length of shape names within the `com.example.weather` namespace to
-between 3 and 80 characters.
+The following example limits the length of shape names within the ``com.example.weather``
+namespace to between 3 and 80 characters.
 
 .. code-block:: smithy
 
@@ -362,11 +383,11 @@ between 3 and 80 characters.
     }
 
 
-Limit Nesting Depth of Input and Output shape members
-==============================================================
+Limit nesting depth of input and output shape members
+=====================================================
 
-This example checks that resources are not deeply nested. In this case, it will check that the nesting
-depth is less than 4.
+This example checks that resources are not deeply nested. In this case, it
+will check that the nesting depth is less than 4.
 
 .. code-block:: smithy
 
@@ -387,7 +408,7 @@ depth is less than 4.
 
 
 Operations should have documentation
-============================================
+====================================
 
 This example checks for documentation on all operation shapes.
 
@@ -407,7 +428,7 @@ This example checks for documentation on all operation shapes.
 
 
 Examples on all operations
-============================================
+==========================
 
 This example checks for examples on all operation shapes.
 
@@ -427,9 +448,10 @@ This example checks for examples on all operation shapes.
 
 
 Operations should have common exception
-============================================
+=======================================
 
-The following example shows how to check that all operations throw a common exception.
+The following example shows how to check that all operations throw a common
+exception.
 
 .. code-block:: smithy
 
@@ -446,18 +468,21 @@ The following example shows how to check that all operations throw a common exce
     }
 
 
-.. note::
-    If you want an operation to throw multiple common errors you likely want to use a validator that
-    checks for a common mixin rather than a single operation. See :ref:`Operations Should Use Common Mixin <operations-should-use-common-mixin>`
+.. tip::
+    If you want an operation to throw multiple common errors, you likely want
+    to use a validator that checks for a common mixin rather than a single
+    error. See :ref:`Operations Should Use Common Mixin
+    <operations-should-use-common-mixin>`
 
 
 .. _operations-should-use-common-mixin:
 
-Operations Should Use Common Mixin
-========================================
+Operations should use common mixin
+==================================
 
-The following example checks that an operation uses a common :ref:`mixin <mixin-trait>`, `CommonMixin`. This is useful
-when you want operations to have a common set of errors added via a common mixin.
+The following example checks that an operation uses a common :ref:`mixin
+<mixin-trait>`, ``CommonMixin``. This is useful when you want operations to
+have a common set of errors added via a common mixin.
 
 .. code-block:: smithy
 
@@ -476,11 +501,12 @@ when you want operations to have a common set of errors added via a common mixin
 
 
 Check that models do not use an internal name
-===================================================
+=============================================
 
-The following example shows how to prevent the use of internal codewords within a smithy model. In this
-case we want to prevent our models from using the word "spork" in any member, structure, resource, operation,
-or service name or within any trait or comment.
+The following example shows how to prevent the use of internal codewords
+within a smithy model. In this case we want to prevent our models from using
+the word "spork" in any member, structure, resource, operation, or service
+name or within any trait or comment.
 
 .. code-block:: smithy
 
@@ -501,11 +527,12 @@ or service name or within any trait or comment.
 
 
 Check that models use a trait at least once
-==================================================
+===========================================
 
-The built-in `EmitNoneSelector` can be used to ensure at least one instance of a trait is found in
-a model. The following example checks that at least one usage of the `@length` trait is found within models
-in the `com.example.weather` namespace.
+The built-in ``EmitNoneSelector`` can be used to ensure at least one instance
+of a trait is found in a model. The following example checks that at least
+one usage of the ``@length`` trait is found within models in the ``com.example
+.weather`` namespace.
 
 .. code-block:: smithy
 
@@ -519,16 +546,16 @@ in the `com.example.weather` namespace.
         }
     }
 
-.. note::
-    It is usually concerning if a model does not use common constraint traits such as `@range`, `@pattern`,
-    or `@length` at all
+.. tip::
+    It is usually concerning if a model does not use common constraint traits
+    such as ``@range``, ``@pattern``, or ``@length`` at all.
 
 
-Exceptions thrown from operations must have an @httpError trait
+Exceptions thrown from operations must have an ``@httpError`` trait
 ===================================================================
 
-This example shows how to enforce that all errors bound to an operation have an httpError trait (and
-therefore httpError code) defined.
+This example shows how to enforce that all errors bound to an operation have
+an httpError trait (and therefore httpError code) defined.
 
 .. code-block:: smithy
 
@@ -545,13 +572,14 @@ therefore httpError code) defined.
     }
 
 .. note::
-    This example only makes sense for services using an httpProtocol
+    This example only makes sense for services using an httpProtocol.
 
 
 Prefix headers with X-
-========================
+======================
 
-Case insensitive check for "X-" prefix on all custom httpHeaders used in your model.
+Case insensitive check for "X-" prefix on all custom httpHeaders used in your
+model.
 
 .. code-block:: smithy
 
@@ -570,17 +598,17 @@ Case insensitive check for "X-" prefix on all custom httpHeaders used in your mo
 .. note::
     This example only makes sense for services using an httpProtocol.
 
-.. note::
+.. tip::
     If you prefer to not prefix custom headers with "X-" then you can flip the logic of this validator by changing the
-    selector to `[trait|httpHeader^="x-" i]`
+    selector to ``[trait|httpHeader^="x-" i]``
 
 
 Lifecycle operation naming
-============================================
+==========================
 
-Checks that operation names match with the lifecycle (CRUD) operations they are bound to. This
-example shows how to check that the operation shape bound to the "create" lifecycle operation prefixed with
-"create" (case insensitive).
+Checks that operation names match with the lifecycle (CRUD) operations they
+are bound to. This example shows how to check that the operation shape bound
+to the "create" lifecycle operation prefixed with "create" (case insensitive).
 
 .. code-block:: smithy
 
@@ -596,11 +624,12 @@ example shows how to check that the operation shape bound to the "create" lifecy
         }
     }
 
-Prefer binding Operations to Resource over Binding Directly to Service
-=======================================================================
+Prefer binding operations to resource over binding directly to a service
+========================================================================
 
-While it is occasionally necessary to bind operations directly to a service, in most cases it is preferable to bind operations to a resource
-over binding to the service directly. The example below shows how to validate that
+While it is occasionally necessary to bind operations directly to a service,
+in most cases it is preferable to bind operations to a resource over binding
+to the service directly. The example below shows how to validate that
 operations are bound to resources and not to the service.
 
 .. code-block:: smithy

--- a/docs/source-2.0/guides/model-validation-examples.rst
+++ b/docs/source-2.0/guides/model-validation-examples.rst
@@ -6,7 +6,7 @@ Model Validation Examples
 common pitfalls and bugs as well as to enforce a common style for APIs
 designed with Smithy.
 
-This document provides a kind of "cookbook" of examples for using,
+This document provides a "cookbook" of examples for using,
 suppressing, and modifying Smithy Validators.
 
 
@@ -555,7 +555,7 @@ Exceptions thrown from operations must have an ``@httpError`` trait
 ===================================================================
 
 This example shows how to enforce that all errors bound to an operation have
-an httpError trait (and therefore httpError code) defined.
+an ``@httpError`` trait (and therefore ``httpError`` code) defined.
 
 .. code-block:: smithy
 
@@ -572,13 +572,13 @@ an httpError trait (and therefore httpError code) defined.
     }
 
 .. note::
-    This example only makes sense for services using an httpProtocol.
+    This example only makes sense for services using an http protocol.
 
 
 Prefix headers with X-
 ======================
 
-Case insensitive check for "X-" prefix on all custom httpHeaders used in your
+Case insensitive check for "X-" prefix on all custom ``@httpHeaders`` used in your
 model.
 
 .. code-block:: smithy
@@ -596,7 +596,7 @@ model.
     }
 
 .. note::
-    This example only makes sense for services using an httpProtocol.
+    This example only makes sense for services using an http protocol.
 
 .. tip::
     If you prefer to not prefix custom headers with "X-" then you can flip the logic of this validator by changing the

--- a/docs/source-2.0/guides/model-validation-examples.rst
+++ b/docs/source-2.0/guides/model-validation-examples.rst
@@ -2,7 +2,7 @@
 Smithy Model Validation Examples
 ========================================
 
-Smithy validators can be used to lint Smithy models to help avoid common pitfalls and bugs as well as
+Smithy :ref:`validator-definition` can be used to lint Smithy models to help avoid common pitfalls and bugs as well as
 to enforce a common style for APIs designed with Smithy.
 
 This document provides a kind of "cookbook" of examples for using, suppressing, and modifying Smithy Validators.
@@ -47,9 +47,9 @@ demonstrates how to suppress the `ShouldHaveUsedTimestamp` validator for all sha
 Execute Validator for All Shapes Matching Selector
 ==============================================================
 
-We can use selectors to only execute a validator for shapes matching that selector. The following example
+We can use selectors to only run a validator for shapes matching that selector. The following example
 demonstrates how to have the `MissingPaginatedTrait` built-in validator ignore any operations with the
-`@internal` trait. The `MissingPaginatedTrait` will execute for only shapes that are not operations with the `@internal`
+`@internal` trait. The `MissingPaginatedTrait` will run for only shapes that are not operations with the `@internal`
 trait.
 
 .. code-block:: smithy
@@ -76,7 +76,7 @@ ignore any shapes in the `smithy.*` or `com.example.*` namespaces.
     }
 
 
-Ignore Validator for specific shape id
+Ignore Validator for specific Shape ID
 ==========================================
 
 Selectors can also be used to ignore one or more shapes based on the shape's id. This example uses selectors to
@@ -88,6 +88,22 @@ is set to ignore the shape with the name "IgnorableShape".
     {
         name: "MissingPaginatedTrait",
         selector: ":not([id|name = 'IgnorableShape' i])"
+    }
+
+
+Set a Custom Severity for Built-in Validator
+=============================================
+
+The following example demonstrates how to update the :ref:`severity <severity-definition>` level of a built-in validator
+to a custom value. The following example will cause validation events emitted by the `MissingPaginatedTrait` validator
+to be emitted at a `WARNING` level instead of at the default `ERROR` severity.
+
+
+.. code-block:: smithy
+
+    {
+        name: "MissingPaginatedTrait",
+        severity: "WARNING""
     }
 
 
@@ -302,25 +318,24 @@ This example shows how to require all integers used in an operation input to hav
     }
 
 
-Pattern Trait Should Not Contain Character
-============================================
+Require @externalDocumentation Trait to Provide a Homepage Entry
+=================================================================
 
-The following example shows how to enforce that a character is not included in pattern traits.
+The following example shows how to enforce that all uses of the :ref:`externaldocumentation-trait` include a
+`Homepage` entry.
 
 .. code-block:: smithy
 
     {
         name: "EmitEachSelector",
-        id: "PatternCannotContainNewlineCharacter",
-        namespace: ["com.example.weather"],
+        id: "ExternalDocumentationMustIncludeHomePageValue",
         configuration: {
             messageTemplate: """
-            Pattern trait value on shape `@{id}` is `@{trait|pattern}` which contains a newline character. \
-            This pattern should only contain new-line characters if intended. Shapes with pattern traits \
-            intentionally containing new-line characters should be added explicitly to the list of suppressions \
-            for this validator.
+            @{id} has the `@@externalDocumentation` trait applied, but does not define a `"HomePage"` entry. \
+            The following keys `@{trait|externalDocumentation|(keys)}` were defined for `@@externalDocumentation`, \
+            but expected `"HomePage"` key.
             """,
-            selector: "[trait|pattern*=\"\n\"]"
+            selector: "[trait|externalDocumentation]:not([trait|externalDocumentation|(keys) = Homepage])"
         }
     }
 
@@ -593,6 +608,7 @@ operations are bound to resources and not to the service.
     {
         name: "EmitEachSelector",
         id: "PreferResourceBindingOverServiceBinding",
+        severity: "WARNING",
         configuration: {
             messageTemplate: """
                 Operation @{id|name} is bound directly to the service @{var|target|id|name}. \

--- a/docs/source-2.0/spec/model-validation-examples.rst
+++ b/docs/source-2.0/spec/model-validation-examples.rst
@@ -1,0 +1,603 @@
+========================================
+Smithy Model Validation Examples
+========================================
+
+Smithy validators can be used to lint Smithy models to help avoid common pitfalls and bugs as well as
+to enforce a common style for APIs designed with Smithy.
+
+This document provides a kind of "cookbook" of examples for using, suppressing, and modifying Smithy Validators.
+
+
+Suppress a Validator for a Single Shape or Member
+======================================================
+
+Use the :ref:`@suppress <suppress-trait>` trait to suppress a validator on a single shape or member.
+The example below shows the use of the suppress trait to suppress the `Foo` and `Bar` validators.
+
+.. code-block:: smithy
+
+    // This trait cannot pass Foo or Bar validators
+    @suppress(["Foo", "Bar"])
+    structure exampleStructure {
+        fieldA: String,
+        fieldB: Integer
+    }
+
+.. note::
+    It is generally recommended to add a comment above the `@suppress` trait to explain the reason for the suppression.
+
+
+Suppress a Validator for a Namespace
+==========================================
+
+Validators can be suppressed for an entire namespace rather than just for a single shape. The following example
+demonstrates how to suppress the `ShouldHaveUsedTimestamp` validator for all shapes within the `com.example.weather` namespace.
+
+.. code-block:: smithy
+
+    metadata suppressions = [
+        {
+            id: "ShouldHaveUsedTimestamp",
+            namespace: "com.example.weather",
+            reason: "Ignore `ShouldHaveUsedTimestamp` validator for com.example.weather namespace."
+        },
+    ]
+
+
+Execute Validator for All Shapes Matching Selector
+==============================================================
+
+We can use selectors to only execute a validator for shapes matching that selector. The following example
+demonstrates how to have the `MissingPaginatedTrait` built-in validator ignore any operations with the
+`@internal` trait. The `MissingPaginatedTrait` will execute for only shapes that are not operations with the `@internal`
+trait.
+
+.. code-block:: smithy
+
+    {
+        name: "MissingPaginatedTrait",
+        selector: ":not(operation[trait|internal])"
+    }
+
+
+Ignore Built-in Validator for Multiple Namespaces
+==================================================
+
+Selectors can be used to ignore a validator for specific namespaces such as the root smithy namespace.
+This can be useful when you want a validator to ignore imported shapes from another smithy package.
+The following example shows how to have the `MissingPaginatedTrait` built-in validator
+ignore any shapes in the `smithy.*` or `com.example.*` namespaces.
+
+.. code-block:: smithy
+
+    {
+        name: "MissingPaginatedTrait",
+        selector: ":not([id|namespace ^= 'com.example', 'smithy.'])"
+    }
+
+
+Ignore Validator for specific shape id
+==========================================
+
+Selectors can also be used to ignore one or more shapes based on the shape's id. This example uses selectors to
+ignore a validator for a shape with a specific name. In this case the `MissingPaginatedTrait` built-in validator
+is set to ignore the shape with the name "IgnorableShape".
+
+.. code-block:: smithy
+
+    {
+        name: "MissingPaginatedTrait",
+        selector: ":not([id|name = 'IgnorableShape' i])"
+    }
+
+
+Common suffix on all Operation Inputs
+============================================
+
+You may want to enforce a convention of all operation inputs ending with a specific string such as "Request".
+The following example creates a custom linter that checks that all operation input names end with "Request".
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "OperationInputName",
+        configuration: {
+            messageTemplate: """
+                `@{id}` is bound as an input of `@{var|operation|id}` \
+                but does not have a name ending with 'Request'.
+                """,
+            selector: "$operation(*) -[input]-> :not([id|name$=Request])"
+        }
+    }
+
+
+Common suffix on all Operation Outputs
+============================================
+
+You may want to enforce a convention of all operation outputs ending with a specific string such as "Response".
+The following example linter checks that all operation output names end with "Response".
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "OperationOutputName",
+        configuration: {
+            messageTemplate: """
+                `@{id}` is bound as an output of `@{var|operation|id}` \
+                but does not have a name ending with 'Response'
+                """,
+            selector: "$operation(*) -[output]-> :not([id|name$=Response])"
+        }
+    }
+
+
+Common Suffix on all Error shapes
+============================================
+
+The following example creates a linter that checks that all error shapes end with "Exception".
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "OperationErrorName",
+        configuration: {
+            messageTemplate: """
+                `@{id}` is bound as an error but does not have a name ending with 'Exception'. \
+                Perhaps you should rename this shape to `@{id|name}Exception`.
+                """,
+            selector: "operation -[error]-> :not([id|name$=Exception])"
+        }
+    }
+
+
+Forbid Prefix on Shape Members
+================================
+
+This example checks that no member names begin with "is" or "Is". This particular case is useful
+to prevent problems when using libraries such as Jackson which changes behavior when object fields have "is" prefixes.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "ForbiddenIsPrefix",
+        message: "This member starts with forbidden prefix 'is'",
+        configuration: {
+            selector: "[id|member ^='is','Is']"
+        }
+    }
+
+
+Require Integers to Have a @range Constraint
+==================================================
+
+This example shows how to require all integers used in an operation input have a range constraint with both a minimum and maximum value.
+The first validator checks that the range trait exists on the shape, while the other two validators check that both the
+maximum and minimum values of the range are both filled out. This validation is split across three separate linters to
+have clear, actionable error messages.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "RawIntegerWithoutRange",
+        configuration: {
+            messageTemplate: """
+            This number shape in member `@{id}` of the operation input `@{var|structure}` \
+            does not have a range constraint on both its minimum or maximum value. \
+            Add the `@@range` trait to this integer shape and provide both minimum and maximum values. \
+            For example, `@@range(min: 1, max: 500)`.
+            """,
+            selector: """
+                operation -[input]-> $structure(*) > member
+                :test(> number:not([trait|range|min]):not([trait|range|max]))
+                """
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "RawIntegerWithoutRangeMin",
+        configuration: {
+            messageTemplate: """
+            This number shape in member `@{id}` of the operation input `@{var|structure}` \
+            does not have a maximum range constraint. \
+            Add a minimum value to the `@@range` trait on this shape. \
+            For example, `@@range(>>> min: 1 <<<, max: 500)`.
+            """,
+            selector: """
+                operation -[input]-> $structure(*) > member
+                :test(> number[trait|range]:not([trait|range|min]))
+                """
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "RawIntegerWithoutRangeMax",
+        configuration: {
+            messageTemplate: """
+            This number shape in member `@{id}` of the operation input `@{var|structure}` \
+            does not have a maximum range constraint. \
+            Add a maximum value to the `@@range` trait on this shape. \
+            For example, `@@range(min: 1, >>> max: 500 <<<)`.
+            """,
+            selector: """
+                operation -[input]-> $structure(*) > member
+                :test(> number[trait|range]:not([trait|range|max]))
+                """
+        }
+    }
+
+
+Require Lists to Have an @length Constraint
+============================================
+
+This example shows how to require all List shapes in the `com.example.weather` namespace to apply the @length constraint trait
+with both a minimum and maximum value. This validation is split across three separate linters to have clear, actionable error messages.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "ListWithoutLengthConstraint",
+        configuration: {
+            messageTemplate: """
+            List shape `@{id}` does not have a length constraint specified. \
+            Add the `@@length` trait to the list shape. For example, `@@length(min: 1, max: 2)`.
+            """,
+            selector: "list:not([trait|length])"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "ListWithoutLengthConstraintMinimum",
+        configuration: {
+            messageTemplate: """
+            List shape `@{id}` does not have a minimum length specified. \
+            Add a `min` value to the `@@length` trait on the list shape. \
+            For example, `@@length(>>> min: 1 <<<, max: 2)`.
+            """,
+            selector: "list[trait|length]:not([trait|length|min])"
+        }
+    },
+    {
+        name: "EmitEachSelector",
+        id: "ListWithoutLengthConstraintMaximum",
+        configuration: {
+            messageTemplate: """
+            List shape `@{id}` does not have a maximum length specified. \
+            Add a `max` value to the `@@length` trait on the list shape. \
+            For example, `@@length(min: 1, >>> max: 2 <<<)`.
+            """,
+            selector: "list[trait|length]:not([trait|length|max])"
+        }
+    }
+
+
+Require Strings to Have a @pattern Constraint
+==================================================
+
+This example shows how to require all integers used in an operation input to have a `@pattern` constraint trait.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "RawStringWithoutPattern",
+        namespace: ["com.example.weather"],
+        configuration: {
+            messageTemplate: """
+            This String shape in member `@{id}` of the operation input `@{var|structure}` \
+            does not have a pattern constraint. \
+            Add the `@@pattern` trait to this string shape and provide a regex pattern. \
+            For example, `@@pattern("^[\\S\\s]+$")`.
+            """,
+            selector: """
+                operation -[input]-> $structure(*) > member
+                :test(> string:not([trait|enum]):not([trait|pattern]))
+                """
+        }
+    }
+
+
+Pattern Trait Should Not Contain Character
+============================================
+
+The following example shows how to enforce that a character is not included in pattern traits.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "PatternCannotContainNewlineCharacter",
+        namespace: ["com.example.weather"],
+        configuration: {
+            messageTemplate: """
+            Pattern trait value on shape `@{id}` is `@{trait|pattern}` which contains a newline character. \
+            This pattern should only contain new-line characters if intended. Shapes with pattern traits \
+            intentionally containing new-line characters should be added explicitly to the list of suppressions \
+            for this validator.
+            """,
+            selector: "[trait|pattern*=\"\n\"]"
+        }
+    }
+
+
+Limit Shape name length
+=============================
+
+The following example limits the length of shape names within the `com.example.weather` namespace to
+between 3 and 80 characters.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector"
+        id: "ShapeNameLength",
+        namespace: ["com.example.weather"],
+        configuration: {
+            messageTemplate: """
+            Shape name @{id|name} is @{id|name|(length)} characters long.
+            Shape names must be less than 60 characters and longer than 3 characters.
+            """,
+            selector: ":not([@id|name: @{(length)} <= 60 && @{(length)} >= 3])"
+        }
+    }
+
+
+Limit Nesting Depth of Input and Output shape members
+==============================================================
+
+This example checks that resources are not deeply nested. In this case, it will check that the nesting
+depth is less than 4.
+
+.. code-block:: smithy
+
+    {
+        "name": "EmitEachSelector",
+        "id": "LimitNestingDepthToFourLayers",
+        "configuration": {
+            messageTemplate: """
+                `@{id}`, bound to operation `@{var|operation}` has a nesting depth >4. This is typically not advised.
+                You should look for ways to reduce the nesting depth of this shape.
+                """,
+            selector: """
+                $operation(*) -[input, output, error]->
+                :test(> member > * > member > * > member > * member > *)
+                """
+        }
+    }
+
+
+Operations should have documentation
+============================================
+
+This example checks for documentation on all operation shapes.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "MissingOperationDocumentation",
+        configuration: {
+            messageTemplate: """
+                Operation `@{id|name}` is missing documentation. Add the `@@documentation` \
+                trait to this operation.
+                """,
+            selector: "operation :not([trait|documentation])"
+        }
+    }
+
+
+Examples on all operations
+============================================
+
+This example checks for examples on all operation shapes.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "MissingOperationExamples",
+        configuration: {
+            messageTemplate: """
+                Operation `@{id|name}` is missing examples. Add the `@@examples` \
+                trait to this operation.
+                """,
+            selector: "operation :not([trait|examples])"
+        }
+    }
+
+
+Operations should have common exception
+============================================
+
+The following example shows how to check that all operations throw a common exception.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "OperationErrorsIncludesCommonException",
+        configuration: {
+            messageTemplate: """
+            Expected error `CommonException` is not bound to operation @{id|name} . Add \
+            `CommonException` to the list of errors bound to this operation.
+            """
+            selector: "operation :not(:test(-[error]-> [id|name=CommonException]))",
+        }
+    }
+
+
+.. note::
+    If you want an operation to throw multiple common errors you likely want to use a validator that
+    checks for a common mixin rather than a single operation. See :ref:`Operations Should Use Common Mixin <operations-should-use-common-mixin>`
+
+
+.. _operations-should-use-common-mixin:
+
+Operations Should Use Common Mixin
+========================================
+
+The following example checks that an operation uses a common :ref:`mixin <mixin-trait>`, `CommonMixin`. This is useful
+when you want operations to have a common set of errors added via a common mixin.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector"
+        id: "OperationShouldUseCommonMixin",
+        namespace: ["com.example.weather"],
+        configuration: {
+            messageTemplate: """
+            Operation `@{id|name}` does not use expected mixin `CommonMixin`. Add the \
+            mixin to this operation. For example, `operation @{id|name} with [ CommonMixin ]`.
+            """
+            selector: "operation :not(-[mixin]-> [id = CommonMixin])"
+        }
+    }
+
+
+Check that models do not use an internal name
+===================================================
+
+The following example shows how to prevent the use of internal codewords within a smithy model. In this
+case we want to prevent our models from using the word "spork" in any member, structure, resource, operation,
+or service name or within any trait or comment.
+
+.. code-block:: smithy
+
+    {
+        id: "DontUseInternalNamesValidator",
+        name: "ReservedWords",
+        configuration: {
+            reserved: [
+                {
+                    words: ["*spork*"],
+                    reason: """
+                    Sporks are a secret type of silverware. We can't let the rest of the world know about them.
+                    """
+                }
+            ]
+        }
+    }
+
+
+Check that models use a trait at least once
+==================================================
+
+The built-in `EmitNoneSelector` can be used to ensure at least one instance of a trait is found in
+a model. The following example checks that at least one usage of the `@length` trait is found within models
+in the `com.example.weather` namespace.
+
+.. code-block:: smithy
+
+    {
+        "name": "EmitNoneSelector",
+        "id": "NoInstancesOfLengthTrait",
+        "message": "No instances of the length trait were found.",
+        "namespace": ["com.example.weather"]
+        "configuration": {
+            "selector": "[trait|length]"
+        }
+    }
+
+.. note::
+    It is usually concerning if a model does not use common constraint traits such as `@range`, `@pattern`,
+    or `@length` at all
+
+
+Exceptions thrown from operations must have an @httpError trait
+===================================================================
+
+This example shows how to enforce that all errors bound to an operation have an httpError trait (and
+therefore httpError code) defined.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "ErrorHasHttpErrorTrait",
+        configuration: {
+            messageTemplate: """
+            `@{id|name}` is bound as an error but does not have the `@@httpErrorTrait`. \
+            Apply the `@@httpErrorTrait` to this shape.
+            """
+            selector: "operation -[error]-> :not([trait|httpError])"
+        }
+    }
+
+.. note::
+    This example only makes sense for services using an httpProtocol
+
+
+Prefix headers with X-
+========================
+
+Case insensitive check for "X-" prefix on all custom httpHeaders used in your model.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "CustomHeadersHaveXDashPrefix",
+        configuration: {
+            messageTemplate: """
+                @{id|name} applies the `@@httpHeader` with a custom header value of `@{trait|httpHeader}` that does not begin with `x-`.
+                Custom headers should be prefixed with `x-`.
+                """
+            selector: "[trait|httpHeader]:not([trait|httpHeader^='x-' i])"
+        }
+    }
+
+.. note::
+    This example only makes sense for services using an httpProtocol.
+
+.. note::
+    If you prefer to not prefix custom headers with "X-" then you can flip the logic of this validator by changing the
+    selector to `[trait|httpHeader^="x-" i]`
+
+
+Lifecycle operation naming
+============================================
+
+Checks that operation names match with the lifecycle (CRUD) operations they are bound to. This
+example shows how to check that the operation shape bound to the "create" lifecycle operation prefixed with
+"create" (case insensitive).
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "LifecycleCreateName",
+        configuration: {
+            messageTemplate: """
+            Operation `@{id|name}` is bound to Lifecycle operation 'create' on resource @{var|resource}. \
+            `Create` operation names should begin with 'Create'. Did you mean `Create@{id|name}`?
+            """,
+            selector: "$resource(*) -[create]-> :not([id|name^=Create i])"
+        }
+    }
+
+Prefer binding Operations to Resource over Binding Directly to Service
+=======================================================================
+
+While it is occasionally necessary to bind operations directly to a service, in most cases it is preferable to bind operations to a resource
+over binding to the service directly. The example below shows how to validate that
+operations are bound to resources and not to the service.
+
+.. code-block:: smithy
+
+    {
+        name: "EmitEachSelector",
+        id: "PreferResourceBindingOverServiceBinding",
+        configuration: {
+            messageTemplate: """
+                Operation @{id|name} is bound directly to the service @{var|target|id|name}. \
+                Consider binding this operation to a resource instead.
+                """
+            selector: "$target(service) ${target} > operation"
+        }
+    }

--- a/docs/source-2.0/spec/model-validation.rst
+++ b/docs/source-2.0/spec/model-validation.rst
@@ -8,6 +8,14 @@ Smithy provides a customizable validation system that can be used by
 API designers and organizations to ensure that their APIs adhere to their
 own standards and best practices.
 
+
+You can find examples uses of Smithy validators here:
+
+.. toctree::
+    :maxdepth: 1
+
+    model-validation-examples.rst
+
 ------------
 Introduction
 ------------

--- a/docs/source-2.0/spec/model-validation.rst
+++ b/docs/source-2.0/spec/model-validation.rst
@@ -9,13 +9,6 @@ API designers and organizations to ensure that their APIs adhere to their
 own standards and best practices.
 
 
-You can find examples uses of Smithy validators here:
-
-.. toctree::
-    :maxdepth: 1
-
-    model-validation-examples.rst
-
 ------------
 Introduction
 ------------


### PR DESCRIPTION
*Description of changes:*
This pull request adds a number of example linters to as a subpage of the Validator page. 

These examples are not exhaustive, but are intended to show users some of the ways smithy validators can prevent common bugs and enforce a common style in their Smithy models.


*Testing* 
I checked each validator against a local model to make sure error messages formatted correctly and that they could be parsed. Then I generated the docs using the `make html` command and visually checked the generated html.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
