### PR TITLE
Make IDL tokenizer package-private for now

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
@@ -35,7 +35,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * Iterates over a Smithy IDL model as a series of tokens.
  */
 @SmithyUnstableApi
-public final class IdlTokenizer implements Iterator<IdlToken> {
+final class IdlTokenizer implements Iterator<IdlToken> {
 
     /** Only allow nesting up to 64 arrays/objects in node values. */
     private static final int MAX_NESTING_LEVEL = 64;


### PR DESCRIPTION
Let's use the tokenizer in the parser, but don't yet expose it so that we can refactor as needed while the token-tree is being built.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
