### PR TITLE
Avoid using String#chars() which is java 9+

### DIFF
--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/AbbreviationNameValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/AbbreviationNameValidator.java
@@ -124,6 +124,12 @@ public final class AbbreviationNameValidator extends AbstractValidator {
     }
 
     private boolean isInvalidWord(String word) {
-        return word.chars().filter(c -> c >= 'A' && c <= 'Z').count() > 1;
+        for (int idx = 0; idx < word.length(); idx++) {
+            char ch = word.charAt(idx);
+            if (ch >= 'A' && ch <= 'Z') {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
*Description of changes:*

~~Remove the use of the `chars()` method that is documented to be only for 9+ version.~~
(There is a default implementation for this on `CharSequence` in Java 8)

Possibly still relevant to remove the use of streams.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
