### PR TITLE
Reduce IDL ambiguity by replacing `*SP` with `[SP]`

### DIFF
--- a/docs/source-1.0/spec/core/idl.rst
+++ b/docs/source-1.0/spec/core/idl.rst
@@ -95,7 +95,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     SP           :1*(%x20 / %x09) ; one or more spaces or tabs
     NL           :%x0A / %x0D.0A ; Newline: \n and \r\n
     NotNL        :%x09 / %x20-10FFFF ; Any character except newline
-    BR           :*`SP` 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
+    BR           :[`Sp`] 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
 
 .. rubric:: Comments
 
@@ -108,13 +108,13 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
 
 .. productionlist:: smithy
     ControlSection   :*(`ControlStatement`)
-    ControlStatement :"$" `NodeObjectKey` *`SP` ":" *`SP` `NodeValue` `BR`
+    ControlStatement :"$" `NodeObjectKey` [`Sp`] ":" [`Sp`] `NodeValue` `BR`
 
 .. rubric:: Metadata
 
 .. productionlist:: smithy
     MetadataSection   :*(`MetadataStatement`)
-    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` *`SP` "=" *`SP` `NodeValue` `BR`
+    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` [`Sp`] "=" [`Sp`] `NodeValue` `BR`
 
 .. rubric:: Node values
 
@@ -164,7 +164,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     Hex                 :DIGIT / %x41-46 / %x61-66
     PreservedDouble     :`Escape` (%x20-21 / %x23-5B / %x5D-10FFFF)
     Escape              :%x5C ; backslash
-    TextBlock           :`ThreeDquotes` *`SP` `NL` *`QuotedChar` `ThreeDquotes`
+    TextBlock           :`ThreeDquotes` [`Sp`] `NL` *`QuotedChar` `ThreeDquotes`
     ThreeDquotes        :DQUOTE DQUOTE DQUOTE
 
 .. rubric:: Shapes
@@ -193,17 +193,17 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     ListStatement           :%s"list" `SP` `Identifier` [`WS`] `ListMembers`
     ListMembers             :"{" [`WS`] `ListMember` [`WS`] "}"
     ListMember              :`TraitStatements` `ExplicitListMember`
-    ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
+    ExplicitListMember      :%s"member" [`Sp`] ":" [`Sp`] `ShapeId`
     SetStatement            :%s"set" `SP` `Identifier` [`WS`] `SetMembers`
     SetMembers              :"{" [`WS`] `SetMember` [`WS`] "}"
     SetMember               :`TraitStatements` `ExplicitSetMember`
