### PR TITLE
Add no-changleog-needed label to gradle plugin automation

### DIFF
--- a/.github/workflows/update-gradle-plugin.yml
+++ b/.github/workflows/update-gradle-plugin.yml
@@ -55,6 +55,7 @@ jobs:
             --title "[Automation] smithy-gradle-plugin Version Bump - \`${{ steps.fetch-latest.outputs.latestSmithyGradle }}\`" \
             --body "Automated pull request to bump smithy gradle plugin version from ${{ steps.get-current.outputs.smithyGradleVersion }} to ${{ steps.fetch-latest.outputs.latestSmithyGradle }}" \
             --base main
+            --label no-changelog-needed
           echo "PR Created for version bump to ${{ steps.fetch-latest.outputs.latestSmithyGradle }}"
         env:
           GITHUB_TOKEN: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION

This adds the no-changelog-needed label to prs created by our automation that updates the gradle plugin version used by various smithy packages (like this one: https://github.com/smithy-lang/smithy/pull/2974).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
