### PR TITLE
Validate that query literal do not conflict with query params

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/pattern/UriPattern.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/pattern/UriPattern.java
@@ -178,4 +178,5 @@ public final class UriPattern extends SmithyPattern {
     public int hashCode() {
         return super.hashCode() + queryLiterals.hashCode();
     }
+
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpQueryTraitValidator.java
@@ -23,10 +23,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.pattern.UriPattern;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.HttpQueryTrait;
+import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidationUtils;
@@ -41,7 +46,7 @@ public final class HttpQueryTraitValidator extends AbstractValidator {
         if (!model.isTraitApplied(HttpQueryTrait.class)) {
             return Collections.emptyList();
         } else {
-            return validateBindings(getQueryBindings(model));
+            return validateBindings(getQueryBindings(model), getStructureToOperations(model));
         }
     }
 
@@ -64,7 +69,10 @@ public final class HttpQueryTraitValidator extends AbstractValidator {
         return queryBindings;
     }
 
-    private List<ValidationEvent> validateBindings(Map<StructureShape, Map<String, Set<String>>> queryBindings) {
+    private List<ValidationEvent> validateBindings(
+        Map<StructureShape, Map<String, Set<String>>> queryBindings,
+        Map<StructureShape, List<OperationShape>> structureToOperations
+    ) {
         List<ValidationEvent> events = new ArrayList<>();
 
         for (Map.Entry<StructureShape, Map<String, Set<String>>> entry : queryBindings.entrySet()) {
@@ -77,8 +85,39 @@ public final class HttpQueryTraitValidator extends AbstractValidator {
                             paramsToMembers.getKey(), ValidationUtils.tickedList(paramsToMembers.getValue()))));
                 }
             }
+
+            List<OperationShape> operations = structureToOperations.getOrDefault(entry.getKey(),
+                                                                                 Collections.emptyList());
+            for (OperationShape operation : operations) {
+                UriPattern pattern = operation.expectTrait(HttpTrait.class).getUri();
+                for (Map.Entry<String, String> literalEntry : pattern.getQueryLiterals().entrySet()) {
+                    String literalKey = literalEntry.getKey();
+                    if (entry.getValue().containsKey(literalKey)) {
+                        events.add(error(entry.getKey(), String.format(
+                            "`httpQuery` parameter name binding conflicts found for the `%s` parameter, the "
+                            + "http trait for the `%s` operation defines a query literal with the same name",
+                            literalKey, operation.getId())));
+                    }
+                }
+            }
         }
 
         return events;
