### PR TITLE
Update doc for @trait to reflect the latest selector

### DIFF
--- a/docs/source-2.0/spec/model.rst
+++ b/docs/source-2.0/spec/model.rst
@@ -908,9 +908,9 @@ shape. Members and references within a model MUST NOT target shapes.
 Summary
     Marks a shape as a :ref:`trait <traits>`.
 Trait selector
-    ``:is(simpleType, list, map, set, structure, union)``
+    ``:is(simpleType, list, map, structure, union)``
 
-    This trait can only be applied to simple types, ``list``, ``map``, ``set``,
+    This trait can only be applied to simple types, ``list``, ``map``,
     ``structure``, and ``union`` shapes.
 Value type
     ``structure``


### PR DESCRIPTION
#### Background
Current doc for `@trait` still have `set` in its selector. Removed `set` to reflect the latest selector.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
