### PR TITLE
Fix ends with selector example

### DIFF
--- a/docs/source-1.0/spec/core/selectors.rst
+++ b/docs/source-1.0/spec/core/selectors.rst
@@ -247,7 +247,7 @@ performed.
 
         .. code-block:: none
 
-            [trait|required $= '_']
+            [id|name $= '_']
     * - ``*=``
       - Matches if the attribute value contains the comparison value.
         This comparator never matches if either value does not exist.

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -248,7 +248,7 @@ performed.
 
         .. code-block:: none
 
-            [trait|required $= '_']
+            [id|name $= '_']
     * - ``*=``
       - Matches if the attribute value contains the comparison value.
         This comparator never matches if either value does not exist.


### PR DESCRIPTION
Fixes examples for `*=` string comparator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
