### PR TITLE
Fix body of awsQueryCompatible test to have __type match the model namespace

### DIFF
--- a/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy
+++ b/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy
@@ -58,7 +58,7 @@ apply NoCustomCodeError @httpResponseTests([
         params: { message: "Hi" }
         code: 400
         headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor" }
-        body: "v2ZfX3R5cGV4MHNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNOb0N1c3RvbUNvZGVFcnJvcmdNZXNzYWdlYkhp/w=="
+        body: "uQACZl9fdHlwZXgtYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI05vQ3VzdG9tQ29kZUVycm9yZ01lc3NhZ2ViSGk="
         bodyMediaType: "application/cbor"
         vendorParamsShape: ErrorCodeParams
         vendorParams: { code: "NoCustomCodeError" }
@@ -79,7 +79,7 @@ apply CustomCodeError @httpResponseTests([
         params: { message: "Hi" }
         code: 400
         headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor", "x-amzn-query-error": "Customized;Sender" }
-        body: "v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDdXN0b21Db2RlRXJyb3JnTWVzc2FnZWJIaf8="
+        body: "uQACZl9fdHlwZXgrYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI0N1c3RvbUNvZGVFcnJvcmdNZXNzYWdlYkhp"
         bodyMediaType: "application/cbor"
         vendorParamsShape: ErrorCodeParams
         vendorParams: { code: "Customized", type: "Sender" }


### PR DESCRIPTION
#### Background
* What do these changes do? 

Current CBOR body of awsQueryCompatible tests have a namespace of `smithy.protocoltests.rpcv2Cbor`. This does not match the actual namespace of the model which is `aws.protocoltests.rpcv2cbor` [here](https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy#L3).

* Why are they important?

This is causing Go v2 SDK to not match the error name, so the type of error generated is the generic error type instead of the more specific error it's supposed to generate.

#### Testing
* How did you test these changes?

Manually pulled the changes into my local and run protocol tests against the SDK

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
