### PR TITLE
Remove suppressing internal tagged enum shape members

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-enum.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-enum.smithy
@@ -39,8 +39,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/string"}]}"""
+                    { "message" : "1 validation error detected. Value at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]",
+                      "fieldList" : [{"message": "Value at '/string' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]", "path": "/string"}]}"""
                 }
             }
         },
@@ -107,8 +107,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/list/0"}]}"""
+                    { "message" : "1 validation error detected. Value at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]",
+                      "fieldList" : [{"message": "Value at '/list/0' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]", "path": "/list/0"}]}"""
                 }
             }
         },
@@ -141,8 +141,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/map"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]",
+                      "fieldList" : [{"message": "Value at '/map' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]", "path": "/map"}]}"""
                 }
             }
         },
@@ -175,8 +175,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/map/abc"}]}"""
+                    { "message" : "1 validation error detected. Value at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]",
+                      "fieldList" : [{"message": "Value at '/map/abc' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]", "path": "/map/abc"}]}"""
                 }
             }
         },
@@ -209,8 +209,8 @@ apply MalformedEnum @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]",
-                      "fieldList" : [{"message": "Value at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]", "path": "/union/first"}]}"""
+                    { "message" : "1 validation error detected. Value at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]",
+                      "fieldList" : [{"message": "Value at '/union/first' failed to satisfy constraint: Member must satisfy enum value set: [abc, def, jkl]", "path": "/union/first"}]}"""
                 }
             }
         },
@@ -243,6 +243,7 @@ enum EnumString {
     JKL = "jkl"
 }
 
+@suppress(["ModelDeprecation"])
 @enum([
     {value: "abc", name: "ABC", tags: ["external"]},
     {value: "def", name: "DEF"},


### PR DESCRIPTION
This PR updates the `restJson1` validation protocol tests so that `internal` tagged enums shape members are no longer suppressed from the validation message. Only enum shape members tagged with the `@internal` trait are suppressed from a validation message.

Enum traits that are tagged as "internal" are still expected to be suppressed from the validation message, as traits cannot be applied to an enum trait definition, leaving the "internal" tag as the only way to suppress an enum value from the validation message.

See https://github.com/awslabs/smithy/issues/1737.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
