### PR TITLE
Extend event ids for Added/RemovedOperationError events

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationError.java
@@ -47,7 +47,7 @@ public final class AddedOperationError extends AbstractDiffEvaluator {
             if (!change.getOldShape().getErrors().contains(error)) {
                 events.add(
                         ValidationEvent.builder()
-                                .id(getEventId() + "." + error)
+                                .id(getEventId() + "." + error.getName())
                                 .severity(Severity.WARNING)
                                 .message(String.format(
                                         "The `%s` error was added to the `%s` operation. This "
@@ -57,7 +57,6 @@ public final class AddedOperationError extends AbstractDiffEvaluator {
                                                 + "parameter to an operation).",
                                         error, change.getShapeId()))
                                 .shape(change.getNewShape())
-                                .sourceLocation(change.getNewShape().getSourceLocation())
                                 .build()
                 );
             }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedOperationError.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
@@ -42,15 +43,23 @@ public final class AddedOperationError extends AbstractDiffEvaluator {
         }
 
         List<ValidationEvent> events = new ArrayList<>();
-        for (ShapeId id : change.getNewShape().getErrors()) {
-            if (!change.getOldShape().getErrors().contains(id)) {
-                events.add(warning(change.getNewShape(), String.format(
-                        "The `%s` error was added to the `%s` operation. This "
-                        + "is backward-compatible if the error is only "
-                        + "encountered as a result of a change in behavior of "
-                        + "the client (for example, the client sends a new "
-                        + "parameter to an operation).",
-                        id, change.getShapeId())));
+        for (ShapeId error : change.getNewShape().getErrors()) {
+            if (!change.getOldShape().getErrors().contains(error)) {
+                events.add(
+                        ValidationEvent.builder()
+                                .id(getEventId() + "." + error)
+                                .severity(Severity.WARNING)
+                                .message(String.format(
+                                        "The `%s` error was added to the `%s` operation. This "
+                                                + "is backward-compatible if the error is only "
+                                                + "encountered as a result of a change in behavior of "
+                                                + "the client (for example, the client sends a new "
+                                                + "parameter to an operation).",
+                                        error, change.getShapeId()))
+                                .shape(change.getNewShape())
+                                .sourceLocation(change.getNewShape().getSourceLocation())
+                                .build()
+                );
             }
         }
 

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedOperationError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedOperationError.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
@@ -42,11 +43,19 @@ public final class RemovedOperationError extends AbstractDiffEvaluator {
         }
 
         List<ValidationEvent> events = new ArrayList<>();
-        for (ShapeId id : change.getOldShape().getErrors()) {
-            if (!change.getNewShape().getErrors().contains(id)) {
-                events.add(warning(change.getNewShape(), String.format(
-                        "The `%s` error was removed from the `%s` operation.",
-                        id, change.getShapeId())));
+        for (ShapeId error : change.getOldShape().getErrors()) {
+            if (!change.getNewShape().getErrors().contains(error)) {
+                events.add(
+                        ValidationEvent.builder()
+                                .id(getEventId() + "." + error)
+                                .severity(Severity.WARNING)
+                                .message(String.format(
+                                        "The `%s` error was removed from the `%s` operation.",
+                                        error, change.getShapeId()))
+                                .shape(change.getNewShape())
+                                .sourceLocation(change.getNewShape().getSourceLocation())
+                                .build()
+                );
             }
         }
 

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedOperationError.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedOperationError.java
@@ -47,13 +47,12 @@ public final class RemovedOperationError extends AbstractDiffEvaluator {
             if (!change.getNewShape().getErrors().contains(error)) {
                 events.add(
                         ValidationEvent.builder()
-                                .id(getEventId() + "." + error)
+                                .id(getEventId() + "." + error.getName())
                                 .severity(Severity.WARNING)
                                 .message(String.format(
                                         "The `%s` error was removed from the `%s` operation.",
                                         error, change.getShapeId()))
                                 .shape(change.getNewShape())
-                                .sourceLocation(change.getNewShape().getSourceLocation())
                                 .build()
                 );
             }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedOperationErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedOperationErrorTest.java
@@ -46,7 +46,7 @@ public class AddedOperationErrorTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "AddedOperationError").size(), equalTo(2));
-        assertThat(TestHelper.findEvents(events, "AddedOperationError.foo.baz#E1").size(), equalTo(1));
-        assertThat(TestHelper.findEvents(events, "AddedOperationError.foo.baz#E2").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationError.E1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationError.E2").size(), equalTo(1));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedOperationErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedOperationErrorTest.java
@@ -46,5 +46,7 @@ public class AddedOperationErrorTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "AddedOperationError").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "AddedOperationError.foo.baz#E1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationError.foo.baz#E2").size(), equalTo(1));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedOperationErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedOperationErrorTest.java
@@ -52,8 +52,8 @@ public class RemovedOperationErrorTest {
 
         // Emits an event for each removal.
         assertThat(TestHelper.findEvents(events, "RemovedOperationError").size(), equalTo(2));
-        assertThat(TestHelper.findEvents(events, "RemovedOperationError.foo.baz#E1").size(), equalTo(1));
-        assertThat(TestHelper.findEvents(events, "RemovedOperationError.foo.baz#E2").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationError.E1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationError.E2").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, "RemovedOperationError").get(0).toString(),
                 startsWith("[WARNING] foo.baz#Operation: The `foo.baz#E1` error was removed " +
                         "from the `foo.baz#Operation` operation. | RemovedOperationError"));

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedOperationErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedOperationErrorTest.java
@@ -52,6 +52,8 @@ public class RemovedOperationErrorTest {
 
         // Emits an event for each removal.
         assertThat(TestHelper.findEvents(events, "RemovedOperationError").size(), equalTo(2));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationError.foo.baz#E1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedOperationError.foo.baz#E2").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, "RemovedOperationError").get(0).toString(),
                 startsWith("[WARNING] foo.baz#Operation: The `foo.baz#E1` error was removed " +
                         "from the `foo.baz#Operation` operation. | RemovedOperationError"));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds the shape ids of the errors themselves to the event ids


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
