### PR TITLE
Add suffixes to all known nullability changes

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/ModelDiff.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/ModelDiff.java
@@ -134,7 +134,7 @@ public final class ModelDiff {
          */
         public Set<ValidationEvent> determineResolvedEvents() {
             Set<ValidationEvent> events = new TreeSet<>(getOldModelEvents());
-            events.removeAll(getNewModelEvents());
+            getNewModelEvents().forEach(events::remove);
             return events;
         }
 
@@ -146,7 +146,7 @@ public final class ModelDiff {
          */
         public Set<ValidationEvent> determineIntroducedEvents() {
             Set<ValidationEvent> events = new TreeSet<>(getNewModelEvents());
-            events.removeAll(getOldModelEvents());
+            getOldModelEvents().forEach(events::remove);
             return events;
         }
 

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedDefaultTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedDefaultTest.java
@@ -250,6 +250,28 @@ public class ChangedDefaultTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedDefault").size(), equalTo(1));
-        assertThat(TestHelper.findEvents(events, "ChangedNullability").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedNullability.RemovedNullDefault").size(), equalTo(1));
+    }
+
+    @Test
+    public void changingFromZeroDefaultToNullIsBreaking() {
+        String originalModel =
+                "$version: \"2\"\n"
+                        + "namespace smithy.example\n"
+                        + "structure Foo {\n"
+                        + "    bar: Integer = 0\n"
+                        + "}\n";
+        String updatedModel =
+                "$version: \"2\"\n"
+                        + "namespace smithy.example\n"
+                        + "structure Foo {\n"
+                        + "    bar: Integer = null\n"
+                        + "}\n";
+        Model modelA = Model.assembler().addUnparsedModel("test.smithy", originalModel).assemble().unwrap();
+        Model modelB = Model.assembler().addUnparsedModel("test.smithy", updatedModel).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "ChangedDefault").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedNullability.AddedNullDefault").size(), equalTo(1));
     }
 }


### PR DESCRIPTION
#### Background

* Added missing suffixes to allow us to identify all cases for when the nullability of a member changed:
  * `RemovedClientOptionalTrait` for when the `@clientOptional` trait is removed
  * `AddedNullDefault` for when a `@default(null)` is changed to a default with non-null value
  * `RemovedNullDefault` for when a `@default(<non-null-value>)` is changed to a default with null value

While there changed the code to move the creation of events out of the logic to classify them, hopefully improving the readability of the logic to classify.


#### Testing
* Added tests.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
