### PR TITLE
[Bugfix] Correctly compute and enforce blob length values in the NodeValidationVisitor

### DIFF
--- a/.changes/next-release/bugfix-d65c300cf8a9e4030d58f209f1359deb3ae4d2aa.json
+++ b/.changes/next-release/bugfix-d65c300cf8a9e4030d58f209f1359deb3ae4d2aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Correctly compute and enforce blob length values in the NodeValidationVisitor",
+  "pull_requests": [
+    "[#2833](https://github.com/smithy-lang/smithy/pull/2833)"
+  ]
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.model.validation;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -106,7 +107,14 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
          *
          * <p>By default, null values are not allowed for optional types.
          */
-        ALLOW_OPTIONAL_NULLS;
+        ALLOW_OPTIONAL_NULLS,
+
+        /**
+         * Ignore validation for blob values that aren't valid base64 encoded values.
+         *
+         * <p>By default, string values which are not valid base64 encoded values will report an error.
+         */
+        SKIP_INVALID_BLOB_VALUES;
 
         public static Feature fromNode(Node node) {
             return Feature.valueOf(node.expectStringNode().getValue());
@@ -177,9 +185,23 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     @Override
     public List<ValidationEvent> blobShape(BlobShape shape) {
-        return value.asStringNode()
-                .map(stringNode -> applyPlugins(shape))
-                .orElseGet(() -> invalidShape(shape, NodeType.STRING));
+        if (!value.isStringNode()) {
+            return invalidShape(shape, NodeType.STRING);
+        }
+
+        byte[] encodedValue = value.expectStringNode().getValue().getBytes(StandardCharsets.UTF_8);
+
+        try {
+            Base64.getDecoder().decode(encodedValue);
+        } catch (IllegalArgumentException e) {
+            if (validationContext.hasFeature(Feature.SKIP_INVALID_BLOB_VALUES)) {
+                return Collections.emptyList();
+            }
+
+            return ListUtils.of(event("Blob value should be a valid base64 string"));
+        }
+
+        return applyPlugins(shape);
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.model.validation.node;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -25,8 +26,9 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
 
     @Override
     protected void check(Shape shape, LengthTrait trait, StringNode node, Context context, Emitter emitter) {
-        String value = node.getValue();
-        int size = value.getBytes(StandardCharsets.UTF_8).length;
+        byte[] encodedValue = node.getValue().getBytes(StandardCharsets.UTF_8);
+        byte[] value = Base64.getDecoder().decode(encodedValue);
+        int size = value.length;
 
         trait.getMin().ifPresent(min -> {
             if (size < min) {
@@ -39,7 +41,7 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
         });
 
         trait.getMax().ifPresent(max -> {
-            if (value.getBytes(StandardCharsets.UTF_8).length > max) {
+            if (size > max) {
                 emitter.accept(node,
                         getSeverity(context),
                         "Value provided for `" + shape.getId()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DefaultTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DefaultTraitValidator.java
@@ -169,6 +169,8 @@ public final class DefaultTraitValidator extends AbstractValidator {
                     // Use WARNING for range trait errors so that a Smithy model 1.0 to 2.0 conversion can automatically
                     // suppress any errors to losslessly handle the conversion.
                     .addFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_ZERO_VALUE_WARNING)
+                    // Preserve existing behavior of warning about non-base64 values
+                    .addFeature(NodeValidationVisitor.Feature.SKIP_INVALID_BLOB_VALUES)
                     .build();
         } else {
             visitor.setValue(value);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -102,15 +102,20 @@ public class NodeValidationVisitorTest {
 
                 // Blobs
                 {"ns.foo#Blob1", "\"\"", null},
-                {"ns.foo#Blob1", "\"foo\"", null},
+                {"ns.foo#Blob1",
+                        "\"{}\"",
+                        new String[] {
+                                "Blob value should be a valid base64 string"
+                        }},
+                {"ns.foo#Blob1", "\"Zm9v\"", null},
                 {"ns.foo#Blob1",
                         "true",
                         new String[] {
                                 "Expected string value for blob shape, `ns.foo#Blob1`; found boolean value, `true`"
                         }},
-                {"ns.foo#Blob2", "\"f\"", null},
+                {"ns.foo#Blob2", "\"Zg==\"", null},
                 {"ns.foo#Blob2",
-                        "\"fooo\"",
+                        "\"Zm9vbw==\"",
                         new String[] {
                                 "Value provided for `ns.foo#Blob2` must have no more than 3 bytes, but the provided value has 4 bytes"}},
                 {"ns.foo#Blob2",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
@@ -67,8 +67,8 @@
                     {
                         "title": "Testing 5",
                         "input": {
-                            "blobMin": "a",
-                            "blobMax": "abcdef",
+                            "blobMin": "YQ==",
+                            "blobMax": "YWJjZGVm",
                             "mapMin": {
                                 "a": "b"
                             },


### PR DESCRIPTION
#### Background
* What do these changes do? 
  * Fixes the computation logic for BlobLengthPlugin to correctly compute the blob's length
  * Correctly reports values which aren't base64 encoded as errors
  * Adds an opt-out Feature for the NodeValidationVisitor to revert back to existing behavior
* Why are they important?
  * Current validation behavior assumes blob values are simply the utf-8 encoding of the string; however, the effective use and spec states that blob values are base64 strings.

#### Testing
* How did you test these changes?
  * Verified unit test that were broken were legitimately wrong
    * Complete, fixed unit tests that were using non-base64 values when testing
  * Added new unit test for the new failure
    * Complete, added new tests specifically to check for the new error

#### Links
* Links to additional context, if necessary
  * N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
