### PR TITLE
Add dependabot config for landing page

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "npm"
+    directory: "/docs/landing-page"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+     - "dependencies"
+     - "no-changelog-needed"
+    groups:
+      npm:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This adds a dependabot config for the landing page build, which uses npm.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
