### PR TITLE
Allow empty enum with non-empty mixins

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/empty-enum-mixin.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/empty-enum-mixin.errors
@@ -1,0 +1,2 @@
+[ERROR] smithy.example#EmptyEnumMixin: enum must have at least one entry | Model
+[ERROR] smithy.example#EmptyEnum: Cannot apply mixin to smithy.example#EmptyEnum: smithy.example#EmptyEnumMixin not found | Model

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/empty-enum-mixin.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/empty-enum-mixin.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@mixin
+enum EmptyEnumMixin {}
+
+enum EmptyEnum with [EmptyEnumMixin] {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/non-empty-enum-mixin.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/mixins/non-empty-enum-mixin.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@mixin
+enum NonEmptyEnumMixin {
+    VALUE = "value"
+}
+
+enum NonEmptyEnum with [NonEmptyEnumMixin] {}


### PR DESCRIPTION
*Issue #, if available:*
Customer tries to apply a non-empty enum mixin to an empty enum:

```
@mixin
enum EnumMixin {
    VALUE = "value"
}

enum EmptyEnum with [EnumMixin] {}
```

Smithy build fails with enum must have at least one entry. This was caused by mixin enum members not getting populated to the synthetic enum trait.

*Description of changes:*
Allow empty enum with non-empty mixins

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
