### PR TITLE
Add minimum value for longPoll timeout

### DIFF
--- a/docs/source-2.0/spec/behavior-traits.rst
+++ b/docs/source-2.0/spec/behavior-traits.rst
@@ -111,8 +111,13 @@ Value type
     This trait is unstable and MAY change in the future.
 
 When making requests for an operation targeted by this trait, clients should
-extend any timeouts they have for the service to respond. They should wait for
-at least the amount of time indicated by the ``timeoutMillis`` member.
+wait for at least the amount of time indicated by the ``timeoutMillis`` member.
+If the client's default timeout is longer, it may use the longer value.
+
+Clients may allow users to configure timeouts. If a user configures a timeout
+value on a client, the client must use the user-configured value regardless of
+whether it is greater or less than timeoutMillis. Similarly, if the user
+configures a timeout value for a request, clients must use that value.
 
 The ``longPoll`` trait is a structure that contains the following members:
 
@@ -126,7 +131,7 @@ The ``longPoll`` trait is a structure that contains the following members:
     * - timeoutMillis
       - ``integer``
       - **Required**. The amount of time in milliseconds that a client should
-        wait for a response.
+        wait for a response. This must be greater than 0.
 
 .. code-block:: smithy
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -664,9 +664,14 @@ structure requiresLength {}
 /// allow them to hold the request open as it waits for information to become
 /// available.
 ///
-/// When making requests for an operation targeted by this trait, clients should extend
-/// any timeouts they have for the service to respond. They should wait for at least the
-/// amount of time indicated by the `timeoutMillis` member.
+/// When making requests for an operation targeted by this trait, clients should
+/// wait for at least the amount of time indicated by the `timeoutMillis` member.
+/// If the client's default timeout is longer, it may use the longer value.
+///
+/// Clients may allow users to configure timeouts. If a user configures a timeout
+/// value on a client, the client must use the user-configured value regardless of
+/// whether it is greater or less than `timeoutMillis`. Similarly, if the user
+/// configures a timeout value for a request, clients must use that value.
 @trait(
     selector: "operation"
 )
@@ -674,6 +679,7 @@ structure requiresLength {}
 structure longPoll {
     /// The amount of time in milliseconds that a client should wait for a response.
     @required
+    @range(min: 1)
     timeoutMillis: Integer
 }
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/long-poll-trait.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/long-poll-trait.errors
@@ -1,1 +1,5 @@
 [WARNING] smithy.example#LongPollWithTimeout: This shape applies a trait that is unstable: smithy.api#longPoll | UnstableTrait.smithy.api#longPoll
+[WARNING] smithy.example#LongPollWithZeroTimeout: This shape applies a trait that is unstable: smithy.api#longPoll | UnstableTrait.smithy.api#longPoll
+[WARNING] smithy.example#LongPollWithNegativeTimeout: This shape applies a trait that is unstable: smithy.api#longPoll | UnstableTrait.smithy.api#longPoll
+[ERROR] smithy.example#LongPollWithZeroTimeout: Error validating trait `longPoll`.timeoutMillis: Value provided for `smithy.api#longPoll$timeoutMillis` must be greater than or equal to 1, but found 0 | TraitValue.Member.InvalidRange
+[ERROR] smithy.example#LongPollWithNegativeTimeout: Error validating trait `longPoll`.timeoutMillis: Value provided for `smithy.api#longPoll$timeoutMillis` must be greater than or equal to 1, but found -1 | TraitValue.Member.InvalidRange

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/long-poll-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/long-poll-trait.smithy
@@ -4,3 +4,9 @@ namespace smithy.example
 
 @longPoll(timeoutMillis: 70000)
 operation LongPollWithTimeout {}
+
+@longPoll(timeoutMillis: 0)
+operation LongPollWithZeroTimeout {}
+
+@longPoll(timeoutMillis: -1)
+operation LongPollWithNegativeTimeout {}


### PR DESCRIPTION
This adds a minimum value for the timeout on the longPoll trait and adds some clarity to the docs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
