### PR TITLE
Remove unused positional [<MODEL>] from diff command

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -29,13 +29,17 @@ final class BuildOptions implements ArgumentReceiver {
 
     private boolean allowUnknownTraits;
     private String output;
+    private boolean noPositionalArguments;
 
     @Override
     public void registerHelp(HelpPrinter printer) {
         printer.option(ALLOW_UNKNOWN_TRAITS, null, "Ignore unknown traits when validating models");
         printer.param("--output", null, "OUTPUT_PATH",
                       "Where to write Smithy artifacts, caches, and other files (defaults to './build/smithy').");
-        printer.positional(MODELS, "Model files and directories to load");
+
+        if (!noPositionalArguments) {
+            printer.positional(MODELS, "Model files and directories to load");
+        }
     }
 
     @Override
@@ -61,5 +65,9 @@ final class BuildOptions implements ArgumentReceiver {
 
     String output() {
         return output;
+    }
+
+    void noPositionalArguments(boolean noPositionalArguments) {
+        this.noPositionalArguments = noPositionalArguments;
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -90,10 +90,15 @@ final class DiffCommand extends ClasspathCommand {
     protected void configureArgumentReceivers(Arguments arguments) {
         super.configureArgumentReceivers(arguments);
         arguments.addReceiver(new Options());
+        arguments.getReceiver(BuildOptions.class).noPositionalArguments(true);
     }
 
     @Override
     int runWithClassLoader(SmithyBuildConfig config, Arguments arguments, Env env, List<String> positional) {
+        if (!arguments.getPositional().isEmpty()) {
+            throw new CliError("Unexpected arguments: " + arguments.getPositional());
+        }
+
         StandardOptions standardOptions = arguments.getReceiver(StandardOptions.class);
         Options options = arguments.getReceiver(Options.class);
         ClassLoader classLoader = env.classLoader();

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
@@ -108,4 +108,12 @@ public class BuildCommandTest {
     public void exceptionsThrownByProjectionsAreDetected() {
         // TODO: need to make a plugin throw an exception
     }
+
+    @Test
+    public void canHideModelsPositional() {
+        CliUtils.Result result = CliUtils.runSmithy("diff", "-h");
+
+        assertThat(result.code(), equalTo(0));
+        assertThat(result.stdout(), not(containsString("[<MODELS>]")));
+    }
 }


### PR DESCRIPTION
The diff command does not use the positional MODEL argument like other commands. I'd like to do a more involved refactor to make this a little cleaner later, but I want to get this help text and validation in place before that lands.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
