### PR TITLE
Fix loading smithy-ts version in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 from smithy.lexer import SmithyLexer
 import requests
+import xml.etree.ElementTree as ET
 
 project = u'Smithy'
 copyright = u'2022, Amazon Web Services'
@@ -73,8 +74,13 @@ def __load_gradle_version():
 
 # Find the latest version of the typescript codegen plugin from maven repo
 def __load_typescript_codegen_version():
-    return requests.get('https://search.maven.org/solrsearch/select?q=g:"software.amazon.smithy.typescript"'
-        + '+AND+a:"smithy-typescript-codegen"&wt=json').json()['response']['docs'][0]['latestVersion']
+    response = requests.get("https://repo1.maven.org/maven2/software/amazon/smithy/typescript/smithy-typescript-codegen/maven-metadata.xml")
+    response.raise_for_status()
+    root = ET.fromstring(response.text)
+    version = root.find('.//latest').text
+    if version is None:
+        raise Exception("Unable to find latest version of smithy-typescript-codegen")
+    return version
 
 # Find the latest version of smithy-java from github
 def __load_java_version():


### PR DESCRIPTION
The docs build fetches the latest smithy-typescript-codegen version to include it in tutorial pages (e.g. https://smithy.io/2.0/guides/using-code-generation/generating-a-client.html#add-the-codegen-plugin). It uses the maven central rest api:
https://central.sonatype.org/search/rest-api-guide/, but that api has frequent outages  (see https://status.maven.org/), which causes docs builds to fail.

This commit changes the docs build to fetch the latest version by pinging repo1.maven.org directly, and parsing the maven metadata.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
