### PR TITLE
Add rudimentary form of error recovery to parser

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
@@ -321,7 +321,7 @@ public final class IdlTokenizer implements Iterator<IdlToken> {
         switch (c) {
             case SimpleParser.EOF:
                 if (currentTokenType == IdlToken.EOF) {
-                    throw new NoSuchElementException("Expected another token but traversed beyond EOF");
+                    throw new NoSuchElementException("Expected another token but reached EOF");
                 }
                 currentTokenEnd = parser.position();
                 return currentTokenType = IdlToken.EOF;
@@ -750,9 +750,15 @@ public final class IdlTokenizer implements Iterator<IdlToken> {
     }
 
     private IdlToken parseIdentifier() {
-        ParserUtils.consumeIdentifier(parser);
+        try {
+            ParserUtils.consumeIdentifier(parser);
+            currentTokenType = IdlToken.IDENTIFIER;
+        } catch (RuntimeException e) {
+            currentTokenType = IdlToken.ERROR;
+            currentTokenError = e.getMessage();
+        }
         currentTokenEnd = parser.position();
-        return currentTokenType = IdlToken.IDENTIFIER;
+        return currentTokenType;
     }
 
     private IdlToken parseString() {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.model.loader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -45,6 +47,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.DynamicTrait;
+import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.model.traits.StringTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitFactory;
@@ -338,5 +341,136 @@ public class IdlModelLoaderTest {
         assertThat(foo.getSourceLocation().getColumn(), is(1));
         assertThat(fooBarMember.getSourceLocation().getLine(), is(7));
         assertThat(fooBarMember.getSourceLocation().getColumn(), is(5));
+    }
+
+    @Test
+    public void doesBasicErrorRecoveryToTrait() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("error-recovery/to-trait.smithy"))
+                .assemble();
+
+        assertThat(result.isBroken(), is(true));
+        assertThat(result.getResult().isPresent(), is(true));
+
+        Model model = result.getResult().get();
+
+        assertThat(model.getShape(ShapeId.from("smithy.example#MyString")).isPresent(), is(true));
+        assertThat(model.getShape(ShapeId.from("smithy.example#MyFooIsBroken")).isPresent(), is(false));
+        assertThat(model.getShape(ShapeId.from("smithy.example#MyInteger")).isPresent(), is(false));
+        assertThat(model.getShape(ShapeId.from("smithy.example#MyInteger2")).isPresent(), is(true));
+
+        boolean foundSyntax = false;
+        boolean foundTrait = false;
+        for (ValidationEvent e : result.getValidationEvents()) {
+            if (e.getSeverity() == Severity.ERROR && e.getMessage().contains(
+                    "Syntax error at line 9, column 9: Expected COLON(':') but found IDENTIFIER('MyInteger')")) {
+                foundSyntax = true;
+            }
+            if (e.getSeverity() == Severity.ERROR && e.getMessage().contains("Unable to resolve trait")) {
+                foundTrait = true;
+            }
+        }
+
+        assertThat(foundSyntax, is(true));
+        assertThat(foundTrait, is(true));
+    }
+
+    @Test
+    public void doesBasicErrorRecoveryToDocs() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("error-recovery/to-docs.smithy"))
+                .assemble();
+
+        assertThat(result.isBroken(), is(true));
+        assertThat(result.getResult().isPresent(), is(true));
+
+        Model model = result.getResult().get();
+
+        ShapeId myInteger = ShapeId.from("smithy.example#MyInteger");
+        assertThat(model.getShape(myInteger).isPresent(), is(true));
+        // Ensure recovery happened on the docs trait, capturing it on the shape.
+        assertThat(model.expectShape(myInteger).hasTrait(DocumentationTrait.class), is(true));
+
+        boolean foundSyntax = false;
+        boolean foundTrait = false;
+        for (ValidationEvent e : result.getValidationEvents()) {
+            if (e.getSeverity() == Severity.ERROR && e.getMessage().contains("Syntax error at line 6, column 28")) {
+                foundSyntax = true;
+            }
+            if (e.getSeverity() == Severity.ERROR && e.getMessage().contains("Unable to resolve trait")) {
+                foundTrait = true;
+            }
+        }
+
+        assertThat(foundSyntax, is(true));
+        assertThat(foundTrait, is(true));
+    }
+
+    @Test
+    public void doesBasicErrorRecoveryToIdentifier() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("error-recovery/to-identifier.smithy"))
+                .assemble();
+
+        assertThat(result.isBroken(), is(true));
+        assertThat(result.getResult().isPresent(), is(true));
+
+        Model model = result.getResult().get();
+
+        ShapeId myString = ShapeId.from("smithy.example#MyString");
+        assertThat(model.getShape(myString).isPresent(), is(true));
+        assertThat(model.expectShape(myString).hasTrait(ExternalDocumentationTrait.class), is(false));
+
+        boolean foundSyntax = result.getValidationEvents().stream()
+                .anyMatch(e -> e.getSeverity() == Severity.ERROR
+                               && e.getMessage().contains("Syntax error at line 6, column 28"));
+
+        assertThat(foundSyntax, is(true));
+    }
+
+    @Test
+    public void doesBasicErrorRecoveryToControl() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("error-recovery/to-dollar.smithy"))
+                .assemble();
+
+        assertThat(result.isBroken(), is(true));
+        assertThat(result.getResult().isPresent(), is(true));
+
+        Model model = result.getResult().get();
+
+        assertThat(model.getShape(ShapeId.from("smithy.example#MyInteger")).isPresent(), is(true));
+
+        boolean foundSyntax = result.getValidationEvents().stream()
+                .anyMatch(e -> e.getSeverity() == Severity.ERROR
+                               && e.getMessage().contains("Syntax error at line 1, column 5"));
+
+        assertThat(foundSyntax, is(true));
+    }
+
+    @Test
+    public void doesBasicErrorRecoveryInMetadata() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("error-recovery/in-metadata.smithy"))
+                .assemble();
+
+        assertThat(result.isBroken(), is(true));
+        assertThat(result.getResult().isPresent(), is(true));
+
+        Model model = result.getResult().get();
+
+        // Ensure the value keys were parsed and invalid keys were not.
+        assertThat(model.getMetadata().keySet(), containsInAnyOrder("valid1", "valid2", "valid3", "valid4"));
+        assertThat(model.getMetadata().get("valid1"), equalTo(Node.from("ok")));
+        assertThat(model.getMetadata().get("valid2"), equalTo(Node.from("ok")));
+        assertThat(model.getMetadata().get("valid3"), equalTo(Node.from("ok")));
+        assertThat(model.getMetadata().get("valid4"), equalTo(Node.from("ok")));
+
+        // Find all four invalid metadata keys.
+        long foundSyntax = result.getValidationEvents().stream()
+                .filter(e -> e.getSeverity() == Severity.ERROR && e.getMessage().contains("Syntax error"))
+                .count();
+
+        assertThat(foundSyntax, equalTo(4L));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/in-metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/in-metadata.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+metadata invalid1 ==
+metadata valid1 = "ok"
+metadata invalid2 = {"bad"}
+metadata valid2 = "ok"
+metadata invalid3 = ]
+metadata valid3 = "ok"
+metadata invalid4 =
+metadata valid4 = "ok"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-docs.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-docs.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Parse error here.
+@externalDocumentation(foo:)
+
+// Then recover on the line below.
+/// Hello
+@unknown
+integer MyInteger

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-dollar.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-dollar.smithy
@@ -1,0 +1,6 @@
+$foo
+$version: "2.0"
+// ^ Recover here
+namespace smithy.example
+
+integer MyInteger

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-identifier.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-identifier.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Parse error here.
+@externalDocumentation(foo:)
+string MyString
+// ^ Recover here

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/error-recovery/to-trait.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace smithy.example
+
+string MyString
+
+structure MyFooIsBroken {
+// The parser will keep trying to parse here, assuming integer is a key and needs to be followed by ":".
+integer MyInteger
+
+// When the above fails, error recovery kicks in, looking for the next token at the start of the line.
+@unknown
+integer MyInteger2


### PR DESCRIPTION
When we encounter a parser error, we'll now attempt some basic error recovery by simply skipping token until we reach a token at the start of a line that is an identifier, documentation comment, or '@'. This should help with things like LSPs that still should be able to utilize jump to definition even with a broken or in-progress model.

(still need to test the experience out in the LSP before merging)
