### PR TITLE
Add templates listing to smithy init command

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -62,8 +62,20 @@ public class InitCommandTest {
             IntegUtils.withTempDir("unexpectedTemplate", dir -> {
                 RunResult result = IntegUtils.run(
                     dir, ListUtils.of("init", "-t", "blabla", "-u", templatesDir.toString()));
-                assertThat(result.getOutput(),
-                    containsString("Missing expected member `blabla` from `templates` object ([3, 18])"));
+
+                String expectedOutput = new StringBuilder()
+                        .append("Invalid template `blabla`. `Smithy-Examples` provides the following templates:")
+                        .append(System.lineSeparator())
+                        .append(System.lineSeparator())
+                        .append("NAME             DOCUMENTATION")
+                        .append(System.lineSeparator())
+                        .append("--------------   ---------------------------------------------------------------")
+                        .append(System.lineSeparator())
+                        .append("quickstart-cli   Smithy Quickstart example weather service using the Smithy CLI.")
+                        .append(System.lineSeparator())
+                        .toString();
+
+                assertThat(result.getOutput(), containsString(expectedOutput));
                 assertThat(result.getExitCode(), is(1));
             });
         });
@@ -82,6 +94,15 @@ public class InitCommandTest {
                 assertThat(result.getExitCode(), is(0));
                 assertThat(Files.exists(Paths.get(dir.toString(), "hello-world")), is(true));
             });
+
+            IntegUtils.withTempDir("withNestedDirectoryArg", dir -> {
+                RunResult result = IntegUtils.run(dir, ListUtils.of(
+                    "init", "-t", "quickstart-cli", "-o", "./hello/world", "-u", templatesDir.toString()));
+                assertThat(result.getOutput(),
+                    containsString("Smithy project created in directory: ./hello/world"));
+                assertThat(result.getExitCode(), is(0));
+                assertThat(Files.exists(Paths.get(dir.toString(), "./hello/world")), is(true));
+            });
         });
     }
 
@@ -98,6 +119,30 @@ public class InitCommandTest {
                         containsString("Smithy project created in directory: hello-world"));
                 assertThat(result.getExitCode(), is(0));
                 assertThat(Files.exists(Paths.get(dir.toString(), "hello-world")), is(true));
+            });
+        });
+    }
+
+    @Test
+    public void withListArg() {
+        IntegUtils.withProject(PROJECT_NAME, templatesDir -> {
+            setupTemplatesDirectory(templatesDir);
+
+            IntegUtils.withTempDir("withListArg", dir -> {
+                RunResult result = IntegUtils.run(dir, ListUtils.of(
+                    "init", "--list", "--url", templatesDir.toString()));
+
+                String expectedOutput = new StringBuilder()
+                    .append("NAME             DOCUMENTATION")
+                    .append(System.lineSeparator())
+                    .append("--------------   ---------------------------------------------------------------")
+                    .append(System.lineSeparator())
+                    .append("quickstart-cli   Smithy Quickstart example weather service using the Smithy CLI.")
+                    .append(System.lineSeparator())
+                    .toString();
+
+                assertThat(result.getOutput(), containsString(expectedOutput));
+                assertThat(result.getExitCode(), is(0));
             });
         });
     }


### PR DESCRIPTION
*Description of changes:*
* Add templates listing to smithy init command
* Allow copying templates to nested output directory in smithy init command

*Testing:*
* `smithy init --template quickstart-cli --output hello/world`
* `smithy init --template quickstart-cli --output ./hello/world`
* `smithy init --template quickstart-cli --output /Volume/workspace/hello/world`
* `smithy init --list`

Output:
```
NAME                           DOCUMENTATION
----------------------------   ----------------------------------------------------------------------------------
custom-annotation-trait        Gradle project for creating a package for a custom annotation trait.              
quickstart-cli                 Smithy Quickstart example weather service using the Smithy CLI.                   
custom-string-trait            Gradle project for creating a package for a custom string trait.                  
common-shapes                  Common package for sharing shapes between multiple Smithy projects.               
custom-linter                  Gradle project for creating a package for a custom Smithy linter                  
filter-internal-projection     Projection that filters out internal shapes and traits.                           
codegen-starter                Directed-codegen plugin that generates simple POJOs.                              
common-linting-configuration   Common package for sharing linting configuration between multiple Smithy projects.
custom-validator               Gradle project for creating a package for a custom Smithy validator.              
custom-structure-trait         Gradle project for creating a package for a custom structure trait.               
quickstart-gradle              Smithy Quickstart example weather service using the Smithy-Gradle-Plugin.         
openapi-conversion             Generates an OpenAPI spec from a Smithy model
```

* `smithy init -t invalid-template`

```
Invalid template `invalid-template`. `Smithy-Examples` provides the following templates:

NAME                           DOCUMENTATION
----------------------------   ----------------------------------------------------------------------------------
custom-annotation-trait        Gradle project for creating a package for a custom annotation trait.              
quickstart-cli                 Smithy Quickstart example weather service using the Smithy CLI.                   
custom-string-trait            Gradle project for creating a package for a custom string trait.                  
common-shapes                  Common package for sharing shapes between multiple Smithy projects.               
custom-linter                  Gradle project for creating a package for a custom Smithy linter                  
filter-internal-projection     Projection that filters out internal shapes and traits.                           
codegen-starter                Directed-codegen plugin that generates simple POJOs.                              
common-linting-configuration   Common package for sharing linting configuration between multiple Smithy projects.
custom-validator               Gradle project for creating a package for a custom Smithy validator.              
custom-structure-trait         Gradle project for creating a package for a custom structure trait.               
quickstart-gradle              Smithy Quickstart example weather service using the Smithy-Gradle-Plugin.         
openapi-conversion             Generates an OpenAPI spec from a Smithy model 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
