### PR TITLE
Update stale docs around MissingPaginatedTrait

### DIFF
--- a/docs/source-2.0/guides/model-linters.rst
+++ b/docs/source-2.0/guides/model-linters.rst
@@ -642,14 +642,16 @@ Configuration
            indicate that an operation MUST be paginated. A ``DANGER`` event
            is emitted if an operation is found to have an input member name
            that case-insensitively matches one of these member names.
-           Defaults to ``["maxResults", "pageSize", "limit", "nextToken", "pageToken", "token"]``
+           Defaults to ``["maxresults", "maxitems", "pagesize", "limit",
+           "nexttoken", "pagetoken", "token", "marker"]``
        * - outputMembersRequirePagination
          - [``string``]
          - Defines the case-insensitive operation output member names that
            indicate that an operation MUST be paginated. A ``DANGER`` event
            is emitted if an operation is found to have an output member name
            that case-insensitively matches one of these member names.
-           Defaults to ``["nextToken", "pageToken", "token", "marker", "nextPage"]``.
+           Defaults to ``["nexttoken", "pagetoken", "token", "marker", "nextpage", "nextpagetoken", "position", "nextmarker",
+           "paginationtoken", "nextpagemarker"]``.
 
 Example:
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/smithy/pull/1764#issuecomment-1581372547

*Description of changes:*
Updated the 2.0 docs to reflect the newest default list of member names that indicate pagination is needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