-    ExplicitSetMember       :%s"member" *`SP` ":" *`SP` `ShapeId`
+    ExplicitSetMember       :%s"member" [`Sp`] ":" [`Sp`] `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`WS`] `MapMembers`
     MapMembers              :"{" [`WS`] `MapKey` `WS` `MapValue` [`WS`] "}"
     MapKey                  :`TraitStatements` `ExplicitMapKey`
-    ExplicitMapKey          :%s"key" *`SP` ":" *`SP` `ShapeId`
+    ExplicitMapKey          :%s"key" [`Sp`] ":" [`Sp`] `ShapeId`
     MapValue                :`TraitStatements` `ExplicitMapValue`
-    ExplicitMapValue        :%s"value" *`SP` ":" *`SP` `ShapeId`
+    ExplicitMapValue        :%s"value" [`Sp`] ":" [`Sp`] `ShapeId`
     StructureStatement      :%s"structure" `SP` `Identifier` [`WS`] `StructureMembers`
     StructureMembers        :"{" [`WS`]
                             :      [`StructureMember` [`WS`]
@@ -211,7 +211,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                             :      `TrailingComma`]
                             :  "}"
     StructureMember         :`TraitStatements` `ExplicitStructureMember`                        
-    ExplicitStructureMember :`Identifier` *`SP` ":" *`SP` `ShapeId`
+    ExplicitStructureMember :`Identifier` [`Sp`] ":" [`Sp`] `ShapeId`
     UnionStatement          :%s"union" `SP` `Identifier` [`WS`] `UnionMembers`
     UnionMembers            :"{" [`WS`]
                             :      `UnionMember` [`WS`]
@@ -219,7 +219,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                             :      `TrailingComma`
                             :  "}"
     UnionMember             :`TraitStatements` `ExplicitUnionMember`
-    ExplicitUnionMember     :`Identifier` *`SP` ":" *`SP` `ShapeId`
+    ExplicitUnionMember     :`Identifier` [`Sp`] ":" [`Sp`] `ShapeId`
     ServiceStatement        :%s"service" `SP` `Identifier` [`WS`] `NodeObject`
     ResourceStatement       :%s"resource" `SP` `Identifier` [`WS`] `NodeObject`
     OperationStatement      :%s"operation" `SP` `Identifier` [`WS`] `NodeObject`

--- a/docs/source-1.0/spec/core/idl.rst
+++ b/docs/source-1.0/spec/core/idl.rst
@@ -95,7 +95,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     SP           :1*(%x20 / %x09) ; one or more spaces or tabs
     NL           :%x0A / %x0D.0A ; Newline: \n and \r\n
     NotNL        :%x09 / %x20-10FFFF ; Any character except newline
-    BR           :[`Sp`] 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
+    BR           :[`SP`] 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
 
 .. rubric:: Comments
 
@@ -108,13 +108,13 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
 
 .. productionlist:: smithy
     ControlSection   :*(`ControlStatement`)
-    ControlStatement :"$" `NodeObjectKey` [`Sp`] ":" [`Sp`] `NodeValue` `BR`
+    ControlStatement :"$" `NodeObjectKey` [`SP`] ":" [`SP`] `NodeValue` `BR`
 
 .. rubric:: Metadata
 
 .. productionlist:: smithy
     MetadataSection   :*(`MetadataStatement`)
-    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` [`Sp`] "=" [`Sp`] `NodeValue` `BR`
+    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` [`SP`] "=" [`SP`] `NodeValue` `BR`
 
 .. rubric:: Node values
 
@@ -164,7 +164,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     Hex                 :DIGIT / %x41-46 / %x61-66
     PreservedDouble     :`Escape` (%x20-21 / %x23-5B / %x5D-10FFFF)
     Escape              :%x5C ; backslash
-    TextBlock           :`ThreeDquotes` [`Sp`] `NL` *`QuotedChar` `ThreeDquotes`
+    TextBlock           :`ThreeDquotes` [`SP`] `NL` *`QuotedChar` `ThreeDquotes`
     ThreeDquotes        :DQUOTE DQUOTE DQUOTE
 
 .. rubric:: Shapes
@@ -193,17 +193,17 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
     ListStatement           :%s"list" `SP` `Identifier` [`WS`] `ListMembers`
     ListMembers             :"{" [`WS`] `ListMember` [`WS`] "}"
     ListMember              :`TraitStatements` `ExplicitListMember`
-    ExplicitListMember      :%s"member" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitListMember      :%s"member" [`SP`] ":" [`SP`] `ShapeId`
     SetStatement            :%s"set" `SP` `Identifier` [`WS`] `SetMembers`
     SetMembers              :"{" [`WS`] `SetMember` [`WS`] "}"
     SetMember               :`TraitStatements` `ExplicitSetMember`
-    ExplicitSetMember       :%s"member" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitSetMember       :%s"member" [`SP`] ":" [`SP`] `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`WS`] `MapMembers`
     MapMembers              :"{" [`WS`] `MapKey` `WS` `MapValue` [`WS`] "}"
     MapKey                  :`TraitStatements` `ExplicitMapKey`
-    ExplicitMapKey          :%s"key" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitMapKey          :%s"key" [`SP`] ":" [`SP`] `ShapeId`
     MapValue                :`TraitStatements` `ExplicitMapValue`
-    ExplicitMapValue        :%s"value" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitMapValue        :%s"value" [`SP`] ":" [`SP`] `ShapeId`
     StructureStatement      :%s"structure" `SP` `Identifier` [`WS`] `StructureMembers`
     StructureMembers        :"{" [`WS`]
                             :      [`StructureMember` [`WS`]
@@ -211,7 +211,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                             :      `TrailingComma`]
                             :  "}"
     StructureMember         :`TraitStatements` `ExplicitStructureMember`                        
