### PR TITLE
Setup latest node in doc build ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,13 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: latest
+        cache: npm
+        cache-dependency-path: "docs/landing-page/package-lock.json"
+
     - name: Install doc dependencies
       run: cd docs && make install
 

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -40,6 +40,8 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: latest
+        cache: npm
+        cache-dependency-path: "docs/landing-page/package-lock.json"
 
     - name: Build JavaDocs
       # run if 'javadocs' is not set to false 


### PR DESCRIPTION
This updates the doc build part of ci to install the latest version of node rather than relying on whatever version happens to be around.

This also adds caching to the make-docs workflow action.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
