### PR TITLE
Fix #1675

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -93,7 +94,7 @@ public final class ModelAssembler {
     private TraitFactory traitFactory;
     private ValidatorFactory validatorFactory;
     private boolean disableValidation;
-    private final Map<String, Supplier<InputStream>> inputStreamModels = new HashMap<>();
+    private final Map<String, Supplier<InputStream>> inputStreamModels = new LinkedHashMap<>();
     private final List<Validator> validators = new ArrayList<>();
     private final List<Node> documentNodes = new ArrayList<>();
     private final List<Model> mergeModels = new ArrayList<>();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -405,8 +407,8 @@ public class ModelAssemblerTest {
                 .addUnparsedModel("b3.smithy", "metadata items = [3]")
                 .assemble()
                 .unwrap();
-        List<Number> metadata1 = model1.getMetadata().get("items").expectArrayNode().getElements().stream().map(s -> s.expectNumberNode().getValue()).toList();
-        List<Number> metadata2 = model2.getMetadata().get("items").expectArrayNode().getElements().stream().map(s -> s.expectNumberNode().getValue()).toList();
+        List<Number> metadata1 = model1.getMetadata().get("items").expectArrayNode().getElements().stream().map(s -> s.expectNumberNode().getValue()).collect(Collectors.toList());
+        List<Number> metadata2 = model2.getMetadata().get("items").expectArrayNode().getElements().stream().map(s -> s.expectNumberNode().getValue()).collect(Collectors.toList());
         assertThat(metadata1, is(metadata2));
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -392,6 +392,26 @@ public class ModelAssemblerTest {
     }
 
     @Test
+    public void metadataIsNotAffectedByTheSourceName() {
+        Model model1 = new ModelAssembler()
+                .addUnparsedModel("a1.smithy", "metadata items = [1]")
+                .addUnparsedModel("a2.smithy", "metadata items = [2]")
+                .addUnparsedModel("a3.smithy", "metadata items = [3]")
+                .assemble()
+                .unwrap();
+        Model model2 = new ModelAssembler()
+                .addUnparsedModel("b1.smithy", "metadata items = [1]")
+                .addUnparsedModel("b2.smithy", "metadata items = [2]")
+                .addUnparsedModel("b3.smithy", "metadata items = [3]")
+                .assemble()
+                .unwrap();
+        List<Number> metadata1 = model1.getMetadata().get("items").expectArrayNode().getElements().stream().map(s -> s.expectNumberNode().getValue()).toList();
+        List<Number> metadata2 = model2.getMetadata().get("items").expectArrayNode().getElements().stream().map(s -> s.expectNumberNode().getValue()).toList();
+        assertThat(metadata1, is(metadata2));
+    }
+
+
+    @Test
     public void mergesMultipleModels() {
         Model model = new ModelAssembler()
                 .addImport(getClass().getResource("merges-1.json"))


### PR DESCRIPTION
Fixes #1675

*Description of changes:*

Makes it so source file names don't affect the order of the built metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
