### PR TITLE
fix error msg for invalid operation io bindings

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/OperationValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/OperationValidator.java
@@ -95,7 +95,7 @@ public final class OperationValidator extends AbstractValidator {
                     }
                 } else if (relName.equals(invalid)) {
                     // Input shouldn't reference output, and vice versa.
-                    events.add(emitInvalidOperationBinding(rel.getShape(), descriptor, invalid));
+                    events.add(emitInvalidOperationBinding(rel.getShape(), shape, relName, descriptor));
                 } else if (rel.getRelationshipType() == RelationshipType.MEMBER_TARGET) {
                     // Members can't target shapes marked with @input or @output.
                     events.add(emitInvalidMemberRef(rel.getShape().asMemberShape().get(), descriptor));
@@ -109,12 +109,19 @@ public final class OperationValidator extends AbstractValidator {
         }
     }
 
-    private ValidationEvent emitInvalidOperationBinding(Shape operation, String property, String invalid) {
+    private ValidationEvent emitInvalidOperationBinding(
+            Shape operation,
+            Shape target,
+            String property,
+            String invalid
+    ) {
         return ValidationEvent.builder()
                 .id(OPERATION_INPUT_OUTPUT_MISUSE)
                 .severity(Severity.ERROR)
                 .shape(operation)
-                .message("Operation " + property + " cannot target structures marked with the @" + invalid + " trait")
+                .message(String.format(
+                        "Operation `%s` cannot target structures marked with the `@%s` trait: `%s`",
+                        property, invalid, target.getId()))
                 .build();
     }
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/operation/input-output-traits/invalid-input-output-operation-bindings.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/operation/input-output-traits/invalid-input-output-operation-bindings.errors
@@ -1,2 +1,2 @@
-[ERROR] smithy.example#GetFoo: Operation input cannot target structures marked with the @output trait | OperationInputOutputMisuse
-[ERROR] smithy.example#GetFoo: Operation output cannot target structures marked with the @input trait | OperationInputOutputMisuse
+[ERROR] smithy.example#GetFoo: Operation `input` cannot target structures marked with the `@output` trait: `smithy.example#GetFooOutput` | OperationInputOutputMisuse
+[ERROR] smithy.example#GetFoo: Operation `output` cannot target structures marked with the `@input` trait: `smithy.example#GetFooInput` | OperationInputOutputMisuse


### PR DESCRIPTION
Fixes issue #1719, which pointed out that error messages when operation input targeted structures with the `@output` trait (and vice-versa) were incorrect. The error message was built using the operation <-> target relationship name for the name of the invalid trait, instead of using it as the operation property which targeted an invalid shape.

The error message was also updated to include the shape id of the targeted shape, and existing tests were updated to reflect that change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
