### PR TITLE
Add restXml protocol test for http label escaping

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy
@@ -44,10 +44,10 @@ apply HttpRequestWithLabels @httpRequestTests([
         documentation: "Sends a GET request that uses URI label bindings",
         protocol: restJson1,
         method: "GET",
-        uri: "/HttpRequestWithLabels/%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z",
+        uri: "/HttpRequestWithLabels/%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z",
         body: "",
         params: {
-            string: "%:/?#[]@!$&'()*+,;=😹",
+            string: " %:/?#[]@!$&'()*+,;=😹",
             short: 1,
             integer: 2,
             long: 3,

--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -149,12 +149,12 @@ apply AllQueryStringTypes @httpRequestTests([
         uri: "/AllQueryStringTypesInput",
         body: "",
         queryParams: [
-		"String=%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9",
+		"String=%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9",
         ],
         params: {
-		queryString: "%:/?#[]@!$&'()*+,;=😹",
+		queryString: " %:/?#[]@!$&'()*+,;=😹",
 		queryParamsMapOfStringList: {
-                    "String": ["%:/?#[]@!$&'()*+,;=😹"]
+                    "String": [" %:/?#[]@!$&'()*+,;=😹"]
                 }
         }
     },

--- a/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-labels.smithy
@@ -39,6 +39,24 @@ apply HttpRequestWithLabels @httpRequestTests([
             timestamp: 1576540098
         }
     },
+    {
+        id: "HttpRequestLabelEscaping",
+        documentation: "Sends a GET request that uses URI label bindings",
+        protocol: restXml,
+        method: "GET",
+        uri: "/HttpRequestWithLabels/%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z",
+        body: "",
+        params: {
+            string: " %:/?#[]@!$&'()*+,;=😹",
+            short: 1,
+            integer: 2,
+            long: 3,
+            float: 4.1,
+            double: 5.1,
+            boolean: true,
+            timestamp: 1576540098
+        }
+    },
 ])
 
 structure HttpRequestWithLabelsInput {

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -119,6 +119,20 @@ apply AllQueryStringTypes @httpRequestTests([
         }
     },
     {
+        id: "RestXmlQueryStringEscaping",
+        documentation: "Handles escaping all required characters in the query string.",
+        protocol: restXml,
+        method: "GET",
+        uri: "/AllQueryStringTypesInput",
+        body: "",
+        queryParams: [
+            "String=%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9",
+        ],
+        params: {
+            queryString: " %:/?#[]@!$&'()*+,;=😹",
+        }
+    },
+    {
         id: "RestXmlSupportsNaNFloatQueryValues",
         documentation: "Supports handling NaN float query values.",
         protocol: restXml,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds an httpRequestTests case to restXml protocol tests to verify that httpLabel bindings in the request URI are percent-encoded. restJson1 had an existing test case for this, but was updated to verify the space character is encoded. An operation was also added to the testing S3 service model with httpRequestTests to verify the same thing, but with S3's virtual host addressing. No other protocols had tests added, because restJson1 and restXml are the only protocols that support httpLabel bindings.

Changes were tested by generating and running protocol tests in aws-sdk-go-v2 and aws-sdk-js-v3, confirming the new test case is generated and runs successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
