### PR TITLE
Map `@httpPayload` of list & map shapes to the document content type

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -369,7 +369,8 @@ public final class HttpBindingIndex implements KnowledgeIndex {
                     break;
                 } else if (StreamingTrait.isEventStream(target)) {
                     return eventStreamContentType;
-                } else if (target.isDocumentShape() || target.isStructureShape() || target.isUnionShape()) {
+                } else if (target.isDocumentShape() || target.isStructureShape() || target.isUnionShape()
+                        || target.isListShape() || target.isMapShape()) {
                     // Document type and structure targets are always the document content-type.
                     return documentContentType;
                 } else if (target.getTrait(MediaTypeTrait.class).isPresent()) {


### PR DESCRIPTION
*Description of changes:*
Matches behavior as documented on the [`@httpPayload` trait serialization rules](https://github.com/awslabs/smithy/blob/98dce46e0622eba4a294444228c171b9d9194885/docs/source-2.0/spec/http-bindings.rst#httppayload-trait:~:text=httpPrefixHeaders%2Dtrait%60.-,Serialization%20rules,-When%20a%20string).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
