### PR TITLE
Convert to internal trait from tag

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.EnumValueTrait;
+import software.amazon.smithy.model.traits.InternalTrait;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
@@ -232,6 +233,9 @@ public final class EnumShape extends StringShape {
             }
             if (definition.isDeprecated()) {
                 builder.addTrait(DeprecatedTrait.builder().build());
+            }
+            if (definition.hasTag("internal")) {
+                builder.addTrait(new InternalTrait());
             }
 
             return Optional.of(builder.build());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -204,7 +204,7 @@ public final class EnumShape extends StringShape {
      * is applied to the converted enum member shape.
      *
      * <p>If an enum definition has an "internal" tag, the InternalTrait is
-     * applied ot the converted enum member shape.
+     * applied to the converted enum member shape.
      *
      * @param parentId The {@link ShapeId} of the enum shape.
      * @param synthesizeName Whether to synthesize a name if possible.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -200,6 +200,12 @@ public final class EnumShape extends StringShape {
     /**
      * Converts an enum definition to the equivalent enum member shape.
      *
+     * <p>If an enum definition is marked as deprecated, the DeprecatedTrait
+     * is applied to the converted enum member shape.
+     *
+     * <p>If an enum definition has an "internal" tag, the InternalTrait is
+     * applied ot the converted enum member shape.
+     *
      * @param parentId The {@link ShapeId} of the enum shape.
      * @param synthesizeName Whether to synthesize a name if possible.
      * @return An optional member shape representing the enum definition,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -515,6 +515,10 @@ public final class ModelTransformer {
      *
      * <p>A member will be created on the shape for each entry in the {@link EnumTrait}.
      *
+     * <p>When the enum definition from the enum trait has been marked as deprecated, or
+     * tagged as "internal", the corresponding enum shape member will be marked with the
+     * DeprecatedTrait or InternalTrait accordingly.
+     *
      * @param model Model to transform.
      * @param synthesizeEnumNames Whether enums without names should have names synthesized if possible.
      * @return Returns the transformed model.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EnumShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EnumShapeTest.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.EnumValueTrait;
+import software.amazon.smithy.model.traits.InternalTrait;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.model.traits.synthetic.SyntheticEnumTrait;
@@ -125,6 +126,7 @@ public class EnumShapeTest {
         EnumDefinition enumDefinition = EnumDefinition.builder()
                 .name("foo")
                 .value("bar")
+                .tags(ListUtils.of("internal"))
                 .build();
         EnumShape shape = builder.setMembersFromEnumTrait(EnumTrait.builder().addEnum(enumDefinition).build()).build();
 
@@ -133,6 +135,8 @@ public class EnumShapeTest {
                         .id(shape.getId().withMember("foo"))
                         .target(UnitTypeTrait.UNIT)
                         .addTrait(EnumValueTrait.builder().stringValue("bar").build())
+                        .addTrait(new InternalTrait())
+                        .addTrait(TagsTrait.builder().addValue("internal").build())
                         .build());
 
         assertTrue(shape.hasTrait(EnumTrait.class));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ChangeShapeTypeTest.java
@@ -46,6 +46,8 @@ import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.EnumValueTrait;
+import software.amazon.smithy.model.traits.InternalTrait;
+import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.model.traits.synthetic.SyntheticEnumTrait;
 import software.amazon.smithy.utils.ListUtils;
@@ -269,6 +271,7 @@ public class ChangeShapeTypeTest {
                 .addEnum(EnumDefinition.builder()
                         .name("foo")
                         .value("bar")
+                        .addTag("internal")
                         .build())
                 .build();
         SourceLocation source = new SourceLocation("/foo", 1, 1);
@@ -280,7 +283,6 @@ public class ChangeShapeTypeTest {
                 .build();
         Model model = Model.assembler().addShape(startShape).assemble().unwrap();
         Model result = ModelTransformer.create().changeShapeType(model, MapUtils.of(id, ShapeType.ENUM));
-
         assertThat(result.expectShape(id).getType(), Matchers.is(ShapeType.ENUM));
         assertThat(result.expectShape(id).getSourceLocation(), Matchers.equalTo(source));
         assertThat(result.expectShape(id).members(), Matchers.hasSize(1));
@@ -288,6 +290,8 @@ public class ChangeShapeTypeTest {
                 .id(id.withMember("foo"))
                 .target(UnitTypeTrait.UNIT)
                 .addTrait(EnumValueTrait.builder().stringValue("bar").build())
+                .addTrait(new InternalTrait())
+                .addTrait(TagsTrait.builder().addValue("internal").build())
                 .build()));
     }
 


### PR DESCRIPTION
This PR updates how EnumShapes are converted from strings with the deprecated `@enum` trait by adding the `@internal` trait to the resulting Enum shape member when when the source enum value was tagged with `internal`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
