### PR TITLE
Add CLI distributions build job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,22 @@ jobs:
           name: java-${{ matrix.java }}-${{ matrix.os }}-test-report
           path: '**/build/reports/tests'
 
+  cli-distributions:
+    runs-on: ubuntu-latest
+    name: Build CLI executables
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: 'corretto'
+          cache: gradle
+
+      - name: Build CLI distributions
+        run: ./gradlew :smithy-cli:images
+
   build-docs:
     runs-on: ubuntu-latest
     name: Documentation Build


### PR DESCRIPTION
Add a `cli-distributions` job that builds Smithy CLI executables for all target platforms using the `:smithy-cli:images` Gradle task. This ensures PRs that update dependencies are validated against the distribution build process.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
