### PR TITLE
Don't run changelog tool on labeled prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+     - "dependencies"
+     - "no-changelog-needed"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+    labels:
+     - "dependencies"
+     - "no-changelog-needed"
     groups:
       gradle:
         update-types:
@@ -24,6 +30,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    labels:
+     - "dependencies"
+     - "no-changelog-needed"
     groups:
       python:
         update-types:

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -3,6 +3,7 @@ on: pull_request_target
 jobs:
     amend:
         name: "Validate staged changelogs"
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}
         runs-on: ubuntu-latest
         permissions:
           # Used to pull the PR and detect changes. This is needed to see


### PR DESCRIPTION
This updates the changelog tool github actions to not run on prs that are labeled with `no-changelog-needed`. This also updates the dependabot config to add that label.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
