### PR TITLE
Remove hidden --discover option from some commands

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/AstCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/AstCommandTest.java
@@ -34,16 +34,7 @@ public class AstCommandTest {
     }
 
     @Test
-    public void convertsSyntacticallyCorrectModels() {
-        IntegUtils.run("invalid-model", ListUtils.of("ast"), result -> {
-            assertThat(result.getExitCode(), equalTo(0));
-            assertThat(result.getOutput(), containsString("\"smithy\""));
-            assertThat(result.getOutput(), not(containsString("WARNING")));
-        });
-    }
-
-    @Test
-    public void showsErrorsForSyntacticallyIncorrectModels() {
+    public void showsErrorsForInvalidModels() {
         IntegUtils.run("model-with-syntax-error", ListUtils.of("ast"), result -> {
             assertThat(result.getExitCode(), equalTo(1));
             assertThat(result.getOutput(), containsString("ERROR"));

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/AstCommand.java
@@ -47,7 +47,6 @@ final class AstCommand implements Command {
     @Override
     public int execute(Arguments arguments, Env env) {
         arguments.addReceiver(new ConfigOptions());
-        arguments.addReceiver(new DiscoveryOptions());
         arguments.addReceiver(new BuildOptions());
 
         CommandAction action = HelpActionWrapper.fromCommand(

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -246,7 +246,7 @@ final class BuildCommand implements Command {
                         w.append(result.getProjectionName());
                         w.append("  ");
                         for (int i = 0; i < remainingLength; i++) {
-                            w.append('─');
+                            w.append("─");
                         }
                         w.println();
                     }, statusStyle);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiffCommand.java
@@ -57,7 +57,6 @@ final class DiffCommand implements Command {
     @Override
     public int execute(Arguments arguments, Env env) {
         arguments.addReceiver(new ConfigOptions());
-        arguments.addReceiver(new DiscoveryOptions());
         arguments.addReceiver(new SeverityOption());
         arguments.addReceiver(new BuildOptions());
         arguments.addReceiver(new Options());

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiscoveryOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/DiscoveryOptions.java
@@ -22,7 +22,7 @@ import software.amazon.smithy.cli.HelpPrinter;
 /**
  * Arguments available to commands that use model discovery.
  *
- * <p>TODO: It would be great to just always do model discovery and remove these hidden options.
+ * <p>This is currently only used by the build and validate commands as hidden options to support the Gradle plugin.
  */
 final class DiscoveryOptions implements ArgumentReceiver {
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/MigrateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/MigrateCommand.java
@@ -119,7 +119,6 @@ final class MigrateCommand implements Command {
     public int execute(Arguments arguments, Env env) {
         arguments.addReceiver(new ConfigOptions());
         arguments.addReceiver(new BuildOptions());
-        arguments.addReceiver(new DiscoveryOptions());
 
         CommandAction action = HelpActionWrapper.fromCommand(
                 this, parentCommandName, this::run);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -72,7 +72,6 @@ final class SelectCommand implements Command {
     @Override
     public int execute(Arguments arguments, Env env) {
         arguments.addReceiver(new ConfigOptions());
-        arguments.addReceiver(new DiscoveryOptions());
         arguments.addReceiver(new BuildOptions());
         arguments.addReceiver(new Options());
 

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/AstCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/AstCommandTest.java
@@ -28,24 +28,6 @@ public class AstCommandTest {
     }
 
     @Test
-    public void usesModelDiscoveryWithCustomValidClasspath() throws Exception {
-        String dir = Paths.get(getClass().getResource("valid.jar").toURI()).toString();
-        CliUtils.Result result = CliUtils.runSmithy("ast", "--debug", "--discover-classpath", dir);
-
-        assertThat(result.code(), equalTo(0));
-        assertThat(result.stdout(), containsString("{"));
-    }
-
-    @Test
-    public void usesModelDiscoveryWithCustomInvalidClasspath() throws Exception {
-        String dir = Paths.get(getClass().getResource("invalid.jar").toURI()).toString();
-        CliUtils.Result result = CliUtils.runSmithy("ast", "--debug", "--discover-classpath", dir);
-
-        assertThat(result.code(), not(0));
-        assertThat(result.stderr(), containsString("ERROR: 1"));
-    }
-
-    @Test
     public void failsOnUnknownTrait() throws Exception {
         String model = Paths.get(getClass().getResource("unknown-trait.smithy").toURI()).toString();
         CliUtils.Result result = CliUtils.runSmithy("ast", model);

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/MigrateCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/MigrateCommandTest.java
@@ -109,11 +109,9 @@ public class MigrateCommandTest {
         SmithyCli.create().run(
                 "upgrade-1-to-2",
                 "--config", config.toString(),
-                "--discover-classpath", tempDir.toAbsolutePath().resolve("jar-import.jar").toString(),
                 modelsDir.toString()
         );
         assertDirEqual(baseDir.getParent().resolve("v2"), tempDir);
-
     }
 
     private void assertDirEqual(Path actualDir, Path expectedDir) throws Exception {

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/directory-cases/with-jar/v1/smithy-build.json
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/commands/upgrade/directory-cases/with-jar/v1/smithy-build.json
@@ -1,3 +1,6 @@
 {
-    "version": "1.0"
+    "version": "1.0",
+    "imports": [
+        "jar-import.jar"
+    ]
 }


### PR DESCRIPTION
The --discover and --discover-classpath options are only necessary for smithy build and smithy validate to support the Gradle pluing and the internal build tool within Amazon. This commit removes those options from ast, diff, migrate, and select, and removes / fixes tests that relied on them.

We should figure out if we can remove these options from build/validate or if we're comfortable with them as public options.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
