### PR TITLE
Relativize file path in calling code

### DIFF
--- a/.changes/smithy_changelog/amend.py
+++ b/.changes/smithy_changelog/amend.py
@@ -127,7 +127,7 @@ def amend(
                     repository=repository,
                     pr_number=pr_number,
                     comment=comment,
-                    file=change_file,
+                    file=change_file.relative_to(repository_dir),
                     start_line=1,
                     end_line=len(change_file.read_text().splitlines()),
                 )


### PR DESCRIPTION
This updates the amend script to relativize the file path when posting a review comment, but it does so in the calling code against the actual root of the pr branch.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
