### PR TITLE
Add ValidationException to error closures of operations of event stream

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/event-stream.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/event-stream.smithy
@@ -7,6 +7,7 @@ use aws.protocoltests.shared#DateTime
 use smithy.test#InitialHttpRequest
 use smithy.test#InitialHttpResponse
 use smithy.test#eventStreamTests
+use smithy.framework#ValidationException
 
 @streaming
 union EventStream {
@@ -584,6 +585,8 @@ operation InputStream {
         @httpPayload
         stream: EventStream
     }
+
+    errors: [ValidationException]
 }
 
 @eventStreamTests([
@@ -1110,6 +1113,7 @@ operation OutputStream {
     }
 
     errors: [
+        ValidationException
         ServiceUnavailableError
     ]
 }
@@ -2098,6 +2102,8 @@ operation DuplexStream {
         @httpPayload
         stream: EventStream
     }
+
+    errors: [ValidationException]
 }
 
 @eventStreamTests([
@@ -2145,6 +2151,8 @@ operation InputStreamWithInitialRequest {
         @httpPayload
         stream: EventStream
     }
+
+    errors: [ValidationException]
 }
 
 @eventStreamTests([
@@ -2327,6 +2335,8 @@ operation DuplexStreamWithDistinctStreams {
         @httpPayload
         stream: SingletonEventStream
     }
+
+    errors: [ValidationException]
 }
 
 union SingletonEventStream {


### PR DESCRIPTION
#### Background
* What do these changes do? 
* Why are they important?

The event stream protocol test operations take constrained input, but do not have `ValidationException` in the error closures. This is causing failures in CI for https://github.com/smithy-lang/smithy-rs/pull/4399.

#### Testing
* How did you test these changes?

Tests pass with the changes in place locally.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
