### PR TITLE
Add a note about how constraint traits affect backward compatibility

### DIFF
--- a/docs/source-2.0/guides/evolving-models.rst
+++ b/docs/source-2.0/guides/evolving-models.rst
@@ -93,6 +93,8 @@ The following changes to a structure are not backward-compatible:
    with the :ref:`clientOptional-trait`.
 #. Removing the :ref:`clientOptional-trait` from a member that is marked as
    ``required``.
+#. Adding or updating :ref:`constraint traits <constraint-traits>`
+   that further restricts the allowed values of a member.
 
 
 Booleans and API evolution
@@ -100,8 +102,8 @@ Booleans and API evolution
 
 A boolean shape is often used to model state flags; however, consider whether
 or not the state of a resource is actually binary. If other states can be
-added in the future, it is often better to use a string shape with an
-:ref:`enum-trait` or a union shape.
+added in the future, it is often better to use a :ref:`enum shape <enum>`
+or a :ref:`union shape <union>`.
 
 
 Updating unions


### PR DESCRIPTION
*Issue #, if available:* #1775

*Description of changes:*

Added a note to the evolving models document to note that adding or updating constraint traits is not backwards compatible. While there, fix the docs to point to enum shapes instead of mentioning the deprecated `enum` traits.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
