### PR TITLE
Limit CLI distribution testing to `checksumImages` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           cache: gradle
 
       - name: Build CLI distributions
-        run: ./gradlew :smithy-cli:images
+        run: ./gradlew :smithy-cli:checksumImages
 
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Testing stops at `checksumImages` since the full `image` task requires signing.


List of steps for reference:

```
:smithy-cli:shadowJar SKIPPED
:smithy-cli:startShadowScripts SKIPPED
:smithy-cli:installShadowDist SKIPPED
:smithy-cli:jre SKIPPED
:smithy-cli:runtime SKIPPED
:smithy-cli:runtimeZip SKIPPED
:smithy-cli:checksumImages SKIPPED
:smithy-cli:signImages SKIPPED
:smithy-cli:images SKIPPED
```

Follow up to #2829, to test the CLI distribution for branch pushes and pull requests. This builds successfully now after merging #2828.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
