### PR TITLE
Add EnumShapeMember, move TraitStatements grammar

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -184,13 +184,14 @@ string support defined in :rfc:`7405`.
     Mixins                  :[`SP`] %s"with" [`WS`] "[" [`WS`] 1*(`ShapeId` [`WS`]) "]"
     EnumShape               :`EnumTypeName` `SP` `Identifier` [`Mixins`] [`WS`] `EnumShapeMembers`
     EnumTypeName            :%s"enum" / %s"intEnum"
-    EnumShapeMembers        :"{" [`WS`] 1*(`TraitStatements` `Identifier` [`ValueAssignment`] [`WS`]) "}"
+    EnumShapeMembers        :"{" [`WS`] 1*(`EnumShapeMember` [`WS`]) "}"
+    EnumShapeMember         :`TraitStatements` `Identifier` [`ValueAssignment`]
     ValueAssignment         :[`SP`] "=" [`SP`] `NodeValue` [`SP`] [`Comma`] `BR`
     AggregateShape          :`AggregateTypeName` `SP` `Identifier` [`ForResource`] [`Mixins`] [`WS`] `ShapeMembers`
     AggregateTypeName       :%s"list" / %s"map" / %s"union" / %s"structure"
     ForResource             :`SP` %s"for" `SP` `ShapeId`
-    ShapeMembers            :"{" [`WS`] *(`TraitStatements` `ShapeMember` [`WS`]) "}"
-    ShapeMember             :(`ExplicitShapeMember` / `ElidedShapeMember`) [`ValueAssignment`]
+    ShapeMembers            :"{" [`WS`] *(`ShapeMember` [`WS`]) "}"
+    ShapeMember             :`TraitStatements` (`ExplicitShapeMember` / `ElidedShapeMember`) [`ValueAssignment`]
     ExplicitShapeMember     :`Identifier` [`SP`] ":" [`SP`] `ShapeId`
     ElidedShapeMember       :"$" `Identifier`
     EntityShape             :`EntityTypeName` `SP` `Identifier` [`Mixins`] [`WS`] `NodeObject`


### PR DESCRIPTION
Adds an EnumShapeMember production to the grammar for consistency with ShapeMember, and moves TraitStatements from EnumShapeMembers and ShapeMembers into EnumShapeMember and ShapeMember respectively.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
