### PR TITLE
Don't relativize files when posting comments

### DIFF
--- a/.changes/smithy_changelog/github.py
+++ b/.changes/smithy_changelog/github.py
@@ -16,8 +16,6 @@ from typing import Literal, NotRequired, Required, Self, TypedDict
 from urllib import request
 from urllib.error import HTTPError
 
-from . import REPO_ROOT
-
 GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 NEXT_PAGE = re.compile(r'(?<=<)([\S]*)(?=>; rel="next")', flags=re.IGNORECASE)
@@ -40,7 +38,7 @@ def post_review_comment(
             "The TARGET_SHA environment variable must be set to post review comments."
         )
 
-    path = str(file.relative_to(REPO_ROOT))
+    path = str(file)
 
     if not allow_duplicate:
         for existing_comment in get_review_comments(repository, pr_number):


### PR DESCRIPTION
This fixes an issue where the changelog tool was trying to relativize a file against the base of the pr. This isn't needed at all since the paths given to it have already been (correctly) realized.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
