### PR TITLE
Add link to Semantic model doc from Selector spec

### DIFF
--- a/docs/source-2.0/guides/building-codegen/using-the-semantic-model.rst
+++ b/docs/source-2.0/guides/building-codegen/using-the-semantic-model.rst
@@ -498,6 +498,7 @@ model that are not connected to the service being generated.
     Set<Shape> closure = walker.walkShapes(someService);
     model = ModelTransformer.create().removeShapesIf(shape -> !closure.contains(shape));
 
+.. _codegen-selectors:
 
 Selectors
 =========

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -9,7 +9,7 @@ shapes within a model. Selectors are used to build custom
 :ref:`validators <EmitEachSelector>` and to specify where it is valid to
 apply a :ref:`trait <defining-traits>`.
 
-For information about how to use selectors within a code generator see
+For information about how to use selectors within a code generator, see
 :ref:`Using the Semantic Model <codegen-selectors>`.
 
 Introduction

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -9,6 +9,8 @@ shapes within a model. Selectors are used to build custom
 :ref:`validators <EmitEachSelector>` and to specify where it is valid to
 apply a :ref:`trait <defining-traits>`.
 
+For information about how to use selectors within a code generator see
+:ref:`Using the Semantic Model <codegen-selectors>`.
 
 Introduction
 ============


### PR DESCRIPTION
*Description of changes:*
Adds a link to the Semantic model doc from the Selector spec. The goal here was just to make it easier to discover the Semantic model section on selectors.

*testing*
Built docs and confirmed that the added link worked as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
