### PR TITLE
Only list new files in changelog tool

### DIFF
--- a/.changes/smithy_changelog/amend.py
+++ b/.changes/smithy_changelog/amend.py
@@ -142,7 +142,7 @@ def _get_new_changes(repository_dir: Path, base: str | None) -> dict[Path, Chang
     with chdir(repository_dir):
         print(f"Running a diff against base branch: {base}")
         result = subprocess.run(
-            f"git diff origin/{base} --name-only",
+            f"git diff origin/{base} --name-only --diff-filter=A",
             check=True,
             shell=True,
             capture_output=True,


### PR DESCRIPTION
This updates the changelog automation tool to only check newly-added files in the diff for changelog entries. This prevents false-positives when changelog entries are removed from `next-release`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
