### PR TITLE
Assert trees are valid, fill in missing tests

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturingTokenizer.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturingTokenizer.java
@@ -137,15 +137,15 @@ final class CapturingTokenizer implements IdlTokenizer {
     }
 
     CapturedToken peekPastSpaces() {
-        return peekWhile(1, token -> token == IdlToken.SPACE);
-    }
-
-    CapturedToken peekPastWs() {
-        return peekWhile(1, token -> token.isWhitespace() || token == IdlToken.DOC_COMMENT);
+        return peekWhile(0, token -> token == IdlToken.SPACE);
     }
 
     CapturedToken peekWhile(int offsetFromPosition, Predicate<IdlToken> predicate) {
         int position = cursor + offsetFromPosition;
+        // If the start position is out of bounds, return the EOF token.
+        if (position >= tokens.size()) {
+            return tokens.get(tokens.size() - 1);
+        }
         CapturedToken token = tokens.get(position);
         while (token.getIdlToken() != IdlToken.EOF && predicate.test(token.getIdlToken())) {
             token = tokens.get(++position);

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeTypeTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeTypeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.loader.IdlTokenizer;
 
@@ -14,6 +15,7 @@ public class TreeTypeTest {
         String idl = "$version: \"2.0\"\n\nnamespace com.foo\n";
         CapturingTokenizer tokenizer = new CapturingTokenizer(IdlTokenizer.create(idl));
         TreeType.IDL.parse(tokenizer);
+        assertTreeIsValid(tokenizer.getRoot());
         rootAndChildTypesEqual(tokenizer.getRoot(),
                 TreeType.IDL,
                 TreeType.CONTROL_SECTION,
@@ -24,9 +26,9 @@ public class TreeTypeTest {
     @Test
     public void controlSection() {
         String controlSection = "$version: \"2.0\"\n$foo: [\"bar\"]\n";
-        CapturingTokenizer tokenizer = new CapturingTokenizer(IdlTokenizer.create(controlSection));
-        TreeType.CONTROL_SECTION.parse(tokenizer);
-        rootAndChildTypesEqual(tokenizer.getRoot().getChildren().get(0),
+        TokenTree tree = getTree(TreeType.CONTROL_SECTION, controlSection);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
                 TreeType.CONTROL_SECTION,
                 TreeType.CONTROL_STATEMENT,
                 TreeType.CONTROL_STATEMENT);
@@ -35,9 +37,9 @@ public class TreeTypeTest {
     @Test
     public void controlStatement() {
         String controlStatement = "$version: \"2.0\"\n";
-        CapturingTokenizer tokenizer = new CapturingTokenizer(IdlTokenizer.create(controlStatement));
-        TreeType.CONTROL_STATEMENT.parse(tokenizer);
-        rootAndChildTypesEqual(tokenizer.getRoot().getChildren().get(0),
+        TokenTree tree = getTree(TreeType.CONTROL_STATEMENT, controlStatement);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
                 TreeType.CONTROL_STATEMENT,
                 TreeType.TOKEN,
                 TreeType.NODE_OBJECT_KEY,
@@ -50,9 +52,9 @@ public class TreeTypeTest {
     @Test
     public void identifierNodeObjectKey() {
         String identifier = "version";
-        CapturingTokenizer tokenizer = new CapturingTokenizer(IdlTokenizer.create(identifier));
-        TreeType.NODE_OBJECT_KEY.parse(tokenizer);
-        rootAndChildTypesEqual(tokenizer.getRoot().getChildren().get(0),
+        TokenTree tree = getTree(TreeType.NODE_OBJECT_KEY, identifier);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
                 TreeType.NODE_OBJECT_KEY,
                 TreeType.IDENTIFIER);
     }
@@ -60,9 +62,9 @@ public class TreeTypeTest {
     @Test
     public void stringNodeObjectKey() {
         String string = "\"foo bar\"";
-        CapturingTokenizer tokenizer = new CapturingTokenizer(IdlTokenizer.create(string));
-        TreeType.NODE_OBJECT_KEY.parse(tokenizer);
-        rootAndChildTypesEqual(tokenizer.getRoot().getChildren().get(0),
+        TokenTree tree = getTree(TreeType.NODE_OBJECT_KEY, string);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
                 TreeType.NODE_OBJECT_KEY,
                 TreeType.QUOTED_TEXT);
     }
@@ -71,6 +73,7 @@ public class TreeTypeTest {
     public void metadataSection() {
         String metadataSection = "metadata foo = bar\nmetadata bar=baz\n";
         TokenTree tree = getTree(TreeType.METADATA_SECTION, metadataSection);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.METADATA_SECTION,
                 TreeType.METADATA_STATEMENT,
@@ -81,6 +84,7 @@ public class TreeTypeTest {
     public void metadataStatement() {
         String statement = "metadata foo = bar // Foo\n\n\t";
         TokenTree tree = getTree(TreeType.METADATA_STATEMENT, statement);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.METADATA_STATEMENT,
                 TreeType.TOKEN,
@@ -97,6 +101,7 @@ public class TreeTypeTest {
     public void shapeSection() {
         String shapeSection = "namespace com.foo\nuse com.bar#Baz\nstructure Foo {}";
         TokenTree tree = getTree(TreeType.SHAPE_SECTION, shapeSection);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE_SECTION,
                 TreeType.NAMESPACE_STATEMENT,
@@ -108,6 +113,7 @@ public class TreeTypeTest {
     public void namespaceStatement() {
         String namespaceStatement = "namespace \t com.foo// Foo\n";
         TokenTree tree = getTree(TreeType.NAMESPACE_STATEMENT, namespaceStatement);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.NAMESPACE_STATEMENT,
                 TreeType.TOKEN,
@@ -120,6 +126,7 @@ public class TreeTypeTest {
     public void namespace() {
         String namespace = "foo.bar.baz.qux";
         TokenTree tree = getTree(TreeType.NAMESPACE, namespace);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.NAMESPACE,
                 TreeType.IDENTIFIER,
@@ -135,18 +142,21 @@ public class TreeTypeTest {
     public void identifier() {
         String identifier1 = "foo";
         TokenTree tree1 = getTree(TreeType.IDENTIFIER, identifier1);
+        assertTreeIsValid(tree1);
         rootAndChildTypesEqual(tree1,
                 TreeType.IDENTIFIER,
                 TreeType.TOKEN);
 
         String identifier2 = "_foo";
         TokenTree tree2 = getTree(TreeType.IDENTIFIER, identifier2);
+        assertTreeIsValid(tree2);
         rootAndChildTypesEqual(tree2,
                 TreeType.IDENTIFIER,
                 TreeType.TOKEN);
 
         String identifier3 = "_1foo";
         TokenTree tree3 = getTree(TreeType.IDENTIFIER, identifier3);
+        assertTreeIsValid(tree3);
         rootAndChildTypesEqual(tree3,
                 TreeType.IDENTIFIER,
                 TreeType.TOKEN);
@@ -162,6 +172,7 @@ public class TreeTypeTest {
     public void useSection() {
         String useSection = "use com.foo#Foo\nuse com.bar#Bar\n";
         TokenTree tree = getTree(TreeType.USE_SECTION, useSection);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.USE_SECTION,
                 TreeType.USE_STATEMENT,
@@ -172,6 +183,7 @@ public class TreeTypeTest {
     public void useStatement() {
         String useStatement = "use \tcom.foo#Bar\t\n";
         TokenTree tree = getTree(TreeType.USE_STATEMENT, useStatement);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.USE_STATEMENT,
                 TreeType.TOKEN,
@@ -184,12 +196,14 @@ public class TreeTypeTest {
     public void shapeId() {
         String id = "foo";
         TokenTree idTree = getTree(TreeType.SHAPE_ID, id);
+        assertTreeIsValid(idTree);
         rootAndChildTypesEqual(idTree,
                 TreeType.SHAPE_ID,
                 TreeType.ROOT_SHAPE_ID);
 
         String withMember = "foo$bar";
         TokenTree withMemberTree = getTree(TreeType.SHAPE_ID, withMember);
+        assertTreeIsValid(withMemberTree);
         rootAndChildTypesEqual(withMemberTree,
                 TreeType.SHAPE_ID,
                 TreeType.ROOT_SHAPE_ID,
@@ -200,12 +214,14 @@ public class TreeTypeTest {
     public void rootShapeId() {
         String absolute = "com.foo.bar#Baz";
         TokenTree absoluteTree = getTree(TreeType.ROOT_SHAPE_ID, absolute);
+        assertTreeIsValid(absoluteTree);
         rootAndChildTypesEqual(absoluteTree,
                 TreeType.ROOT_SHAPE_ID,
                 TreeType.ABSOLUTE_ROOT_SHAPE_ID);
 
         String id = "foo";
         TokenTree idTree = getTree(TreeType.ROOT_SHAPE_ID, id);
+        assertTreeIsValid(idTree);
         rootAndChildTypesEqual(idTree,
                 TreeType.ROOT_SHAPE_ID,
                 TreeType.IDENTIFIER);
@@ -215,6 +231,7 @@ public class TreeTypeTest {
     public void absoluteRootShapeId() {
         String absolute = "com.foo.bar#Baz";
         TokenTree tree = getTree(TreeType.ABSOLUTE_ROOT_SHAPE_ID, absolute);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.ABSOLUTE_ROOT_SHAPE_ID,
                 TreeType.NAMESPACE,
@@ -226,6 +243,7 @@ public class TreeTypeTest {
     public void shapeIdMember() {
         String shapeIdMember = "$foo";
         TokenTree tree = getTree(TreeType.SHAPE_ID_MEMBER, shapeIdMember);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE_ID_MEMBER,
                 TreeType.TOKEN,
@@ -236,6 +254,7 @@ public class TreeTypeTest {
     public void shapeStatements() {
         String statements = "structure Foo {\n\tfoo: Bar\n}\n\napply foo @bar\n";
         TokenTree tree = getTree(TreeType.SHAPE_STATEMENTS, statements);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE_STATEMENTS,
                 TreeType.SHAPE_OR_APPLY_STATEMENT,
@@ -248,12 +267,14 @@ public class TreeTypeTest {
     public void shapeOrApplyStatement() {
         String shape = "string Foo";
         TokenTree shapeTree = getTree(TreeType.SHAPE_OR_APPLY_STATEMENT, shape);
+        assertTreeIsValid(shapeTree);
         rootAndChildTypesEqual(shapeTree,
                 TreeType.SHAPE_OR_APPLY_STATEMENT,
                 TreeType.SHAPE_STATEMENT);
 
         String apply = "apply foo @bar";
         TokenTree applyTree = getTree(TreeType.SHAPE_OR_APPLY_STATEMENT, apply);
+        assertTreeIsValid(applyTree);
         rootAndChildTypesEqual(applyTree,
                 TreeType.SHAPE_OR_APPLY_STATEMENT,
                 TreeType.APPLY_STATEMENT);
@@ -263,6 +284,7 @@ public class TreeTypeTest {
     public void shapeStatement() {
         String statement = "@foo\nstring Foo";
         TokenTree tree = getTree(TreeType.SHAPE_STATEMENT, statement);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE_STATEMENT,
                 TreeType.TRAIT_STATEMENTS,
@@ -273,6 +295,7 @@ public class TreeTypeTest {
     public void shape() {
         String shape = "structure Foo {}\n";
         TokenTree tree = getTree(TreeType.SHAPE, shape);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE,
                 TreeType.AGGREGATE_SHAPE);
@@ -282,6 +305,7 @@ public class TreeTypeTest {
     public void simpleShape() {
         String shape = "string \tFoo";
         TokenTree shapeTree = getTree(TreeType.SIMPLE_SHAPE, shape);
+        assertTreeIsValid(shapeTree);
         rootAndChildTypesEqual(shapeTree,
                 TreeType.SIMPLE_SHAPE,
                 TreeType.SIMPLE_TYPE_NAME,
@@ -290,19 +314,21 @@ public class TreeTypeTest {
 
         String withMixins = "string Foo with [Bar]";
         TokenTree withMixinsTree = getTree(TreeType.SIMPLE_SHAPE, withMixins);
+        assertTreeIsValid(withMixinsTree);
         rootAndChildTypesEqual(withMixinsTree,
                 TreeType.SIMPLE_SHAPE,
                 TreeType.SIMPLE_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.SHAPE_MIXINS);
+                TreeType.MIXINS);
     }
 
     @Test
     public void simpleTypeName() {
         String simpleTypeName = "string";
         TokenTree tree = getTree(TreeType.SIMPLE_TYPE_NAME, simpleTypeName);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SIMPLE_TYPE_NAME,
                 TreeType.TOKEN);
@@ -310,8 +336,9 @@ public class TreeTypeTest {
 
     @Test
     public void enumShape() {
-        String enumShape = "enum Foo\n\t{foo = 1}";
+        String enumShape = "enum Foo\n\t{foo = 1\n}";
         TokenTree tree = getTree(TreeType.ENUM_SHAPE, enumShape);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.ENUM_SHAPE,
                 TreeType.ENUM_TYPE_NAME,
@@ -322,13 +349,14 @@ public class TreeTypeTest {
 
         String withMixins = "enum Foo with [Bar] \n{foo}";
         TokenTree withMixinsTree = getTree(TreeType.ENUM_SHAPE, withMixins);
+        assertTreeIsValid(withMixinsTree);
         rootAndChildTypesEqual(withMixinsTree,
                 TreeType.ENUM_SHAPE,
                 TreeType.ENUM_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.SHAPE_MIXINS,
+                TreeType.MIXINS,
                 TreeType.WS,
                 TreeType.ENUM_SHAPE_MEMBERS);
     }
@@ -337,6 +365,7 @@ public class TreeTypeTest {
     public void enumTypeName() {
         String enumTypeName = "intEnum";
         TokenTree tree = getTree(TreeType.ENUM_TYPE_NAME, enumTypeName);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.ENUM_TYPE_NAME,
                 TreeType.TOKEN);
@@ -346,6 +375,7 @@ public class TreeTypeTest {
     public void enumShapeMembers() {
         String members = "{\nfoo bar baz\n}";
         TokenTree tree = getTree(TreeType.ENUM_SHAPE_MEMBERS, members);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.ENUM_SHAPE_MEMBERS,
                 TreeType.TOKEN,
@@ -363,29 +393,33 @@ public class TreeTypeTest {
     public void enumShapeMember() {
         String member = "FOO";
         TokenTree tree = getTree(TreeType.ENUM_SHAPE_MEMBER, member);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.ENUM_SHAPE_MEMBER,
                 TreeType.TRAIT_STATEMENTS,
                 TreeType.IDENTIFIER);
 
-        String withValue = "FOO = BAR";
+        String withValue = "FOO = BAR\n";
         TokenTree withValueTree = getTree(TreeType.ENUM_SHAPE_MEMBER, withValue);
+        assertTreeIsValid(withValueTree);
         rootAndChildTypesEqual(withValueTree,
                 TreeType.ENUM_SHAPE_MEMBER,
                 TreeType.TRAIT_STATEMENTS,
                 TreeType.IDENTIFIER,
                 TreeType.VALUE_ASSIGNMENT);
 
-        String noWs = "FOO=BAR";
+        String noWs = "FOO=BAR\n";
         TokenTree noWsTree = getTree(TreeType.ENUM_SHAPE_MEMBER, noWs);
+        assertTreeIsValid(noWsTree);
         rootAndChildTypesEqual(noWsTree,
                 TreeType.ENUM_SHAPE_MEMBER,
                 TreeType.TRAIT_STATEMENTS,
                 TreeType.IDENTIFIER,
                 TreeType.VALUE_ASSIGNMENT);
 
-        String withTraits = "\n@foo\n@bar\nFOO";
+        String withTraits = "@foo\n@bar\nFOO";
         TokenTree withTraitsTree = getTree(TreeType.ENUM_SHAPE_MEMBER, withTraits);
+        assertTreeIsValid(withTraitsTree);
         rootAndChildTypesEqual(withTraitsTree,
                 TreeType.ENUM_SHAPE_MEMBER,
                 TreeType.TRAIT_STATEMENTS,
@@ -396,6 +430,7 @@ public class TreeTypeTest {
     public void aggregateShape() {
         String shape = "structure Foo {}";
         TokenTree tree = getTree(TreeType.AGGREGATE_SHAPE, shape);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.AGGREGATE_SHAPE,
                 TreeType.AGGREGATE_TYPE_NAME,
@@ -406,16 +441,27 @@ public class TreeTypeTest {
     }
 
     @Test
+    public void aggregateTypeName() {
+        String typeName = "structure";
+        TokenTree tree = getTree(TreeType.AGGREGATE_TYPE_NAME, typeName);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
+                TreeType.AGGREGATE_TYPE_NAME,
+                TreeType.TOKEN);
+    }
+
+    @Test
     public void aggregateShapeForResource() {
         String shape = "structure Foo for Bar {}";
         TokenTree tree = getTree(TreeType.AGGREGATE_SHAPE, shape);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.AGGREGATE_SHAPE,
                 TreeType.AGGREGATE_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.AGGREGATE_SHAPE_RESOURCE,
+                TreeType.FOR_RESOURCE,
                 TreeType.SP,
                 TreeType.SHAPE_MEMBERS);
     }
@@ -424,13 +470,14 @@ public class TreeTypeTest {
     public void aggregateShapeMixins() {
         String shape = "structure Foo with [Bar, Baz] {}";
         TokenTree tree = getTree(TreeType.AGGREGATE_SHAPE, shape);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.AGGREGATE_SHAPE,
                 TreeType.AGGREGATE_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.SHAPE_MIXINS,
+                TreeType.MIXINS,
                 TreeType.WS,
                 TreeType.SHAPE_MEMBERS);
     }
@@ -439,15 +486,16 @@ public class TreeTypeTest {
     public void aggregateShapeForResourceAndMixins() {
         String shape = "structure Foo for Bar with [Baz] {}";
         TokenTree tree = getTree(TreeType.AGGREGATE_SHAPE, shape);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.AGGREGATE_SHAPE,
                 TreeType.AGGREGATE_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.AGGREGATE_SHAPE_RESOURCE,
+                TreeType.FOR_RESOURCE,
                 TreeType.SP,
-                TreeType.SHAPE_MIXINS,
+                TreeType.MIXINS,
                 TreeType.WS,
                 TreeType.SHAPE_MEMBERS);
     }
@@ -455,10 +503,11 @@ public class TreeTypeTest {
     @Test
     public void forResource() {
         String forResource = "for Foo";
-        TokenTree tree = getTree(TreeType.AGGREGATE_SHAPE_RESOURCE, forResource);
+        TokenTree tree = getTree(TreeType.FOR_RESOURCE, forResource);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
-                TreeType.AGGREGATE_SHAPE_RESOURCE,
-                TreeType.IDENTIFIER,
+                TreeType.FOR_RESOURCE,
+                TreeType.TOKEN,
                 TreeType.SP,
                 TreeType.SHAPE_ID);
     }
@@ -466,10 +515,11 @@ public class TreeTypeTest {
     @Test
     public void mixins() {
         String mixins = "with [Foo, Bar]";
-        TokenTree tree = getTree(TreeType.SHAPE_MIXINS, mixins);
+        TokenTree tree = getTree(TreeType.MIXINS, mixins);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
-                TreeType.SHAPE_MIXINS,
-                TreeType.IDENTIFIER,
+                TreeType.MIXINS,
+                TreeType.TOKEN,
                 TreeType.WS,
                 TreeType.TOKEN,
                 TreeType.SHAPE_ID,
@@ -482,6 +532,7 @@ public class TreeTypeTest {
     public void shapeMembers() {
         String shapeMembers = "{\n\n\tfoo: Bar\n\tbar: Baz\n}";
         TokenTree tree = getTree(TreeType.SHAPE_MEMBERS, shapeMembers);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE_MEMBERS,
                 TreeType.TOKEN,
@@ -497,6 +548,7 @@ public class TreeTypeTest {
     public void shapeMember() {
         String shapeMember = "@foo\n/// Foo\n\tfoo: Bar";
         TokenTree tree = getTree(TreeType.SHAPE_MEMBER, shapeMember);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.SHAPE_MEMBER,
                 TreeType.TRAIT_STATEMENTS,
@@ -507,6 +559,7 @@ public class TreeTypeTest {
     public void traitStatements() {
         String traitStatements = "@foo\t// Foo\n\t/// Foo\n@bar\n";
         TokenTree tree = getTree(TreeType.TRAIT_STATEMENTS, traitStatements);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.TRAIT_STATEMENTS,
                 TreeType.TRAIT,
@@ -519,6 +572,7 @@ public class TreeTypeTest {
     public void trait() {
         String trait = "@com.foo#Bar";
         TokenTree tree = getTree(TreeType.TRAIT, trait);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.TRAIT,
                 TreeType.TOKEN,
@@ -529,6 +583,7 @@ public class TreeTypeTest {
     public void traitWithEmptyBody() {
         String trait = "@abc()";
         TokenTree tree = getTree(TreeType.TRAIT, trait);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                                TreeType.TRAIT,
                                TreeType.TOKEN,
@@ -540,6 +595,7 @@ public class TreeTypeTest {
     public void traitWithNonEmptyBody() {
         String trait = "@abc(hi)";
         TokenTree tree = getTree(TreeType.TRAIT, trait);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                                TreeType.TRAIT,
                                TreeType.TOKEN,
@@ -551,6 +607,7 @@ public class TreeTypeTest {
     public void traitBody() {
         String traitBody = "(\nfoo: Bar\n)";
         TokenTree tree = getTree(TreeType.TRAIT_BODY, traitBody);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.TRAIT_BODY,
                 TreeType.TOKEN,
@@ -563,6 +620,7 @@ public class TreeTypeTest {
     public void traitBodyTraitStructure() {
         String traitBody = "foo: bar";
         TokenTree tree = getTree(TreeType.TRAIT_STRUCTURE, traitBody);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree, TreeType.TRAIT_STRUCTURE, TreeType.NODE_OBJECT_KVP);
     }
 
@@ -570,6 +628,7 @@ public class TreeTypeTest {
     public void traitBodyTraitNodeString() {
         String traitBody = "(\"foo\")";
         TokenTree tree = getTree(TreeType.TRAIT_BODY, traitBody);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree, TreeType.TRAIT_BODY, TreeType.TOKEN, TreeType.TRAIT_NODE, TreeType.TOKEN);
     }
 
@@ -577,6 +636,7 @@ public class TreeTypeTest {
     public void traitBodyWithWs() {
         String traitBody = "( \"foo\" )";
         TokenTree tree = getTree(TreeType.TRAIT_BODY, traitBody);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.TRAIT_BODY,
                 TreeType.TOKEN,
@@ -589,13 +649,15 @@ public class TreeTypeTest {
     public void traitBodyTraitNodeStructure() {
         String traitBody = "({ foo: bar })";
         TokenTree tree = getTree(TreeType.TRAIT_BODY, traitBody);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree, TreeType.TRAIT_BODY, TreeType.TOKEN, TreeType.TRAIT_NODE, TreeType.TOKEN);
     }
 
     @Test
-    public void traitNodeTest() {
+    public void traitNode() {
         String traitBody = "\"foo\"";
         TokenTree tree = getTree(TreeType.TRAIT_NODE, traitBody);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree, TreeType.TRAIT_NODE, TreeType.NODE_VALUE);
     }
 
@@ -603,6 +665,7 @@ public class TreeTypeTest {
     public void traitStructure() {
         String traitStructure = "foo: bar, bar: baz\n\n// Baz\nbaz: qux\n";
         TokenTree tree = getTree(TreeType.TRAIT_STRUCTURE, traitStructure);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.TRAIT_STRUCTURE,
                 TreeType.NODE_OBJECT_KVP,
@@ -617,6 +680,7 @@ public class TreeTypeTest {
     public void explicitShapeMember() {
         String explicitShapeMember = "foo \t: \t com.foo#Bar";
         TokenTree tree = getTree(TreeType.EXPLICIT_SHAPE_MEMBER, explicitShapeMember);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.EXPLICIT_SHAPE_MEMBER,
                 TreeType.IDENTIFIER,
@@ -630,6 +694,7 @@ public class TreeTypeTest {
     public void elidedShapeMember() {
         String elidedShapeMember = "$foo";
         TokenTree tree = getTree(TreeType.ELIDED_SHAPE_MEMBER, elidedShapeMember);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.ELIDED_SHAPE_MEMBER,
                 TreeType.TOKEN,
@@ -640,6 +705,7 @@ public class TreeTypeTest {
     public void valueAssignment() {
         String valueAssignment = "\t =  \t foo , \n";
         TokenTree tree = getTree(TreeType.VALUE_ASSIGNMENT, valueAssignment);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.VALUE_ASSIGNMENT,
                 TreeType.SP,
@@ -655,9 +721,10 @@ public class TreeTypeTest {
     public void entityShape() {
         String entityShape = "service Foo {}";
         TokenTree entityShapeTree = getTree(TreeType.ENTITY_SHAPE, entityShape);
+        assertTreeIsValid(entityShapeTree);
         rootAndChildTypesEqual(entityShapeTree,
                 TreeType.ENTITY_SHAPE,
-                TreeType.TOKEN,
+                TreeType.ENTITY_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
@@ -665,35 +732,43 @@ public class TreeTypeTest {
 
         String noWs = "service Foo{}";
         TokenTree noWsTree = getTree(TreeType.ENTITY_SHAPE, noWs);
+        assertTreeIsValid(noWsTree);
         rootAndChildTypesEqual(noWsTree,
                 TreeType.ENTITY_SHAPE,
-                TreeType.TOKEN,
+                TreeType.ENTITY_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.NODE_OBJECT);
 
         String withMixins = "service Foo with [Bar] {}";
         TokenTree withMixinsTree = getTree(TreeType.ENTITY_SHAPE, withMixins);
+        assertTreeIsValid(withMixinsTree);
         rootAndChildTypesEqual(withMixinsTree,
                 TreeType.ENTITY_SHAPE,
-                TreeType.TOKEN,
+                TreeType.ENTITY_TYPE_NAME,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.SHAPE_MIXINS,
+                TreeType.MIXINS,
                 TreeType.WS,
                 TreeType.NODE_OBJECT);
     }
 
     @Test
     public void entityTypeName() {
-        // TODO
+        String typeName = "service";
+        TokenTree tree = getTree(TreeType.ENTITY_TYPE_NAME, typeName);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
+                TreeType.ENTITY_TYPE_NAME,
+                TreeType.TOKEN);
     }
 
     @Test
     public void operationShape() {
         String shape = "operation Foo {input: Foo output: Bar}";
         TokenTree shapeTree = getTree(TreeType.OPERATION_SHAPE, shape);
+        assertTreeIsValid(shapeTree);
         rootAndChildTypesEqual(shapeTree,
                 TreeType.OPERATION_SHAPE,
                 TreeType.TOKEN,
@@ -704,6 +779,7 @@ public class TreeTypeTest {
 
         String noWs = "operation Foo{input: Foo output: Bar}";
         TokenTree noWsTree = getTree(TreeType.OPERATION_SHAPE, noWs);
+        assertTreeIsValid(noWsTree);
         rootAndChildTypesEqual(noWsTree,
                 TreeType.OPERATION_SHAPE,
                 TreeType.TOKEN,
@@ -713,26 +789,165 @@ public class TreeTypeTest {
 
         String withMixins = "operation Foo with [Bar] {input: Foo output: Bar}";
         TokenTree withMixinsTree = getTree(TreeType.OPERATION_SHAPE, withMixins);
+        assertTreeIsValid(withMixinsTree);
         rootAndChildTypesEqual(withMixinsTree,
                 TreeType.OPERATION_SHAPE,
                 TreeType.TOKEN,
                 TreeType.SP,
                 TreeType.IDENTIFIER,
                 TreeType.SP,
-                TreeType.SHAPE_MIXINS,
+                TreeType.MIXINS,
                 TreeType.WS,
                 TreeType.OPERATION_BODY);
     }
 
     @Test
     public void operationBody() {
-        // TODO When we update operation body grammar
+        String operationBody = "{ input: foo\noutput: bar }";
+        TokenTree operationBodyTree = getTree(TreeType.OPERATION_BODY, operationBody);
+        assertTreeIsValid(operationBodyTree);
+        rootAndChildTypesEqual(operationBodyTree,
+                TreeType.OPERATION_BODY,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.OPERATION_PROPERTY,
+                TreeType.WS,
+                TreeType.OPERATION_PROPERTY,
+                TreeType.WS,
+                TreeType.TOKEN);
+
+        String noWs = "{input:foo}";
+        TokenTree noWsTree = getTree(TreeType.OPERATION_BODY, noWs);
+        assertTreeIsValid(noWsTree);
+        rootAndChildTypesEqual(noWsTree,
+                TreeType.OPERATION_BODY,
+                TreeType.TOKEN,
+                TreeType.OPERATION_PROPERTY,
+                TreeType.TOKEN);
+
+        String onlyWs = "{\n// Foo\n \n}";
+        TokenTree onlyWsTree = getTree(TreeType.OPERATION_BODY, onlyWs);
+        assertTreeIsValid(onlyWsTree);
+        rootAndChildTypesEqual(onlyWsTree,
+                TreeType.OPERATION_BODY,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TOKEN);
+    }
+
+    @Test
+    public void operationProperty() {
+        String input = "input: foo";
+        TokenTree inputTree = getTree(TreeType.OPERATION_PROPERTY, input);
+        assertTreeIsValid(inputTree);
+        rootAndChildTypesEqual(inputTree,
+                TreeType.OPERATION_PROPERTY,
+                TreeType.OPERATION_INPUT);
+
+        String output = "output: foo";
+        TokenTree outputTree = getTree(TreeType.OPERATION_PROPERTY, output);
+        assertTreeIsValid(outputTree);
+        rootAndChildTypesEqual(outputTree,
+                TreeType.OPERATION_PROPERTY,
+                TreeType.OPERATION_OUTPUT);
+
+        String errors = "errors: []";
+        TokenTree errorsTree = getTree(TreeType.OPERATION_PROPERTY, errors);
+        assertTreeIsValid(errorsTree);
+        rootAndChildTypesEqual(errorsTree,
+                TreeType.OPERATION_PROPERTY,
+                TreeType.OPERATION_ERRORS);
+    }
+
+    @Test
+    public void operationInput() {
+        String withWs = "input\n//Foo\n : foo";
+        TokenTree withWsTree = getTree(TreeType.OPERATION_INPUT, withWs);
+        assertTreeIsValid(withWsTree);
+        rootAndChildTypesEqual(withWsTree,
+                TreeType.OPERATION_INPUT,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.SHAPE_ID);
+
+        String noWs = "input:foo";
+        TokenTree noWsTree = getTree(TreeType.OPERATION_INPUT, noWs);
+        assertTreeIsValid(noWsTree);
+        rootAndChildTypesEqual(noWsTree,
+                TreeType.OPERATION_INPUT,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.SHAPE_ID);
+
+        String shapeId = "input: foo.bar#Baz";
+        TokenTree shapeIdTree = getTree(TreeType.OPERATION_INPUT, shapeId);
+        assertTreeIsValid(shapeIdTree);
+        rootAndChildTypesEqual(shapeIdTree,
+                TreeType.OPERATION_INPUT,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.SHAPE_ID);
+
+        String inline = "input := {}";
+        TokenTree inlineTree = getTree(TreeType.OPERATION_INPUT, inline);
+        assertTreeIsValid(inlineTree);
+        rootAndChildTypesEqual(inlineTree,
+                TreeType.OPERATION_INPUT,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.INLINE_AGGREGATE_SHAPE);
+    }
+
+    @Test
+    public void operationOutput() {
+        String withWs = "output\n//Foo\n : foo";
+        TokenTree withWsTree = getTree(TreeType.OPERATION_OUTPUT, withWs);
+        assertTreeIsValid(withWsTree);
+        rootAndChildTypesEqual(withWsTree,
+                TreeType.OPERATION_OUTPUT,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.SHAPE_ID);
+
+        String noWs = "output:foo";
+        TokenTree noWsTree = getTree(TreeType.OPERATION_OUTPUT, noWs);
+        assertTreeIsValid(noWsTree);
+        rootAndChildTypesEqual(noWsTree,
+                TreeType.OPERATION_OUTPUT,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.SHAPE_ID);
+
+        String shapeId = "output: foo.bar#Baz";
+        TokenTree shapeIdTree = getTree(TreeType.OPERATION_OUTPUT, shapeId);
+        assertTreeIsValid(shapeIdTree);
+        rootAndChildTypesEqual(shapeIdTree,
+                TreeType.OPERATION_OUTPUT,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.SHAPE_ID);
+
+        String inline = "output := {}";
+        TokenTree inlineTree = getTree(TreeType.OPERATION_OUTPUT, inline);
+        assertTreeIsValid(inlineTree);
+        rootAndChildTypesEqual(inlineTree,
+                TreeType.OPERATION_OUTPUT,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.INLINE_AGGREGATE_SHAPE);
     }
 
     @Test
     public void inlineAggregateShape() {
         String basic = ":= { foo: bar }";
         TokenTree basicTree = getTree(TreeType.INLINE_AGGREGATE_SHAPE, basic);
+        assertTreeIsValid(basicTree);
         rootAndChildTypesEqual(basicTree,
                 TreeType.INLINE_AGGREGATE_SHAPE,
                 TreeType.TOKEN,
@@ -742,6 +957,7 @@ public class TreeTypeTest {
 
         String withTraits = ":= @foo\n\n@bar\n\n{ foo: bar }";
         TokenTree withTraitsTree = getTree(TreeType.INLINE_AGGREGATE_SHAPE, withTraits);
+        assertTreeIsValid(withTraitsTree);
         rootAndChildTypesEqual(withTraitsTree,
                 TreeType.INLINE_AGGREGATE_SHAPE,
                 TreeType.TOKEN,
@@ -751,9 +967,52 @@ public class TreeTypeTest {
     }
 
     @Test
+    public void operationErrors() {
+        String empty = "errors: []";
+        TokenTree emptyTree = getTree(TreeType.OPERATION_ERRORS, empty);
+        assertTreeIsValid(emptyTree);
+        rootAndChildTypesEqual(emptyTree,
+                TreeType.OPERATION_ERRORS,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.TOKEN);
+
+        String noWs = "errors:[foo]";
+        TokenTree noWsTree = getTree(TreeType.OPERATION_ERRORS, noWs);
+        assertTreeIsValid(noWsTree);
+        rootAndChildTypesEqual(noWsTree,
+                TreeType.OPERATION_ERRORS,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.TOKEN,
+                TreeType.SHAPE_ID,
+                TreeType.TOKEN);
+
+        String withWs = "errors\n//Foo\n: \n[\nfoo // Foo\nbar ]";
+        TokenTree withWsTree = getTree(TreeType.OPERATION_ERRORS, withWs);
+        assertTreeIsValid(withWsTree);
+        rootAndChildTypesEqual(withWsTree,
+                TreeType.OPERATION_ERRORS,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.SHAPE_ID,
+                TreeType.WS,
+                TreeType.SHAPE_ID,
+                TreeType.WS,
+                TreeType.TOKEN);
+    }
+
+    @Test
     public void applyStatement() {
         String applyStatement = "apply foo @bar";
         TokenTree tree = getTree(TreeType.APPLY_STATEMENT, applyStatement);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.APPLY_STATEMENT,
                 TreeType.APPLY_STATEMENT_SINGULAR);
@@ -763,6 +1022,7 @@ public class TreeTypeTest {
     public void applyStatementSingular() {
         String singular = "apply foo\n\t@bar";
         TokenTree tree = getTree(TreeType.APPLY_STATEMENT_SINGULAR, singular);
+        assertTreeIsValid(tree);
         rootAndChildTypesEqual(tree,
                 TreeType.APPLY_STATEMENT_SINGULAR,
                 TreeType.TOKEN,
@@ -775,8 +1035,36 @@ public class TreeTypeTest {
     @Test
     public void applyStatementBlock() {
         String block = "apply foo\n\t{@foo\n@bar\n}";
-        TokenTree tree = getTree(TreeType.APPLY_STATEMENT_BLOCK, block);
-        rootAndChildTypesEqual(tree,
+        TokenTree blockTree = getTree(TreeType.APPLY_STATEMENT_BLOCK, block);
+        assertTreeIsValid(blockTree);
+        rootAndChildTypesEqual(blockTree,
+                TreeType.APPLY_STATEMENT_BLOCK,
+                TreeType.TOKEN,
+                TreeType.SP,
+                TreeType.SHAPE_ID,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.TRAIT_STATEMENTS,
+                TreeType.TOKEN);
+
+        String withLeadingWsInBlock = "apply foo\n{// Bar\n@foo\n}";
+        TokenTree withLeadingWsInBlockTree = getTree(TreeType.APPLY_STATEMENT_BLOCK, withLeadingWsInBlock);
+        assertTreeIsValid(withLeadingWsInBlockTree);
+        rootAndChildTypesEqual(withLeadingWsInBlockTree,
+                TreeType.APPLY_STATEMENT_BLOCK,
+                TreeType.TOKEN,
+                TreeType.SP,
+                TreeType.SHAPE_ID,
+                TreeType.WS,
+                TreeType.TOKEN,
+                TreeType.WS,
+                TreeType.TRAIT_STATEMENTS,
+                TreeType.TOKEN);
+
+        String minimalWs = "apply foo {@bar}";
+        TokenTree minimalWsTree = getTree(TreeType.APPLY_STATEMENT_BLOCK, minimalWs);
+        assertTreeIsValid(minimalWsTree);
+        rootAndChildTypesEqual(minimalWsTree,
                 TreeType.APPLY_STATEMENT_BLOCK,
                 TreeType.TOKEN,
                 TreeType.SP,
@@ -791,54 +1079,63 @@ public class TreeTypeTest {
     public void nodeValue() {
         String array = "[]";
         TokenTree arrayTree = getTree(TreeType.NODE_VALUE, array);
+        assertTreeIsValid(arrayTree);
         rootAndChildTypesEqual(arrayTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_ARRAY);
 
         String object = "{}";
         TokenTree objectTree = getTree(TreeType.NODE_VALUE, object);
+        assertTreeIsValid(objectTree);
         rootAndChildTypesEqual(objectTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_OBJECT);
 
         String number = "1";
         TokenTree numberTree = getTree(TreeType.NODE_VALUE, number);
+        assertTreeIsValid(numberTree);
         rootAndChildTypesEqual(numberTree,
                 TreeType.NODE_VALUE,
                 TreeType.NUMBER);
 
         String trueKeyword = "true";
         TokenTree trueTree = getTree(TreeType.NODE_VALUE, trueKeyword);
+        assertTreeIsValid(trueTree);
         rootAndChildTypesEqual(trueTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_KEYWORD);
 
         String falseKeyword = "false";
         TokenTree falseTree = getTree(TreeType.NODE_VALUE, falseKeyword);
+        assertTreeIsValid(falseTree);
         rootAndChildTypesEqual(falseTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_KEYWORD);
 
         String nullKeyword = "null";
         TokenTree nullTree = getTree(TreeType.NODE_VALUE, nullKeyword);
+        assertTreeIsValid(nullTree);
         rootAndChildTypesEqual(nullTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_KEYWORD);
 
         String shapeId = "foo";
         TokenTree shapeIdTree = getTree(TreeType.NODE_VALUE, shapeId);
+        assertTreeIsValid(shapeIdTree);
         rootAndChildTypesEqual(shapeIdTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_STRING_VALUE);
 
         String quotedText = "\"foo\"";
         TokenTree quotedTextTree = getTree(TreeType.NODE_VALUE, quotedText);
+        assertTreeIsValid(quotedTextTree);
         rootAndChildTypesEqual(quotedTextTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_STRING_VALUE);
 
         String textBlock = "\"\"\"\nfoo\"\"\"";
         TokenTree textBlockTree = getTree(TreeType.NODE_VALUE, textBlock);
+        assertTreeIsValid(textBlockTree);
         rootAndChildTypesEqual(textBlockTree,
                 TreeType.NODE_VALUE,
                 TreeType.NODE_STRING_VALUE);
@@ -848,6 +1145,7 @@ public class TreeTypeTest {
     public void nodeArray() {
         String empty = "[]";
         TokenTree emptyTree = getTree(TreeType.NODE_ARRAY, empty);
+        assertTreeIsValid(emptyTree);
         rootAndChildTypesEqual(emptyTree,
                 TreeType.NODE_ARRAY,
                 TreeType.TOKEN,
@@ -855,6 +1153,7 @@ public class TreeTypeTest {
 
         String emptyWs = "[\n\n\t//Foo\n]";
         TokenTree emptyWsTree = getTree(TreeType.NODE_ARRAY, emptyWs);
+        assertTreeIsValid(emptyWsTree);
         rootAndChildTypesEqual(emptyWsTree,
                 TreeType.NODE_ARRAY,
                 TreeType.TOKEN,
@@ -863,6 +1162,7 @@ public class TreeTypeTest {
 
         String withElements = "[ foo\n bar, baz // foo\n\tqux ]";
         TokenTree withElementsTree = getTree(TreeType.NODE_ARRAY, withElements);
+        assertTreeIsValid(withElementsTree);
         rootAndChildTypesEqual(withElementsTree,
                 TreeType.NODE_ARRAY,
                 TreeType.TOKEN,
@@ -879,6 +1179,7 @@ public class TreeTypeTest {
 
         String noWs = "[foo]";
         TokenTree noWsTree = getTree(TreeType.NODE_ARRAY, noWs);
+        assertTreeIsValid(noWsTree);
         rootAndChildTypesEqual(noWsTree,
                 TreeType.NODE_ARRAY,
                 TreeType.TOKEN,
@@ -890,6 +1191,7 @@ public class TreeTypeTest {
     public void nodeObject() {
         String empty = "{}";
         TokenTree emptyTree = getTree(TreeType.NODE_OBJECT, empty);
+        assertTreeIsValid(emptyTree);
         rootAndChildTypesEqual(emptyTree,
                 TreeType.NODE_OBJECT,
                 TreeType.TOKEN,
@@ -897,6 +1199,7 @@ public class TreeTypeTest {
 
         String emptyWs = "{// Foo\n\n\t}";
         TokenTree emptyWsTree = getTree(TreeType.NODE_OBJECT, emptyWs);
+        assertTreeIsValid(emptyWsTree);
         rootAndChildTypesEqual(emptyWsTree,
                 TreeType.NODE_OBJECT,
                 TreeType.TOKEN,
@@ -905,6 +1208,7 @@ public class TreeTypeTest {
 
         String withElements = "{ foo: bar\n// Foo\n\tbaz: qux\n}";
         TokenTree withElementsTree = getTree(TreeType.NODE_OBJECT, withElements);
+        assertTreeIsValid(withElementsTree);
         rootAndChildTypesEqual(withElementsTree,
                 TreeType.NODE_OBJECT,
                 TreeType.TOKEN,
@@ -917,6 +1221,7 @@ public class TreeTypeTest {
 
         String noWs = "{foo:bar}";
         TokenTree noWsTree = getTree(TreeType.NODE_OBJECT, noWs);
+        assertTreeIsValid(noWsTree);
         rootAndChildTypesEqual(noWsTree,
                 TreeType.NODE_OBJECT,
                 TreeType.TOKEN,
@@ -928,6 +1233,7 @@ public class TreeTypeTest {
     public void nodeObjectKvp() {
         String kvp = "foo\n:\nbar";
         TokenTree kvpTree = getTree(TreeType.NODE_OBJECT_KVP, kvp);
+        assertTreeIsValid(kvpTree);
         rootAndChildTypesEqual(kvpTree,
                 TreeType.NODE_OBJECT_KVP,
                 TreeType.NODE_OBJECT_KEY,
@@ -938,6 +1244,7 @@ public class TreeTypeTest {
 
         String noWs = "foo:bar";
         TokenTree noWsTree = getTree(TreeType.NODE_OBJECT_KVP, noWs);
+        assertTreeIsValid(noWsTree);
         rootAndChildTypesEqual(noWsTree,
                 TreeType.NODE_OBJECT_KVP,
                 TreeType.NODE_OBJECT_KEY,
@@ -949,25 +1256,37 @@ public class TreeTypeTest {
     public void nodeObjectKey() {
         String quoted = "\"foo bar\"";
         TokenTree quotedTree = getTree(TreeType.NODE_OBJECT_KEY, quoted);
+        assertTreeIsValid(quotedTree);
         rootAndChildTypesEqual(quotedTree, TreeType.NODE_OBJECT_KEY, TreeType.QUOTED_TEXT);
 
         String identifier = "foo";
         TokenTree idTree = getTree(TreeType.NODE_OBJECT_KEY, identifier);
+        assertTreeIsValid(idTree);
         rootAndChildTypesEqual(idTree, TreeType.NODE_OBJECT_KEY, TreeType.IDENTIFIER);
     }
 
     @Test
     public void nodeStringValue() {
-        String shapeId = "com.foo#Bar$baz";
-        TokenTree shapeIdTree = getTree(TreeType.NODE_STRING_VALUE, shapeId);
-        rootAndChildTypesEqual(shapeIdTree, TreeType.NODE_STRING_VALUE, TreeType.IDENTIFIER);
+        String identifier = "foo";
+        TokenTree idTree = getTree(TreeType.NODE_STRING_VALUE, identifier);
+        assertTreeIsValid(idTree);
+        rootAndChildTypesEqual(idTree, TreeType.NODE_STRING_VALUE, TreeType.IDENTIFIER);
+
+        /*
+         TODO: Right now grammar is ambiguous, no way to tell if its an identifier or shape id.
+         String shapeId = "com.foo#Bar$baz";
+         TokenTree shapeIdTree = getTree(TreeType.NODE_STRING_VALUE, shapeId);
+         rootAndChildTypesEqual(shapeIdTree, TreeType.NODE_STRING_VALUE, TreeType.SHAPE_ID);
+        */
 
         String quoted = "\"foo bar\"";
         TokenTree quotedTree = getTree(TreeType.NODE_STRING_VALUE, quoted);
+        assertTreeIsValid(quotedTree);
         rootAndChildTypesEqual(quotedTree, TreeType.NODE_STRING_VALUE, TreeType.QUOTED_TEXT);
 
         String block = "\"\"\"\nfoo\"\"\"";
         TokenTree blockTree = getTree(TreeType.NODE_STRING_VALUE, block);
+        assertTreeIsValid(blockTree);
         rootAndChildTypesEqual(blockTree, TreeType.NODE_STRING_VALUE, TreeType.TEXT_BLOCK);
     }
 
@@ -975,10 +1294,12 @@ public class TreeTypeTest {
     public void textBlock() {
         String empty = "\"\"\"\n\"\"\"";
         TokenTree emptyTree = getTree(TreeType.TEXT_BLOCK, empty);
+        assertTreeIsValid(emptyTree);
         rootAndChildTypesEqual(emptyTree, TreeType.TEXT_BLOCK, TreeType.TOKEN);
         
         String withQuotes = "\"\"\"\n\"\"foo\"\n\"\"bar\"\"\"";
         TokenTree withQuotesTree = getTree(TreeType.TEXT_BLOCK, withQuotes);
+        assertTreeIsValid(withQuotesTree);
         rootAndChildTypesEqual(withQuotesTree, TreeType.TEXT_BLOCK, TreeType.TOKEN);
 
     }
@@ -988,6 +1309,16 @@ public class TreeTypeTest {
         String actual = actualTree.getChildren().stream().map(t -> t.getType().toString()).collect(Collectors.joining(","));
         String expected = Arrays.stream(expectedChildren).map(Object::toString).collect(Collectors.joining(","));
         assertEquals(expected, actual);
+    }
+
+    private static void assertTreeIsValid(TokenTree tree) {
+        if (tree.getType() == TreeType.ERROR) {
+            Assertions.fail(() -> "Expected tree to be valid, but found error: " + tree);
+        } else {
+            for (TokenTree child : tree.getChildren()) {
+                assertTreeIsValid(child);
+            }
+        }
     }
 
     private static TokenTree getTree(TreeType type, String forText) {


### PR DESCRIPTION
All TreeTypeTests now expect the entire tree to be valid. This helps us find ambiguity and inconsistencies in the parser for cases when parsing a child tree is invalid only due to the context of the parent. Fixes minor bugs that caused trees to be invalid:
- enumMember test didn't have a BR after VALUE_ASSIGNMENT

Fills in missing tests for:
- Operations
- Block apply statements
- Entity type name
- Aggregate type name

Other minor changes and improvements:
- Adds util methods for parsing optional for-resource, mixins, and value assignment productions.
- Adds util method for parsing any shape type and name.
- Updates peekPastSpaces to not skip the current token, in case it is not SP. This simplifies parsing value assignments, and has more intuitive behavior.
- Removes peekPastWs, which was only used for TRAIT_BODY_VALUE, inlining the implementation. peekPastWs skipped the current token like peekPastSpaces, which is necessary for TRAIT_BODY_VALUE.
- Add ENTITY_TYPE_NAME production.
- Updates name of some productions to be consistent with grammar.
- Fixed a few places where TOKEN was parsed as IDENTIFIER.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
