### PR TITLE
Enable commonmark-ish docs via myst-parser plugin

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,12 @@ author = "Amazon Web Services"
 
 # -- General configuration ------------------------------------------------
 
-extensions = ["sphinx_copybutton", "sphinx_substitution_extensions", "smithy"]
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_substitution_extensions",
+    "smithy",
+]
 templates_path = ["../_templates", "../root"]
 
 pygments_style = "default"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -24,7 +24,10 @@ dependencies = [
     "sphinx-autobuild==2025.8.25",
 
     # needs to be added as it is removed in python3.13
-    "standard-imghdr==3.13.0"
+    "standard-imghdr==3.13.0",
+
+    # Allows writing docs in markdown
+    "myst-parser==4.0.1"
 ]
 
 [project.entry-points."pygments.lexers"]


### PR DESCRIPTION
This adds the [myst-parser plugin](https://myst-parser.readthedocs.io/en/latest/index.html) plugin to the sphinx docs configuration. myst is a markdown flavor that extends commonmark with the ability to call sphinx directives and roles, like so:

```rst
.. directivename:: arguments
   :key1: val1
   :key2: val2

   This is
   directive content
```

~~~md
```{directivename} arguments
:key1: val1
:key2: val2

This is
directive content
```
~~~

Smithy's own doc traits are in commonmark format so I think it makes sense to add this here. I've not attempted to re-write any existing docs as I think that would be a waste of time. With the plugin installed, both rst and markdown are supported simultaneously, differentiated based on the file extension.

I also ran the black formatter on `conf.py` as part of this.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
