### PR TITLE
Remove fractional seconds from http-date

### DIFF
--- a/docs/source-1.0/spec/core/protocol-traits.rst
+++ b/docs/source-1.0/spec/core/protocol-traits.rst
@@ -310,10 +310,7 @@ Smithy defines the following built-in timestamp formats:
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,
-        ``Tue, 29 Apr 2014 18:30:38 GMT``). Note that in addition to the
-        ``IMF-fixdate`` format specified in the RFC, implementations MUST
-        also support optional fractional seconds (for example,
-        ``Sun, 02 Jan 2000 20:34:56.000 GMT``).
+        ``Tue, 29 Apr 2014 18:30:38 GMT``).
     * - epoch-seconds
       - Also known as Unix time, the number of seconds that have elapsed since
         00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970,

--- a/docs/source-2.0/spec/protocol-traits.rst
+++ b/docs/source-2.0/spec/protocol-traits.rst
@@ -226,10 +226,7 @@ Smithy defines the following built-in timestamp formats:
     * - http-date
       - An HTTP date as defined by the ``IMF-fixdate`` production in
         :rfc:`7231#section-7.1.1.1` (for example,
-        ``Tue, 29 Apr 2014 18:30:38 GMT``). Note that in addition to the
-        ``IMF-fixdate`` format specified in the RFC, implementations MUST
-        also support optional fractional seconds (for example,
-        ``Sun, 02 Jan 2000 20:34:56.000 GMT``).
+        ``Tue, 29 Apr 2014 18:30:38 GMT``).
     * - epoch-seconds
       - Also known as Unix time, the number of seconds that have elapsed since
         00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970,

--- a/smithy-aws-protocol-tests/model/awsJson1_1/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/fractional-seconds.smithy
@@ -4,11 +4,9 @@ namespace aws.protocoltests.json
 
 use aws.protocols#awsJson1_1
 use aws.protocoltests.shared#DateTime
-use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
-// These tests are for verifying the client can correctly parse
-// the `DateTime` and `HttpDate` timestamps with fractional seconds
+// These tests verify that clients can parse `DateTime` timestamps with fractional seconds.
 @tags(["client-only"])
 operation FractionalSeconds {
     output: FractionalSecondsOutput
@@ -33,29 +31,9 @@ apply FractionalSeconds @httpResponseTests([
             "Content-Type": "application/x-amz-json-1.1"
         },
         appliesTo: "client"
-    },
-    {
-        id: "AwsJson11HttpDateWithFractionalSeconds",
-        documentation: """
-        Ensures that clients can correctly parse http-date timestamps with fractional seconds""",
-        protocol: awsJson1_1,
-        code: 200,
-        body:
-        """
-              {
-                  "httpdate": "Sun, 02 Jan 2000 20:34:56.456 GMT"
-              }
-        """,
-        params: { httpdate: 946845296.456 }
-        bodyMediaType: "application/json",
-        headers: {
-            "Content-Type": "application/x-amz-json-1.1"
-        },
-        appliesTo: "client"
     }
 ])
 
 structure FractionalSecondsOutput {
     datetime: DateTime
-    httpdate: HttpDate
 }

--- a/smithy-aws-protocol-tests/model/awsQuery/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/fractional-seconds.smithy
@@ -4,11 +4,9 @@ namespace aws.protocoltests.query
 
 use aws.protocols#awsQuery
 use aws.protocoltests.shared#DateTime
-use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
-// These tests are for verifying the client can correctly parse
-// the `DateTime` and `HttpDate` timestamps with fractional seconds
+// These tests verify that clients can parse `DateTime` timestamps with fractional seconds.
 @tags(["client-only"])
 operation FractionalSeconds {
     output: FractionalSecondsOutput
@@ -35,29 +33,8 @@ apply FractionalSeconds @httpResponseTests([
         },
         appliesTo: "client"
     }
-    {
-        id: "AwsQueryHttpDateWithFractionalSeconds",
-        documentation: """
-        Ensures that clients can correctly parse http-date timestamps with fractional seconds""",
-        protocol: awsQuery,
-        code: 200,
-        body: """
-              <FractionalSecondsResponse xmlns="https://example.com/">
-                  <FractionalSecondsResult>
-                      <httpdate>Sun, 02 Jan 2000 20:34:56.456 GMT</httpdate>
-                  </FractionalSecondsResult>
-              </FractionalSecondsResponse>
-              """,
-        params: { httpdate: 946845296.456 }
-        bodyMediaType: "application/xml",
-        headers: {
-            "Content-Type": "text/xml"
-        },
-        appliesTo: "client"
-    }
 ])
 
 structure FractionalSecondsOutput {
     datetime: DateTime
-    httpdate: HttpDate
 }

--- a/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
@@ -4,11 +4,9 @@ namespace aws.protocoltests.ec2
 
 use aws.protocols#ec2Query
 use aws.protocoltests.shared#DateTime
-use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
-// These tests are for verifying the client can correctly parse
-// the `DateTime` and `HttpDate` timestamps with fractional seconds
+// These tests verify that clients can parse `DateTime` timestamps with fractional seconds.
 @tags(["client-only"])
 operation FractionalSeconds {
     output: FractionalSecondsOutput
@@ -32,28 +30,9 @@ apply FractionalSeconds @httpResponseTests([
             "Content-Type": "text/xml;charset=UTF-8"
         },
         params: { datetime: 946845296.123 }
-    },
-    {
-        id: "Ec2QueryHttpDateWithFractionalSeconds",
-        documentation: """
-        Ensures that clients can correctly parse http-date timestamps with fractional seconds""",
-        protocol: ec2Query,
-        code: 200,
-        body: """
-              <FractionalSecondsResponse xmlns="https://example.com/">
-                  <httpdate>Sun, 02 Jan 2000 20:34:56.456 GMT</httpdate>
-                  <RequestId>requestid</RequestId>
-              </FractionalSecondsResponse>
-              """,
-        bodyMediaType: "application/xml",
-        headers: {
-            "Content-Type": "text/xml;charset=UTF-8"
-        },
-        params: { httpdate: 946845296.456 }
     }
 ])
 
 structure FractionalSecondsOutput {
     datetime: DateTime
-    httpdate: HttpDate
 }

