### PR TITLE
add hierarchical IDs for DefaultTrait collisions

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -428,14 +428,14 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     private List<ValidationEvent> applyPlugins(Shape shape) {
         List<ValidationEvent> events = new ArrayList<>();
-        timestampValidationStrategy.apply(shape, value, validationContext, (location, severity, message) -> {
-            events.add(event(message, severity, location.getSourceLocation()));
-        });
+        timestampValidationStrategy.apply(shape, value, validationContext,
+                (location, severity, message, additionalEventIdParts) ->
+                        events.add(event(message, severity, location.getSourceLocation(), additionalEventIdParts)));
 
         for (NodeValidatorPlugin plugin : BUILTIN) {
-            plugin.apply(shape, value, validationContext, (location, severity, message) -> {
-                events.add(event(message, severity, location.getSourceLocation()));
-            });
+            plugin.apply(shape, value, validationContext,
+                    (location, severity, message, additionalEventIdParts) ->
+                            events.add(event(message, severity, location.getSourceLocation(), additionalEventIdParts)));
         }
 
         return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/NodeValidatorPlugin.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public interface NodeValidatorPlugin {
+     String[] EMPTY_STRING_ARRAY = new String[0];
 
     /**
      * Applies the plugin to the given shape, node value, and model.
@@ -125,10 +126,17 @@ public interface NodeValidatorPlugin {
     @SmithyInternalApi
     @FunctionalInterface
     interface Emitter {
-        void accept(FromSourceLocation sourceLocation, Severity severity, String message);
+        void accept(FromSourceLocation sourceLocation,
+                    Severity severity,
+                    String message,
+                    String... additionalEventIdParts);
 
         default void accept(FromSourceLocation sourceLocation, String message) {
-            accept(sourceLocation, Severity.ERROR, message);
+            accept(sourceLocation, Severity.ERROR, message, EMPTY_STRING_ARRAY);
+        }
+
+        default void accept(FromSourceLocation sourceLocation, Severity severity, String message) {
+            accept(sourceLocation, severity, message, EMPTY_STRING_ARRAY);
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -55,13 +55,13 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
             if (trait.getMin().isPresent() && value.equals(NonNumericFloat.NEGATIVE_INFINITY)) {
                 emitter.accept(node, Severity.ERROR, String.format(
                         "Value provided for `%s` must be greater than or equal to %s, but found \"%s\"",
-                        shape.getId(), trait.getMin().get(), node.getValue()));
+                        shape.getId(), trait.getMin().get(), node.getValue()), shape.getId().toString());
             }
 
             if (trait.getMax().isPresent() && value.equals(NonNumericFloat.POSITIVE_INFINITY)) {
                 emitter.accept(node, Severity.ERROR, String.format(
                         "Value provided for `%s` must be less than or equal to %s, but found \"%s\"",
-                        shape.getId(), trait.getMax().get(), node.getValue()));
+                        shape.getId(), trait.getMax().get(), node.getValue()), shape.getId().toString());
             }
         });
     }
@@ -76,7 +76,7 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
             if (decimal.compareTo(new BigDecimal(min.toString())) < 0) {
                 emitter.accept(node, getSeverity(node, zeroValueWarning), String.format(
                         "Value provided for `%s` must be greater than or equal to %s, but found %s",
-                        shape.getId(), min, number));
+                        shape.getId(), min, number), shape.getId().toString());
             }
         });
 
@@ -84,7 +84,7 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
             if (decimal.compareTo(new BigDecimal(max.toString())) > 0) {
                 emitter.accept(node, getSeverity(node, zeroValueWarning), String.format(
                         "Value provided for `%s` must be less than or equal to %s, but found %s",
-                        shape.getId(), max, number));
+                        shape.getId(), max, number), shape.getId().toString());
             }
         });
     }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/defaults/detects-default-out-of-range.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/defaults/detects-default-out-of-range.errors
@@ -6,3 +6,5 @@
 [WARNING] smithy.example#MinOne: Error validating @default trait: Value provided for `smithy.example#MinOne` must be greater than or equal to 1, but found 0 | DefaultTrait
 [WARNING] smithy.example#MinAndMax: Error validating @default trait: Value provided for `smithy.example#MinAndMax` must be greater than or equal to 1, but found 0 | DefaultTrait
 [WARNING] smithy.example#MaxNegativeOne: Error validating @default trait: Value provided for `smithy.example#MaxNegativeOne` must be less than or equal to -1, but found 0 | DefaultTrait
+[WARNING] smithy.example#Integers$doublyInvalidDefault: Error validating @default trait: Value provided for `smithy.example#Integers$doublyInvalidDefault` must be greater than or equal to 1, but found 0 | DefaultTrait.smithy.example#Integers$doublyInvalidDefault
+[WARNING] smithy.example#Integers$doublyInvalidDefault: Error validating @default trait: Value provided for `smithy.example#MinOne` must be greater than or equal to 1, but found 0 | DefaultTrait.smithy.example#MinOne

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/defaults/detects-default-out-of-range.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/defaults/detects-default-out-of-range.smithy
@@ -1,31 +1,45 @@
-$version: "1.0"
+$version: "2.0"
 
 namespace smithy.example
 
 structure Integers {
+    @default(0)
     noRange: PrimitiveInteger,
 
     @range(min: 0, max: 1)
+    @default(0)
     valid: PrimitiveInteger,
 
     @range(min: 1)
+    @default(0)
     invalidMin: PrimitiveInteger,
 
     @range(max: -1, min: -100)
+    @default(0)
     invalidMax: PrimitiveInteger,
 
+    @default(0)
     invalidTargetMin: MinOne,
 
+    @default(0)
     invalidTagetMax: MaxNegativeOne,
 
-    invalidMinWithMax: MinAndMax
+    @default(0)
+    invalidMinWithMax: MinAndMax,
+
+    @range(min: 1)
+    @default(0)
+    doublyInvalidDefault: MinOne
 }
 
 @range(min: 1)
+@default(0)
 integer MinOne
 
 @range(min: 1, max: 100)
+@default(0)
 integer MinAndMax
 
 @range(max: -1)
+@default(0)
 integer MaxNegativeOne


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When specifying an invalid default, it may be invalid for both the member range and the targeted shape root range. This previously resulted in two violations with the same target shape and eventId, which this PR improves by making the eventId include the specific range scope


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
