### PR TITLE
Fix awsJson docs examples and awsJson1_1 error namespaces

### DIFF
--- a/docs/source-1.0/spec/aws/aws-json-1_0-protocol.rst
+++ b/docs/source-1.0/spec/aws/aws-json-1_0-protocol.rst
@@ -112,7 +112,7 @@ preferred over ``http/1.1``.
 
     use aws.protocols#awsJson1_0
 
-    @awsJson1_1(
+    @awsJson1_0(
         http: ["h2", "http/1.1"],
         eventStreamHttp: ["h2", "http/1.1"]
     )

--- a/docs/source-1.0/spec/aws/aws-json.rst.template
+++ b/docs/source-1.0/spec/aws/aws-json.rst.template
@@ -174,8 +174,8 @@ All of the following error values resolve to ``FooError``:
 
 * ``FooError``
 * ``FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/``
-* ``aws.protocoltests.restjson#FooError``
-* ``aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/``
+* ``smithy.example#FooError``
+* ``smithy.example#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/``
 
 
 -----------------------------------------------------

--- a/docs/source-2.0/aws/protocols/aws-json-1_0-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-json-1_0-protocol.rst
@@ -100,7 +100,7 @@ preferred over ``http/1.1``.
 
     use aws.protocols#awsJson1_0
 
-    @awsJson1_1(
+    @awsJson1_0(
         http: ["h2", "http/1.1"],
         eventStreamHttp: ["h2", "http/1.1"]
     )

--- a/docs/source-2.0/aws/protocols/aws-json.rst.template
+++ b/docs/source-2.0/aws/protocols/aws-json.rst.template
@@ -198,8 +198,8 @@ All of the following error values resolve to ``FooError``:
 
 * ``FooError``
 * ``FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/``
-* ``aws.protocoltests.restjson#FooError``
-* ``aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/``
+* ``smithy.example#FooError``
+* ``smithy.example#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/``
 
 
 -----------------------------------------------------
@@ -231,4 +231,3 @@ These compliance tests define a model that is used to define test cases and
 the expected serialized HTTP requests and responses for each case.
 
 *TODO: Add event stream handling specifications.*
-

--- a/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
@@ -145,7 +145,7 @@ apply FooError @httpResponseTests([
         protocol: awsJson1_1,
         code: 500,
         headers: {
-            "X-Amzn-Errortype": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
+            "X-Amzn-Errortype": "aws.protocoltests.json#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
         },
         appliesTo: "client",
     },
@@ -181,7 +181,7 @@ apply FooError @httpResponseTests([
         },
         body: """
               {
-                  "code": "aws.protocoltests.restjson#FooError"
+                  "code": "aws.protocoltests.json#FooError"
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
@@ -199,7 +199,7 @@ apply FooError @httpResponseTests([
         },
         body: """
               {
-                  "code": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+                  "code": "aws.protocoltests.json#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
@@ -231,7 +231,7 @@ apply FooError @httpResponseTests([
         },
         body: """
               {
-                  "__type": "aws.protocoltests.restjson#FooError"
+                  "__type": "aws.protocoltests.json#FooError"
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
@@ -249,7 +249,7 @@ apply FooError @httpResponseTests([
         },
         body: """
               {
-                  "__type": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+                  "__type": "aws.protocoltests.json#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
@@ -269,7 +269,7 @@ apply FooError @httpResponseTests([
         },
         body: """
               {
-                  "__type": "aws.protocoltests.restjson#FooError",
+                  "__type": "aws.protocoltests.json#FooError",
                   "ErrorDetails": [
                     {
                         "__type": "com.amazon.internal#ErrorDetails",


### PR DESCRIPTION
#### Background
* What do these changes do?
  * Replace hardcoded `aws.protocoltests.restjson#FooError...` examples in shared AWS JSON docs templates with neutral `smithy.example#FooError...` examples.
  * Fix an `awsJson1_0` docs typo where an example incorrectly used `@awsJson1_1`.
  * Align `awsJson1_1` protocol test error namespace examples in `smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy` from `aws.protocoltests.restjson#FooError...` to `aws.protocoltests.json#FooError...`.
* Why are they important?
  * Ensures docs are protocol-agnostic where shared and avoids misleading namespace examples.
  * Ensures `awsJson1_0` docs examples are internally consistent.
  * Ensures `awsJson1_1` error protocol tests are consistent with the model namespace (`aws.protocoltests.json`).

#### Testing
* How did you test these changes?
  * TODO

#### Links
* Links to additional context, if necessary
  * [AWS JSON 1.0 Protocol](https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html)
  * [AWS JSON 1.1 Protocol](https://smithy.io/2.0/aws/protocols/aws-json-1_1-protocol.html)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.