### PR TITLE
Fixes the fix for duplicate ChangedNullability events

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
@@ -97,32 +97,32 @@ public class ChangedNullability extends AbstractDiffEvaluator {
         boolean newHasInput = hasInputTrait(differences.getNewModel(), newMember);
         ShapeId shape = change.getShapeId();
         Shape newTarget = differences.getNewModel().expectShape(newMember.getTarget());
-        int currentEventSize = events.size();
+        List<ValidationEvent> eventsToAdd = new ArrayList<>();
 
         if (oldHasInput && !newHasInput) {
             // If there was an input trait before, but not now, then the nullability must have
             // changed from nullable to non-nullable.
-            events.add(emit(Severity.ERROR, "RemovedInputTrait", shape, message,
+            eventsToAdd.add(emit(Severity.ERROR, "RemovedInputTrait", shape, message,
                             "The @input trait was removed from " + newMember.getContainer()));
         } else if (!oldHasInput && newHasInput) {
             // If there was no input trait before, but there is now, then the nullability must have
             // changed from non-nullable to nullable.
-            events.add(emit(Severity.DANGER, "AddedInputTrait", shape, message,
+            eventsToAdd.add(emit(Severity.DANGER, "AddedInputTrait", shape, message,
                             "The @input trait was added to " + newMember.getContainer()));
         } else if (!newHasInput) {
             // Can't add nullable to a preexisting required member.
             if (change.isTraitAdded(ClientOptionalTrait.ID) && change.isTraitInBoth(RequiredTrait.ID)) {
-                events.add(emit(Severity.ERROR, "AddedNullableTrait", shape, message,
+                eventsToAdd.add(emit(Severity.ERROR, "AddedNullableTrait", shape, message,
                                 "The @nullable trait was added to a @required member."));
             }
             // Can't add required to a member unless the member is marked as nullable.
             if (change.isTraitAdded(RequiredTrait.ID) && !newMember.hasTrait(ClientOptionalTrait.ID)) {
-                events.add(emit(Severity.ERROR, "AddedRequiredTrait", shape, message,
+                eventsToAdd.add(emit(Severity.ERROR, "AddedRequiredTrait", shape, message,
                                 "The @required trait was added to a member that is not marked as @nullable."));
             }
             // Can't add the default trait to a member unless the member was previously required.
             if (change.isTraitAdded(DefaultTrait.ID) && !change.isTraitRemoved(RequiredTrait.ID)) {
-                events.add(emit(Severity.ERROR, "AddedDefaultTrait", shape, message,
+                eventsToAdd.add(emit(Severity.ERROR, "AddedDefaultTrait", shape, message,
                                 "The @default trait was added to a member that was not previously @required."));
             }
             // Can only remove the required trait if the member was nullable or replaced by the default trait.
@@ -130,12 +130,12 @@ public class ChangedNullability extends AbstractDiffEvaluator {
                     && !newMember.hasTrait(DefaultTrait.ID)
                     && !oldMember.hasTrait(ClientOptionalTrait.ID)) {
                 if (newTarget.isStructureShape() || newTarget.isUnionShape()) {
-                    events.add(emit(Severity.WARNING, "RemovedRequiredTrait.StructureOrUnion", shape, message,
-                                    "The @required trait was removed from a member that targets a "
+                    eventsToAdd.add(emit(Severity.WARNING, "RemovedRequiredTrait.StructureOrUnion", shape,
+                                    message, "The @required trait was removed from a member that targets a "
                                     + newTarget.getType() + ". This is backward compatible in generators that "
                                     + "always treat structures and unions as optional (e.g., AWS generators)"));
                 } else {
-                    events.add(emit(Severity.ERROR, "RemovedRequiredTrait", shape, message,
+                    eventsToAdd.add(emit(Severity.ERROR, "RemovedRequiredTrait", shape, message,
                                     "The @required trait was removed and not replaced with the @default trait and "
                                     + "@addedDefault trait."));
                 }
@@ -143,9 +143,11 @@ public class ChangedNullability extends AbstractDiffEvaluator {
         }
 
         // If not specific event was emitted, emit a generic event.
-        if (events.size() == currentEventSize) {
-            events.add(emit(Severity.ERROR, null, shape, null, message));
+        if (eventsToAdd.isEmpty()) {
+            eventsToAdd.add(emit(Severity.ERROR, null, shape, null, message));
         }
+
+        events.addAll(eventsToAdd);
     }
 
     private boolean hasInputTrait(Model model, MemberShape member) {

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedNullabilityTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedNullabilityTest.java
@@ -208,6 +208,9 @@ public class ChangedNullabilityTest {
                            .filter(event -> event.getId().equals("ChangedNullability.AddedInputTrait"))
                            .filter(event -> event.getMessage().contains("The @input trait was added to"))
                            .count(), equalTo(1L));
+        assertThat(events.stream()
+                            .filter(event -> event.getId().contains("ChangedNullability"))
+                            .count(), equalTo(1L));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous bugfix PR https://github.com/awslabs/smithy/pull/1806/files was incomplete as it turns out. Because of the deduping logic, when the second instance of the same event would have been added, nothing happens (this is intentional). However this ends up triggering the fallback codepath that emits a generic event when it thinks no more-specific event was emitted. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
