### PR TITLE
Defer projection failure until after plugins run

### DIFF
--- a/smithy-build/src/test/resources/software/amazon/smithy/build/defers-failure.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/defers-failure.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "plugins": {
+    "broken": {},
+    "test1Serial": {}
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
#1277 

*Description of changes:*
This changes `SmithyBuildImpl` to continue applying plugins after one fails, throwing the error (if present) after they have all completed. This is useful for example when you want to see the serialized output of a model you know is valid but a plugin is causing the whole build to fail. A new test case was added to ensure that artifacts produced by valid plugins are still created despite the build failing.

This was originally implemented in #1416, but was rolled back in #1429 as a precaution since we had an unrelated issue ocurring at the time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
