### PR TITLE
Add unstable to the longPoll trait

### DIFF
--- a/docs/source-2.0/spec/behavior-traits.rst
+++ b/docs/source-2.0/spec/behavior-traits.rst
@@ -107,6 +107,9 @@ Trait selector
 Value type
     ``structure``
 
+.. warning::
+    This trait is unstable and MAY change in the future.
+
 When making requests for an operation targeted by this trait, clients should
 extend any timeouts they have for the service to respond. They should wait for
 at least the amount of time indicated by the ``timeoutMillis`` member.

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -670,6 +670,7 @@ structure requiresLength {}
 @trait(
     selector: "operation"
 )
+@unstable
 structure longPoll {
     /// The amount of time in milliseconds that a client should wait for a response.
     @required

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/long-poll-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/long-poll-trait.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#LongPollWithTimeout: This shape applies a trait that is unstable: smithy.api#longPoll | UnstableTrait.smithy.api#longPoll


### PR DESCRIPTION
This marks the longPoll trait as unstable so we can make some changes if needed. I don't expect changes, but we need to socialize it a bit more.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
