### PR TITLE
Shade prettier4j in smithy-syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,9 +118,9 @@ subprojects {
     apply plugin: "signing"
     apply plugin: "com.github.johnrengelman.shadow"
 
-    // This is a little hacky, but currently needed to build a shadowed CLI JAR with the same customizations
-    // as other JARs.
-    if (project.name != "smithy-cli") {
+    // This is a little hacky, but currently needed to build a shadowed CLI JAR and smithy-syntax JAR with the same
+    // customizations as other JARs.
+    if (project.name != "smithy-cli" && project.name != "smithy-syntax") {
         tasks.shadowJar.enabled = false
     }
 

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation project(":smithy-model")
     implementation project(":smithy-build")
     implementation project(":smithy-diff")
-    implementation project(":smithy-syntax")
+    implementation project(path: ':smithy-syntax', configuration: 'shadow')
 
     // This is needed to ensure the above dependencies are added to the runtime image.
     shadow project(":smithy-model")

--- a/smithy-syntax/build.gradle
+++ b/smithy-syntax/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -24,4 +24,27 @@ dependencies {
     api project(":smithy-utils")
     api project(":smithy-model")
     implementation "com.opencastsoftware:prettier4j:0.1.1"
+
+    // This is needed to export these as dependencies since we aren't shading them.
+    shadow project(":smithy-model")
+    shadow project(":smithy-utils")
 }
+
+shadowJar {
+    // Replace the normal JAR with the shaded JAR. We don't want to publish a JAR that isn't shaded.
+    archiveClassifier = ''
+
+    mergeServiceFiles()
+
+    // Shade and relocate prettier4j.
+    relocate('com.opencastsoftware.prettier4j', 'software.amazon.smithy.syntax.shaded.prettier4j')
+
+    // Despite the "shadow" configuration under dependencies, we unfortunately need to also list here that
+    // smithy-model and smithy-utils aren't shaded. These are normal dependencies that we want consumers to resolve.
+    dependencies {
+        exclude(project(':smithy-utils'))
+        exclude(project(':smithy-model'))
+    }
+}
+
+tasks['jar'].finalizedBy(tasks['shadowJar'])


### PR DESCRIPTION
Testing:

(1) All code builds correctly using `./gradlew clean build :smithy-cli:integ`.

(2) Verified a single JAR is created by smithy-syntax:

```
❯ ls -l smithy-syntax/build/libs/
╭───┬───────────────────────────────────────────────────┬──────┬────────┬──────────┬───────────┬───────────┬───────────┬─────────┬───────┬──────────┬──────────────┬──────────────┬──────────────╮
│ # │                       name                        │ type │ target │ readonly │   mode    │ num_links │   inode   │   uid   │ group │   size   │   created    │   accessed   │   modified   │
├───┼───────────────────────────────────────────────────┼──────┼────────┼──────────┼───────────┼───────────┼───────────┼─────────┼───────┼──────────┼──────────────┼──────────────┼──────────────┤
│ 0 │ smithy-syntax/build/libs/smithy-syntax-1.32.0.jar │ file │        │ false    │ rw-r--r-- │         1 │ 105034396 │ dowling │ staff │ 118.0 KB │ a minute ago │ a minute ago │ a minute ago │
╰───┴───────────────────────────────────────────────────┴──────┴────────┴──────────┴───────────┴───────────┴───────────┴─────────┴───────┴──────────┴──────────────┴──────────────┴──────────────╯
```

(3) Verified that smithy-model and smithy-utils are not shaded in smithy-syntax:

```
❯ jar tf smithy-syntax/build/libs/smithy-syntax-1.32.0.jar | grep Model
❯ jar tf smithy-syntax/build/libs/smithy-syntax-1.32.0.jar | grep StringUtils
```

(4) Verified that smithy-syntax exports a dependency on smithy-model and smithy-utils in its POM:

```
❯ ./gradlew :smithy-syntax:generatePomFileForMavenJavaPublication
...
❯ cat smithy-syntax/build/publications/mavenJava/pom-default.xml
...
  <dependencies>
    <dependency>
      <groupId>software.amazon.smithy</groupId>
      <artifactId>smithy-model</artifactId>
      <version>1.32.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>software.amazon.smithy</groupId>
      <artifactId>smithy-utils</artifactId>
      <version>1.32.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
...
```

(5) Verified that the CLI's shaded JAR does not include smithy-syntax classes

```
❯ jar tf smithy-cli/build/libs/smithy-cli-1.32.0.jar | grep TokenTree
```

(6) Verified that the CLI does not include prettier4j

```
❯ jar tf smithy-cli/build/libs/smithy-cli-1.32.0.jar | grep Doc
```

(7) Verified that the CLI does not export a dependency on prettier4j, but does on smithy-syntax

```
❯ ./gradlew :smithy-cli:generatePomFileForMavenJavaPublication
❯ cat smithy-cli/build/publications/mavenJava/pom-default.xml
...
  <dependencies>
    <dependency>
      <groupId>software.amazon.smithy</groupId>
      <artifactId>smithy-model</artifactId>
      <version>1.32.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>software.amazon.smithy</groupId>
      <artifactId>smithy-build</artifactId>
      <version>1.32.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>software.amazon.smithy</groupId>
      <artifactId>smithy-diff</artifactId>
      <version>1.32.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>software.amazon.smithy</groupId>
      <artifactId>smithy-syntax</artifactId>
      <version>1.32.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
...
```

(8) Make sure `smithy format` works with the CLI

```
❯ ./gradlew :smithy-cli:runtime
❯ smithy-cli/build/image/smithy-cli-darwin-aarch64/bin/smithy format ~/projects/smithy-demo-model/model/main.smithy
(exited 200)
```
