### PR TITLE
Add protocol test for httpQueryParams when no other query parameters exist

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query-params-only.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query-params-only.smithy
@@ -1,0 +1,55 @@
+// This file defines test cases that test HTTP query params behavior when no other query parameters exist.
+// See: https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait
+
+$version: "2.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use smithy.test#httpRequestTests
+
+/// This example tests httpQueryParams when no other query parameters exist.
+@readonly
+@http(uri: "/http-query-params-only", method: "GET")
+operation HttpQueryParamsOnlyOperation {
+    input: HttpQueryParamsOnlyInput,
+}
+
+apply HttpQueryParamsOnlyOperation @httpRequestTests([
+    {
+        id: "HttpQueryParamsOnlyRequest",
+        documentation: "Test that httpQueryParams are included in request when no other query parameters exist",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/http-query-params-only",
+        queryParams: ["a=b", "c=d"],
+        params: {
+            queryMap: {
+                "a": "b",
+                "c": "d"
+            }
+        },
+        appliesTo: "client",
+    },
+    {
+        id: "HttpQueryParamsOnlyEmptyRequest",
+        documentation: "Test that empty httpQueryParams map results in no query parameters",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/http-query-params-only",
+        params: {
+            queryMap: {}
+        },
+        appliesTo: "client",
+    }
+])
+
+structure HttpQueryParamsOnlyInput {
+    @httpQueryParams
+    queryMap: QueryMap,
+}
+
+map QueryMap {
+    key: String,
+    value: String,
+}

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -49,6 +49,7 @@ service RestJson {
         OmitsSerializingEmptyLists,
         QueryIdempotencyTokenAutoFill,
         QueryPrecedence,
+        HttpQueryParamsOnlyOperation,
         QueryParamsAsStringListMap,
 
         // @httpPrefixHeaders tests


### PR DESCRIPTION
#### Background
This test verifies that httpQueryParams are correctly included in requests when no other query parameters are present, and that empty httpQueryParams maps result in no query parameters being added to the request.

This is the result of a bug from smithy-rs (https://github.com/smithy-lang/smithy-rs/pull/4346)

#### Testing
This protocol test ran in smithy-rs


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
