### PR TITLE
[Discussion] Quote dates in header tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -111,7 +111,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         body: "",
         params: {
@@ -259,7 +259,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         params: {
             headerTimestampList: [1576540098, 1576540098]
@@ -452,11 +452,11 @@ apply TimestampFormatHeaders @httpRequestTests([
         uri: "/TimestampFormatHeaders",
         headers: {
             "X-memberEpochSeconds": "1576540098",
-            "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-memberHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-memberDateTime": "2019-12-16T23:48:18Z",
-            "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-defaultFormat": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetEpochSeconds": "1576540098",
-            "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetDateTime": "2019-12-16T23:48:18Z",
         },
         body: "",
@@ -480,11 +480,11 @@ apply TimestampFormatHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-memberEpochSeconds": "1576540098",
-            "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-memberHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-memberDateTime": "2019-12-16T23:48:18Z",
-            "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-defaultFormat": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetEpochSeconds": "1576540098",
-            "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetDateTime": "2019-12-16T23:48:18Z",
         },
         params: {

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -97,7 +97,7 @@ apply InputAndOutputWithHeaders @httpRequestTests([
         method: "POST",
         uri: "/InputAndOutputWithHeaders",
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         body: "",
         params: {
@@ -236,7 +236,7 @@ apply InputAndOutputWithHeaders @httpResponseTests([
         protocol: restXml,
         code: 200,
         headers: {
-            "X-TimestampList": "Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"
+            "X-TimestampList": "\"Mon, 16 Dec 2019 23:48:18 GMT\", \"Mon, 16 Dec 2019 23:48:18 GMT\""
         },
         body: "",
         params: {
@@ -435,11 +435,11 @@ apply TimestampFormatHeaders @httpRequestTests([
         uri: "/TimestampFormatHeaders",
         headers: {
             "X-memberEpochSeconds": "1576540098",
-            "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-memberHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-memberDateTime": "2019-12-16T23:48:18Z",
-            "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-defaultFormat": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetEpochSeconds": "1576540098",
-            "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetDateTime": "2019-12-16T23:48:18Z",
         },
         body: "",
@@ -463,11 +463,11 @@ apply TimestampFormatHeaders @httpResponseTests([
         code: 200,
         headers: {
             "X-memberEpochSeconds": "1576540098",
-            "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-memberHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-memberDateTime": "2019-12-16T23:48:18Z",
-            "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-defaultFormat": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetEpochSeconds": "1576540098",
-            "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
+            "X-targetHttpDate": "\"Mon, 16 Dec 2019 23:48:18 GMT\"",
             "X-targetDateTime": "2019-12-16T23:48:18Z",
         },
         body: "",


### PR DESCRIPTION
*Description of changes:*

The http-date timestamp values currently present in the protocol compliance tests are impossible (or much harder) to parse into a `List<String>`, because the commas present in the rendered date are not escaped. The values being parseable is desirable considering may http libraries represent headers as something similar to `MultiMap<String, String>`, which allows for a greater precision of comparison between expected values and received values. 

In other words, it's way harder  for `"Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT"` to be separated in `["Mon, 16 Dec 2019 23:48:18 GMT", "Mon, 16 Dec 2019 23:48:18 GMT"]`, because without the additional information of quotes the commas after `Mon` can be interpreted as a separating character. 

It makes it harder to use these tests specifications to automate tests of protocol implementations. It's also 
This PR attempts at alleviating this problem by quoting individual dates in the header value. 

I'm following the precedent set by the [StringList](https://github.com/awslabs/smithy/blob/c619a9a4a16f8cffbf4adcc06d32ecbe73ade669/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy#L57-L63) test. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
