### PR TITLE
Fix null result handling in CFG terminal nodes

### DIFF
--- a/.changes/next-release/feature-49ce7cc4340df5b247027e9a2f5858e380ad129c.json
+++ b/.changes/next-release/feature-49ce7cc4340df5b247027e9a2f5858e380ad129c.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Fix null result handling in CFG terminal nodes",
+  "pull_requests": [
+    "[#2881](https://github.com/smithy-lang/smithy/pull/2881)"
+  ]
+}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/ResultNode.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/ResultNode.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.rulesengine.logic.cfg;
 
 import java.util.Objects;
+import software.amazon.smithy.rulesengine.language.syntax.rule.NoMatchRule;
 import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
 
 /**
@@ -13,15 +14,11 @@ import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
 public final class ResultNode extends CfgNode {
     private final Rule result;
     private final int hash;
-    private static final ResultNode TERMINAL = new ResultNode();
+    private static final ResultNode TERMINAL = new ResultNode(NoMatchRule.INSTANCE);
 
     public ResultNode(Rule result) {
-        this.result = result;
-        this.hash = result == null ? 11 : result.hashCode();
-    }
-
-    private ResultNode() {
-        this(null);
+        this.result = Objects.requireNonNull(result, "result cannot be null; use NoMatchRule.INSTANCE for no-match");
+        this.hash = result.hashCode();
     }
 
     /**
@@ -49,7 +46,7 @@ public final class ResultNode extends CfgNode {
         } else if (object == null || getClass() != object.getClass()) {
             return false;
         } else {
-            return Objects.equals(result, (((ResultNode) object)).result);
+            return result.equals(((ResultNode) object).result);
         }
     }
 

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/logic/bdd/get-attr.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/logic/bdd/get-attr.smithy
@@ -1,0 +1,75 @@
+$version: "2.0"
+
+namespace smithy.tests.endpointrules.getattr
+
+use smithy.rules#clientContextParams
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@suppress(["UnstableTrait"])
+@endpointRuleSet({
+    "version": "1.0",
+    "parameters": {
+        "Bucket": {
+            "type": "string",
+            "documentation": "docs"
+        }
+    },
+    "rules": [
+        {
+            "documentation": "bucket is set, handle bucket specific endpoints",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Bucket"
+                        }
+                    ]
+                },
+                {
+                    "fn": "parseURL",
+                    "argv": [
+                        "{Bucket}"
+                    ],
+                    "assign": "bucketUrl"
+                },
+                {
+                    "fn": "getAttr",
+                    "argv": [
+                        {
+                            "ref": "bucketUrl"
+                        },
+                        "path"
+                    ],
+                    "assign": "path"
+                }
+            ],
+            "endpoint": {
+                "url": "https://{bucketUrl#authority}{path}"
+            },
+            "type": "endpoint"
+        }
+    ]
+})
+
+@endpointTests({
+    "version": "1.0",
+    "testCases": [
+        {
+            "documentation": "getAttr on top level values in function and template"
+            "params": {
+                "Bucket": "http://example.com/path"
+            }
+            "expect": {
+                "endpoint": {
+                    "url": "https://example.com/path"
+                }
+            }
+        }
+    ]
+})
+@clientContextParams(
+    Bucket: {type: "string", documentation: "docs"}
+)
+service FizzBuzz {}


### PR DESCRIPTION
ResultNode.terminal() now uses NoMatchRule.INSTANCE instead of null, ensuring all CFG paths have explicit result rules. This fixes BDD serialization failures for rule sets without catch-all fallback rules.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
