### PR TITLE
ignore lists and maps for camelcase validation

### DIFF
--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
@@ -193,8 +193,10 @@ public final class CamelCaseValidator extends AbstractValidator {
         for (MemberShape memberShape : memberShapes) {
             // Exclude members of enums from CamelCase validation,
             // as they're intended to be CAPS_SNAKE.
+            // Also exclude list and map members as their names are constant.
             Shape container = model.expectShape(memberShape.getContainer());
-            if (!container.isEnumShape() && !container.isIntEnumShape()) {
+            if (!container.isEnumShape() && !container.isIntEnumShape()
+                    && !container.isListShape() && !container.isMapShape()) {
                 if (MemberNameHandling.UPPER.getRegex().matcher(memberShape.getMemberName()).find()) {
                     upperCamelMemberNamesCount++;
                 } else {

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.errors
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.errors
@@ -11,6 +11,8 @@
 [DANGER] ns.foo#Structure$ThirdUpperCamelCase: Member shape member name, `ThirdUpperCamelCase`, is not lower camel case; members in the MyService must all use lower camel case. | LowerCamelCase
 [DANGER] ns.foo#Structure$FourthUpperCamelCase: Member shape member name, `FourthUpperCamelCase`, is not lower camel case; members in the MyService must all use lower camel case. | LowerCamelCase
 [DANGER] ns.foo#Structure$snake_case: Member shape member name, `snake_case`, is not lower camel case; members in the MyService must all use lower camel case. | LowerCamelCase
+[DANGER] ns.foo#Structure$List: Member shape member name, `List`, is not lower camel case; members in the MyService must all use lower camel case. | LowerCamelCase
+[DANGER] ns.foo#Structure$Map: Member shape member name, `Map`, is not lower camel case; members in the MyService must all use lower camel case. | LowerCamelCase
 
 
 [DANGER] ns.foo#InvalidTrait: string trait definition, `InvalidTrait`, is not lower camel case | UpperCamelCase

--- a/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.json
+++ b/smithy-linters/src/test/resources/software/amazon/smithy/linters/errorfiles/camel-case-validator-defaults-test.json
@@ -72,6 +72,21 @@
                 "smithy.api#trait": {}
             }
         },
+        "ns.baz#MyList": {
+            "type": "list",
+            "member": {
+                "target": "ns.foo#Foo"
+            }
+        },
+        "ns.baz#MyMap": {
+            "type": "map",
+            "key": {
+                "target": "ns.foo#Foo"
+            },
+            "value": {
+                "target": "ns.foo#Foo"
+            }
+        },
         "ns.foo#Foo": {
             "type": "string"
         },
@@ -104,6 +119,12 @@
                 },
                 "snake_case": {
                     "target": "ns.foo#snake_case"
+                },
+                "List": {
+                    "target": "ns.baz#MyList"
+                },
+                "Map": {
+                    "target": "ns.baz#MyMap"
                 }
             }
         },


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Ignore list and map "members" for the purpose of camel case validating, as they are _always_ fixed to the strings "member", "key", and "value".


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
