### PR TITLE
Add shared space for plugins

### DIFF
--- a/.changes/next-release/feature-aa81f6943bf8a339f4e4952ec9d2a403e6d99440.json
+++ b/.changes/next-release/feature-aa81f6943bf8a339f4e4952ec9d2a403e6d99440.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "This adds a space for plugins to write data that is intended to be consumable by other plugins. This appears under a directory called `shared` in the the projection's output directory.",
+  "pull_requests": [
+    "[#2764](https://github.com/awslabs/smithy/pull/2764)"
+  ]
+}

--- a/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionResult.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/ProjectionResult.java
@@ -21,6 +21,7 @@ public final class ProjectionResult {
     private final String projectionName;
     private final Model model;
     private final Map<String, FileManifest> pluginManifests;
+    private final FileManifest sharedFileManifest;
     private final List<ValidationEvent> events;
 
     private ProjectionResult(Builder builder) {
@@ -28,6 +29,7 @@ public final class ProjectionResult {
         this.model = SmithyBuilder.requiredState("model", builder.model);
         this.events = builder.events.copy();
         this.pluginManifests = builder.pluginManifests.copy();
+        this.sharedFileManifest = builder.sharedFileManifest;
     }
 
     /**
@@ -103,12 +105,31 @@ public final class ProjectionResult {
     }
 
     /**
+     * Gets the shared result manifest.
+     *
+     * @return Returns files created by plugins in shared space.
+     */
+    public FileManifest getSharedManifest() {
+        // This will always be set in actual Smithy builds, as it is set by
+        // SmithyBuildImpl. We therefore don't want the return type to be
+        // optional, since in real usage it isn't. This was introduced after
+        // the class was made public, however, and this class is likely being
+        // manually constructed in tests. So instead of checking if it's set
+        // in the builder, we check when it's actually used.
+        if (sharedFileManifest == null) {
+            SmithyBuilder.requiredState("sharedFileManifest", sharedFileManifest);
+        }
+        return sharedFileManifest;
+    }
+
+    /**
      * Builds up a {@link ProjectionResult}.
      */
     public static final class Builder implements SmithyBuilder<ProjectionResult> {
         private String projectionName;
         private Model model;
         private final BuilderRef<Map<String, FileManifest>> pluginManifests = BuilderRef.forUnorderedMap();
+        private FileManifest sharedFileManifest;
         private final BuilderRef<List<ValidationEvent>> events = BuilderRef.forList();
 
         @Override
@@ -150,6 +171,17 @@ public final class ProjectionResult {
          */
         public Builder addPluginManifest(String artifactName, FileManifest manifest) {
             pluginManifests.get().put(artifactName, manifest);
+            return this;
+        }
+
+        /**
+         * Sets the shared result manifest.
+         *
+         * @param sharedFileManifest File manifest shared by all plugins.
+         * @return Returns the builder.
+         */
+        public Builder sharedFileManifest(FileManifest sharedFileManifest) {
+            this.sharedFileManifest = sharedFileManifest;
             return this;
         }
 

--- a/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/PluginContextTest.java
@@ -72,6 +72,7 @@ public class PluginContextTest {
         PluginContext context = PluginContext.builder()
                 .projection("foo", ProjectionConfig.builder().build())
                 .fileManifest(new MockManifest())
+                .sharedFileManifest(new MockManifest())
                 .model(Model.builder().build())
                 .originalModel(Model.builder().build())
                 .settings(Node.objectNode().withMember("foo", "bar"))
@@ -83,6 +84,7 @@ public class PluginContextTest {
         assertThat(context.getModel(), equalTo(context2.getModel()));
         assertThat(context.getOriginalModel(), equalTo(context2.getOriginalModel()));
         assertThat(context.getFileManifest(), is(context2.getFileManifest()));
+        assertThat(context.getSharedFileManifest(), is(context2.getSharedFileManifest()));
         assertThat(context.getSources(), equalTo(context2.getSources()));
         assertThat(context.getEvents(), equalTo(context2.getEvents()));
     }

--- a/smithy-build/src/test/java/software/amazon/smithy/build/TestSharingPlugin1.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/TestSharingPlugin1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.build;
+
+public class TestSharingPlugin1 implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "testSharing1";
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        FileManifest manifest = context.getSharedFileManifest();
+        String count = String.valueOf(manifest.getFiles().size() + 1);
+        manifest.getFiles().forEach(file -> {
+            manifest.writeFile(file, count);
+        });
+        manifest.writeFile("helloShare1", count);
+    }
+}

--- a/smithy-build/src/test/java/software/amazon/smithy/build/TestSharingPlugin2.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/TestSharingPlugin2.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.build;
+
+public class TestSharingPlugin2 implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "testSharing2";
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        FileManifest manifest = context.getSharedFileManifest();
+        String count = String.valueOf(manifest.getFiles().size() + 1);
+        manifest.getFiles().forEach(file -> {
+            manifest.writeFile(file, count);
+        });
+        manifest.writeFile("helloShare2", count);
+    }
+}

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/applies-plugins-with-shared-space.json
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/applies-plugins-with-shared-space.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0",
+  "plugins": {
+    "testSharing1": {}
+  },
+  "projections": {
+    "testProjection": {
+      "plugins": {
+        "testSharing2": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a space for plugins to write data that is intended to be consumable by other plugins. This appears under a directory called `shared` in the the projection's output directory.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
