### PR TITLE
Clairfy api key auth's scheme

### DIFF
--- a/docs/source-2.0/spec/authentication-traits.rst
+++ b/docs/source-2.0/spec/authentication-traits.rst
@@ -182,8 +182,10 @@ properties:
         This value can be set to ``header`` or ``query``.
     * - scheme
       - ``string``
-      - Defines the security scheme to use on the ``Authorization`` header value
-        This can only be set if the "in" property is set to ``header``.
+      - Defines the scheme to use on the ``Authorization`` header value. As
+        defined in :rfc:`9110#section-11.4`. This scheme SHOULD be one of the
+        schemes defined in the `IANA Authentication Scheme Registry`_. This can
+        only be set if the "in" property is set to ``header``.
 
 The following example defines a service that accepts an API key in the "X-Api-Key"
 HTTP header:
@@ -367,3 +369,6 @@ authentication scheme trait that is not applied to the service:
 
     @auth([httpBasicAuth]) // <-- Invalid!
     operation OperationA {}
+
+
+.. _IANA Authentication Scheme Registry: https://www.iana.org/assignments/http-authschemes


### PR DESCRIPTION
It wasn't super obvious what scheme actually was or how to use it, so I added some clarifying links to the relevant rfc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
