### PR TITLE
Add square bracket encoding protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -700,3 +700,30 @@ structure QueryParamsAsStringListMapInput {
     @httpQueryParams
     foo: StringListMap
 }
+
+/// Does not encode `[]` chars in serialized URIs.
+@readonly
+@http(uri: "/SkipsEncodingSquareBrackets", method: "GET")
+operation SkipsEncodingSquareBrackets {
+    input := {
+        @httpQuery("brackets[]")
+        paramWithBrackets: String
+    }
+}
+
+apply SkipsEncodingSquareBrackets @httpRequestTests([
+    {
+        id: "RestJsonSkipsEncodingSquareBrackets"
+        documentation: "Do not encode square brackets (`[` and `]`) in the names of query parameters."
+        protocol: restJson1
+        method: "GET"
+        uri: "/SkipsEncodingSquareBrackets"
+        body: ""
+        queryParams: [
+            "brackets[]=Text"
+        ]
+        params: {
+            paramWithBrackets: "Text"
+        }
+    }
+])

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -50,6 +50,7 @@ service RestJson {
         QueryIdempotencyTokenAutoFill,
         QueryPrecedence,
         QueryParamsAsStringListMap,
+        SkipsEncodingSquareBrackets
 
         // @httpPrefixHeaders tests
         HttpPrefixHeaders,

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -586,3 +586,30 @@ structure QueryParamsAsStringListMapInput {
     @httpQueryParams
     foo: StringListMap
 }
+
+/// Does not encode `[]` chars in serialized URIs.
+@readonly
+@http(uri: "/SkipsEncodingSquareBrackets", method: "GET")
+operation SkipsEncodingSquareBrackets {
+    input := {
+        @httpQuery("brackets[]")
+        paramWithBrackets: String
+    }
+}
+
+apply SkipsEncodingSquareBrackets @httpRequestTests([
+    {
+        id: "RestXmlSkipsEncodingSquareBrackets"
+        documentation: "Do not encode square brackets (`[` and `]`) in the names of query parameters."
+        protocol: restXml
+        method: "GET"
+        uri: "/SkipsEncodingSquareBrackets"
+        body: ""
+        queryParams: [
+            "brackets[]=Text"
+        ]
+        params: {
+            paramWithBrackets: "Text"
+        }
+    }
+])

--- a/smithy-aws-protocol-tests/model/restXml/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/main.smithy
@@ -45,6 +45,7 @@ service RestXml {
         QueryIdempotencyTokenAutoFill,
         QueryPrecedence,
         QueryParamsAsStringListMap,
+        SkipsEncodingSquareBrackets
 
         // @httpPrefixHeaders tests
         HttpPrefixHeaders,


### PR DESCRIPTION
This commit adds protocol tests to both restJson1 and restXml that validate square brackets ('[' and ']') are not encoded when present in query parameter keys.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
