### PR TITLE
Fix inline io parsing with mixins

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelLoader.java
@@ -1083,7 +1083,6 @@ final class IdlModelLoader {
             }
             // Remove any pending, invalid docs that may have come before the inline shape.
             tokenizer.removePendingDocCommentLines();
-            tokenizer.next();
             // don't skip docs here in case there are docs on the inlined structure.
             tokenizer.skipWs();
             consumer.accept(parseInlineStructure(id.getName() + suffix, defaultTrait));

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/inline-io/inline-io.smithy
@@ -30,7 +30,8 @@ structure NameBearer {
 }
 
 operation UsesMixins {
-    input := with [NameBearer] {
+    // Parser handles weird/missing SP
+    input :=with [NameBearer] {
         id: String
     }
 


### PR DESCRIPTION
When there was no space between the `:=` and `with` tokens when parsing an inline io statement, for example:
```
operation Foo {
  input :=with [Bar] {}
}
```
the parser would skip the `with` and so not realize its parsing a mixin, failing when it sees a `[` instead of a `{`. This was due to an extra call to `tokenizer.next()`, which skipped the `with`. Usually the `next()` would just skip the space before the `with`, but when the space wasn't present it skipped the `with`.

The inline-io test was updated to include this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
