### PR TITLE
Make smithy diff default to arbitrary diff mode

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ModelBuilder.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ModelBuilder.java
@@ -61,6 +61,7 @@ final class ModelBuilder {
     private ValidatedResult<Model> validatedResult;
     private String titleLabel;
     private Style[] titleLabelStyles;
+    private boolean disableConfigModels;
 
     public ModelBuilder arguments(Arguments arguments) {
         this.arguments = arguments;
@@ -109,6 +110,11 @@ final class ModelBuilder {
         return this;
     }
 
+    public ModelBuilder disableConfigModels(boolean disableConfigModels) {
+        this.disableConfigModels = disableConfigModels;
+        return this;
+    }
+
     public Model build() {
         SmithyBuilder.requiredState("arguments", arguments);
         SmithyBuilder.requiredState("models", models);
@@ -143,9 +149,14 @@ final class ModelBuilder {
 
             handleModelDiscovery(assembler, classLoader, config);
             handleUnknownTraitsOption(buildOptions, assembler);
-            config.getSources().forEach(assembler::addImport);
+
+            // Add imports and sources from the config by default, but this can be disabled (e.g., smithy diff).
+            if (!disableConfigModels) {
+                config.getSources().forEach(assembler::addImport);
+                config.getImports().forEach(assembler::addImport);
+            }
+
             models.forEach(assembler::addImport);
-            config.getImports().forEach(assembler::addImport);
             validatedResult = assembler.assemble();
             clearStatusUpdateIfPresent(issueCount, stderr);
         }


### PR DESCRIPTION
Smithy Diff should require --new, and --old models, and perform arbitrary diffs by defualt, meaning the diff does not use imports or sources found in smithy-build.json files. This matches the previous behavior of smithy diff. We will add more diff modes later that will support loading models defined in project config files.

Smithy Diff should only accept a single --old and --new argument to make it easier to expand diff capabilities in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