-    ExplicitStructureMember :`Identifier` [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitStructureMember :`Identifier` [`SP`] ":" [`SP`] `ShapeId`
     UnionStatement          :%s"union" `SP` `Identifier` [`WS`] `UnionMembers`
     UnionMembers            :"{" [`WS`]
                             :      `UnionMember` [`WS`]
@@ -219,7 +219,7 @@ string support defined in `RFC 5234 <https://www.rfc-editor.org/rfc/rfc7405>`_.
                             :      `TrailingComma`
                             :  "}"
     UnionMember             :`TraitStatements` `ExplicitUnionMember`
-    ExplicitUnionMember     :`Identifier` [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitUnionMember     :`Identifier` [`SP`] ":" [`SP`] `ShapeId`
     ServiceStatement        :%s"service" `SP` `Identifier` [`WS`] `NodeObject`
     ResourceStatement       :%s"resource" `SP` `Identifier` [`WS`] `NodeObject`
     OperationStatement      :%s"operation" `SP` `Identifier` [`WS`] `NodeObject`

--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -102,7 +102,7 @@ string support defined in :rfc:`7405`.
     SP   :1*(%x20 / %x09) ; one or more spaces or tabs
     NL   :%x0A / %x0D.0A ; Newline: \n and \r\n
     NotNL:%x09 / %x20-10FFFF ; Any character except newline
-    BR   :*`SP` 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
+    BR   :[`Sp`] 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
 
 .. rubric:: Comments
 
@@ -115,13 +115,13 @@ string support defined in :rfc:`7405`.
 
 .. productionlist:: smithy
     ControlSection   :*(`ControlStatement`)
-    ControlStatement :"$" `NodeObjectKey` *`SP` ":" *`SP` `NodeValue` `BR`
+    ControlStatement :"$" `NodeObjectKey` [`Sp`] ":" [`Sp`] `NodeValue` `BR`
 
 .. rubric:: Metadata
 
 .. productionlist:: smithy
     MetadataSection   :*(`MetadataStatement`)
-    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` *`SP` "=" *`SP` `NodeValue` `BR`
+    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` [`Sp`] "=" [`Sp`] `NodeValue` `BR`
 
 .. rubric:: Node values
 
@@ -160,7 +160,7 @@ string support defined in :rfc:`7405`.
     UnicodeEscape       :%s"u" `Hex` `Hex` `Hex` `Hex`
     Hex                 :DIGIT / %x41-46 / %x61-66
     Escape              :%x5C ; backslash
-    TextBlock           :`ThreeDquotes` *`SP` `NL` *`TextBlockContent` `ThreeDquotes`
+    TextBlock           :`ThreeDquotes` [`Sp`] `NL` *`TextBlockContent` `ThreeDquotes`
     TextBlockContent    :`QuotedChar` / (1*2DQUOTE 1*`QuotedChar`)
     ThreeDquotes        :DQUOTE DQUOTE DQUOTE
 
@@ -188,30 +188,30 @@ string support defined in :rfc:`7405`.
                             :/ %s"byte" / %s"short" / %s"integer" / %s"long"
                             :/ %s"float" / %s"double" / %s"bigInteger"
                             :/ %s"bigDecimal" / %s"timestamp"
-    Mixins                  :*`SP` %s"with" [`WS`] "[" 1*([`WS`] `ShapeId`) [`WS`] "]"
+    Mixins                  :[`Sp`] %s"with" [`WS`] "[" 1*([`WS`] `ShapeId`) [`WS`] "]"
     EnumShapeStatement      :`EnumTypeName` `SP` `Identifier` [`Mixins`] [`WS`] `EnumShapeMembers`
     EnumTypeName            :%s"enum" / %s"intEnum"
     EnumShapeMembers        :"{" [`WS`] 1*(`TraitStatements` `Identifier` [`ValueAssignment`] [`WS`]) "}"
-    ValueAssignment         :*`SP` "=" *`SP` `NodeValue` `BR`
+    ValueAssignment         :[`Sp`] "=" [`Sp`] `NodeValue` `BR`
     ListStatement           :%s"list" `SP` `Identifier` [`Mixins`] [`WS`] `ListMembers`
     ListMembers             :"{" [`WS`] [`ListMember`] [`WS`] "}"
     ListMember              :`TraitStatements` (`ElidedListMember` / `ExplicitListMember`)
     ElidedListMember        :%s"$member"
-    ExplicitListMember      :%s"member" *`SP` ":" *`SP` `ShapeId`
+    ExplicitListMember      :%s"member" [`Sp`] ":" [`Sp`] `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] [`WS`] `MapMembers`
     MapMembers              :"{" [`WS`] [`MapKey` / `MapValue` / (`MapKey` `WS` `MapValue`)] [`WS`] "}"
     MapKey                  :`TraitStatements` (`ElidedMapKey` / `ExplicitMapKey`)
     MapValue                :`TraitStatements` (`ElidedMapValue` / `ExplicitMapValue`)
     ElidedMapKey            :%s"$key"
-    ExplicitMapKey          :%s"key" *`SP` ":" *`SP` `ShapeId`
+    ExplicitMapKey          :%s"key" [`Sp`] ":" [`Sp`] `ShapeId`
     ElidedMapValue          :%s"$value"
-    ExplicitMapValue        :%s"value" *`SP` ":" *`SP` `ShapeId`
+    ExplicitMapValue        :%s"value" [`Sp`] ":" [`Sp`] `ShapeId`
     StructureStatement      :%s"structure" `SP` `Identifier` [`StructureResource`]
                             :        [`Mixins`] [`WS`] `StructureMembers`
     StructureResource       :`SP` %s"for" `SP` `ShapeId`
     StructureMembers        :"{" [`WS`] *(`TraitStatements` `StructureMember` [`WS`]) "}"
     StructureMember         :(`ExplicitStructureMember` / `ElidedStructureMember`) [`ValueAssignment`]
-    ExplicitStructureMember :`Identifier` *`SP` ":" *`SP` `ShapeId`
+    ExplicitStructureMember :`Identifier` [`Sp`] ":" [`Sp`] `ShapeId`
     ElidedStructureMember   :"$" `Identifier`
     UnionStatement          :%s"union" `SP` `Identifier` [`Mixins`] [`WS`] `UnionMembers`
     UnionMembers            :"{" [`WS`] *(`TraitStatements` `UnionMember` [`WS`]) "}"

--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -102,7 +102,7 @@ string support defined in :rfc:`7405`.
     SP   :1*(%x20 / %x09) ; one or more spaces or tabs
     NL   :%x0A / %x0D.0A ; Newline: \n and \r\n
     NotNL:%x09 / %x20-10FFFF ; Any character except newline
-    BR   :[`Sp`] 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
+    BR   :[`SP`] 1*(`Comment` / `NL`) [`WS`]; line break followed by whitespace
 
 .. rubric:: Comments
 
@@ -115,13 +115,13 @@ string support defined in :rfc:`7405`.
 
 .. productionlist:: smithy
     ControlSection   :*(`ControlStatement`)
-    ControlStatement :"$" `NodeObjectKey` [`Sp`] ":" [`Sp`] `NodeValue` `BR`
+    ControlStatement :"$" `NodeObjectKey` [`SP`] ":" [`SP`] `NodeValue` `BR`
 
 .. rubric:: Metadata
 
 .. productionlist:: smithy
     MetadataSection   :*(`MetadataStatement`)
-    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` [`Sp`] "=" [`Sp`] `NodeValue` `BR`
+    MetadataStatement :%s"metadata" `SP` `NodeObjectKey` [`SP`] "=" [`SP`] `NodeValue` `BR`
 
 .. rubric:: Node values
 
@@ -160,7 +160,7 @@ string support defined in :rfc:`7405`.
     UnicodeEscape       :%s"u" `Hex` `Hex` `Hex` `Hex`
     Hex                 :DIGIT / %x41-46 / %x61-66
     Escape              :%x5C ; backslash
-    TextBlock           :`ThreeDquotes` [`Sp`] `NL` *`TextBlockContent` `ThreeDquotes`
+    TextBlock           :`ThreeDquotes` [`SP`] `NL` *`TextBlockContent` `ThreeDquotes`
     TextBlockContent    :`QuotedChar` / (1*2DQUOTE 1*`QuotedChar`)
     ThreeDquotes        :DQUOTE DQUOTE DQUOTE
 
@@ -188,30 +188,30 @@ string support defined in :rfc:`7405`.
                             :/ %s"byte" / %s"short" / %s"integer" / %s"long"
                             :/ %s"float" / %s"double" / %s"bigInteger"
                             :/ %s"bigDecimal" / %s"timestamp"
-    Mixins                  :[`Sp`] %s"with" [`WS`] "[" 1*([`WS`] `ShapeId`) [`WS`] "]"
+    Mixins                  :[`SP`] %s"with" [`WS`] "[" 1*([`WS`] `ShapeId`) [`WS`] "]"
     EnumShapeStatement      :`EnumTypeName` `SP` `Identifier` [`Mixins`] [`WS`] `EnumShapeMembers`
     EnumTypeName            :%s"enum" / %s"intEnum"
     EnumShapeMembers        :"{" [`WS`] 1*(`TraitStatements` `Identifier` [`ValueAssignment`] [`WS`]) "}"
-    ValueAssignment         :[`Sp`] "=" [`Sp`] `NodeValue` `BR`
+    ValueAssignment         :[`SP`] "=" [`SP`] `NodeValue` `BR`
     ListStatement           :%s"list" `SP` `Identifier` [`Mixins`] [`WS`] `ListMembers`
     ListMembers             :"{" [`WS`] [`ListMember`] [`WS`] "}"
     ListMember              :`TraitStatements` (`ElidedListMember` / `ExplicitListMember`)
     ElidedListMember        :%s"$member"
-    ExplicitListMember      :%s"member" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitListMember      :%s"member" [`SP`] ":" [`SP`] `ShapeId`
     MapStatement            :%s"map" `SP` `Identifier` [`Mixins`] [`WS`] `MapMembers`
     MapMembers              :"{" [`WS`] [`MapKey` / `MapValue` / (`MapKey` `WS` `MapValue`)] [`WS`] "}"
     MapKey                  :`TraitStatements` (`ElidedMapKey` / `ExplicitMapKey`)
     MapValue                :`TraitStatements` (`ElidedMapValue` / `ExplicitMapValue`)
     ElidedMapKey            :%s"$key"
-    ExplicitMapKey          :%s"key" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitMapKey          :%s"key" [`SP`] ":" [`SP`] `ShapeId`
     ElidedMapValue          :%s"$value"
-    ExplicitMapValue        :%s"value" [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitMapValue        :%s"value" [`SP`] ":" [`SP`] `ShapeId`
     StructureStatement      :%s"structure" `SP` `Identifier` [`StructureResource`]
                             :        [`Mixins`] [`WS`] `StructureMembers`
     StructureResource       :`SP` %s"for" `SP` `ShapeId`
     StructureMembers        :"{" [`WS`] *(`TraitStatements` `StructureMember` [`WS`]) "}"
     StructureMember         :(`ExplicitStructureMember` / `ElidedStructureMember`) [`ValueAssignment`]
-    ExplicitStructureMember :`Identifier` [`Sp`] ":" [`Sp`] `ShapeId`
+    ExplicitStructureMember :`Identifier` [`SP`] ":" [`SP`] `ShapeId`
     ElidedStructureMember   :"$" `Identifier`
     UnionStatement          :%s"union" `SP` `Identifier` [`Mixins`] [`WS`] `UnionMembers`
     UnionMembers            :"{" [`WS`] *(`TraitStatements` `UnionMember` [`WS`]) "}"


### PR DESCRIPTION
https://github.com/awslabs/smithy/issues/1249

This is the same change as https://github.com/awslabs/smithy/pull/1699