### PR TITLE
Restore TopDownIndex default to sorting

### DIFF
--- a/.changes/releases/1.64.0.json
+++ b/.changes/releases/1.64.0.json
@@ -80,7 +80,7 @@
     },
     {
       "type": "feature",
-      "description": "Updated `TopDownIndex` to return results in modeled order.",
+      "description": "Updated `TopDownIndex` to allow disabling the sorting behavior, instead returning results in the order that they are discovered.",
       "pull_requests": [
         "[#2746](https://github.com/smithy-lang/smithy/pull/2746)"
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@
   shapes of the same type to see if they are compatible with each other.
   ([#2796](https://github.com/smithy-lang/smithy/pull/2796/))
 
-- Updated `TopDownIndex` to return results in modeled order.
+- Updated `TopDownIndex` to allow disabling the sorting behavior, instead
+  returning results in the order that they are discovered.
   ([#2746](https://github.com/smithy-lang/smithy/pull/2746))
 
 - Updated `ReplaceShapes` to use `DependencyGraph` to sort shapes.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/TopDownIndexTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/knowledge/TopDownIndexTest.java
@@ -80,7 +80,7 @@ public class TopDownIndexTest {
 
         TopDownIndex index = TopDownIndex.of(model);
         List<ShapeId> serviceOperations = index
-                .getContainedOperations(ShapeId.from("com.example#Service"))
+                .getContainedOperations(ShapeId.from("com.example#Service"), false)
                 .stream()
                 .map(Shape::toShapeId)
                 .collect(Collectors.toList());
@@ -94,7 +94,7 @@ public class TopDownIndexTest {
                         ShapeId.from("com.example#OperationG")));
 
         List<ShapeId> resourceOperations = index
-                .getContainedOperations(ShapeId.from("com.example#ResourceA"))
+                .getContainedOperations(ShapeId.from("com.example#ResourceA"), false)
                 .stream()
                 .map(Shape::toShapeId)
                 .collect(Collectors.toList());
@@ -105,7 +105,7 @@ public class TopDownIndexTest {
                         ShapeId.from("com.example#OperationG")));
 
         List<ShapeId> serviceResources = index
-                .getContainedResources(ShapeId.from("com.example#Service"))
+                .getContainedResources(ShapeId.from("com.example#Service"), false)
                 .stream()
                 .map(Shape::toShapeId)
                 .collect(Collectors.toList());
@@ -116,7 +116,7 @@ public class TopDownIndexTest {
                         ShapeId.from("com.example#ResourceB")));
 
         List<ShapeId> resourceResources = index
-                .getContainedResources(ShapeId.from("com.example#ResourceA"))
+                .getContainedResources(ShapeId.from("com.example#ResourceA"), false)
                 .stream()
                 .map(Shape::toShapeId)
                 .collect(Collectors.toList());
@@ -124,5 +124,60 @@ public class TopDownIndexTest {
                 contains(
                         ShapeId.from("com.example#ResourceC"),
                         ShapeId.from("com.example#ResourceB")));
+    }
+
+    @Test
+    public void sortsResultsByDefault() {
+        Model model = Model.assembler()
+                .addImport(TopDownIndexTest.class.getResource("top-down-order.smithy"))
+                .assemble()
+                .unwrap();
+
+        TopDownIndex index = TopDownIndex.of(model);
+        List<ShapeId> serviceOperations = index
+                .getContainedOperations(ShapeId.from("com.example#Service"))
+                .stream()
+                .map(Shape::toShapeId)
+                .collect(Collectors.toList());
+        assertThat(serviceOperations,
+                contains(
+                        ShapeId.from("com.example#OperationA"),
+                        ShapeId.from("com.example#OperationB"),
+                        ShapeId.from("com.example#OperationC"),
+                        ShapeId.from("com.example#OperationD"),
+                        ShapeId.from("com.example#OperationG"),
+                        ShapeId.from("com.example#OperationO")));
+
+        List<ShapeId> resourceOperations = index
+                .getContainedOperations(ShapeId.from("com.example#ResourceA"))
+                .stream()
+                .map(Shape::toShapeId)
+                .collect(Collectors.toList());
+        assertThat(resourceOperations,
+                contains(
+                        ShapeId.from("com.example#OperationD"),
+                        ShapeId.from("com.example#OperationG"),
+                        ShapeId.from("com.example#OperationO")));
+
+        List<ShapeId> serviceResources = index
+                .getContainedResources(ShapeId.from("com.example#Service"))
+                .stream()
+                .map(Shape::toShapeId)
+                .collect(Collectors.toList());
+        assertThat(serviceResources,
+                contains(
+                        ShapeId.from("com.example#ResourceA"),
+                        ShapeId.from("com.example#ResourceB"),
+                        ShapeId.from("com.example#ResourceC")));
+
+        List<ShapeId> resourceResources = index
+                .getContainedResources(ShapeId.from("com.example#ResourceA"))
+                .stream()
+                .map(Shape::toShapeId)
+                .collect(Collectors.toList());
+        assertThat(resourceResources,
+                contains(
+                        ShapeId.from("com.example#ResourceB"),
+                        ShapeId.from("com.example#ResourceC")));
     }
 }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetParameterValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetParameterValidator.java
@@ -6,7 +6,6 @@ package software.amazon.smithy.rulesengine.validators;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -73,8 +72,7 @@ public final class RuleSetParameterValidator extends AbstractValidator {
     ) {
         // Pull all the parameters used in this service related to endpoints, validating that
         // they are of matching types across the traits that can define them.
-        List<OperationShape> operations = new ArrayList<>(topDownIndex.getContainedOperations(service));
-        Collections.reverse(operations);
+        Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
 
         Map<String, Parameter> modelParams = validateAndExtractParameters(errors, model, service, operations);
         // Make sure parameters align across Params <-> RuleSet transitions.


### PR DESCRIPTION
This updates `TopDownIndex` to once again sort shapes by default. This sort can be opted-out if the discovery order is desired.

This change is being done because there has been some concern that changing something that was previously sorted could cause a lot of churn in any code generated that used the ordering provided by `TopDownIndex`. This differs from #602 because in that case the previous state was an unreliable order based on `HashSet` whereas in this case the previous state was a stable sort based on `TreeSet`.

These sorting changes are related to #2699. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
