### PR TITLE
Fix `@title` trait selector in docs

### DIFF
--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -390,9 +390,7 @@ Summary
     used in automatically generated documentation and other contexts to
     provide a user friendly name for a shape.
 Trait selector
-    ``:not(member)``
-
-    *Any service or resource*
+    ``*``
 Value type
     ``string``
 


### PR DESCRIPTION
#### Background
- Updated trait selector doc which was missed in https://github.com/smithy-lang/smithy/pull/2791

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
