### PR TITLE
Remove redundant sentence in arnNamespace docs

### DIFF
--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -167,8 +167,7 @@ used in ARNs assigned to resources in the service. If not set, this value
 defaults to the lowercase name of the service shape. This value must match
 the following regex: ``^[a-z0-9.\-]{1,63}$``.
 
-If not set, this value defaults to the name of the service shape converted
-to lowercase. This value is combined with resources contained within the
+This value is combined with resources contained within the
 service to form ARNs for resources. Only resources that explicitly define
 the :ref:`aws.api#arn-trait` are assigned ARNs, and their relative ARNs
 are combined with the service's arnNamespace to form an ARN.


### PR DESCRIPTION
#### Background
Removed a redundant sentence I came across while reading the `arnNamespace` documentation.



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
