### PR TITLE
Allow enforced tail-style pagination

### DIFF
--- a/.changes/next-release/feature-e40be9ef35b78107d477cebe67de874fb59940e6.json
+++ b/.changes/next-release/feature-e40be9ef35b78107d477cebe67de874fb59940e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Relaxed the optionality constraint on pagination output tokens to report a DANGER when the output token is required instead of ERROR.",
+  "pull_requests": [
+    "[#2983](https://github.com/smithy-lang/smithy/pull/2983)"
+  ]
+}

--- a/docs/source-2.0/spec/behavior-traits.rst
+++ b/docs/source-2.0/spec/behavior-traits.rst
@@ -210,8 +210,8 @@ The ``paginated`` trait is a structure that contains the following members:
         operation output, it indicates that there are more results to retrieve.
         To get the next page of results, the client passes the received output
         continuation token to the input continuation token of the next request.
-        This output member MUST NOT be marked as ``required`` and SHOULD target
-        a string shape. It can, but SHOULD NOT target a map shape.
+        This output member SHOULD NOT be marked as ``required`` and SHOULD
+        target a string shape. It can, but SHOULD NOT target a map shape.
 
         When contained within a service, a paginated operation MUST either
         configure ``outputToken`` on the operation itself or inherit it from

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidationUtils;
 import software.amazon.smithy.utils.SetUtils;
@@ -84,19 +85,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
 
         // Validate input.
         events.addAll(validateMember(opIndex, model, null, operation, trait, new InputTokenValidator()));
-        PageSizeValidator pageSizeValidator = new PageSizeValidator();
-        events.addAll(validateMember(opIndex, model, null, operation, trait, pageSizeValidator));
-        pageSizeValidator.getMember(model, opIndex, operation, trait)
-                .filter(MemberShape::isRequired)
-                .ifPresent(member -> events.add(warning(
-                        operation,
-                        trait,
-                        String.format(
-                                "paginated trait `%s` member `%s` should not be required",
-                                pageSizeValidator.propertyName(),
-                                member.getMemberName()),
-                        SHOULD_NOT_BE_REQUIRED,
-                        pageSizeValidator.propertyName())));
+        events.addAll(validateMember(opIndex, model, null, operation, trait, new PageSizeValidator()));
 
         // Validate output.
         events.addAll(validateMember(opIndex, model, null, operation, trait, new OutputTokenValidator()));
@@ -161,14 +150,38 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         }
 
         List<ValidationEvent> events = new ArrayList<>();
-        if (validator.mustBeOptional() && member.isRequired()) {
-            events.add(error(operation,
-                    trait,
-                    String.format(
-                            "%spaginated trait `%s` member `%s` must not be required",
-                            prefix,
-                            validator.propertyName(),
-                            member.getMemberName())));
+        if (member.isRequired()) {
+            switch (validator.optionality()) {
+                case MUST:
+                    events.add(error(
+                            operation,
+                            trait,
+                            String.format(
+                                    "%spaginated trait `%s` member `%s` must not be required",
+                                    prefix,
+                                    validator.propertyName(),
+                                    member.getMemberName())));
+                    break;
+                case SHOULD:
+                    // Page size historically was a warning, so we want to keep it that way.
+                    // In other cases this will be used when we lower severity from error,
+                    // so it's best to only lower one step to danger.
+                    Severity severity = validator instanceof PageSizeValidator ? Severity.WARNING : Severity.DANGER;
+                    events.add(createEvent(
+                            severity,
+                            operation,
+                            trait,
+                            String.format(
+                                    "%spaginated trait `%s` member `%s` should not be required",
+                                    prefix,
+                                    validator.propertyName(),
+                                    member.getMemberName()),
+                            SHOULD_NOT_BE_REQUIRED,
+                            validator.propertyName()));
+                    break;
+                default:
+                    break;
+            }
         }
 
         Shape target = model.getShape(member.getTarget()).orElse(null);
@@ -221,8 +234,25 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         return events;
     }
 
+    private enum Optionality {
+        /**
+         * The property MUST be optional. It MUST NOT have the required trait.
+         */
+        MUST,
+
+        /**
+         * The property SHOULD be optional. It SHOULD NOT have the required trait.
+         */
+        SHOULD,
+
+        /**
+         * The property MAY be required or optional.
+         */
+        MAY;
+    }
+
     private abstract static class PropertyValidator {
-        abstract boolean mustBeOptional();
+        abstract Optionality optionality();
 
         abstract boolean isRequiredToBePresent();
 
@@ -274,8 +304,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
     }
 
     private static final class InputTokenValidator extends PropertyValidator {
-        boolean mustBeOptional() {
-            return true;
+        Optionality optionality() {
+            return Optionality.MUST;
         }
 
         boolean isRequiredToBePresent() {
@@ -310,8 +340,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
     }
 
     private static final class OutputTokenValidator extends OutputPropertyValidator {
-        boolean mustBeOptional() {
-            return true;
+        Optionality optionality() {
+            return Optionality.SHOULD;
         }
 
         boolean isRequiredToBePresent() {
@@ -336,8 +366,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
     }
 
     private static final class PageSizeValidator extends PropertyValidator {
-        boolean mustBeOptional() {
-            return false;
+        Optionality optionality() {
+            return Optionality.SHOULD;
         }
 
         boolean isRequiredToBePresent() {
@@ -372,8 +402,8 @@ public final class PaginatedTraitValidator extends AbstractValidator {
     }
 
     private static final class ItemValidator extends OutputPropertyValidator {
-        boolean mustBeOptional() {
-            return false;
+        Optionality optionality() {
+            return Optionality.MAY;
         }
 
         boolean isRequiredToBePresent() {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated/paginated-invalid.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/paginated/paginated-invalid.errors
@@ -4,7 +4,7 @@
 [ERROR] ns.foo#Invalid3: paginated trait `items` targets a member `items` that does not exist | PaginatedTrait
 [ERROR] ns.foo#Invalid3: paginated trait `outputToken` member `nextToken` targets a integer shape, but must target one of the following: [`map`, `string`] | PaginatedTrait
 [ERROR] ns.foo#Invalid4: paginated trait `inputToken` member `nextToken` must not be required | PaginatedTrait
-[ERROR] ns.foo#Invalid4: paginated trait `outputToken` member `nextToken` must not be required | PaginatedTrait
+[DANGER] ns.foo#Invalid4: paginated trait `outputToken` member `nextToken` should not be required | PaginatedTrait
 [WARNING] ns.foo#Invalid4: paginated trait `pageSize` member `pageSize` should not be required | PaginatedTrait.ShouldNotBeRequired.pageSize
 [ERROR] ns.foo#Invalid5: paginated trait `pageSize` member `pageSize` targets a string shape, but must target one of the following: [`byte`, `integer`, `long`, `short`] | PaginatedTrait
 [ERROR] ns.foo#Invalid6: paginated trait `items` member `items` targets a string shape, but must target one of the following: [`list`, `map`] | PaginatedTrait


### PR DESCRIPTION
This relaxes the optionality constraint on pagination output tokens to report a DANGER when the output token is required instead of ERROR. While we don't want to encourage these sort of tail-style pagination strategies, we do and have supported them.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
