### PR TITLE
Fix ValueAssignment grammar production

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -190,7 +190,7 @@ string support defined in :rfc:`7405`.
     EnumStatement           :`EnumTypeName` `SP` `Identifier` [`Mixins`] [`WS`] `EnumShapeMembers`
     EnumTypeName            :%s"enum" / %s"intEnum"
     EnumShapeMembers        :"{" [`WS`] 1*(`TraitStatements` `Identifier` [`ValueAssignment`] [`WS`]) "}"
-    ValueAssignment         :[`SP`] "=" [`SP`] `NodeValue` `BR`
+    ValueAssignment         :[`SP`] "=" [`SP`] `NodeValue` [`SP`] [`Comma`] `BR`
     AggregateShapeStatement :`AggregateTypeName` `SP` `Identifier` [`Mixins`] `ShapeMembers`
     AggregateTypeName       :%s"list" / %s"map" / %s"union"
     StructureStatement      :%s"structure" `SP` `Identifier` [`StructureResource`]


### PR DESCRIPTION
https://github.com/awslabs/smithy/pull/1782 clobbered changes in https://github.com/awslabs/smithy/pull/1783, which this commit fixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
