### PR TITLE
Fix issues handling high-precision numbers

### DIFF
--- a/.changes/next-release/feature-6289218d427df9d332b7104ad0012f630797168f.json
+++ b/.changes/next-release/feature-6289218d427df9d332b7104ad0012f630797168f.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Fix issues handling high-precision numbers",
+  "pull_requests": [
+    "[#3004](https://github.com/smithy-lang/smithy/pull/3004)"
+  ]
+}

--- a/smithy-jmespath/build.gradle.kts
+++ b/smithy-jmespath/build.gradle.kts
@@ -10,3 +10,7 @@ description = "A standalone JMESPath parser"
 
 extra["displayName"] = "Smithy :: JMESPath"
 extra["moduleName"] = "software.amazon.smithy.jmespath"
+
+dependencies {
+    api(project(":smithy-utils"))
+}

--- a/smithy-jmespath/src/main/java/software/amazon/smithy/jmespath/Lexer.java
+++ b/smithy-jmespath/src/main/java/software/amazon/smithy/jmespath/Lexer.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import software.amazon.smithy.jmespath.ast.LiteralExpression;
 import software.amazon.smithy.jmespath.evaluation.JmespathRuntime;
+import software.amazon.smithy.utils.NumberUtils;
 
 final class Lexer<T> {
 
@@ -468,12 +469,7 @@ final class Lexer<T> {
         String lexeme = sliceFrom(start);
 
         try {
-            Number number;
-            if (lexeme.contains(".") || lexeme.toLowerCase().contains("e")) {
-                number = Double.parseDouble(lexeme);
-            } else {
-                number = Long.parseLong(lexeme);
-            }
+            Number number = NumberUtils.parseNumber(lexeme);
             LiteralExpression node = new LiteralExpression(number, currentLine, currentColumn);
             return new Token(TokenType.NUMBER, node, currentLine, currentColumn);
         } catch (NumberFormatException e) {

--- a/smithy-jmespath/src/test/java/software/amazon/smithy/jmespath/LexerTest.java
+++ b/smithy-jmespath/src/test/java/software/amazon/smithy/jmespath/LexerTest.java
@@ -10,8 +10,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -540,6 +542,49 @@ public class LexerTest {
         assertThat(tokens.get(2).type, equalTo(TokenType.EOF));
         assertThat(tokens.get(2).line, equalTo(1));
         assertThat(tokens.get(2).column, equalTo(25));
+    }
+
+    @Test
+    public void parsesDoublePrecisionCompatibleNumber() {
+        List<Token> tokens = tokenize("1.5");
+
+        assertThat(tokens.get(0).type, equalTo(TokenType.NUMBER));
+        Number value = tokens.get(0).value.expectNumberValue();
+        assertThat(value, is(instanceOf(Double.class)));
+        assertThat(value.doubleValue(), equalTo(1.5));
+    }
+
+    @Test
+    public void parsesDoublePrecisionIncompatibleNumberAsBigDecimal() {
+        // 2^53 + 1 with a decimal triggers the float path but loses precision as a double.
+        List<Token> tokens = tokenize("9007199254740993.0");
+
+        assertThat(tokens.get(0).type, equalTo(TokenType.NUMBER));
+        Number value = tokens.get(0).value.expectNumberValue();
+        assertThat(value, is(instanceOf(BigDecimal.class)));
+        assertThat(value.toString(), equalTo("9007199254740993.0"));
+    }
+
+    @Test
+    public void parsesOverflowPositiveDoubleAsBigDecimal() {
+        // 1e309 overflows Double to +Infinity, but is a valid BigDecimal.
+        List<Token> tokens = tokenize("1e309");
+
+        assertThat(tokens.get(0).type, equalTo(TokenType.NUMBER));
+        Number value = tokens.get(0).value.expectNumberValue();
+        assertThat(value, is(instanceOf(BigDecimal.class)));
+        assertThat(value, equalTo(new BigDecimal("1e309")));
+    }
+
+    @Test
+    public void parsesOverflowNegativeDoubleAsBigDecimal() {
+        // -1e309 overflows Double to -Infinity, but is a valid BigDecimal.
+        List<Token> tokens = tokenize("-1e309");
+
+        assertThat(tokens.get(0).type, equalTo(TokenType.NUMBER));
+        Number value = tokens.get(0).value.expectNumberValue();
+        assertThat(value, is(instanceOf(BigDecimal.class)));
+        assertThat(value, equalTo(new BigDecimal("-1e309")));
     }
 
     @Test

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/DefaultTokenizer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/DefaultTokenizer.java
@@ -4,10 +4,9 @@
  */
 package software.amazon.smithy.model.loader;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.NoSuchElementException;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.utils.NumberUtils;
 import software.amazon.smithy.utils.SimpleParser;
 
 class DefaultTokenizer implements IdlTokenizer {
@@ -318,22 +317,7 @@ class DefaultTokenizer implements IdlTokenizer {
 
     private IdlToken parseNumber() {
         try {
-            String lexeme = ParserUtils.parseNumber(parser);
-            if (lexeme.contains("e") || lexeme.contains("E") || lexeme.contains(".")) {
-                double value = Double.parseDouble(lexeme);
-                if (Double.isFinite(value)) {
-                    currentTokenNumber = value;
-                } else {
-                    currentTokenNumber = new BigDecimal(lexeme);
-                }
-            } else {
-                try {
-                    currentTokenNumber = Long.parseLong(lexeme);
-                } catch (NumberFormatException e) {
-                    currentTokenNumber = new BigInteger(lexeme);
-                }
-            }
-
+            currentTokenNumber = NumberUtils.parseNumber(ParserUtils.parseNumber(parser));
             currentTokenEnd = parser.position();
             return currentTokenType = IdlToken.NUMBER;
         } catch (RuntimeException e) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/NodeHandler.java
@@ -6,8 +6,6 @@ package software.amazon.smithy.model.node.internal;
 
 import java.io.StringWriter;
 import java.io.Writer;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.BooleanNode;
@@ -16,6 +14,7 @@ import software.amazon.smithy.model.node.NullNode;
 import software.amazon.smithy.model.node.NumberNode;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.utils.NumberUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -69,21 +68,7 @@ public final class NodeHandler extends JsonHandler<ArrayNode.Builder, ObjectNode
 
     @Override
     void endNumber(String string, SourceLocation location) {
-        if (string.contains("e") || string.contains("E") || string.contains(".")) {
-            double doubleValue = Double.parseDouble(string);
-            if (Double.isFinite(doubleValue)) {
-                value = new NumberNode(doubleValue, location);
-            } else {
-                value = new NumberNode(new BigDecimal(string), location);
-            }
-        } else {
-            try {
-                value = new NumberNode(Long.parseLong(string), location);
-            } catch (NumberFormatException e) {
-                value = new NumberNode(new BigInteger(string), location);
-            }
-
-        }
+        value = new NumberNode(NumberUtils.parseNumber(string), location);
     }
 
     @Override

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TokenizerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TokenizerTest.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.model.loader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import java.util.NoSuchElementException;
@@ -197,6 +198,49 @@ public class TokenizerTest {
 
         assertThat(tokenizer.next(), is(IdlToken.NUMBER));
         assertThat(tokenizer.getCurrentTokenNumberValue(), equalTo(10L));
+    }
+
+    @Test
+    public void parsesDoublePrecisionCompatibleFloat() {
+        IdlTokenizer tokenizer = IdlTokenizer.create("1.5");
+
+        assertThat(tokenizer.next(), is(IdlToken.NUMBER));
+        Number value = tokenizer.getCurrentTokenNumberValue();
+        assertThat(value, instanceOf(Double.class));
+        assertThat(value.doubleValue(), equalTo(1.5));
+    }
+
+    @Test
+    public void parsesDoublePrecisionIncompatibleFloatAsBigDecimal() {
+        // 2^53 + 1 with a decimal triggers the float path but loses precision as a double.
+        IdlTokenizer tokenizer = IdlTokenizer.create("9007199254740993.0");
+
+        assertThat(tokenizer.next(), is(IdlToken.NUMBER));
+        Number value = tokenizer.getCurrentTokenNumberValue();
+        assertThat(value, instanceOf(java.math.BigDecimal.class));
+        assertThat(value.toString(), equalTo("9007199254740993.0"));
+    }
+
+    @Test
+    public void parsesOverflowPositiveDoubleAsBigDecimal() {
+        // 1e309 overflows Double to +Infinity, but is a valid BigDecimal.
+        IdlTokenizer tokenizer = IdlTokenizer.create("1e309");
+
+        assertThat(tokenizer.next(), is(IdlToken.NUMBER));
+        Number value = tokenizer.getCurrentTokenNumberValue();
+        assertThat(value, instanceOf(java.math.BigDecimal.class));
+        assertThat(value, equalTo(new java.math.BigDecimal("1e309")));
+    }
+
+    @Test
+    public void parsesOverflowNegativeDoubleAsBigDecimal() {
+        // -1e309 overflows Double to -Infinity, but is a valid BigDecimal.
+        IdlTokenizer tokenizer = IdlTokenizer.create("-1e309");
+
+        assertThat(tokenizer.next(), is(IdlToken.NUMBER));
+        Number value = tokenizer.getCurrentTokenNumberValue();
+        assertThat(value, instanceOf(java.math.BigDecimal.class));
+        assertThat(value, equalTo(new java.math.BigDecimal("-1e309")));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeParserTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeParserTest.java
@@ -6,9 +6,11 @@ package software.amazon.smithy.model.node;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -69,9 +71,47 @@ public class NodeParserTest {
         Node result = Node.parse("1.5");
 
         assertThat(result.isNumberNode(), is(true));
+        assertThat(result.expectNumberNode().getValue(), is(instanceOf(Double.class)));
         assertThat(result.expectNumberNode().getValue(), equalTo(1.5));
         assertThat(result.getSourceLocation().getLine(), is(1));
         assertThat(result.getSourceLocation().getColumn(), is(1));
+    }
+
+    @Test
+    public void parsesDoublePrecisionIncompatibleNumberAsBigDecimal() {
+        // 2^53 + 1 with a decimal triggers the float path but loses precision as a double.
+        Node result = Node.parse("9007199254740993.0");
+        assertThat(result.isNumberNode(), is(true));
+
+        NumberNode numberNode = result.expectNumberNode();
+        assertThat(numberNode.getValue(), is(instanceOf(BigDecimal.class)));
+        assertThat(numberNode.getValue().toString(), equalTo("9007199254740993.0"));
+        assertThat(numberNode.getSourceLocation().getLine(), is(1));
+        assertThat(numberNode.getSourceLocation().getColumn(), is(1));
+    }
+
+    @Test
+    public void parsesOverflowPositiveDoubleAsBigDecimal() {
+        // 1e309 overflows Double to +Infinity, but is a valid BigDecimal.
+        Node result = Node.parse("1e309");
+
+        NumberNode numberNode = result.expectNumberNode();
+        assertThat(numberNode.getValue(), is(instanceOf(BigDecimal.class)));
+        assertThat(numberNode.getValue(), equalTo(new BigDecimal("1e309")));
+        assertThat(numberNode.getSourceLocation().getLine(), is(1));
+        assertThat(numberNode.getSourceLocation().getColumn(), is(1));
+    }
+
+    @Test
+    public void parsesOverflowNegativeDoubleAsBigDecimal() {
+        // -1e309 overflows Double to -Infinity, but is a valid BigDecimal.
+        Node result = Node.parse("-1e309");
+
+        NumberNode numberNode = result.expectNumberNode();
+        assertThat(numberNode.getValue(), is(instanceOf(BigDecimal.class)));
+        assertThat(numberNode.getValue(), equalTo(new BigDecimal("-1e309")));
+        assertThat(numberNode.getSourceLocation().getLine(), is(1));
+        assertThat(numberNode.getSourceLocation().getColumn(), is(1));
     }
 
     @Test

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/NumberUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/NumberUtils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Functions that make working with numbers easier.
+ */
+public final class NumberUtils {
+    private NumberUtils() {}
+
+    /**
+     * Parses a numeric string into the most appropriate Number type.
+     *
+     * <p>Extreme values ("Infinity", "NaN", and their signed variants) are
+     * recognized first and returned as {@link Double}.
+     *
+     * <p>Strings containing ".", "e", or "E" are treated as decimal numbers
+     * and parsed via {@link #parseDecimalNumber}. All other strings are
+     * parsed as integers, trying {@link Long} first and falling back to
+     * {@link BigInteger} for values that overflow long.
+     *
+     * @param lexeme A numeric string.
+     * @return A Long, BigInteger, Double, or BigDecimal representing the value.
+     */
+    public static Number parseNumber(String lexeme) {
+        Number extremeValue = parseExtremeValue(lexeme);
+        if (extremeValue != null) {
+            return extremeValue;
+        }
+        if (lexeme.contains("e") || lexeme.contains("E") || lexeme.contains(".")) {
+            return parseDecimalNumber(lexeme);
+        }
+        try {
+            return Long.parseLong(lexeme);
+        } catch (NumberFormatException e) {
+            return new BigInteger(lexeme);
+        }
+    }
+
+    private static Number parseExtremeValue(String lexeme) {
+        // Short circuit if we won't get a match later.
+        if (!lexeme.contains("I") && !lexeme.contains("N")) {
+            return null;
+        }
+        switch (lexeme) {
+            case "+Infinity":
+            case "Infinity":
+                return Double.POSITIVE_INFINITY;
+            case "-Infinity":
+                return Double.NEGATIVE_INFINITY;
+            case "+NaN":
+            case "NaN":
+            case "-NaN":
+                return Double.NaN;
+        }
+        return null;
+    }
+
+    /**
+     * Parses a decimal (floating-point or scientific notation) string into the
+     * most precise Number type that preserves the value.
+     *
+     * <p>Extreme values ("Infinity", "NaN", and their signed variants) are
+     * recognized first and returned as {@link Double}.
+     *
+     * <p>Returns a {@link Double} when the value can be represented without
+     * precision loss. Returns a {@link BigDecimal} when the value exceeds
+     * double range (would become infinity) or loses precision in IEEE-754.
+     *
+     * @param lexeme A numeric string containing ".", "e"/"E", or an extreme
+     *     value literal.
+     * @return A Double or BigDecimal representing the parsed value.
+     */
+    public static Number parseDecimalNumber(String lexeme) {
+        Number extremeValue = parseExtremeValue(lexeme);
+        if (extremeValue != null) {
+            return extremeValue;
+        }
+        Double doubleValue = Double.valueOf(lexeme);
+        if (doubleValue.isInfinite()) {
+            // Doubles parse values outside their range as infinity.
+            // Literal infinity is handled by the `I` test, so parse the real value.
+            return new BigDecimal(lexeme);
+        }
+        BigDecimal bigDecimalValue = new BigDecimal(lexeme);
+        if (isDoublePrecisionCompatible(bigDecimalValue, doubleValue)) {
+            return doubleValue;
+        }
+        return bigDecimalValue;
+    }
+
+    /**
+     * Checks whether the bigDecimalValue is represented in the doubleValue without
+     * a loss of precision due to IEEE-754 floating-point representation.
+     *
+     * <p>Returns {@code true} unconditionally for infinite and NaN doubles,
+     * since those values have no BigDecimal equivalent to compare against.
+     *
+     * @param bigDecimalValue The value as a BigDecimal.
+     * @param doubleValue The value as a double.
+     * @return true if the bigDecimalValue is precisely represented by the doubleValue,
+     *     or if the doubleValue is infinite or NaN.
+     */
+    public static boolean isDoublePrecisionCompatible(BigDecimal bigDecimalValue, Double doubleValue) {
+        if (doubleValue.isInfinite() || doubleValue.isNaN()) {
+            return true;
+        }
+        return bigDecimalValue.compareTo(BigDecimal.valueOf(doubleValue)) == 0;
+    }
+}

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/NumberUtilsTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/NumberUtilsTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class NumberUtilsTest {
+
+    @Test
+    public void parseNumberDelegatesToParseDecimalForDecimalString() {
+        Number result = NumberUtils.parseNumber("1.5");
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result, equalTo(1.5));
+    }
+
+    @Test
+    public void parseNumberReturnsLongForSmallInteger() {
+        Number result = NumberUtils.parseNumber("42");
+        assertThat(result, instanceOf(Long.class));
+        assertThat(result, equalTo(42L));
+    }
+
+    @Test
+    public void parseNumberReturnsBigIntegerForOverflowingLong() {
+        Number result = NumberUtils.parseNumber("9999999999999999999");
+        assertThat(result, instanceOf(BigInteger.class));
+        assertThat(result, equalTo(new BigInteger("9999999999999999999")));
+    }
+
+    @Test
+    public void parseNumberReturnsDoubleForNegativeInfinity() {
+        Number result = NumberUtils.parseNumber("-Infinity");
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result, equalTo(Double.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    public void parseNumberReturnsDoubleForNaN() {
+        Number result = NumberUtils.parseNumber("NaN");
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result.doubleValue(), equalTo(Double.NaN));
+    }
+
+    @Test
+    public void parseDecimalNumberReturnsDoubleForCompatibleValue() {
+        Number result = NumberUtils.parseDecimalNumber("1.5");
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result, equalTo(1.5));
+    }
+
+    @Test
+    public void parseDecimalNumberReturnsBigDecimalForIncompatibleValue() {
+        Number result = NumberUtils.parseDecimalNumber("9007199254740993.0");
+        assertThat(result, instanceOf(BigDecimal.class));
+    }
+
+    @Test
+    public void parseDecimalNumberReturnsBigDecimalForOverflow() {
+        Number result = NumberUtils.parseDecimalNumber("1e309");
+        assertThat(result, instanceOf(BigDecimal.class));
+        assertThat(result, equalTo(new BigDecimal("1e309")));
+    }
+
+    @Test
+    public void parseDecimalNumberReturnsDoubleForInfinityLiteral() {
+        Number result = NumberUtils.parseDecimalNumber("Infinity");
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result, equalTo(Double.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void parseDecimalNumberReturnsDoubleForNaNLiteral() {
+        Number result = NumberUtils.parseDecimalNumber("NaN");
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result.doubleValue(), equalTo(Double.NaN));
+    }
+
+    @ParameterizedTest
+    @MethodSource("compatibleValues")
+    public void detectsDoublePrecisionCompatibleValues(BigDecimal bd, Double d) {
+        assertThat(NumberUtils.isDoublePrecisionCompatible(bd, d), is(true));
+    }
+
+    static Stream<Arguments> compatibleValues() {
+        return Stream.of(
+                // Zero
+                Arguments.of(new BigDecimal("0"), 0.0),
+                // Negative zero is mathematically equal to zero
+                Arguments.of(new BigDecimal("0"), -0.0),
+                // Small positive integer
+                Arguments.of(new BigDecimal("1"), 1.0),
+                // Trailing zeros in BigDecimal scale don't affect compareTo
+                Arguments.of(new BigDecimal("1.00"), 1.0),
+                // Negative integer
+                Arguments.of(new BigDecimal("-42"), -42.0),
+                // Simple decimal that doubles represent exactly
+                Arguments.of(new BigDecimal("0.5"), 0.5),
+                // Power-of-two fraction
+                Arguments.of(new BigDecimal("0.25"), 0.25),
+                // Another power-of-two fraction
+                Arguments.of(new BigDecimal("0.125"), 0.125),
+                // Larger exact integer within double range
+                Arguments.of(new BigDecimal("1048576"), 1048576.0),
+                // Max safe integer for doubles (2^53)
+                Arguments.of(new BigDecimal("9007199254740992"), 9007199254740992.0),
+                // Negative max safe integer
+                Arguments.of(new BigDecimal("-9007199254740992"), -9007199254740992.0),
+                // Small negative decimal
+                Arguments.of(new BigDecimal("-0.5"), -0.5),
+                // Double.MAX_VALUE round-trips through Double.toString
+                Arguments.of(new BigDecimal(String.valueOf(Double.MAX_VALUE)), Double.MAX_VALUE),
+                // Double.MIN_VALUE round-trips through Double.toString
+                Arguments.of(new BigDecimal(String.valueOf(Double.MIN_VALUE)), Double.MIN_VALUE),
+                // 0.1 round-trips: BigDecimal.valueOf(0.1) equals BigDecimal("0.1")
+                Arguments.of(new BigDecimal("0.1"), 0.1),
+                // 0.2 round-trips cleanly
+                Arguments.of(new BigDecimal("0.2"), 0.2),
+                // 0.3 round-trips cleanly
+                Arguments.of(new BigDecimal("0.3"), 0.3),
+                // Negative decimal round-trips cleanly
+                Arguments.of(new BigDecimal("-0.1"), -0.1),
+                // Infinities are only storable as doubles
+                Arguments.of(BigDecimal.ZERO, Double.POSITIVE_INFINITY),
+                // NaNs are only storable as doubles
+                Arguments.of(BigDecimal.ZERO, Double.NaN));
+    }
+
+    @ParameterizedTest
+    @MethodSource("incompatibleValues")
+    public void detectsDoublePrecisionIncompatibleValues(BigDecimal bd, Double d) {
+        assertThat(NumberUtils.isDoublePrecisionCompatible(bd, d), is(false));
+    }
+
+    static Stream<Arguments> incompatibleValues() {
+        return Stream.of(
+                // Integer beyond 2^53Loses precision
+                Arguments.of(new BigDecimal("9007199254740993"), 9007199254740993.0),
+                // Large integer that rounds in double
+                Arguments.of(new BigDecimal("9007199254740995"), 9007199254740995.0),
+                // High-precision decimal beyond what double can distinguish
+                Arguments.of(new BigDecimal("1.0000000000000001"), 1.0000000000000001),
+                // Precision loss in negative large integer
+                Arguments.of(new BigDecimal("-9007199254740993"), -9007199254740993.0),
+                // Decimal with many significant digits
+                Arguments.of(new BigDecimal("123456789.123456789"), 123456789.123456789),
+                // Small value with precision beyond double's capability
+                Arguments.of(new BigDecimal("0.10000000000000001"), 0.10000000000000001),
+                // Precision beyond what Double.toString preserves
+                Arguments.of(new BigDecimal("3.141592653589793238"), 3.141592653589793238),
+                // Very small difference from an integer, not representable at stated precision
+                Arguments.of(new BigDecimal("2.00000000000000005"), 2.00000000000000005),
+                // Large number with fractional precision loss
+                Arguments.of(new BigDecimal("1e308").add(new BigDecimal("1")), 1e308),
+                // Negative high-precision decimal beyond double's digits
+                Arguments.of(new BigDecimal("-0.123456789012345678"), -0.123456789012345678));
+    }
+}


### PR DESCRIPTION
The Double.isFinite method was incorrectly used to detect if a value would fit in a double. The method handles this properly, but it's not actually what we want - we want to know if the value will be accurately represented by a double.

To resolve this, a NumberUtils class is added with a method that validates precision compatibility. Tests are added for this and all call sites to ensure the behavior remains consistent.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
