### PR TITLE
(doc): Minor rephrase for Timestamp description.

### DIFF
--- a/docs/source-1.0/spec/core/protocol-traits.rst
+++ b/docs/source-1.0/spec/core/protocol-traits.rst
@@ -303,7 +303,7 @@ Smithy defines the following built-in timestamp formats:
     * - date-time
       - Date time as defined by the ``date-time`` production in
         `RFC3339 section 5.6 <https://www.rfc-editor.org/rfc/rfc3339#section-5.6>`_
-        with no UTC offset and optional fractional precision (for example,
+        with optional fractional precision but no UTC offset (for example,
         ``1985-04-12T23:20:50.52Z``).
         *However*, offsets are parsed gracefully, but the datetime is normalized
         to an offset of zero by converting to UTC.

--- a/docs/source-2.0/spec/model.rst
+++ b/docs/source-2.0/spec/model.rst
@@ -789,8 +789,8 @@ target from traits and how their values are defined in
       - number | string
       - If a number is provided, it represents Unix epoch seconds with optional
         millisecond precision. If a string is provided, it MUST be a valid
-        :rfc:`3339` string with no UTC offset and optional fractional
-        precision (for example, ``1985-04-12T23:20:50.52Z``).
+        :rfc:`3339` string with optional fractional precision but no UTC offset 
+        (for example, ``1985-04-12T23:20:50.52Z``).
     * - list
       - array
       - Each value in the array MUST be compatible with the targeted member.

--- a/docs/source-2.0/spec/protocol-traits.rst
+++ b/docs/source-2.0/spec/protocol-traits.rst
@@ -219,7 +219,7 @@ Smithy defines the following built-in timestamp formats:
     * - date-time
       - Date time as defined by the ``date-time`` production in
         :rfc:`3339#section-5.6`
-        with no UTC offset and optional fractional precision (for example,
+        with optional fractional precision but no UTC offset (for example,
         ``1985-04-12T23:20:50.52Z``).
         *However*, offsets are parsed gracefully, but the datetime is normalized
         to an offset of zero by converting to UTC.


### PR DESCRIPTION
*Issue #, if available:*

Minor timestamp description update. 

*Description of changes:*

The description was slightly confusing as I thought it was no (UTC offset and fractional milliseconds) instead of (no UTC) and (fractional milliseconds). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
