### PR TITLE
Implement updated grammar and improve trees

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturedToken.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturedToken.java
@@ -16,6 +16,8 @@
 package software.amazon.smithy.syntax;
 
 import java.util.function.Function;
+import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.IdlToken;
 import software.amazon.smithy.model.loader.IdlTokenizer;
 
@@ -27,9 +29,10 @@ import software.amazon.smithy.model.loader.IdlTokenizer;
  * token. Because smithy-syntax needs to create a token-tree rather than go directly to an AST, it requires arbitrary
  * lookahead of tokens, which means it needs to persist tokens in memory, using this {@code CapturedToken}.
  */
-public final class CapturedToken {
+public final class CapturedToken implements FromSourceLocation {
 
     private final IdlToken token;
+    private final String filename;
     private final int position;
     private final int startLine;
     private final int startColumn;
@@ -42,6 +45,7 @@ public final class CapturedToken {
 
     private CapturedToken(
             IdlToken token,
+            String filename,
             int position,
             int startLine,
             int startColumn,
@@ -53,6 +57,7 @@ public final class CapturedToken {
             String errorMessage
     ) {
         this.token = token;
+        this.filename = filename;
         this.position = position;
         this.startLine = startLine;
         this.startColumn = startColumn;
@@ -90,6 +95,7 @@ public final class CapturedToken {
         String errorMessage = token == IdlToken.ERROR ? tokenizer.getCurrentTokenError() : null;
         Number numberValue = token == IdlToken.NUMBER ? tokenizer.getCurrentTokenNumberValue() : null;
         return new CapturedToken(token,
+                                 tokenizer.getSourceFilename(),
                                  tokenizer.getCurrentTokenStart(),
                                  tokenizer.getCurrentTokenLine(),
                                  tokenizer.getCurrentTokenColumn(),
@@ -108,6 +114,15 @@ public final class CapturedToken {
      */
     public IdlToken getIdlToken() {
         return token;
+    }
+
+    @Override
+    public SourceLocation getSourceLocation() {
+        return new SourceLocation(getFilename(), getStartLine(), getStartColumn());
+    }
+
+    public String getFilename() {
+        return filename;
     }
 
     public int getPosition() {

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturingTokenizer.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturingTokenizer.java
@@ -32,10 +32,6 @@ import software.amazon.smithy.model.loader.StringTable;
  */
 final class CapturingTokenizer implements IdlTokenizer {
 
-    // For now, this also skips doc comments. We may later move doc comments out of WS.
-    private static final IdlToken[] WS_CHARS = {IdlToken.SPACE, IdlToken.NEWLINE, IdlToken.COMMA,
-                                                IdlToken.COMMENT, IdlToken.DOC_COMMENT};
-
     private final IdlTokenizer delegate;
     private final TokenTree root = TokenTree.of(TreeType.IDL);
     private final Deque<TokenTree> trees = new ArrayDeque<>();
@@ -186,29 +182,6 @@ final class CapturingTokenizer implements IdlTokenizer {
             trees.removeFirst();
         }
         return tree;
-    }
-
-    void expectWs() {
-        expect(WS_CHARS);
-        do {
-            next();
-        } while (isWs());
-    }
-
-    boolean isWs() {
-        return isToken(WS_CHARS);
-    }
-
-    private boolean isToken(IdlToken... tokens) {
-        IdlToken currentTokenType = getCurrentToken();
-
-        for (IdlToken token : tokens) {
-            if (currentTokenType == token) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     // Performs basic error recovery by skipping tokens until a $, identifier, or @ is found at column 1.

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTree.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTree.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.syntax;
 
 import java.util.List;
 import java.util.stream.Stream;
+import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.loader.IdlTokenizer;
 
 /**
@@ -25,7 +26,7 @@ import software.amazon.smithy.model.loader.IdlTokenizer;
  * <p>This abstraction is a kind of parse tree based on lexer tokens. Each consumed token is present in the tree,
  * and grouped together into nodes with labels defined by {@link TreeType}.
  */
-public interface TokenTree {
+public interface TokenTree extends FromSourceLocation {
 
     /**
      * Create a TokenTree from a {@link IdlTokenizer}.
@@ -82,6 +83,13 @@ public interface TokenTree {
      * @return Returns direct children.
      */
     List<TokenTree> getChildren();
+
+    /**
+     * Detect if the tree is empty.
+     *
+     * @return Return true if the tree has no children or tokens.
+     */
+    boolean isEmpty();
 
     /**
      * Check if the tree has an immediate child of the given type.

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeLeaf.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeLeaf.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+import software.amazon.smithy.model.SourceLocation;
 
 final class TokenTreeLeaf implements TokenTree {
 
@@ -26,6 +27,11 @@ final class TokenTreeLeaf implements TokenTree {
 
     TokenTreeLeaf(CapturedToken token) {
         this.token = token;
+    }
+
+    @Override
+    public SourceLocation getSourceLocation() {
+        return token.getSourceLocation();
     }
 
     @Override
@@ -41,6 +47,11 @@ final class TokenTreeLeaf implements TokenTree {
     @Override
     public List<TokenTree> getChildren() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
     }
 
     @Override

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeNode.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+import software.amazon.smithy.model.SourceLocation;
 
 class TokenTreeNode implements TokenTree {
 
@@ -27,6 +28,11 @@ class TokenTreeNode implements TokenTree {
 
     TokenTreeNode(TreeType treeType) {
         this.treeType = treeType;
+    }
+
+    @Override
+    public SourceLocation getSourceLocation() {
+        return getChildren().isEmpty() ? SourceLocation.NONE : getChildren().get(0).getSourceLocation();
     }
 
     @Override
@@ -42,6 +48,11 @@ class TokenTreeNode implements TokenTree {
     @Override
     public final List<TokenTree> getChildren() {
         return children;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getChildren().isEmpty();
     }
 
     @Override

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeCursorTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeCursorTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.syntax;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -12,7 +11,6 @@ import static org.hamcrest.Matchers.nullValue;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.model.loader.IdlToken;
 import software.amazon.smithy.model.loader.IdlTokenizer;
 import software.amazon.smithy.utils.IoUtils;
 
@@ -55,22 +53,6 @@ public class TreeCursorTest {
         assertThat(cursor.getFirstChild(TreeType.CONTROL_SECTION).getPreviousSibling(), nullValue());
         assertThat(cursor.getFirstChild(TreeType.METADATA_SECTION).getPreviousSibling(), equalTo(children.get(0)));
         assertThat(cursor.getFirstChild(TreeType.SHAPE_SECTION).getPreviousSibling(), equalTo(children.get(1)));
-    }
-
-    @Test
-    public void recursivelyFindsAllChildren() {
-        TokenTree tree = createTree();
-        System.out.println(tree);
-        TreeCursor cursor = tree.zipper();
-
-        List<TreeCursor> matches = cursor.findChildrenByToken(IdlToken.IDENTIFIER);
-
-        assertThat(matches, not(empty()));
-
-        for (TreeCursor match : matches) {
-            assertThat(match.getTree().getType(), equalTo(TreeType.TOKEN));
-            assertThat(match.getTree().tokens().iterator().next().getIdlToken(), equalTo(IdlToken.IDENTIFIER));
-        }
     }
 
     @Test


### PR DESCRIPTION
This change implements the updated grammar for traits and operations in #1800. WS and BR handling is now more explicit, including individual token trees for comments, spaces, and commas.

NODE_OBJECT_KEY now contains an IDENTIFIER and QUOTED_TEXT tree rather than raw tokens.

This change also cleans up token trees and adds some new features:
* They implement FromSourceLocation
* Removed unused methods.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