+    }
+
+    private Map<StructureShape, List<OperationShape>> getStructureToOperations(Model model) {
+        Map<StructureShape, List<OperationShape>> structureToOperations = new HashMap<>();
+        for (ServiceShape service : model.getServiceShapes()) {
+            for (OperationShape operation : TopDownIndex.of(model).getContainedOperations(service)) {
+                if (operation.hasTrait(HttpTrait.class)) {
+                    model.expectShape(operation.getInputShape())
+                         .asStructureShape()
+                         .ifPresent(structure -> structureToOperations
+                             .computeIfAbsent(structure, key -> new ArrayList<>())
+                             .add(operation));
+                }
+            }
+        }
+        return structureToOperations;
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict1.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict1.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationOne` operation defines a query literal with the same name | HttpQueryTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict1.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict1.errors
@@ -1,1 +1,1 @@
-[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationOne` operation defines a query literal with the same name | HttpQueryTrait
+[ERROR] smithy.example#OperationOneInput: `httpQuery` name `code` conflicts with the `http` trait of the `smithy.example#OperationOne` operation: `/example?code` | HttpQueryTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict1.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict1.smithy
@@ -1,0 +1,36 @@
+$version: "2"
+namespace smithy.example
+
+// OperationOne defines a query literal `code` that conflicts with the
+// query param defined in the input structure.
+
+service SmithyExample {
+    operations: [
+        OperationOne
+    ]
+}
+
+@http(code: 200, method: "GET", uri: "/example?code")
+@readonly
+operation OperationOne {
+    input: OperationOneInput
+    output: OperationOneOutput
+}
+
+structure OperationOneInput {
+    @httpQuery("code")
+    code: String
+
+    @httpQuery("state")
+    state: String
+}
+
+structure OperationOneOutput {
+    @required
+    @httpHeader("Content-Type")
+    contentType: String
+
+    @required
+    @httpPayload
+    content: Blob
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict2.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict2.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationOne` operation defines a query literal with the same name | HttpQueryTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict2.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict2.errors
@@ -1,1 +1,1 @@
-[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationOne` operation defines a query literal with the same name | HttpQueryTrait
+[ERROR] smithy.example#OperationOneInput: `httpQuery` name `code` conflicts with the `http` trait of the `smithy.example#OperationOne` operation: `/example?code=bar` | HttpQueryTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict2.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict2.smithy
@@ -1,0 +1,36 @@
+$version: "2"
+namespace smithy.example
+
+// OperationOne defines a query literal `code` with value `bar` that
+// conflicts with the query param defined in the input structure.
+
+service SmithyExample {
+    operations: [
+        OperationOne
+    ]
+}
+
+@http(code: 200, method: "GET", uri: "/example?code=bar")
+@readonly
+operation OperationOne {
+    input: OperationOneInput
+    output: OperationOneOutput
+}
+
+structure OperationOneInput {
+    @httpQuery("code")
+    code: String
+
+    @httpQuery("state")
+    state: String
+}
+
+structure OperationOneOutput {
+    @required
+    @httpHeader("Content-Type")
+    contentType: String
+
+    @required
+    @httpPayload
+    content: Blob
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict3.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict3.errors
@@ -1,2 +1,3 @@
-[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationOne` operation defines a query literal with the same name | HttpQueryTrait
-[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationTwo` operation defines a query literal with the same name | HttpQueryTrait
+[ERROR] smithy.example#OperationOneInput: `httpQuery` name `code` conflicts with the `http` trait of the `smithy.example#OperationOne` operation: `/one?code` | HttpQueryTrait
+[ERROR] smithy.example#OperationOneInput: `httpQuery` name `code` conflicts with the `http` trait of the `smithy.example#OperationTwo` operation: `/two?code=bar` | HttpQueryTrait
+

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict3.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict3.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationOne` operation defines a query literal with the same name | HttpQueryTrait
+[ERROR] smithy.example#OperationOneInput: `httpQuery` parameter name binding conflicts found for the `code` parameter, the http trait for the `smithy.example#OperationTwo` operation defines a query literal with the same name | HttpQueryTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict3.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/http-query-literals-and-bindings-conflict3.smithy
@@ -1,0 +1,45 @@
+$version: "2"
+namespace smithy.example
+
+// OperationOne and OperationTwo define a query literal `code` and
+// `code=bar` that conflicts with the query param defined in the input
+// structure.
+
+service SmithyExample {
+    operations: [
+        OperationOne
+        OperationTwo
+    ]
+}
+
+@http(code: 200, method: "GET", uri: "/one?code")
+@readonly
+operation OperationOne {
+    input: OperationOneInput
+    output: OperationOneOutput
+}
+
+@http(code: 200, method: "GET", uri: "/two?code=bar")
+@readonly
+operation OperationTwo {
+    input: OperationOneInput
+    output: OperationOneOutput
+}
+
+structure OperationOneInput {
+    @httpQuery("code")
+    code: String
+
+    @httpQuery("state")
+    state: String
+}
+
+structure OperationOneOutput {
+    @required
+    @httpHeader("Content-Type")
+    contentType: String
+
+    @required
+    @httpPayload
+    content: Blob
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Validate that query literal do not conflict with query params. Currently is possible to define a model like the following, that defines `code` as a query literal in the URI part of the `@http` trait and also the same query param in the `OperationOneShape`. This change will disallow this model that is not valid in practice.

```smithy
$version: "2"
namespace smithy.example

// OperationOne defines a query literal `code` that conflicts with the
// query param defined in the input structure.

service SmithyExample {
    operations: [
        OperationOne
    ]
}

@http(code: 200, method: "GET", uri: "/example?code")
@readonly
operation OperationOne {
    input: OperationOneInput
    output: OperationOneOutput
}

structure OperationOneInput {
    @httpQuery("code")
    code: String

    @httpQuery("state")
    state: String
}

structure OperationOneOutput {
    @required
    @httpHeader("Content-Type")
    contentType: String

    @required
    @httpPayload
    content: Blob
}
```
