### PR TITLE
Remove unused use statements and fix node parsing

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/Formatter.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/Formatter.java
@@ -29,6 +29,9 @@ import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Formats valid Smithy IDL models.
+ *
+ * <p>This formatter will by default sort use statements, remove unused use statements, and fix documentation
+ * comments that should be normal comments.
  */
 public final class Formatter {
 
@@ -63,6 +66,7 @@ public final class Formatter {
 
         root = new SortUseStatements().apply(root);
         root = new FixBadDocComments().apply(root);
+        root = new RemoveUnusedUseStatements().apply(root);
 
         // Strip trailing spaces from each line.
         String result = new TreeVisitor(maxWidth).visit(root.zipper()).render(maxWidth).trim();

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RemoveUnusedUseStatements.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RemoveUnusedUseStatements.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.syntax;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+final class RemoveUnusedUseStatements implements Function<TokenTree, TokenTree> {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoveUnusedUseStatements.class.getName());
+
+    @Override
+    public TokenTree apply(TokenTree tree) {
+        TreeCursor root = tree.zipper();
+        Map<String, TreeCursor> useShapeNames = parseShapeIds(root);
+
+        if (useShapeNames.isEmpty()) {
+            return tree;
+        }
+
+        // SHAPE_SECTION is always present at this point if there are detected use statements.
+        TreeCursor shapeStatements = Objects.requireNonNull(root.getFirstChild(TreeType.SHAPE_SECTION))
+                .getFirstChild(TreeType.SHAPE_STATEMENTS);
+
+        if (shapeStatements == null) {
+            return tree;
+        }
+
+        for (TreeCursor identifier : shapeStatements.findChildrenByType(TreeType.SHAPE_ID)) {
+            String name = identifier.getTree().concatTokens();
+
+            // Absolute shape IDs don't interact with use statements.
+            if (name.contains("#")) {
+                continue;
+            }
+
+            // Remove the member if found.
+            if (name.contains("$")) {
+                name = name.substring(0, name.indexOf("$"));
+            }
+
+            useShapeNames.remove(name);
+        }
+
+        // Anything left in the map needs to be removed from the tree.
+        for (TreeCursor unused : useShapeNames.values()) {
+            LOGGER.fine(() -> "Removing unused use statement: "
+                              + unused.getFirstChild(TreeType.ABSOLUTE_ROOT_SHAPE_ID)
+                                      .getTree().concatTokens());
+            unused.getParent().getTree().removeChild(unused.getTree());
+        }
+
+        return tree;
+    }
+
+    // Create a map of shape name to the TreeCursor of the use statement.
+    private Map<String, TreeCursor> parseShapeIds(TreeCursor root) {
+        List<TreeCursor> useStatements = Optional.ofNullable(root.getFirstChild(TreeType.SHAPE_SECTION))
+                .flatMap(shapeSection -> Optional.ofNullable(shapeSection.getFirstChild(TreeType.USE_SECTION)))
+                .map(useSection -> useSection.getChildrenByType(TreeType.USE_STATEMENT))
+                .orElse(Collections.emptyList());
+
+        Map<String, TreeCursor> result = new HashMap<>(useStatements.size());
+        for (TreeCursor useStatement : useStatements) {
+            TreeCursor idCursor = useStatement.getFirstChild(TreeType.ABSOLUTE_ROOT_SHAPE_ID);
+            if (idCursor != null) {
+                result.put(ShapeId.from(idCursor.getTree().concatTokens()).getName(), useStatement);
+            }
+        }
+
+        return result;
+    }
+}

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeType.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeType.java
@@ -831,7 +831,7 @@ public enum TreeType {
                         break;
                     case IDENTIFIER:
                     default:
-                        IDENTIFIER.parse(tokenizer);
+                        SHAPE_ID.parse(tokenizer);
                 }
             });
         }

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeTypeTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeTypeTest.java
@@ -1270,7 +1270,7 @@ public class TreeTypeTest {
         String identifier = "foo";
         TokenTree idTree = getTree(TreeType.NODE_STRING_VALUE, identifier);
         assertTreeIsValid(idTree);
-        rootAndChildTypesEqual(idTree, TreeType.NODE_STRING_VALUE, TreeType.IDENTIFIER);
+        rootAndChildTypesEqual(idTree, TreeType.NODE_STRING_VALUE, TreeType.SHAPE_ID);
 
         /*
          TODO: Right now grammar is ambiguous, no way to tell if its an identifier or shape id.

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.formatted.smithy
@@ -115,4 +115,15 @@ structure MyStruct {
     // g
     // h
 } // i
+
 // j
+structure MyStructure2 {
+    // k
+    // l
+    i: Integer
+
+    l: Long
+
+    // m
+} // n
+// o

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.smithy
@@ -84,3 +84,10 @@ structure MyStruct // a
     // h
 } // i
 // j
+
+structure MyStructure2 { //k
+    // l
+    i: Integer
+    l: Long // m
+} // n
+// o

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/remove-unusued-use.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/remove-unusued-use.formatted.smithy
@@ -1,0 +1,19 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Integer
+use smithy.api#String
+use smithy.api#range
+use smithy.api#required
+use smithy.api#sensitive
+
+structure Foo {
+    @required
+    // this is strange, but resolve to the full ID
+    @documentation(Integer)
+    a: String
+
+    @tags([sensitive, range$min, smithy.api#Long, smithy.api#Short])
+    b: String
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/remove-unusued-use.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/remove-unusued-use.smithy
@@ -1,0 +1,27 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Boolean
+use smithy.api#Document
+use smithy.api#Integer
+use smithy.api#Long
+use smithy.api#String
+use smithy.api#range
+use smithy.api#required
+use smithy.api#sensitive
+
+structure Foo {
+    @required
+    // this is strange, but resolve to the full ID
+    @documentation(Integer)
+    a: String
+
+    @tags([
+        sensitive
+        range$min
+        smithy.api#Long
+        smithy.api#Short
+    ])
+    b: String
+}


### PR DESCRIPTION
Node string values should parse as a SHAPE_ID not as an IDENTIFIER.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
