### PR TITLE
Tweak wording of integers with ranges message

### DIFF
--- a/.changes/next-release/documentation-25cc6401a5c0dd1c0973d796b257ac34f47f6f25.json
+++ b/.changes/next-release/documentation-25cc6401a5c0dd1c0973d796b257ac34f47f6f25.json
@@ -1,0 +1,7 @@
+{
+  "type": "documentation",
+  "description": "Tweak wording of integers with ranges message",
+  "pull_requests": [
+    "[#2971](https://github.com/smithy-lang/smithy/pull/2971)"
+  ]
+}

--- a/docs/source-2.0/guides/model-validation-examples.rst
+++ b/docs/source-2.0/guides/model-validation-examples.rst
@@ -219,9 +219,9 @@ to have clear, actionable error messages.
         id: "RawIntegerWithoutRange",
         configuration: {
             messageTemplate: """
-            This number shape in member `@{id}` of the operation input `@{var|structure}` \
+            This number shape targeted by the member `@{id}` of the operation input `@{var|structure}` \
             does not have a range constraint on both its minimum or maximum value. \
-            Add the `@@range` trait to this integer shape and provide both minimum and maximum values. \
+            Add the `@@range` trait to the targeted integer shape and provide both minimum and maximum values. \
             For example, `@@range(min: 1, max: 500)`.
             """,
             selector: """
@@ -235,9 +235,9 @@ to have clear, actionable error messages.
         id: "RawIntegerWithoutRangeMin",
         configuration: {
             messageTemplate: """
-            This number shape in member `@{id}` of the operation input `@{var|structure}` \
+            This number shape targeted by the member `@{id}` of the operation input `@{var|structure}` \
             does not have a maximum range constraint. \
-            Add a minimum value to the `@@range` trait on this shape. \
+            Add a minimum value to the `@@range` trait on this shape's target. \
             For example, `@@range(>>> min: 1 <<<, max: 500)`.
             """,
             selector: """
@@ -251,9 +251,9 @@ to have clear, actionable error messages.
         id: "RawIntegerWithoutRangeMax",
         configuration: {
             messageTemplate: """
-            This number shape in member `@{id}` of the operation input `@{var|structure}` \
+            This number shape targeted by the member `@{id}` of the operation input `@{var|structure}` \
             does not have a maximum range constraint. \
-            Add a maximum value to the `@@range` trait on this shape. \
+            Add a maximum value to the `@@range` trait on this shape's target. \
             For example, `@@range(min: 1, >>> max: 500 <<<)`.
             """,
             selector: """


### PR DESCRIPTION
#### Background
The purpose of this validation is to push `@range` traits on to distinct `integer`s in a model, so clarify the message to apply to targets.

##### Why not make this target members?

Having this apply to members means that each place the same potential values need to be specified, they must be kept in sync. This is prone to mistakes if the same value in the range needs to be adjusted in multiple locations.

##### Why not exclude the prelude `smithy.api#Integer`?

This doesn't solve the problem that the validation expects. Exempting members that target the prelude integer doesn't force _all_ integer input to be bound.

#### Links
* See also #2966 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
