### PR TITLE
Use pretty validation output with smithy diff

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/DiffCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/DiffCommandTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.ListUtils;
+
+public class DiffCommandTest {
+    @Test
+    public void passingDiffEventsExitZero() {
+        IntegUtils.withTempDir("diff", dir -> {
+            Path a = dir.resolve("a.smithy");
+            writeFile(a, "$version: \"2.0\"\nnamespace example\nstring A\n");
+
+            RunResult result = IntegUtils.run(dir, ListUtils.of("diff", "--old", a.toString(), "--new", a.toString()));
+            assertThat(result.getExitCode(), equalTo(0));
+        });
+    }
+
+    @Test
+    public void showsLabelForOldModelEvents() {
+        IntegUtils.withTempDir("diff", dir -> {
+            Path a = dir.resolve("a.smithy");
+            writeFile(a, "$version: \"2.0\"\nnamespace example\n@aaaaaa\nstring A\n");
+
+            RunResult result = IntegUtils.run(dir, ListUtils.of("diff", "--old", a.toString(), "--new", a.toString()));
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("──  OLD ─ ERROR  ──"));
+        });
+    }
+
+    @Test
+    public void showsLabelForNewModelEvents() {
+        IntegUtils.withTempDir("diff", dir -> {
+            Path a = dir.resolve("a.smithy");
+            writeFile(a, "$version: \"2.0\"\nnamespace example\nstring A\n");
+
+            Path b = dir.resolve("b.smithy");
+            writeFile(b, "$version: \"2.0\"\nnamespace example\n@aaaaaa\nstring A\n");
+
+            RunResult result = IntegUtils.run(dir, ListUtils.of("diff", "--old", a.toString(), "--new", b.toString()));
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(), containsString("──  NEW ─ ERROR  ──"));
+        });
+    }
+
+    @Test
+    public void showsLabelForDiffEvents() {
+        IntegUtils.withTempDir("diff", dir -> {
+            Path a = dir.resolve("a.smithy");
+            writeFile(a, "$version: \"2.0\"\nnamespace example\nstring A\n");
+
+            Path b = dir.resolve("b.smithy");
+            writeFile(b, "$version: \"2.0\"\nnamespace example\nstring A\nstring B\n"); // Added B.
+
+            RunResult result = IntegUtils.run(dir, ListUtils.of(
+                    "diff",
+                    "--old", a.toString(),
+                    "--new", b.toString(),
+                    "--severity", "NOTE")); // Note that this is required since the default severity is WARNING.
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("──  DIFF ─ NOTE  ──"));
+        });
+    }
+
+    private void writeFile(Path path, String contents) {
+        try {
+            FileWriter fileWriter = new FileWriter(path.toString());
+            PrintWriter printWriter = new PrintWriter(fileWriter);
+            printWriter.print(contents);
+            printWriter.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -91,7 +91,7 @@ public final class IntegUtils {
         throw new RuntimeException("No SMITHY_BINARY location was set. Did you build the Smithy jlink CLI?");
     }
 
-    private static void withTempDir(String name, Consumer<Path> consumer) {
+    static void withTempDir(String name, Consumer<Path> consumer) {
         try {
             Path path = Files.createTempDirectory(name.replace("/", "_"));
             try {

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/PrettyAnsiValidationFormatterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/PrettyAnsiValidationFormatterTest.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.cli.AnsiColorFormatter;
 import software.amazon.smithy.cli.ColorFormatter;
+import software.amazon.smithy.cli.Style;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.sourcecontext.SourceContextLoader;
@@ -111,7 +112,7 @@ public class PrettyAnsiValidationFormatterTest {
 
     private PrettyAnsiValidationFormatter createFormatter(ColorFormatter colors) {
         SourceContextLoader loader = SourceContextLoader.createLineBasedLoader(2);
-        return new PrettyAnsiValidationFormatter(loader, colors);
+        return PrettyAnsiValidationFormatter.builder().sourceContextLoader(loader).colors(colors).build();
     }
 
     private String formatTestEventWithSeverity(PrettyAnsiValidationFormatter pretty, Severity severity) {
@@ -135,7 +136,10 @@ public class PrettyAnsiValidationFormatterTest {
         SourceContextLoader loader = s -> {
             throw new UncheckedIOException(new IOException("Error!!!"));
         };
-        PrettyAnsiValidationFormatter pretty = new PrettyAnsiValidationFormatter(loader, colors);
+        PrettyAnsiValidationFormatter pretty = PrettyAnsiValidationFormatter.builder()
+                .sourceContextLoader(loader)
+                .colors(colors)
+                .build();
         ValidationEvent event = ValidationEvent.builder()
                 .id("Foo")
                 .severity(Severity.NOTE)
@@ -153,5 +157,30 @@ public class PrettyAnsiValidationFormatterTest {
                 + "Invalid source file: Error!!!\n"
                 + "\n"
                 + "Hello\n"));
+    }
+
+    @Test
+    public void showsTitleLabelsWhenPresent() {
+        PrettyAnsiValidationFormatter pretty = PrettyAnsiValidationFormatter.builder()
+                .sourceContextLoader(SourceContextLoader.createLineBasedLoader(4))
+                .colors(AnsiColorFormatter.FORCE_COLOR)
+                .titleLabel("FOO", Style.BG_BLUE, Style.BLACK)
+                .build();
+        ValidationEvent event = ValidationEvent.builder()
+                .id("Hello")
+                .severity(Severity.WARNING)
+                .shapeId(ShapeId.from("smithy.example#Foo"))
+                .message("hello")
+                .build();
+
+        String formatted =  normalizeLinesAndFiles(pretty.format(event));
+
+        assertThat(formatted, equalTo(
+                "\n"
+                + "\u001B[33m── \u001B[0m\u001B[44;30m FOO \u001B[0m \u001B[43;30m WARNING \u001B[0m\u001B[33m "
+                + "─────────────────────────────────────────────────────── \u001B[0mHello\n"
+                + "\u001B[90mShape: \u001B[0m\u001B[34msmithy.example#Foo\u001B[0m\n"
+                + "\n"
+                + "hello\n"));
     }
 }


### PR DESCRIPTION
Smithy diff now uses the pretty validation output.

The old and new models are both validated, but only build-failing errors are shown. When the original model fails, a label is added before ERROR/DANGER to show it's on the OLD model. When the new model fails, it shows a NEW label.

When running the diff with two valid models, events have a label of DIFF. The events shown here use the --severity option and default to WARNING when not set.

![image](https://user-images.githubusercontent.com/190930/229330451-95b16889-a038-455e-aeb6-b3804974ca47.png)

![image](https://user-images.githubusercontent.com/190930/229330507-e9e7976d-5c5b-41a5-be5c-761065e6ccdc.png)

![image](https://user-images.githubusercontent.com/190930/229330516-845b56f7-ed4d-4eda-820e-390723c9f72b.png)

With `--no-color`:

![image](https://user-images.githubusercontent.com/190930/229330568-86f0a96c-709f-4a1b-ad4f-9c0fc6147258.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
