### PR TITLE
chore: run container as non-root user and add healthcheck

### DIFF
--- a/.changes/next-release/other-3000a7752c41a4776f985fed358751406c3f5f29.json
+++ b/.changes/next-release/other-3000a7752c41a4776f985fed358751406c3f5f29.json
@@ -1,0 +1,7 @@
+{
+  "type": "other",
+  "description": "Run container as non-root user",
+  "pull_requests": [
+    "[#2934](https://github.com/smithy-lang/smithy/pull/2934)"
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,10 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
+# Add a non-root user and set permissions
+RUN useradd -m smithy && \
+    chown -R smithy:smithy /smithy
+
+USER smithy
+
 ENTRYPOINT [ "/smithy/bin/smithy" ]


### PR DESCRIPTION
I've split out the Docker hardening changes as discussed in #2933. 

This PR updates the Dockerfile to:
1. Create and switch to a non-root `smithy` user. I also made sure to `chown` the `/smithy` directory so the new user has the right permissions to run the CLI and manage its class data sharing archive.
2. Add a `HEALTHCHECK` using `smithy --version` to monitor container health.

I think this covers what we talked about for the container side of things. Let me know if you want any further tweaks to the setup!