### PR TITLE
Fix SSA transform for transitive dependencies

### DIFF
--- a/.changes/next-release/feature-54a545d60b4d10ec40b2c5bf72ab0f1b11ea6145.json
+++ b/.changes/next-release/feature-54a545d60b4d10ec40b2c5bf72ab0f1b11ea6145.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Fix SSA transform for transitive dependencies",
+  "pull_requests": [
+    "[#2946](https://github.com/smithy-lang/smithy/pull/2946)"
+  ]
+}


### PR DESCRIPTION
When variable A references variable B, and B gets SSA-renamed, A also needs unique names even if A's expression text is identical across branches.

Example:
1. parts = split(input, delim, 0); part1 = getAttr(parts, "[0]")
2. parts = split(input, delim, 1); part1 = getAttr(parts, "[0]")

"parts" gets renamed to parts_ssa_1/parts_ssa_2, but "part1" wasn't being renamed despite referencing "parts". After rewriting, the expressions diverge, causing BDD validation failures.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
