### PR TITLE
Add action-specific env vars to the cli build command

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ActionEnvOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ActionEnvOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import software.amazon.smithy.cli.ArgumentReceiver;
+import software.amazon.smithy.cli.HelpPrinter;
+
+public class ActionEnvOptions implements ArgumentReceiver {
+    private static final Logger LOGGER = Logger.getLogger(ActionEnvOptions.class.getName());
+
+    @Override
+    public void registerHelp(HelpPrinter printer) {
+        printer.param("--env", "-e", "MY_VAR=myValue...",
+            "Environment variable to use for commmand execution. Note: overrides local env.");
+    }
+
+    @Override
+    public Consumer<String> testParameter(String name) {
+        switch (name) {
+            case "--env":
+            case "-e":
+                return this::addToProperties;
+            default:
+                return null;
+        }
+    }
+
+    private void addToProperties(String input) {
+         String[] values = input.split("=");
+         if (values.length != 2) {
+             LOGGER.warning("Environment variable incorrect. Expected Key value pair of form "
+                 + "KEY=VALUE, but found `" + input + "`");
+             return;
+         }
+         LOGGER.info("Adding environment variable to action environment: " + input);
+         System.setProperty(values[0], values[1]);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildCommand.java
@@ -75,6 +75,7 @@ final class BuildCommand implements Command {
         arguments.addReceiver(new SeverityOption());
         arguments.addReceiver(new BuildOptions());
         arguments.addReceiver(new Options());
+        arguments.addReceiver(new ActionEnvOptions());
 
         CommandAction action = HelpActionWrapper.fromCommand(
                 this, parentCommandName, new ClasspathAction(dependencyResolverFactory, this::runWithClassLoader));


### PR DESCRIPTION
[DRAFT]

### Description of changes
This PR adds a new option to the build command, action-specific environment variables. This option allows users to set an environment variable via command-line option for only the context of that specific command, overriding any existing environment variables (but not overwriting or unsetting them). 

Environment variables and Java System properties can be used in the smithy-build.json file (see [here](https://smithy.io/2.0/guides/building-models/build-config.html?highlight=environment%20variables#environment-variables)) to define variables for use in plugins. . Customers will be able to modify the variables in their smithy-build.json from the CLI with this option without changing any local environment variable settings.

Action specific environment variables supports the following customer use case: 
- quickly testing/creating one-off build outputs using different environment variables without changing the current environment variables

This option could also be useful in build tools such as Gradle, allowing build tasks wrapping the CLI to set variables without modifying the task environment.

These environment variables are added as java system properties for a few reasons: 
1. Java system properties are available only to the process that created them so these will be cleaned up and not re-used for subsequent actions.
2. System properties are checked before Environment Variables in the CLI so these will overwrite both environment variables and previously set system properties with the same name which is the desired behavior.

### Testing
*WIP*: I will add unit testing and clean up if we decide to proceed with the PR.

I tested these changes on a local model with an environment variable in the `excludeShapesByTrait`
```smithy 
{
            "name": "excludeShapesByTrait",
            "args": {
              "traits": ["${FOO}"]
            }
 }
```
The command `smithy build -e FOO=smithy.api#internal` was executed and correctly filtered out internal shapes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
