### PR TITLE
Recommend HTTP code SHOULD be between 200 and 299

### DIFF
--- a/docs/source-1.0/spec/core/http-traits.rst
+++ b/docs/source-1.0/spec/core/http-traits.rst
@@ -53,7 +53,7 @@ The ``http`` trait is a structure that supports the following members:
     * - code
       - ``integer``
       - The HTTP status code of a successful response. Defaults to ``200`` if
-        not provided. The provided value SHOULD be between 100 and 599, and
+        not provided. The provided value SHOULD be between 200 and 299, and
         it MUST be between 100 and 999. Status codes that do not allow a body
         like 204 and 205 SHOULD bind all output members to locations other than
         the body of the response.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update the spec to mention that HTTP code SHOULD be between 200 and 299. This aligns with the [validator's current implementation](https://github.com/awslabs/smithy/blob/c619a9a4a16f8cffbf4adcc06d32ecbe73ade669/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpResponseCodeSemanticsValidator.java#L55-L57) which throws a `danger`-level error when it's outside of this range. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
