### PR TITLE
chore: update the restart server command in the quickstart project

### DIFF
--- a/docs/source-2.0/languages/typescript/quickstart.rst
+++ b/docs/source-2.0/languages/typescript/quickstart.rst
@@ -232,7 +232,7 @@ Let's try to start our server:
 
 .. code-block:: sh
 
-    cd server && yarn start
+    cd server && yarn setup && yarn start
 
 This will fail with a compilation error:
 


### PR DESCRIPTION
#### Background
* include missing `setup` step, otherwise the error is different (module `@com.example/coffee-shop-server` is missing)
* without this change, the flow in the quickstart project cannot be cleanly followed

#### Testing
* `./gradlew clean build`
* successfully starting the TS server in quickstart project after making the documented changes to the `main.smithy`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
