### PR TITLE
Use IntPredicate and inline end of line parsing

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
@@ -641,7 +641,7 @@ public final class IdlTokenizer implements Iterator<IdlToken> {
     }
 
     private IdlToken tokenizeSpace() {
-        parser.consumeUntilNoLongerMatches(c -> c == ' ' || c == '\t');
+        parser.consumeWhile(c -> c == ' ' || c == '\t');
         currentTokenEnd = parser.position();
         return currentTokenType = IdlToken.SPACE;
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ParserUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ParserUtils.java
@@ -46,13 +46,13 @@ public final class ParserUtils {
             }
         }
 
-        parser.consumeUntilNoLongerMatches(ParserUtils::isDigit);
+        parser.consumeWhile(ParserUtils::isDigit);
 
         // Consume decimals.
         char peek = parser.peek();
         if (peek == '.') {
             parser.skip();
-            if (parser.consumeUntilNoLongerMatches(ParserUtils::isDigit) == 0) {
+            if (parser.consumeWhile(ParserUtils::isDigit) == 0) {
                 throw parser.syntax(createInvalidString(parser, startPosition, "'.' must be followed by a digit"));
             }
         }
@@ -65,7 +65,7 @@ public final class ParserUtils {
             if (peek == '+' || peek == '-') {
                 parser.skip();
             }
-            if (parser.consumeUntilNoLongerMatches(ParserUtils::isDigit) == 0) {
+            if (parser.consumeWhile(ParserUtils::isDigit) == 0) {
                 throw parser.syntax(
                         createInvalidString(parser, startPosition, "'e', '+', and '-' must be followed by a digit"));
             }
@@ -158,7 +158,7 @@ public final class ParserUtils {
         // Parse identifier_start
         char c = parser.peek();
         if (c == '_') {
-            parser.consumeUntilNoLongerMatches(next -> next == '_');
+            parser.consumeWhile(next -> next == '_');
             if (!ParserUtils.isValidIdentifierCharacter(parser.peek())) {
                 throw invalidIdentifier(parser);
             }
@@ -170,7 +170,7 @@ public final class ParserUtils {
         parser.skip();
 
         // Parse identifier_chars
-        parser.consumeUntilNoLongerMatches(ParserUtils::isValidIdentifierCharacter);
+        parser.consumeWhile(ParserUtils::isValidIdentifierCharacter);
     }
 
     private static RuntimeException invalidIdentifier(SimpleParser parser) {
@@ -185,6 +185,16 @@ public final class ParserUtils {
      * @return Returns true if the character is allowed in an identifier.
      */
     public static boolean isValidIdentifierCharacter(char c) {
+        return isValidIdentifierCharacter((int) c);
+    }
+
+    /**
+     * Returns true if the given character is allowed in an identifier.
+     *
+     * @param c Character to check.
+     * @return Returns true if the character is allowed in an identifier.
+     */
+    public static boolean isValidIdentifierCharacter(int c) {
         return isIdentifierStart(c) || isDigit(c);
     }
 
@@ -195,6 +205,16 @@ public final class ParserUtils {
      * @return Returns true if the character can start an identifier.
      */
     public static boolean isIdentifierStart(char c) {
+        return isIdentifierStart((int) c);
+    }
+
+    /**
+     * Returns true if the given character is allowed to start an identifier.
+     *
+     * @param c Character to check.
+     * @return Returns true if the character can start an identifier.
+     */
+    public static boolean isIdentifierStart(int c) {
         return c == '_' ||  isAlphabetic(c);
     }
 
@@ -205,6 +225,16 @@ public final class ParserUtils {
      * @return Returns true if the character is a digit.
      */
     public static boolean isDigit(char c) {
+        return isDigit((int) c);
+    }
+
+    /**
+     * Returns true if the given value is a digit 0-9.
+     *
+     * @param c Character to check.
+     * @return Returns true if the character is a digit.
+     */
+    public static boolean isDigit(int c) {
         return c >= '0' && c <= '9';
     }
 
@@ -216,6 +246,17 @@ public final class ParserUtils {
      * @return Returns true if the character is an alphabetic character.
      */
     public static boolean isAlphabetic(char c) {
+        return isAlphabetic((int) c);
+    }
+
+    /**
+     * Returns true if the given character is an alphabetic character
+     * A-Z, a-z. This is a stricter version of {@link Character#isAlphabetic}.
+     *
+     * @param c Character to check.
+     * @return Returns true if the character is an alphabetic character.
+     */
+    public static boolean isAlphabetic(int c) {
         return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/linters/EmitEachSelectorValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/linters/EmitEachSelectorValidator.java
@@ -233,7 +233,7 @@ public final class EmitEachSelectorValidator extends AbstractValidator {
 
         MessageTemplate parse() {
             while (!eof()) {
-                consumeUntilNoLongerMatches(c -> c != '@');
+                consumeWhile(c -> c != '@');
                 // '@' followed by '@' is an escaped '@", so keep parsing
                 // the marked literal if that's the case.
                 if (peek(1) == '@') {

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
@@ -482,7 +482,7 @@ final class CodeFormatter {
             if (parser.peek() == '@') {
                 parser.skip();
                 int start = parser.position();
-                parser.consumeUntilNoLongerMatches(this::isNameCharacter);
+                parser.consumeWhile(this::isNameCharacter);
                 String sectionName = parser.sliceFrom(start);
                 ensureNameIsValid(sectionName);
                 operation = Operation.inlineSection(sectionName, operation);
@@ -518,7 +518,7 @@ final class CodeFormatter {
         }
 
         void skipTrailingWhitespaceInParser() {
-            parser.consumeUntilNoLongerMatches(Character::isWhitespace);
+            parser.consumeWhile(Character::isWhitespace);
         }
 
         private boolean isAllLeadingWhitespaceOnLine(int startPosition, int startColumn) {
@@ -549,13 +549,13 @@ final class CodeFormatter {
                         parser.expect('s');
                         parser.sp();
                         int startPos = parser.position();
-                        parser.consumeUntilNoLongerMatches(this::isNameCharacter);
+                        parser.consumeWhile(this::isNameCharacter);
                         keyPrefix = parser.sliceFrom(startPos);
                         ensureNameIsValid(keyPrefix);
                         parser.expect(',');
                         parser.sp();
                         startPos = parser.position();
-                        parser.consumeUntilNoLongerMatches(this::isNameCharacter);
+                        parser.consumeWhile(this::isNameCharacter);
                         value = parser.sliceFrom(startPos);
                         ensureNameIsValid(value);
                     }
@@ -646,7 +646,7 @@ final class CodeFormatter {
 
         private String parseArgumentName() {
             int start = parser.position();
-            parser.consumeUntilNoLongerMatches(this::isNameCharacter);
+            parser.consumeWhile(this::isNameCharacter);
             String name = parser.sliceFrom(start);
             ensureNameIsValid(name);
             return name;
@@ -694,7 +694,7 @@ final class CodeFormatter {
 
             relativeIndex = -1;
             int startPosition = parser.position();
-            parser.consumeUntilNoLongerMatches(Character::isDigit);
+            parser.consumeWhile(Character::isDigit);
             int index = Integer.parseInt(parser.sliceFrom(startPosition)) - 1;
 
             if (index < 0 || index >= arguments.length) {
@@ -713,7 +713,7 @@ final class CodeFormatter {
             }
         }
 
-        private boolean isNameCharacter(char c) {
+        private boolean isNameCharacter(int c) {
             return (c >= 'a' && c <= 'z')
                    || (c >= 'A' && c <= 'Z')
                    || (c >= '0' && c <= '9')

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/MediaType.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/MediaType.java
@@ -225,7 +225,7 @@ public final class MediaType {
 
         private String parseToken() {
             int start = position();
-            consumeUntilNoLongerMatches(TOKEN::contains);
+            consumeWhile(c -> TOKEN.contains((char) c));
 
             // Fail if the token was empty.
             if (start == position()) {

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/SimpleParser.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/SimpleParser.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.utils;
 
 import java.nio.CharBuffer;
 import java.util.Objects;
+import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 /**
@@ -303,7 +304,11 @@ public class SimpleParser {
      * the contents of the skipped characters using {@link #sliceFrom(int)}.
      */
     public void consumeRemainingCharactersOnLine() {
-        consumeUntilNoLongerMatches(c -> c != '\n' && c != '\r');
+        char ch = peek();
+        while (ch != EOF && ch != '\n' && ch != '\r') {
+            skip();
+            ch = peek();
+        }
     }
 
     /**
@@ -340,23 +345,30 @@ public class SimpleParser {
         return CharBuffer.wrap(input, start, position - removeRight);
     }
 
+    @Deprecated
+    public final int consumeUntilNoLongerMatches(Predicate<Character> predicate) {
+        int startPosition = position;
+        char ch = peek();
+        while (ch != EOF && predicate.test(ch)) {
+            skip();
+            ch = peek();
+        }
+        return position - startPosition;
+    }
+
     /**
-     * Reads a lexeme from the expression while the given {@code predicate}
-     * matches each peeked character.
+     * Reads a lexeme from the expression while the given {@code predicate} matches each peeked character.
      *
      * @param predicate Predicate that filters characters.
      * @return Returns the consumed lexeme (or an empty string on no matches).
      */
-    public final int consumeUntilNoLongerMatches(Predicate<Character> predicate) {
+    public final int consumeWhile(IntPredicate predicate) {
         int startPosition = position;
-        while (!eof()) {
-            char peekedChar = peek();
-            if (!predicate.test(peekedChar)) {
-                break;
-            }
+        char ch = peek();
+        while (ch != EOF && predicate.test(ch)) {
             skip();
+            ch = peek();
         }
-
         return position - startPosition;
     }
 


### PR DESCRIPTION
This commit makes minor performance improvements to parsing so that we can use consumeWhile with an IntPredicate rather than needing to box a char with a Predicate<Character>. To accommodate this, I deprecated `consumeUntilNoLongerMatches(Predicate<Character>)` in favor of `consumeWhile(IntPredicate)`. I also added overloads to ParserUtils to accept int in addition to char, matching how other classes in the JDK work like Character.isDigit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
