### PR TITLE
Fix incorrect javadoc generated with leading '@'

### DIFF
--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/DocumentationTraitInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/DocumentationTraitInterceptor.java
@@ -18,7 +18,8 @@ final class DocumentationTraitInterceptor implements CodeInterceptor<JavaDocSect
 
     @Override
     public void write(TraitCodegenWriter writer, String previousText, JavaDocSection section) {
-        writer.write(section.shape().expectTrait(DocumentationTrait.class).getValue());
+        String docs = section.shape().expectTrait(DocumentationTrait.class).getValue();
+        writer.write(escapeAt(docs));
 
         if (!previousText.isEmpty()) {
             // Add spacing if tags have been added to the javadoc
@@ -35,5 +36,27 @@ final class DocumentationTraitInterceptor implements CodeInterceptor<JavaDocSect
     @Override
     public boolean isIntercepted(JavaDocSection section) {
         return section.shape().hasTrait(DocumentationTrait.ID);
+    }
+
+    // Escapes '@' at the beginning of a line to prevent javac from interpreting
+    // it as a Javadoc block tag.
+    private static String escapeAt(String docs) {
+        StringBuilder result = new StringBuilder(docs.length());
+        boolean lineStart = true;
+        for (int i = 0; i < docs.length(); i++) {
+            char current = docs.charAt(i);
+            if (current == '@' && lineStart) {
+                if (i + 1 < docs.length() && docs.charAt(i + 1) == '@') {
+                    result.append("@@");
+                    i++;
+                } else {
+                    result.append("{@literal @}");
+                }
+            } else {
+                result.append(current);
+            }
+            lineStart = current == '\n';
+        }
+        return result.toString();
     }
 }

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/integrations/javadoc/JavadocTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/integrations/javadoc/JavadocTest.java
@@ -53,6 +53,11 @@ public class JavadocTest {
         String fileContents = getFileContentsFromShapeName("DocumentationWrapping", true);
         String expected = "/**\n" +
                 " * Basic class-level documentation\n" +
+                " * {@literal @}foo\n" +
+                " * {@code}\n" +
+                " * abc@example.com\n" +
+                " * @@foo\n" +
+                " * {@literal @}foo and @bar\n" +
                 " */\n" +
                 "@SmithyGenerated\n" +
                 "public final class DocumentationWrappingTrait extends AbstractTrait implements ToSmithyBuilder<DocumentationWrappingTrait> {";

--- a/smithy-trait-codegen/src/test/resources/software/amazon/smithy/traitcodegen/integrations/javadoc/javadoc-test.smithy
+++ b/smithy-trait-codegen/src/test/resources/software/amazon/smithy/traitcodegen/integrations/javadoc/javadoc-test.smithy
@@ -3,6 +3,11 @@ $version: "2"
 namespace com.example.javadoc
 
 /// Basic class-level documentation
+/// @foo
+/// {@code}
+/// abc@example.com
+/// @@foo
+/// @foo and @bar
 @trait
 structure DocumentationWrapping {
     /// This is a long long docstring that should be wrapped. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
Current trait codegen did not escape for the usage of `@` at the beginning of the line in documentation trait. This PR added the escape for the leading `@`.
```smithy
/// @foo (this will be {literal @}foo)
/// @@foo (no escape)
/// foo@bar.com (no escape)
// {@code} (no escape)
```

This should resolve the #2989 after merge.