### PR TITLE
Add git diff mode to CLI

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -229,6 +229,11 @@ task integ(type: Test) {
     testClassesDirs = sourceSets["it"].output.classesDirs
     classpath = sourceSets["it"].runtimeClasspath
     maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+
+    testLogging {
+        events = ["passed", "skipped", "failed"]
+        exceptionFormat = "full"
+    }
 }
 
 // Runtime images need to be created before integration tests can run.

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -33,10 +33,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 public final class IntegUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(IntegUtils.class.getName());
 
     private IntegUtils() {}
 
@@ -97,7 +101,11 @@ public final class IntegUtils {
             try {
                 consumer.accept(path);
             } finally {
-                IoUtils.rmdir(path);
+                try {
+                    IoUtils.rmdir(path);
+                } catch (Exception e) {
+                    LOGGER.log(Level.INFO, "Unable to delete temp directory", e);
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/HelpPrinter.java
@@ -260,6 +260,12 @@ public final class HelpPrinter {
         LineWrapper appendWithinLine(String text) {
             if (column + text.length() > maxLength) {
                 newLine();
+                // If the text starts with a space, then eat the space since it isn't needed to separate words now.
+                if (text.startsWith(" ")) {
+                    builder.append(text, 1, text.length());
+                    column += text.length() - 1;
+                    return this;
+                }
             }
 
             builder.append(text);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -15,7 +15,11 @@
 
 package software.amazon.smithy.cli.commands;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.function.Consumer;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.HelpPrinter;
 
@@ -69,5 +73,22 @@ final class BuildOptions implements ArgumentReceiver {
 
     void noPositionalArguments(boolean noPositionalArguments) {
         this.noPositionalArguments = noPositionalArguments;
+    }
+
+    /**
+     * Resolves the correct build directory by looking at the --output argument, outputDirectory config setting,
+     * and finally the default build directory.
+     *
+     * @param config Config to check.
+     * @return Returns the resolved build directory.
+     */
+    Path resolveOutput(SmithyBuildConfig config) {
+        if (output != null) {
+            return Paths.get(output);
+        } else {
+            return config.getOutputDirectory()
+                    .map(Paths::get)
+                    .orElseGet(SmithyBuild::getDefaultOutputDirectory);
+        }
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/HelpPrinterTest.java
@@ -2,6 +2,7 @@ package software.amazon.smithy.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
 import org.junit.jupiter.api.Test;
@@ -173,7 +174,7 @@ public class HelpPrinterTest {
                            + "Goodbye18 Goodbye19 Goodbye20 Goodbye21.");
         help.print(AnsiColorFormatter.NO_COLOR, printer);
 
-        assertThat(printer.toString(), startsWith(
+        assertThat(printer.toString().trim(), equalTo(
                 "Usage: foo [--foo | -f] \n"
                 + "\n"
                 + "Hello1 Hello2 Hello3 Hello4 Hello5 Hello6 Hello7 Hello8 Hello9 Hello10 Hello11 Hello12 Hello13 \n"
@@ -184,8 +185,7 @@ public class HelpPrinterTest {
                 + "        The foo value\n"
                 + "    \n"
                 + "Goodbye1 Goodbye2 Goodbye3 Goodbye4 Goodbye5 Goodbye6 Goodbye7 Goodbye8 Goodbye9 Goodbye10 Goodbye11\n"
-                + " Goodbye12 Goodbye13 Goodbye14 Goodbye15 Goodbye16 Goodbye17 Goodbye18 Goodbye19 Goodbye20 \n"
-                + "Goodbye21."));
+                + "Goodbye12 Goodbye13 Goodbye14 Goodbye15 Goodbye16 Goodbye17 Goodbye18 Goodbye19 Goodbye20 Goodbye21."));
     }
 
     @Test

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildOptionsTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildOptionsTest.java
@@ -1,0 +1,36 @@
+package software.amazon.smithy.cli.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.SmithyBuild;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
+
+public class BuildOptionsTest {
+    @Test
+    public void usesExplicitOutputArgument() {
+        BuildOptions options = new BuildOptions();
+        options.testParameter("--output").accept("test");
+        SmithyBuildConfig config = SmithyBuildConfig.builder().version("1").outputDirectory("foo").build();
+
+        assertThat(options.resolveOutput(config), equalTo(Paths.get("test")));
+    }
+
+    @Test
+    public void usesConfigOutputDirectory() {
+        BuildOptions options = new BuildOptions();
+        SmithyBuildConfig config = SmithyBuildConfig.builder().version("1").outputDirectory("foo").build();
+
+        assertThat(options.resolveOutput(config), equalTo(Paths.get("foo")));
+    }
+
+    @Test
+    public void usesDefaultBuildDirectory() {
+        BuildOptions options = new BuildOptions();
+        SmithyBuildConfig config = SmithyBuildConfig.builder().version("1").build();
+
+        assertThat(options.resolveOutput(config), equalTo(SmithyBuild.getDefaultOutputDirectory()));
+    }
+}


### PR DESCRIPTION
This commit adds support for running Smithy diff using a "git" mode so that the current state of a project is compared against the previous state of a project. By default, the previous state is the last commit of the current branch:

```
smithy diff --mode git
```

You can compare against a differet commit using:

```
smithy diff --mode git --old HEAD~2
smithy diff --mode git --old main
```

The way this works it that `git` mode is a wrapper around `project` mode. Smithy will create a git worktree for a specific branch named `__smithy-diff-worktree` located at
"build/smithy/diff-worktree". Each time the command is run, the worktree is either created and pointed at the correct commit, or uses `git reset --hard $COMMIT`. When creating the worktree, we first call "git worktree prune" in case the worktree was previously created and deleted from a `smithy clean` operation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
