### PR TITLE
Add warning about API Gateway request validation limitations

### DIFF
--- a/docs/source-2.0/aws/amazon-apigateway.rst
+++ b/docs/source-2.0/aws/amazon-apigateway.rst
@@ -296,6 +296,11 @@ Then following example enables request validation on a service:
     This trait should be considered internal-only and not exposed to your
     customers.
 
+.. warning::
+
+    API Gateway request validation uses `JSON Schema <https://datatracker.ietf.org/doc/html/draft-zyp-json-schema-04>`_
+    to validate requests against models and may not meet all the
+    validation needs of your application.
 
 .. smithy-trait:: aws.apigateway#integration
 .. _aws.apigateway#integration-trait:


### PR DESCRIPTION
*Description of changes:*
Adds a small warning to remind users that API Gateway uses an older version of JSON Schema that may not meet their needs. This is added because we have had a number of users surprised by the validation behavior in API Gateway applications

*Testing* 
Generated docs use `make html` and manually reviewed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
