### PR TITLE
Fix basic HTTP authentication when resolving dependencies

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation "org.apache.maven.resolver:maven-resolver-transport-file:1.9.2"
     implementation "org.apache.maven.resolver:maven-resolver-transport-http:1.9.2"
     implementation "org.slf4j:slf4j-jdk14:1.7.36" // Route slf4j used by Maven through JUL like the rest of Smithy.
+
+    testImplementation "org.mock-server:mockserver-netty:3.10.8"
 }
 
 // ------ Shade Maven dependency resolvers into the JAR. -------

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -229,7 +229,7 @@ public class MavenResolverTest {
                                      ListUtils.of("validate", "--debug", "model"),
                                      MapUtils.of(EnvironmentVariable.SMITHY_MAVEN_REPOS.toString(), repo),
                                      result -> {
-            assertThat(result.getOutput(), containsString("with xxx=****"));
+            assertThat(result.getOutput(), containsString("username=xxx, password=***"));
             assertThat(result.getExitCode(), equalTo(1));
         });
     }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -75,7 +75,7 @@ public class MavenResolverTest {
                             .request()
                             .withMethod("GET")
                             .withHeader("Authorization", "Basic eHh4Onl5eQ==")
-                            .withPath("/maven/not/there/software/amazon/smithy/smithy-aws-iam-traits/.*\\." + "jar")
+                            .withPath("/maven/not/there/software/amazon/smithy/smithy-aws-iam-traits/.*\\.jar")
             ).respond(
                     HttpResponse
                             .response()
@@ -99,8 +99,6 @@ public class MavenResolverTest {
                         assertThat(result.getExitCode(), equalTo(1));
                         assertThat(result.getOutput(), containsString("HttpAuthenticator - Selected authentication options: [BASIC [complete=true]]"));
                         assertThat(result.getOutput(), containsString("HttpAuthenticator - Authentication succeeded"));
-
-                        System.err.println(result.getOutput());
                     });
         } finally {
             if(mockServer!=null) {

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-auth/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-auth/smithy-build.json
@@ -3,7 +3,8 @@
     "maven": {
         "repositories": [
             {
-                "url": "https://localhost:1234/maven/not/there",
+                // Use HTTP instead of HTTPS because we're running a mock server during tests
+                "url": "http://localhost:1234/maven/not/there",
                 "httpCredentials": "xxx:yyy"
             }
         ],

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
@@ -23,8 +23,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Logger;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -36,9 +34,6 @@ import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.eclipse.aether.repository.Authentication;
-import org.eclipse.aether.repository.AuthenticationContext;
-import org.eclipse.aether.repository.AuthenticationDigest;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -49,8 +44,8 @@ import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import software.amazon.smithy.build.model.MavenRepository;
-import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Resolves Maven dependencies for the Smithy CLI using Maven resolvers.
@@ -121,7 +116,12 @@ public final class MavenDependencyResolver implements DependencyResolver {
         if (parts.length != 2) {
             throw new DependencyResolverException("Invalid credentials provided for " + uri);
         }
-        builder.setAuthentication(new MavenAuth(parts[0], parts[1]));
+        builder.setAuthentication(
+            new AuthenticationBuilder()
+                .addUsername(parts[0])
+                .addPassword(parts[1])
+                .build()
+        );
     }
 
     @Override
@@ -188,53 +188,6 @@ public final class MavenDependencyResolver implements DependencyResolver {
             return results;
         } catch (DependencyResolutionException e) {
             throw new DependencyResolverException(e);
-        }
-    }
-
-    /**
-     * Based on Maven's StringAuthentication. There doesn't appear to be another way to do this.
-     */
-    private static final class MavenAuth implements Authentication {
-        private final String key;
-        private final String value;
-
-        private MavenAuth(String key, String value) {
-            if (StringUtils.isEmpty(key)) {
-                throw new IllegalArgumentException("Authentication key must be provided");
-            }
-            this.key = key;
-            this.value = value;
-        }
-
-        @Override
-        public void fill(AuthenticationContext context, String key, Map<String, String> data) {
-            context.put(this.key, value);
-        }
-
-        @Override
-        public void digest(AuthenticationDigest digest) {
-            digest.update(key, value);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            } else if (obj == null || !getClass().equals(obj.getClass())) {
-                return false;
-            }
-            MavenAuth that = (MavenAuth) obj;
-            return Objects.equals(key, that.key) && Objects.equals(value, that.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(key, value);
-        }
-
-        @Override
-        public String toString() {
-            return key + "=****";
         }
     }
 }


### PR DESCRIPTION
*Issue #1837 *

*Description of changes:*
Fixes broken http authentication.

Replace `MavenAuth` with existing aether builder to configure the repository auth context.
Modify the auth test to use a mock server to actually run the authentication flow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
