### PR TITLE
Add default template

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -34,23 +34,30 @@ public class InitCommandTest {
     }
 
     @Test
-    public void missingTemplate() {
+    public void usesDefaultTemplate() {
         IntegUtils.withProject(PROJECT_NAME, templatesDir -> {
             setupTemplatesDirectory(templatesDir);
 
-            IntegUtils.withTempDir("missingTemplate", dir -> {
+            IntegUtils.withTempDir("defaultTemplate", dir -> {
                 RunResult result = IntegUtils.run(
-                    dir, ListUtils.of("init", "-u", templatesDir.toString()));
+                        dir, ListUtils.of("init", "-u", templatesDir.toString()));
                 assertThat(result.getOutput(),
-                    containsString("Please specify a template using `--template` or `-t`"));
-                assertThat(result.getExitCode(), is(1));
+                        containsString("Smithy project created in directory: quickstart-cli"));
+                assertThat(result.getExitCode(), is(0));
             });
+        });
+    }
+
+    @Test
+    public void missingTemplate() {
+        IntegUtils.withProject(PROJECT_NAME, templatesDir -> {
+            setupTemplatesDirectory(templatesDir);
 
             IntegUtils.withTempDir("emptyTemplateName", dir -> {
                 RunResult result = IntegUtils.run(
                     dir, ListUtils.of("init", "-t", "", "-u", templatesDir.toString()));
                 assertThat(result.getOutput(),
-                    containsString("Please specify a template using `--template` or `-t`"));
+                    containsString("Please specify a template name using `--template` or `-t`"));
                 assertThat(result.getExitCode(), is(1));
             });
         });

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -156,6 +156,10 @@ final class InitCommand implements Command {
     private void cloneTemplate(Path temp, ObjectNode smithyTemplatesNode, String template, String directory, Env env)
             throws IOException, InterruptedException, URISyntaxException {
 
+        if (template == null || template.isEmpty()) {
+            throw new IllegalArgumentException("Please specify a template name using `--template` or `-t`");
+        }
+
         ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);
         if (!templatesNode.containsMember(template)) {
             throw new IllegalArgumentException(String.format(

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -44,7 +44,7 @@ import software.amazon.smithy.utils.ListUtils;
 final class InitCommand implements Command {
     private static final String SMITHY_TEMPLATE_JSON = "smithy-templates.json";
     private static final String DEFAULT_REPOSITORY_URL = "https://github.com/smithy-lang/smithy-examples.git";
-
+    private static final String DEFAULT_TEMPLATE_NAME = "quickstart-cli";
     private static final String DOCUMENTATION = "documentation";
 
     private static final String NAME = "name";
@@ -155,10 +155,6 @@ final class InitCommand implements Command {
 
     private void cloneTemplate(Path temp, ObjectNode smithyTemplatesNode, String template, String directory, Env env)
             throws IOException, InterruptedException, URISyntaxException {
-
-        if (template == null || template.isEmpty()) {
-            throw new IllegalArgumentException("Please specify a template using `--template` or `-t`");
-        }
 
         ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);
         if (!templatesNode.containsMember(template)) {
@@ -275,7 +271,7 @@ final class InitCommand implements Command {
     }
 
     private static final class Options implements ArgumentReceiver {
-        private String template;
+        private String template = DEFAULT_TEMPLATE_NAME;
         private String directory;
         private Boolean listTemplates = false;
         private String repositoryUrl = DEFAULT_REPOSITORY_URL;


### PR DESCRIPTION
*Description of changes:*
Makes the `quickstart-cli` example ([here](https://github.com/smithy-lang/smithy-examples/tree/main/quickstart-examples/quickstart-cli)) the default example template. 
This allows customers to call `smithy init` with no`-t` or `--template` flag.

*Testing*: 
Executed `smithy init` with no `-t` flag using locally build CLI. Confirmed `quickstart-cli` folder was created and builds correctly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
