### PR TITLE
Update aws.iam.json - Remove member from actionName as type is string

### DIFF
--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.json
@@ -267,9 +267,6 @@
         },
         "aws.iam#actionName": {
             "type": "string",
-            "member": {
-                "target": "aws.iam#IamIdentifier"
-            },
             "traits": {
                 "smithy.api#trait": {
                     "selector": "operation"


### PR DESCRIPTION
Remove member from actionName as type is string

*Issue #, if available:*

*Description of changes:*
Update aws.iam.json - Remove member from actionName as type is string

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
