### PR TITLE
Fix event stream test bytes optionality

### DIFF
--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/Event.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/Event.java
@@ -5,9 +5,11 @@
 package software.amazon.smithy.protocoltests.traits.eventstream;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -137,7 +139,7 @@ public final class Event implements ToSmithyBuilder<Event> {
      * @return Returns an optional binary representation of the entire event.
      */
     public Optional<byte[]> getBytes() {
-        return Optional.of(bytes);
+        return Optional.ofNullable(bytes);
     }
 
     /**
@@ -183,6 +185,37 @@ public final class Event implements ToSmithyBuilder<Event> {
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Event)) {
+            return false;
+        }
+        Event event = (Event) o;
+        return type == event.type && Objects.equals(params, event.params)
+                && Objects.equals(headers, event.headers)
+                && Objects.equals(forbidHeaders, event.forbidHeaders)
+                && Objects.equals(requireHeaders, event.requireHeaders)
+                && Objects.equals(body, event.body)
+                && Objects.equals(bodyMediaType, event.bodyMediaType)
+                && Objects.deepEquals(bytes, event.bytes)
+                && Objects.equals(vendorParams, event.vendorParams)
+                && Objects.equals(vendorParamsShape, event.vendorParamsShape);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type,
+                params,
+                headers,
+                forbidHeaders,
+                requireHeaders,
+                body,
+                bodyMediaType,
+                Arrays.hashCode(bytes),
+                vendorParams,
+                vendorParamsShape);
     }
 
     /**
@@ -244,7 +277,11 @@ public final class Event implements ToSmithyBuilder<Event> {
         }
 
         public Builder bytes(String bytes) {
-            this.bytes = Base64.getDecoder().decode(bytes.getBytes(StandardCharsets.UTF_8));
+            if (bytes == null) {
+                this.bytes = null;
+            } else {
+                this.bytes = Base64.getDecoder().decode(bytes.getBytes(StandardCharsets.UTF_8));
+            }
             return this;
         }
 

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/EventStreamTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/EventStreamTestCase.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.protocoltests.traits.eventstream;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -193,6 +194,45 @@ public final class EventStreamTestCase implements ToSmithyBuilder<EventStreamTes
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof EventStreamTestCase)) {
+            return false;
+        }
+        EventStreamTestCase that = (EventStreamTestCase) o;
+        return Objects.equals(id, that.id) && Objects.equals(protocol, that.protocol)
+                && Objects.equals(initialRequestParams, that.initialRequestParams)
+                && Objects.equals(initialRequest, that.initialRequest)
+                && Objects.equals(initialRequestShape, that.initialRequestShape)
+                && Objects.equals(initialResponseParams, that.initialResponseParams)
+                && Objects.equals(initialResponse, that.initialResponse)
+                && Objects.equals(initialResponseShape, that.initialResponseShape)
+                && Objects.equals(events, that.events)
+                && Objects.equals(expectation, that.expectation)
+                && Objects.equals(vendorParams, that.vendorParams)
+                && Objects.equals(vendorParamsShape, that.vendorParamsShape)
+                && Objects.equals(documentation, that.documentation)
+                && appliesTo == that.appliesTo;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id,
+                protocol,
+                initialRequestParams,
+                initialRequest,
+                initialRequestShape,
+                initialResponseParams,
+                initialResponse,
+                initialResponseShape,
+                events,
+                expectation,
+                vendorParams,
+                vendorParamsShape,
+                documentation,
+                appliesTo);
     }
 
     /**

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/EventStreamTestsTrait.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/EventStreamTestsTrait.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.protocoltests.traits.eventstream;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
@@ -56,6 +57,20 @@ public final class EventStreamTestsTrait extends AbstractTrait {
         return testCases.stream()
                 .filter(test -> !test.getAppliesTo().filter(value -> value != appliesTo).isPresent())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof EventStreamTestsTrait)) {
+            return false;
+        }
+        EventStreamTestsTrait that = (EventStreamTestsTrait) o;
+        return Objects.equals(testCases, that.testCases);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), testCases);
     }
 
     @Override

--- a/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/eventstream/EventTest.java
+++ b/smithy-protocol-test-traits/src/test/java/software/amazon/smithy/protocoltests/traits/eventstream/EventTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.protocoltests.traits.eventstream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.NodeMapper;
+
+public class EventTest {
+    @Test
+    public void testReserializeEventWithoutBytes() {
+        NodeMapper mapper = new NodeMapper();
+        Event expected = Event.builder()
+                .type(EventType.REQUEST)
+                .build();
+        Event actual = mapper.deserialize(mapper.serialize(expected), Event.class);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
This fixes a bug in the event stream test trait where events without `bytes` would fail to serialize due to not using `Optional.ofNullable`.

Note that there's no changelog because the trait hasn't been released yet.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
