### PR TITLE
Remove `OperationBody` indefinite repition in IDL

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -220,7 +220,7 @@ string support defined in :rfc:`7405`.
     ResourceStatement       :%s"resource" `SP` `Identifier` [`Mixins`] [`WS`] `NodeObject`
     OperationStatement      :%s"operation" `SP` `Identifier` [`Mixins`] [`WS`] `OperationBody`
     OperationBody           :"{" [`WS`]
-                            :    *([`OperationInput`] / [`OperationOutput`] / [`OperationErrors`])
+                            :    *(`OperationInput` / `OperationOutput` / `OperationErrors`)
                             :    [`WS`] "}"
                             :    ; only one of each property can be specified.
     OperationInput          :%s"input" [`WS`] (`InlineStructure` / (":" [`WS`] `ShapeId`)) `WS`


### PR DESCRIPTION
https://github.com/awslabs/smithy/issues/1249

A grammar containing

```
*[ ... ]
```

will match the empty string indefinitely.

We can remove an instance of this in `OperationBody`.