### PR TITLE
Extended AddedEntityBinding/RemovedEntityBinding event ids with granularity

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedEntityBinding.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.EntityShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -37,6 +38,8 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class AddedEntityBinding extends AbstractDiffEvaluator {
     private static final String ADDED_RESOURCE = "AddedResourceBinding";
     private static final String ADDED_OPERATION = "AddedOperationBinding";
+    private static final String TO_RESOURCE = ".ToResourceAdded.";
+    private static final String TO_SERVICE = ".ToServiceAdded.";
 
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
@@ -59,15 +62,16 @@ public final class AddedEntityBinding extends AbstractDiffEvaluator {
         return added;
     }
 
-    private ValidationEvent createAddedEvent(String eventId, EntityShape entity, ShapeId addedShape) {
-        String descriptor = eventId.equals(ADDED_RESOURCE) ? "Resource" : "Operation";
+    private ValidationEvent createAddedEvent(String typeOfAddition, EntityShape parentEntity, ShapeId childShape) {
+        String childType = typeOfAddition.equals(ADDED_RESOURCE) ? "Resource" : "Operation";
+        String typeOfParentShape = ShapeType.RESOURCE.equals(parentEntity.getType()) ? TO_RESOURCE : TO_SERVICE;
         String message = String.format(
                 "%s binding of `%s` was added to the %s shape, `%s`",
-                descriptor, addedShape, entity.getType(), entity.getId());
+                childType, childShape, parentEntity.getType(), parentEntity.getId());
         return ValidationEvent.builder()
-                .id(eventId)
+                .id(typeOfAddition + typeOfParentShape + childShape)
                 .severity(Severity.NOTE)
-                .shape(entity)
+                .shape(parentEntity)
                 .message(message)
                 .build();
     }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedEntityBinding.java
@@ -38,8 +38,8 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class AddedEntityBinding extends AbstractDiffEvaluator {
     private static final String ADDED_RESOURCE = "AddedResourceBinding";
     private static final String ADDED_OPERATION = "AddedOperationBinding";
-    private static final String TO_RESOURCE = ".ToResourceAdded.";
-    private static final String TO_SERVICE = ".ToServiceAdded.";
+    private static final String TO_RESOURCE = ".ToResource.";
+    private static final String TO_SERVICE = ".ToService.";
 
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
@@ -69,7 +69,7 @@ public final class AddedEntityBinding extends AbstractDiffEvaluator {
                 "%s binding of `%s` was added to the %s shape, `%s`",
                 childType, childShape, parentEntity.getType(), parentEntity.getId());
         return ValidationEvent.builder()
-                .id(typeOfAddition + typeOfParentShape + childShape)
+                .id(typeOfAddition + typeOfParentShape + childShape.getName())
                 .severity(Severity.NOTE)
                 .shape(parentEntity)
                 .message(message)

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.EntityShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -37,6 +38,8 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class RemovedEntityBinding extends AbstractDiffEvaluator {
     private static final String REMOVED_RESOURCE = "RemovedResourceBinding";
     private static final String REMOVED_OPERATION = "RemovedOperationBinding";
+    private static final String FROM_RESOURCE = ".FromResourceRemoved.";
+    private static final String FROM_SERVICE = ".FromServiceRemoved.";
 
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
@@ -59,15 +62,16 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
         return removed;
     }
 
-    private ValidationEvent createRemovedEvent(String eventId, EntityShape entity, ShapeId removedShape) {
-        String descriptor = eventId.equals(REMOVED_RESOURCE) ? "Resource" : "Operation";
+    private ValidationEvent createRemovedEvent(String typeOfRemoval, EntityShape parentEntity, ShapeId childShape) {
+        String childType = typeOfRemoval.equals(REMOVED_RESOURCE) ? "Resource" : "Operation";
+        String typeOfParentShape = ShapeType.RESOURCE.equals(parentEntity.getType()) ? FROM_RESOURCE : FROM_SERVICE;
         String message = String.format(
                 "%s binding of `%s` was removed from %s shape, `%s`",
-                descriptor, removedShape, entity.getType(), entity.getId());
+                childType, childShape, parentEntity.getType(), parentEntity.getId());
         return ValidationEvent.builder()
-                .id(eventId)
+                .id(typeOfRemoval + typeOfParentShape + childShape)
                 .severity(Severity.ERROR)
-                .shape(entity)
+                .shape(parentEntity)
                 .message(message)
                 .build();
     }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -38,8 +38,8 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public final class RemovedEntityBinding extends AbstractDiffEvaluator {
     private static final String REMOVED_RESOURCE = "RemovedResourceBinding";
     private static final String REMOVED_OPERATION = "RemovedOperationBinding";
-    private static final String FROM_RESOURCE = ".FromResourceRemoved.";
-    private static final String FROM_SERVICE = ".FromServiceRemoved.";
+    private static final String FROM_RESOURCE = ".FromResource.";
+    private static final String FROM_SERVICE = ".FromService.";
 
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
@@ -69,7 +69,7 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
                 "%s binding of `%s` was removed from %s shape, `%s`",
                 childType, childShape, parentEntity.getType(), parentEntity.getId());
         return ValidationEvent.builder()
-                .id(typeOfRemoval + typeOfParentShape + childShape)
+                .id(typeOfRemoval + typeOfParentShape + childShape.getName())
                 .severity(Severity.ERROR)
                 .shape(parentEntity)
                 .message(message)

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedEntityBindingTest.java
@@ -41,7 +41,7 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service1, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedOperationBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationBinding.ToServiceAdded.foo.baz#Operation").size(), equalTo(1));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(r1, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedOperationBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationBinding.ToResourceAdded.foo.baz#Operation").size(), equalTo(1));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service1, r).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedResourceBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedResourceBinding.ToServiceAdded.foo.baz#Resource").size(), equalTo(1));
     }
 
     @Test
@@ -81,6 +81,6 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(p1, child).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedResourceBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedResourceBinding.ToResourceAdded.foo.baz#C").size(), equalTo(1));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedEntityBindingTest.java
@@ -41,7 +41,7 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service1, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedOperationBinding.ToServiceAdded.foo.baz#Operation").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationBinding.ToService.Operation").size(), equalTo(1));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(r1, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedOperationBinding.ToResourceAdded.foo.baz#Operation").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationBinding.ToResource.Operation").size(), equalTo(1));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service1, r).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedResourceBinding.ToServiceAdded.foo.baz#Resource").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedResourceBinding.ToService.Resource").size(), equalTo(1));
     }
 
     @Test
