### PR TITLE
Fill in missing changelog entries

### DIFF
--- a/.changes/next-release/feature-5f3d9eb77c7ef182b96c992f2b47a945136a41b7.json
+++ b/.changes/next-release/feature-5f3d9eb77c7ef182b96c992f2b47a945136a41b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Added missing suffixes to allow identification of all cases for when the nullability of a member changed\n\n* `RemovedClientOptionalTrait` for when the `@clientOptional` trait is removed.\n* `AddedNullDefault` for when a `@default(null)` is changed to a default with non-null value.\n* `RemovedNullDefault` for when a `@default(<non-null-value>)` is changed to a default with null value.",
+  "pull_requests": [
+      "[#2805](https://github.com/smithy-lang/smithy/pull/2805)"
+  ]
+}

--- a/.changes/next-release/feature-9d99ada83fb4eaabb1f0d929c0da87d73134dd3e.json
+++ b/.changes/next-release/feature-9d99ada83fb4eaabb1f0d929c0da87d73134dd3e.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Add the ability for smithy build plugins to declare that they must be run before or after other plugins. These dependencies are soft, so missing dependencies will be logged and ignored.",
+  "description": "Added the ability for smithy build plugins to declare that they must be run before or after other plugins. These dependencies are soft, so missing dependencies will be logged and ignored.",
   "pull_requests": [
     "[#2774](https://github.com/smithy-lang/smithy/pull/2774)"
   ]

--- a/.changes/next-release/feature-a0bc9f42abb206c7689621d7d9b4243d859a456d.json
+++ b/.changes/next-release/feature-a0bc9f42abb206c7689621d7d9b4243d859a456d.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Added support for mapping the `title` trait in JSON Schema's `oneOf` enum strategy.",
+  "pull_requests": [
+    "[#2791](https://github.com/smithy-lang/smithy/pull/2791)"
+  ]
+}

--- a/.changes/next-release/feature-a27ee78fbff2659e05b80b588630b78f500ffa8e.json
+++ b/.changes/next-release/feature-a27ee78fbff2659e05b80b588630b78f500ffa8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Expanded `title` trait to apply to members.",
+  "pull_requests": [
+    "[#2791](https://github.com/smithy-lang/smithy/pull/2791)"
+  ]
+}

--- a/.changes/next-release/feature-aa81f6943bf8a339f4e4952ec9d2a403e6d99440.json
+++ b/.changes/next-release/feature-aa81f6943bf8a339f4e4952ec9d2a403e6d99440.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "This adds a space for plugins to write data that is intended to be consumable by other plugins. This appears under a directory called `shared` in the the projection's output directory.",
+  "description": "Added a space for plugins to write data that is intended to be consumable by other plugins. This appears under a directory called `shared` in the the projection's output directory.",
   "pull_requests": [
     "[#2764](https://github.com/awslabs/smithy/pull/2764)"
   ]

--- a/.changes/next-release/feature-d368237cdeb1655c7c10969e36c6aa3ca3b3034a.json
+++ b/.changes/next-release/feature-d368237cdeb1655c7c10969e36c6aa3ca3b3034a.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Add a generic dependency graph to smithy-utils to be used for sorting various dependent objects, such as integrations and plugins.",
+  "description": "Added a generic dependency graph to smithy-utils to be used for sorting various dependent objects, such as integrations and plugins.",
   "pull_requests": [
     "[#2774](https://github.com/smithy-lang/smithy/pull/2774)"
   ]

--- a/.changes/next-release/feature-fe065dff18b519e46bf2c1060d2558e6aefd1c93.json
+++ b/.changes/next-release/feature-fe065dff18b519e46bf2c1060d2558e6aefd1c93.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Added builder method support for `ServiceResolvedConditionKeysTrait`.",
+  "pull_requests": [
+    "[#2779](https://github.com/smithy-lang/smithy/pull/2779)"
+  ]
+}

--- a/.changes/next-release/other-5c80a84c4b3ba5298e7eb2b1d645e37f48ed83dd.json
+++ b/.changes/next-release/other-5c80a84c4b3ba5298e7eb2b1d645e37f48ed83dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "other",
+  "description": "Added `restJson1` protocol tests for `httpQueryParams` when no params exist.",
+  "pull_requests": [
+    "[#2792](https://github.com/smithy-lang/smithy/pull/2792)"
+  ]
+}


### PR DESCRIPTION
This fills in changelog entries for changes that were merged after the `1.63.0` release that didn't include changelog entries. Now the changelog automation should ensure that PRs include entries, at least so long as contributors and reviewers comply.

This also does some editing on currently staged entries to fix the tense. These were all mine - mea culpa

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
