### PR TITLE
Gracefully handle the case when additionSchema targets an invalid shape

### DIFF
--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
@@ -150,11 +150,12 @@ public final class CfnResourceIndex implements KnowledgeIndex {
                         // setting, but gracefully handle if they're not.
                         model.getShape(additionalSchema)
                                 .map(Shape::asStructureShape)
-                                .map(Optional::get)
-                                .ifPresent(shape -> {
-                                    addAdditionalIdentifiers(builder, computeResourceAdditionalIdentifiers(shape));
-                                    updatePropertyMutabilities(builder, model, resourceId, null, shape,
-                                            SetUtils.of(), Function.identity());
+                                .ifPresent(optionalStructure -> {
+                                    optionalStructure.ifPresent(shape -> {
+                                        addAdditionalIdentifiers(builder, computeResourceAdditionalIdentifiers(shape));
+                                        updatePropertyMutabilities(builder, model, resourceId, null, shape,
+                                                SetUtils.of(), Function.identity());
+                                    });
                                 });
                     }
 

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
@@ -149,13 +149,11 @@ public final class CfnResourceIndex implements KnowledgeIndex {
                         // These shapes should be present given the @idRef failWhenMissing
                         // setting, but gracefully handle if they're not.
                         model.getShape(additionalSchema)
-                                .map(Shape::asStructureShape)
-                                .ifPresent(optionalStructure -> {
-                                    optionalStructure.ifPresent(shape -> {
-                                        addAdditionalIdentifiers(builder, computeResourceAdditionalIdentifiers(shape));
-                                        updatePropertyMutabilities(builder, model, resourceId, null, shape,
-                                                SetUtils.of(), Function.identity());
-                                    });
+                                .flatMap(Shape::asStructureShape)
+                                .ifPresent(shape -> {
+                                    addAdditionalIdentifiers(builder, computeResourceAdditionalIdentifiers(shape));
+                                    updatePropertyMutabilities(builder, model, resourceId, null, shape,
+                                            SetUtils.of(), Function.identity());
                                 });
                     }
 
@@ -288,7 +286,7 @@ public final class CfnResourceIndex implements KnowledgeIndex {
             Function<Set<Mutability>, Set<Mutability>> updater
     ) {
         return definition -> {
-            CfnResourceProperty.Builder builder =  definition.toBuilder().addShapeId(member.getId());
+            CfnResourceProperty.Builder builder = definition.toBuilder().addShapeId(member.getId());
 
             if (explicitMutability.isEmpty()) {
                 // Update the existing mutabilities.

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/invalid-additional-schemas-shape.errors
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/invalid-additional-schemas-shape.errors
@@ -1,0 +1,3 @@
+[ERROR] smithy.example#InvalidAdditionalSchemasShapeResource: Error validating trait `aws.cloudformation#cfnResource`.additionalSchemas.0: Shape ID `smithy.example#ListShape` does not match selector `structure` | TraitValue
+[NOTE] smithy.example#ListShape: The list shape is not connected to from any service shape. | UnreferencedShape
+[WARNING] smithy.example#InvalidAdditionalSchemasShapeResource: This shape applies a trait that is unstable: aws.cloudformation#cfnResource | UnstableTrait

--- a/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/invalid-additional-schemas-shape.smithy
+++ b/smithy-aws-cloudformation-traits/src/test/resources/software/amazon/smithy/aws/cloudformation/traits/errorfiles/invalid-additional-schemas-shape.smithy
@@ -1,0 +1,58 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use aws.cloudformation#cfnResource
+
+service InvalidAdditionalSchemasShape {
+    version: "2020-07-02",
+    resources: [
+        InvalidAdditionalSchemasShapeResource,
+    ],
+}
+
+@cfnResource(
+  additionalSchemas: [ListShape]
+)
+resource InvalidAdditionalSchemasShapeResource {
+    identifiers: {
+        fooId: String,
+    },
+    create: CreateInvalidAdditionalSchemasShapeResource,
+    read: GetInvalidAdditionalSchemasShapeResource,
+}
+
+list ListShape {
+    member: String
+}
+
+operation CreateInvalidAdditionalSchemasShapeResource {
+    input: CreateInvalidAdditionalSchemasShapeResourceRequest,
+    output: CreateInvalidAdditionalSchemasShapeResourceResponse
+}
+
+@input
+structure CreateInvalidAdditionalSchemasShapeResourceRequest {
+    bar: String,
+}
+
+@output
+structure CreateInvalidAdditionalSchemasShapeResourceResponse {}
+
+@readonly
+operation GetInvalidAdditionalSchemasShapeResource {
+    input: GetInvalidAdditionalSchemasShapeResourceRequest,
+    output: GetInvalidAdditionalSchemasShapeResourceResponse,
+}
+
+@input
+structure GetInvalidAdditionalSchemasShapeResourceRequest {
+    @required
+    fooId: String,
+}
+
+@output
+structure GetInvalidAdditionalSchemasShapeResourceResponse {
+    bar: String,
+}
+


### PR DESCRIPTION
*Description of changes:*

Update the logic that gets process the shape of the `additionalSchema` property to avoid attempting to dereference a non-structure shape. Without this the `Optional::get` throws and exception when the shape is not an `structure` and hides out the actual error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
