### PR TITLE
bugfix for validator ids and hierarchical subparts

### DIFF
--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/validator-configuration-test.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/validator-configuration-test.errors
@@ -1,0 +1,2 @@
+[DANGER] smithy.example#GetFooInput: This structure is the input of `smithy.example#GetFoo`, but it is not marked with the @input trait. The @input trait gives operations more flexibility to evolve their top-level input members in ways that would otherwise be backward incompatible. | CustomInputOutputStructureReuse.Input.GetFoo
+[DANGER] smithy.example#GetFooOutput: This structure is the output of `smithy.example#GetFoo`, but it is not marked with the @output trait. | CustomInputOutputStructureReuse.Output.GetFoo

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/validator-configuration-test.smithy
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/validator-configuration-test.smithy
@@ -1,0 +1,31 @@
+$version: "2.0"
+
+metadata validators = [
+    {
+        name: "InputOutputStructureReuse",
+        id: "CustomInputOutputStructureReuse"
+        severity: "DANGER",
+    }
+]
+
+namespace smithy.example
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+structure GetFooInput {}
+
+structure GetFooOutput {}
+
+operation GetBaz {
+    input: GetBazInput,
+    output: GetBazOutput
+}
+
+@input
+structure GetBazInput {}
+
+@output
+structure GetBazOutput {}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ValidatorDefinition.java
@@ -72,7 +72,7 @@ final class ValidatorDefinition {
             } else {
                 // Modify the event by changing the id, severity, or message.
                 ValidationEvent.Builder builder = event.toBuilder();
-                builder.id(id != null ? id : event.getId());
+                builder.id(replaceId(event.getId(), id));
                 builder.severity(severity != null ? severity : event.getSeverity());
                 if (message != null) {
                     builder.message(message.replace("{super}", event.getMessage()));
@@ -96,5 +96,14 @@ final class ValidatorDefinition {
         }
 
         return true;
+    }
+
+    private String replaceId(String eventId, String validatorId) {
+        int index = eventId.indexOf(".");
+        if (index == -1) {
+            return validatorId;
+        } else {
+            return validatorId + eventId.substring(index);
+        }
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ValidatorDefinitionTest.java
@@ -35,7 +35,7 @@ public class ValidatorDefinitionTest {
                                ? Optional.of(
                                        model -> model.shapes()
                                                .map(shape -> ValidationEvent.builder()
-                                                       .id(name)
+                                                       .id("hello.subpart")
                                                        .shape(shape)
                                                        .severity(Severity.WARNING)
                                                        .message("Hello!")
@@ -48,12 +48,12 @@ public class ValidatorDefinitionTest {
                 .getValidationEvents();
 
         assertThat(events, not(empty()));
-        Assertions.assertEquals(2, events.stream().filter(e -> e.getId().equals("hello")).count());
-        Assertions.assertEquals(4, events.stream().filter(e -> e.getId().equals("custom")).count());
+        Assertions.assertEquals(2, events.stream().filter(e -> e.getId().equals("hello.subpart")).count());
+        Assertions.assertEquals(4, events.stream().filter(e -> e.getId().equals("customHello.subpart")).count());
 
         // Ensure that template expansion works.
         for (ValidationEvent event : events) {
-            if (event.getId().equals("custom")) {
+            if (event.getId().equals("customHello.subpart")) {
                 assertThat(event.getMessage(), equalTo("Test Hello!"));
             }
         }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/validator-filtering-and-mapping.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/validator-filtering-and-mapping.smithy
@@ -9,7 +9,7 @@ metadata validators = [
   },
   { // Picks up 4 shapes
     name: "hello",
-    id: "custom",
+    id: "customHello",
     message: "Test {super}"
   },
 ]


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Previously, hierarchical event ids would be lost when specifying either a custom Smithy linter validator id or severity level. This fixes that and adds some test cases 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
