### PR TITLE
Wrap the trait in a code block to avoid confusing javadoc

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PropertyBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PropertyBindingIndex.java
@@ -133,7 +133,7 @@ public final class PropertyBindingIndex implements KnowledgeIndex {
     /**
      * Resolves and returns the output shape of an operation that contains the
      * top-level resource bound properties. Handles adjustments made with
-     * @nestedProperties trait.
+     * {@code @nestedProperties} trait.
      *
      * @param operation operation to retrieve output properties shape for.
      * @return the output shape of an operation that contains top-level resource
@@ -148,7 +148,7 @@ public final class PropertyBindingIndex implements KnowledgeIndex {
     /**
      * Resolves and returns the input shape of an operation that contains the
      * top-level resource bound properties. Handles adjustments made with
-     * @nestedProperties trait.
+     * {@code @nestedProperties} trait.
      *
      * @param operation operation to retrieve output properties shape for
      * @return the input shape of an operation that contains top-level resource


### PR DESCRIPTION
#### Background
Fixes the following warning:

```
> Task :smithy-model:javadoc
/Users/sugmanue/Sources/smithy/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PropertyBindingIndex.java:136: warning: unknown tag. Unregistered custom tag?
     * @nestedProperties trait.
       ^
/Users/sugmanue/Sources/smithy/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PropertyBindingIndex.java:151: warning: unknown tag. Unregistered custom tag?
     * @nestedProperties trait.
       ^
2 warnings
```

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
