### PR TITLE
Add a sufix to distinguish added required traits to structures or unions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 junit5 = "5.13.4"
+junit-platform = "1.13.4"
 hamcrest = "3.0"
 jmh = "0.7.2"
 spotbugs = "6.2.4"
@@ -40,7 +41,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit5" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 mockserver = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
@@ -124,12 +124,24 @@ public class ChangedNullability extends AbstractDiffEvaluator {
             }
             // Can't add required to a member unless the member is marked as @clientOptional or part of @input.
             if (change.isTraitAdded(RequiredTrait.ID) && !newMember.hasTrait(ClientOptionalTrait.ID)) {
-                eventsToAdd.add(emit(Severity.ERROR,
-                        "AddedRequiredTrait",
-                        shape,
-                        oldMemberSourceLocation,
-                        message,
-                        "The @required trait was added to a member."));
+                if (newTarget.isStructureShape() || newTarget.isUnionShape()) {
+                    eventsToAdd.add(emit(Severity.WARNING,
+                            "AddedRequiredTrait.StructureOrUnion",
+                            shape,
+                            oldMemberSourceLocation,
+                            message,
+                            "The @required trait was added to a member "
+                                    + "that targets a " + newTarget.getType() + ". This is backward compatible in "
+                                    + "generators that always treat structures and unions as optional "
+                                    + "(e.g., AWS generators)"));
+                } else {
+                    eventsToAdd.add(emit(Severity.ERROR,
+                            "AddedRequiredTrait",
+                            shape,
+                            oldMemberSourceLocation,
+                            message,
+                            "The @required trait was added to a member."));
+                }
             }
             // Can't add the default trait to a member unless the member was previously required.
             if (change.isTraitAdded(DefaultTrait.ID) && !change.isTraitRemoved(RequiredTrait.ID)) {


### PR DESCRIPTION
#### Background

Added a new suffix to the changed nullability test for when the `@required` was added to a member that refers to an structure or a union. That case is backwards compatible for SDK generators using the nullability check `CheckMode.CLIENT_CAREFUL`, such as AWS SDKs. This is similar to what we already do [here](https://github.com/smithy-lang/smithy/blob/b51e9fa71787e03dc9473852df2d5d4f93d7045d/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java#L147-L157) for the `@required` trait is removed.

#### Testing

Added a unit test.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
