### PR TITLE
Add a missing colon to the includeShapesBySelector example

### DIFF
--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -734,7 +734,7 @@ Includes only the shapes matching the given :ref:`selector <selectors>`.
                         "name": "includeShapesBySelector",
                         "args": {
                             // Includes only shapes in the FooService closure.
-                            "selector": "[id=smithy.example#FooService] is(*, ~> *)"
+                            "selector": "[id=smithy.example#FooService] :is(*, ~> *)"
                         }
                     }
                 ]


### PR DESCRIPTION
*Description of changes:*

Fix the example in the `includeShapesBySelector` example. The correct selector should use `:is` instead of just `is`.
