### PR TITLE
Add --flatten flag to the AST command

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/AstCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/AstCommandTest.java
@@ -41,4 +41,20 @@ public class AstCommandTest {
             assertThat(result.getOutput(), containsString("bar // <- invalid syntax"));
         });
     }
+
+    @Test
+    public void doesNotFlattenModelsWithoutFlattenOption() {
+        IntegUtils.run("model-with-mixins", ListUtils.of("ast"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), containsString("\"smithy.api#mixin\": {}"));
+        });
+    }
+
+    @Test
+    public void flattensModelsWithFlattenOption() {
+        IntegUtils.run("model-with-mixins", ListUtils.of("ast", "--flatten"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            assertThat(result.getOutput(), not(containsString("\"smithy.api#mixin\": {}")));
+        });
+    }
 }

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-mixins/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-mixins/model/main.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+namespace com.amazon.example
+
+@mixin
+@tags(["a"])
+structure A1 {
+    @private
+    a: String
+}
+
+@mixin
+@documentation("Structure A2 docs")
+structure A2 {
+    @required
+    a: String
+}
+
+structure Valid with [A1, A2] {
+   c: Integer
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-mixins/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/model-with-mixins/smithy-build.json
@@ -1,0 +1,4 @@
+{
+    "version": "1.0",
+    "sources": ["model"]
+}


### PR DESCRIPTION
*Description of changes:*

Adds a new `--flatten` flag to the AST command that will flatten and remove the mixins from the model. This helps a lot with understanding how the model looks like without any mixins.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
