### PR TITLE
Document changeStringEnumsToEnumShapes transformer

### DIFF
--- a/docs/source-1.0/guides/building-models/build-config.rst
+++ b/docs/source-1.0/guides/building-models/build-config.rst
@@ -248,6 +248,54 @@ Applies the transforms defined in the given projection names.
         }
 
 
+.. _changeStringEnumsToEnumShapes:
+
+changeStringEnumsToEnumShapes
+-----------------------------
+
+Changes string shapes with enum traits into enum shapes.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - synthesizeNames
+      - ``boolean``
+      - Whether enums without names should have names synthesized if possible.
+
+This transformer will attempt to convert strings with :ref:`enum traits <enum-trait>`
+into enum shapes. To successfully convert to an enum shape, each enum
+definition within the source enum trait must have a ``name`` property, or the
+``synthesizeNames`` transform config option must be enabled. By default, ``synthesizeNames``
+is disabled. If an enum definition from the enum trait is marked as deprecated, the
+:ref:`deprecated trait <deprecated-trait>` will be applied to the resulting
+enum shape member. Tags on the enum definition will be converted to a :ref:`tags trait <tags-trait>`
+on the enum shape member. Additionally, if the enum definition is tagged as
+internal, the enum shape member will have the :ref:`internal trait <internal-trait>`
+applied.
+
+.. code-block:: json
+
+    {
+        "version": "1.0",
+        "projections": {
+            "exampleProjection": {
+                "transforms": [
+                    {
+                        "name": "changeStringEnumsToEnumShapes",
+                        "args": {
+                            "synthesizeNames": true
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+
 .. _changeTypes:
 
 changeTypes
@@ -265,6 +313,9 @@ Changes the types of shapes.
     * - shapeTypes
       - ``Map<ShapeId, String>``
       - A map of shape IDs to the type to assign to the shape.
+    * - synthesizeEnumNames
+      - ``boolean``
+      - Whether enums without names should have names synthesized if possible.
 
 Only the following shape type changes are supported:
 
@@ -273,29 +324,33 @@ Only the following shape type changes are supported:
 * Set to list
 * Structure to union
 * Union to structure
+* String to enum
 
-.. tabs::
+.. code-block:: json
 
-    .. code-tab:: json
-
-        {
-            "version": "1.0",
-            "projections": {
-                "exampleProjection": {
-                    "transforms": [
-                        {
-                            "name": "changeTypes",
-                            "args": {
-                                "shapeTypes": {
-                                    "smithy.example#Foo": "string",
-                                    "smithy.example#Baz": "union"
-                                }
-                            }
+    {
+        "version": "1.0",
+        "projections": {
+            "exampleProjection": {
+                "transforms": [
+                    {
+                        "name": "changeTypes",
+                        "args": {
+                            "shapeTypes": {
+                                "smithy.example#Foo": "string",
+                                "smithy.example#Baz": "union",
+                                "smithy.example#Qux": "enum"
+                            },
+                            "synthesizeEnumNames": true
                         }
-                    ]
-                }
+                    }
+                ]
             }
         }
+    }
+
+
+.. seealso:: :ref:`changeStringEnumsToEnumShapes`
 
 
 .. _excludeShapesByTag-transform:

--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -472,6 +472,53 @@ Applies the transforms defined in the given projection names.
         }
     }
 
+.. _changeStringEnumsToEnumShapes:
+
+changeStringEnumsToEnumShapes
+-----------------------------
+
+Changes string shapes with enum traits into enum shapes.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Property
+      - Type
+      - Description
+    * - synthesizeNames
+      - ``boolean``
+      - Whether enums without names should have names synthesized if possible.
+
+This transformer will attempt to convert strings with :ref:`enum traits <enum-trait>`
+into enum shapes. To successfully convert to an enum shape, each enum
+definition within the source enum trait must have a ``name`` property, or the
+``synthesizeNames`` transform config option must be enabled. By default, ``synthesizeNames``
+is disabled. If an enum definition from the enum trait is marked as deprecated, the
+:ref:`deprecated trait <deprecated-trait>` will be applied to the resulting
+enum shape member. Tags on the enum definition will be converted to a :ref:`tags trait <tags-trait>`
+on the enum shape member. Additionally, if the enum definition is tagged as
+internal, the enum shape member will have the :ref:`internal trait <internal-trait>`
+applied.
+
+.. code-block:: json
+
+    {
+        "version": "1.0",
+        "projections": {
+            "exampleProjection": {
+                "transforms": [
+                    {
+                        "name": "changeStringEnumsToEnumShapes",
+                        "args": {
+                            "synthesizeNames": true
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
 
 .. _changeTypes:
 
@@ -490,6 +537,9 @@ Changes the types of shapes.
     * - shapeTypes
       - ``Map<ShapeId, String>``
       - A map of shape IDs to the type to assign to the shape.
+    * - synthesizeEnumNames
+      - ``boolean``
+      - Whether enums without names should have names synthesized if possible.
 
 Only the following shape type changes are supported:
 
@@ -498,6 +548,7 @@ Only the following shape type changes are supported:
 * Set to list
 * Structure to union
 * Union to structure
+* String to enum
 
 .. code-block:: json
 
@@ -511,14 +562,19 @@ Only the following shape type changes are supported:
                         "args": {
                             "shapeTypes": {
                                 "smithy.example#Foo": "string",
-                                "smithy.example#Baz": "union"
-                            }
+                                "smithy.example#Baz": "union",
+                                "smithy.example#Qux": "enum"
+                            },
+                            "synthesizeEnumNames": true
                         }
                     }
                 ]
             }
         }
     }
+
+
+.. seealso:: :ref:`changeStringEnumsToEnumShapes`
 
 
 .. _excludeShapesBySelector-transform:

--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -519,6 +519,11 @@ applied.
         }
     }
 
+.. note::
+
+    The :ref:`enum trait <enum-trait>` is deprecated. It is recommended to
+    use an :ref:`enum shape <enum>` instead to avoid needing to use this
+    transform.
 
 .. _changeTypes:
 

--- a/docs/source-2.0/spec/constraint-traits.rst
+++ b/docs/source-2.0/spec/constraint-traits.rst
@@ -436,6 +436,13 @@ An *enum definition* is a structure that supports the following members:
         the Smithy model.
 
 
+.. note::
+
+    While the :ref:`changeStringEnumsToEnumShapes <changeStringEnumsToEnumShapes>`
+    transform can be used to convert to an enum shape, it is recommended to use
+    the :ref:`enum shape <enum>` instead.
+
+
 .. _ECMA 262 regular expression dialect: https://www.ecma-international.org/ecma-262/8.0/index.html#sec-patterns
 .. _CommonMark: https://spec.commonmark.org/
 .. _OWASP Regular expression Denial of Service: https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS


### PR DESCRIPTION
Adds docs for changeStringEnumsToEnumShapes transformer, including behavior from https://github.com/awslabs/smithy/pull/1739

Additionally, it updates the `changeTypes` documentation to include its ability to transform Strings with `@enum` traits to Enums.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