@@ -81,6 +81,6 @@ public class AddedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(p1, child).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "AddedResourceBinding.ToResourceAdded.foo.baz#C").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedResourceBinding.ToResource.C").size(), equalTo(1));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -41,7 +41,7 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service2, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromServiceRemoved.foo.baz#Operation").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromService.Operation").size(), equalTo(1));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(r2, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromResourceRemoved.foo.baz#Operation").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromResource.Operation").size(), equalTo(1));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service2, r).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromServiceRemoved.foo.baz#Resource").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromService.Resource").size(), equalTo(1));
     }
 
     @Test
@@ -81,6 +81,6 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(p2, child).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromResourceRemoved.foo.baz#C").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromResource.C").size(), equalTo(1));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -41,7 +41,7 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service2, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromServiceRemoved.foo.baz#Operation").size(), equalTo(1));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(r2, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromResourceRemoved.foo.baz#Operation").size(), equalTo(1));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(service2, r).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromServiceRemoved.foo.baz#Resource").size(), equalTo(1));
     }
 
     @Test
@@ -81,6 +81,6 @@ public class RemovedEntityBindingTest {
         Model modelB = Model.assembler().addShapes(p2, child).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromResourceRemoved.foo.baz#C").size(), equalTo(1));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Extended AddedResourceBinding, AddedOperationBinding, RemovedResourceBinding,  RemovedOperationBinding event ids with
1. the type of the parent entity
2. the id of the child shape being added/removed


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
