### PR TITLE
Update queryCompatibleTest to not require serializing an empty body

### DIFF
--- a/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy
+++ b/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy
@@ -17,8 +17,7 @@ use smithy.test#httpResponseTests
         headers: { "smithy-protocol": "rpc-v2-cbor", Accept: "application/cbor" }
         forbidHeaders: ["x-amzn-query-mode"]
         uri: "/service/NonQueryCompatibleRpcV2Protocol/operation/QueryIncompatibleOperation"
-        body: "{}"
-        bodyMediaType: "application/json"
+        body: ""
     }
 ])
 @idempotent


### PR DESCRIPTION
#### Background
* What do these changes do? 
Remove the check for body on a protocol test. Since the request has no input, we in Go don't serialize any body, and our protocol tests fail because no body != `{}`. Removed also check for `application/json` content since even with a body, this would be cbor and not json

* Why are they important?


#### Testing
* How did you test these changes?
Test them locally with AWS SDK Go v2

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
