### PR TITLE
Downgrade SdkServiceIdValidator to DANGER

### DIFF
--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/SdkServiceIdValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/SdkServiceIdValidator.java
@@ -133,7 +133,7 @@ public final class SdkServiceIdValidator extends AbstractValidator {
             validateServiceId(value);
             return Optional.empty();
         } catch (IllegalArgumentException e) {
-            return Optional.of(error(service, trait, e.getMessage()));
+            return Optional.of(danger(service, trait, e.getMessage()));
         }
     }
 

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/SdkServiceIdValidatorTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/SdkServiceIdValidatorTest.java
@@ -42,7 +42,7 @@ public class SdkServiceIdValidatorTest {
                 .discoverModels(getClass().getClassLoader())
                 .assemble();
 
-        assertThat(result.getValidationEvents(Severity.ERROR), not(empty()));
+        assertThat(result.getValidationEvents(Severity.DANGER), not(empty()));
     }
 
     @Test


### PR DESCRIPTION
This PR downgrades the validation events emitted by the SdkServiceIdValidator from `ERROR` to `DANGER`, allowing for them to be suppressible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
