### PR TITLE
feat: Expand @title to members, and map the title for oneOf variants

### DIFF
--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -386,7 +386,7 @@ tags trait are arbitrary and up to the model author.
 ===============
 
 Summary
-    Defines a proper name for a service or resource shape. This title can be
+    Defines a proper name for a shape. This title can be
     used in automatically generated documentation and other contexts to
     provide a user friendly name for a shape.
 Trait selector

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -267,9 +267,13 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
                     MemberShape member = entry.getValue();
                     Schema enumSchema = Schema.builder()
                             .constValue(StringNode.from(enumValues.get(memberName)))
+                            .title(member.getTrait(TitleTrait.class)
+                                    .map(TitleTrait::getValue)
+                                    .orElse(null))
                             .description(member.getTrait(DocumentationTrait.class)
                                     .map(DocumentationTrait::getValue)
                                     .orElse(null))
+
                             .build();
 
                     schemas.add(enumSchema);

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums-one-of.jsonschema.v07.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums-one-of.jsonschema.v07.json
@@ -17,7 +17,8 @@
           "description": "it really does foo"
         },
         {
-          "const": "Bar"
+          "const": "Bar",
+          "title": "TestEnum Bar"
         }
       ]
     }

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums.smithy
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums.smithy
@@ -10,5 +10,6 @@ structure Foo {
 enum TestEnum {
     @documentation("it really does foo")
     FOO = "Foo"
+    @title("TestEnum Bar")
     BAR = "Bar"
 }

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -666,11 +666,11 @@ list tags {
     member: String
 }
 
-/// Defines a proper name for a service or resource shape.
+/// Defines a proper name for a shape.
 ///
 /// This title can be used in automatically generated documentation
-/// and other contexts to provide a user friendly for shapes.
-@trait(selector: ":not(member)")
+/// and other contexts to provide a user-friendly for shapes.
+@trait
 string title
 
 /// Constrains the acceptable values of a string to a fixed set


### PR DESCRIPTION
#### Background
- With the oneOf enum variant change (https://github.com/smithy-lang/smithy/pull/2504), descriptions were mapped but titles were not
- This change maps the title as well, but additionally removes the condition that title be applied to non-member shapes
  - Alternatively, we can expand to selector to allow only enum members 

#### Testing
- small test update

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