--- a/smithy-aws-protocol-tests/model/restJson1/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/fractional-seconds.smithy
@@ -4,11 +4,9 @@ namespace aws.protocoltests.restjson
 
 use aws.protocols#restJson1
 use aws.protocoltests.shared#DateTime
-use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
-// These tests are for verifying the client can correctly parse
-// the `DateTime` and `HttpDate` timestamps with fractional seconds
+// These tests verify that clients can parse `DateTime` timestamps with fractional seconds.
 @tags(["client-only"])
 @http(uri: "/FractionalSeconds", method: "POST")
 operation FractionalSeconds {
@@ -31,26 +29,9 @@ apply FractionalSeconds @httpResponseTests([
         params: { datetime: 946845296.123 }
         bodyMediaType: "application/json",
         appliesTo: "client"
-    },
-    {
-        id: "RestJsonHttpDateWithFractionalSeconds",
-        documentation: """
-        Ensures that clients can correctly parse http-date timestamps with fractional seconds""",
-        protocol: restJson1,
-        code: 200,
-        body:
-        """
-              {
-                  "httpdate": "Sun, 02 Jan 2000 20:34:56.456 GMT"
-              }
-        """,
-        params: { httpdate: 946845296.456 }
-        bodyMediaType: "application/json",
-        appliesTo: "client"
     }
 ])
 
 structure FractionalSecondsOutput {
     datetime: DateTime
-    httpdate: HttpDate
 }

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-body.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-body.smithy
@@ -126,8 +126,7 @@ apply MalformedTimestampBodyDefault @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
-                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT"]
         },
         tags : ["timestamp"]
     },
@@ -156,8 +155,7 @@ apply MalformedTimestampBodyDateTime @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
-                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT"]
         },
         tags : ["timestamp"]
     },

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-header.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-timestamp-header.smithy
@@ -97,8 +97,7 @@ apply MalformedTimestampHeaderDateTime @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
-                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT"]
         },
         tags : ["timestamp"]
     },
@@ -213,8 +212,7 @@ apply MalformedTimestampHeaderEpoch @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT",
-                       "Sun, 02 Jan 2000 20:34:56.000 GMT"]
+            "value" : ["Tue, 29 Apr 2014 18:30:38 GMT"]
         },
         tags : ["timestamp"]
     },

--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-uniqueItems.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-uniqueItems.smithy
@@ -333,7 +333,7 @@ apply MalformedUniqueItems @httpMalformedRequestTests([
             }
         },
         testParameters: {
-            value: ["[\"Tue, 29 Apr 2014 18:30:38 GMT\", \"Tue, 29 Apr 2014 18:30:38 GMT\"]", "[\"Sun, 02 Jan 2000 20:34:56.000 GMT\", \"Sun, 02 Jan 2000 20:34:56.000 GMT\"]"]
+            value: ["[\"Tue, 29 Apr 2014 18:30:38 GMT\", \"Tue, 29 Apr 2014 18:30:38 GMT\"]"]
         }
     },
     {

--- a/smithy-aws-protocol-tests/model/restXml/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/fractional-seconds.smithy
@@ -4,11 +4,9 @@ namespace aws.protocoltests.restxml
 
 use aws.protocols#restXml
 use aws.protocoltests.shared#DateTime
-use aws.protocoltests.shared#HttpDate
 use smithy.test#httpResponseTests
 
-// These tests are for verifying the client can correctly parse
-// the `DateTime` and `HttpDate` timestamps with fractional seconds
+// These tests verify that clients can parse `DateTime` timestamps with fractional seconds.
 @tags(["client-only"])
 @http(uri: "/FractionalSeconds", method: "POST")
 operation FractionalSeconds {
@@ -32,27 +30,9 @@ apply FractionalSeconds @httpResponseTests([
             "Content-Type": "application/xml"
         },
         params: { datetime: 946845296.123 }
-    },
-    {
-        id: "RestXmlHttpDateWithFractionalSeconds",
-        documentation: """
-        Ensures that clients can correctly parse http-date timestamps with fractional seconds""",
-        protocol: restXml,
-        code: 200,
-        body: """
-            <FractionalSecondsOutput>
-                <httpdate>Sun, 02 Jan 2000 20:34:56.456 GMT</httpdate>
-            </FractionalSecondsOutput>
-            """,
-        bodyMediaType: "application/xml",
-        headers: {
-            "Content-Type": "application/xml"
-        },
-        params: { httpdate: 946845296.456 }
     }
 ])
 
 structure FractionalSecondsOutput {
     datetime: DateTime
-    httpdate: HttpDate
 }


### PR DESCRIPTION
*Description of changes:*

The description of http-date previously stated that implementations MUST support fractional seconds. However, fractional seconds are not permitted by the imf-fixdate grammar. The original intent of this wording in the specification was that clients can gracefully handle parsing these timestamps with fractional precision, but not send fractional precision to avoid client/server incompatibilities. However, this caused confusion in implementations, and when clients send http-date timestamps with optional fractional precision, some servers, including S3, cannot parse the timestamp.

To avoid these issues altogether, this commit removes any kind of specification and protocol test for handling optional fractional seconds with `http-date` timestamps.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
