### PR TITLE
Update LineComment grammar

### DIFF
--- a/docs/source-2.0/spec/idl.rst
+++ b/docs/source-2.0/spec/idl.rst
@@ -110,7 +110,7 @@ string support defined in :rfc:`7405`.
 .. productionlist:: smithy
     Comment              : `DocumentationComment` / `LineComment`
     DocumentationComment :"///" *`NotNL` `NL`
-    LineComment          : "//" *`NotNL` `NL`
+    LineComment          : "//" [(%x09 / %x20-2E / %x30-10FFF) *`NotNL`] `NL` ; First character after "//" can't be "/"
 
 .. rubric:: Control
 


### PR DESCRIPTION
Previously, the LineComment grammar was a superset of DocumentationComment. This commit removes the ambiguity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
