### PR TITLE
update default list of members for pagination flagging

### DIFF
--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingPaginatedTraitValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingPaginatedTraitValidator.java
@@ -62,9 +62,11 @@ public final class MissingPaginatedTraitValidator extends AbstractValidator {
     private static final Set<String> DEFAULT_VERBS_REQUIRE = SetUtils.of("list", "search");
     private static final Set<String> DEFAULT_VERBS_SUGGEST = SetUtils.of("describe", "get");
     private static final Set<String> DEFAULT_INPUT_MEMBERS = SetUtils.of(
-            "maxresults", "pagesize", "limit", "nexttoken", "pagetoken", "token");
+            "maxresults", "maxitems", "pagesize", "limit",
+            "nexttoken", "pagetoken", "token", "marker");
     private static final Set<String> DEFAULT_OUTPUT_MEMBERS = SetUtils.of(
-            "nexttoken", "pagetoken", "token", "marker", "nextpage");
+            "nexttoken", "pagetoken", "token", "marker", "nextpage", "nextpagetoken", "position", "nextmarker",
+            "paginationtoken", "nextpagemarker");
 
     public static final class Config {
         private Set<String> verbsRequirePagination = DEFAULT_VERBS_REQUIRE;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a couple new default input/output member names that will flag an operation for missing pagination

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
