### PR TITLE
Bump beryx runtime plugin to 2.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ json-schema = "1.12.1"
 shadow = "9.2.2"
 api-guardian = "1.1.2"
 jreleaser = "1.20.0"
-runtime = "2.0.0"
+runtime = "2.0.1"
 gradle-checksum = "1.4.0"
 
 [libraries]


### PR DESCRIPTION
This fixes a bug where creating a runtime zip failed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
