### PR TITLE
Add `disableDefaultDeprecatedMessage` configuration option for json schema

### DIFF
--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -136,6 +136,7 @@ public class JsonSchemaConfig {
     private boolean disableIntEnums = false;
     private boolean addReferenceDescriptions = false;
     private boolean useInlineMaps = false;
+    private boolean disableDefaultDeprecatedMessage = false;
 
     public JsonSchemaConfig() {
         nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.IGNORE);
@@ -465,6 +466,24 @@ public class JsonSchemaConfig {
      */
     public void setDisableIntEnums(boolean disableIntEnums) {
         this.disableIntEnums = disableIntEnums;
+    }
+
+    public boolean getDisableDefaultDeprecatedMessage() {
+        return disableDefaultDeprecatedMessage;
+    }
+
+    /**
+     * Set to true to disable adding default deprecated messages to schema descriptions
+     * when the @deprecated trait is present but has no message or since.
+     *
+     * <p>By default, when a shape has the @deprecated trait, a default message like
+     * "This operation is deprecated." is added to the schema description. Setting this
+     * to true will prevent the default description from being added.
+     *
+     * @param disableDefaultDeprecatedMessage True to disable default description for @deprecated trait.
+     */
+    public void setDisableDefaultDeprecatedMessage(boolean disableDefaultDeprecatedMessage) {
+        this.disableDefaultDeprecatedMessage = disableDefaultDeprecatedMessage;
     }
 
     /**

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -381,11 +381,21 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
         shape
                 .getTrait(DocumentationTrait.class)
                 .ifPresent(trait -> builder.append(trait.getValue()));
+
+        JsonSchemaConfig config = converter.getConfig();
+        boolean disableDefaultDeprecatedMessage = config.getDisableDefaultDeprecatedMessage();
+
         shape
                 .getTrait(DeprecatedTrait.class)
-                .ifPresent(trait -> builder
-                        .append("\n")
-                        .append(trait.getDeprecatedDescription(shape.getType())));
+                .ifPresent(trait -> {
+                    if (!disableDefaultDeprecatedMessage || trait.getMessage().isPresent()
+                            || trait.getSince().isPresent()) {
+                        builder
+                                .append("\n")
+                                .append(trait.getDeprecatedDescription(shape.getType()));
+                    }
+                });
+
         String description = builder.toString().trim();
         return description.isEmpty() ? Optional.empty() : Optional.of(description);
     }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
@@ -140,6 +140,95 @@ public class OpenApiJsonSchemaMapperTest {
     }
 
     @Test
+    public void disableDefaultDeprecatedMessage() {
+        IntegerShape shape = IntegerShape.builder()
+                .id("a.b#C")
+                .addTrait(DeprecatedTrait.builder().build())
+                .addTrait(new DocumentationTrait("This is an integer."))
+                .build();
+        Model model = Model.builder().addShape(shape).build();
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setDisableDefaultDeprecatedMessage(true);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .addMapper(new OpenApiJsonSchemaMapper())
+                .model(model)
+                .config(config)
+                .build()
+                .convertShape(shape);
+
+        String expected = "This is an integer.";
+        assertThat(document.getRootSchema().getDescription().get(), equalTo(expected));
+
+        // Asserts that deprecated node is still there
+        assertThat(document.getRootSchema().getExtension("deprecated").get(), equalTo(Node.from(true)));
+    }
+
+    @Test
+    public void disableDefaultDeprecatedMessageStillAllowsCustomMessage() {
+        String message = "Use a.b#D instead.";
+        IntegerShape shape = IntegerShape.builder()
+                .id("a.b#C")
+                .addTrait(DeprecatedTrait.builder().message(message).build())
+                .addTrait(new DocumentationTrait("This is an integer."))
+                .build();
+        Model model = Model.builder().addShape(shape).build();
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setDisableDefaultDeprecatedMessage(true);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .addMapper(new OpenApiJsonSchemaMapper())
+                .model(model)
+                .config(config)
+                .build()
+                .convertShape(shape);
+
+        String expected = "This is an integer.\nThis shape is deprecated: Use a.b#D instead.";
+        assertThat(document.getRootSchema().getDescription().get(), equalTo(expected));
+    }
+
+    @Test
+    public void disableDefaultDeprecatedMessageStillAllowsSince() {
+        String since = "2020-01-01";
+        IntegerShape shape = IntegerShape.builder()
+                .id("a.b#C")
+                .addTrait(DeprecatedTrait.builder().since(since).build())
+                .addTrait(new DocumentationTrait("This is an integer."))
+                .build();
+        Model model = Model.builder().addShape(shape).build();
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setDisableDefaultDeprecatedMessage(true);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .addMapper(new OpenApiJsonSchemaMapper())
+                .model(model)
+                .config(config)
+                .build()
+                .convertShape(shape);
+
+        String expected = "This is an integer.\nThis shape is deprecated since 2020-01-01.";
+        assertThat(document.getRootSchema().getDescription().get(), equalTo(expected));
+    }
+
+    @Test
+    public void disableDefaultDeprecatedMessageOnlyAffectsIfTrue() {
+        IntegerShape shape = IntegerShape.builder()
+                .id("a.b#C")
+                .addTrait(DeprecatedTrait.builder().build())
+                .addTrait(new DocumentationTrait("This is an integer."))
+                .build();
+        Model model = Model.builder().addShape(shape).build();
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setDisableDefaultDeprecatedMessage(false);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .addMapper(new OpenApiJsonSchemaMapper())
+                .model(model)
+                .config(config)
+                .build()
+                .convertShape(shape);
+
+        String expected = "This is an integer.\nThis shape is deprecated.";
+        assertThat(document.getRootSchema().getDescription().get(), equalTo(expected));
+    }
+
+    @Test
     public void supportsInt32() {
         IntegerShape shape = IntegerShape.builder().id("a.b#C").build();
         Model model = Model.builder().addShape(shape).build();


### PR DESCRIPTION
#### Background
* What do these changes do? 

This adds support for a new json schema setting,`disableDefaultDeprecatedMessage`, that disables the default `This {shape} is deprecated.` descriptions. 

I'm new to this codebase, let me know if there are other considerations I may have missed here

* Why are they important?

https://github.com/smithy-lang/smithy/issues/2693

#### Testing
* How did you test these changes?

- added test cases to `OpenApiJsonSchemaMapperTest.java`
- ran `./gradlew :smithy-openapi:test --tests "*OpenApiJsonSchemaMapperTest*disableDefaultDeprecatedMessage*"`
- ran `./gradlew build`

#### Links
* https://github.com/smithy-lang/smithy/issues/2693

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
