### PR TITLE
Fix selector in RawIntegerWithoutRange examples

### DIFF
--- a/docs/source-2.0/guides/model-validation-examples.rst
+++ b/docs/source-2.0/guides/model-validation-examples.rst
@@ -226,7 +226,7 @@ to have clear, actionable error messages.
             """,
             selector: """
                 operation -[input]-> $structure(*) > member
-                :test(> number:not([trait|range|min]):not([trait|range|max]))
+                :test(> number):not([trait|range|min]):not([trait|range|max])
                 """
         }
     },
@@ -242,7 +242,7 @@ to have clear, actionable error messages.
             """,
             selector: """
                 operation -[input]-> $structure(*) > member
-                :test(> number[trait|range]:not([trait|range|min]))
+                :test(> number)[trait|range]:not([trait|range|min])
                 """
         }
     },
@@ -258,7 +258,7 @@ to have clear, actionable error messages.
             """,
             selector: """
                 operation -[input]-> $structure(*) > member
-                :test(> number[trait|range]:not([trait|range|max]))
+                :test(> number)[trait|range]:not([trait|range|max])
                 """
         }
     }


### PR DESCRIPTION
#### Background
* What do these changes do? 
  Fixes the selector in each example
* Why are they important?
  Examples should work as advertised

##### Existing documentation excerpt

Ref: <https://smithy.io/2.0/guides/model-validation-examples.html#require-integers-to-have-a-range-constraint>

> This example shows how to ***require all integers used in an operation input have a range constraint with both a minimum and maximum value.*** The first validator checks that the range trait exists on the shape, while the other two validators check that both the maximum and minimum values of the range are both filled out.

##### Existing experience

![screenshot1](https://github.com/user-attachments/assets/ffb730ee-f95b-431e-96ff-5bf9c233a292)

##### Proposed experience

![screenshot2](https://github.com/user-attachments/assets/e9acd95c-8ae0-44f7-99ce-b8249a08a973)

![screenshot3](https://github.com/user-attachments/assets/23143bea-f19f-4a64-bb7a-3fa359554a05)

#### Testing
* How did you test these changes?
  In my current project. AWS employee, so feel free to DM me if you have questions.

#### Links
* Links to additional context, if necessary
  <https://smithy.io/2.0/guides/model-validation-examples.html#require-integers-to-have-a-range-constraint> 
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)
  * Fixes #2965

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
