### PR TITLE
Implement tagged literals for IDL 2.1

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/DefaultTokenizer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/DefaultTokenizer.java
@@ -21,10 +21,15 @@ class DefaultTokenizer implements IdlTokenizer {
     private Number currentTokenNumber;
     private CharSequence currentTokenStringSlice;
     private String currentTokenError;
+    private Version version;
 
     DefaultTokenizer(String filename, CharSequence model) {
         this.filename = filename;
         this.parser = new SimpleParser(model, 64);
+    }
+
+    void setVersion(Version version) {
+        this.version = version;
     }
 
     @Override
@@ -165,7 +170,7 @@ class DefaultTokenizer implements IdlTokenizer {
             case ')':
                 return singleCharToken(IdlToken.RPAREN);
             case '#':
-                return singleCharToken(IdlToken.POUND);
+                return parsePoundOrTaggedLiteral();
             case '=':
                 return singleCharToken(IdlToken.EQUAL);
             case ':':
@@ -342,6 +347,117 @@ class DefaultTokenizer implements IdlTokenizer {
         }
         currentTokenEnd = parser.position();
         return currentTokenType;
+    }
+
+    private IdlToken parsePoundOrTaggedLiteral() {
+        // Tagged string literals require IDL version 2.1 or later.
+        if (version == null || !version.supportsTaggedLiterals()) {
+            return singleCharToken(IdlToken.POUND);
+        }
+
+        // Save state in case we need to revert to a plain POUND token.
+        int savedPos = parser.position();
+        int savedLine = parser.line();
+        int savedCol = parser.column();
+
+        parser.skip(); // skip '#'
+
+        // Check if the next characters form a known tag identifier.
+        if (!ParserUtils.isIdentifierStart(parser.peek())) {
+            currentTokenEnd = parser.position();
+            return currentTokenType = IdlToken.POUND;
+        }
+
+        int tagStart = parser.position();
+        parser.consumeWhile(ParserUtils::isValidIdentifierCharacter);
+        String tag = parser.sliceFrom(tagStart);
+
+        if (!TaggedStringLiteral.hasHandler(tag)) {
+            // Not a known tag — rewind and emit POUND.
+            parser.rewind(savedPos, savedLine, savedCol);
+            return singleCharToken(IdlToken.POUND);
+        }
+
+        // Skip optional spaces between tag and string.
+        parser.consumeWhile(c -> c == ' ' || c == '\t');
+
+        if (parser.peek() != '"') {
+            // Tag not followed by a string — rewind and emit POUND.
+            parser.rewind(savedPos, savedLine, savedCol);
+            return singleCharToken(IdlToken.POUND);
+        }
+
+        // Parse the string with the tag-specific handler.
+        return parseTaggedString(tag);
+    }
+
+    private IdlToken parseTaggedString(String tag) {
+        parser.skip(); // skip first quote.
+        boolean isTextBlock = false;
+
+        if (parser.peek() == '"') {
+            parser.skip(); // skip second quote.
+            if (parser.peek() == '"') {
+                parser.skip(); // skip third quote — it's a text block.
+                isTextBlock = true;
+            } else {
+                // Empty string.
+                currentTokenEnd = parser.position();
+                return applyTagResult(tag, TaggedStringLiteral.scan(tag, "", false), false);
+            }
+        }
+
+        try {
+            CharSequence rawContent = parseRawStringContents(isTextBlock);
+            TaggedStringLiteral.Result result = TaggedStringLiteral.scan(tag, rawContent, isTextBlock);
+            currentTokenEnd = parser.position();
+            return applyTagResult(tag, result, isTextBlock);
+        } catch (RuntimeException e) {
+            currentTokenEnd = parser.position();
+            currentTokenError = "Error parsing tagged string #" + tag + ": " + e.getMessage();
+            return currentTokenType = IdlToken.ERROR;
+        }
+    }
+
+    private IdlToken applyTagResult(String tag, TaggedStringLiteral.Result result, boolean isTextBlock) {
+        switch (result.token) {
+            case NUMBER:
+                currentTokenNumber = result.numberValue;
+                return currentTokenType = IdlToken.NUMBER;
+            case STRING:
+            default:
+                currentTokenStringSlice = result.stringValue;
+                return currentTokenType = isTextBlock ? IdlToken.TEXT_BLOCK : IdlToken.STRING;
+        }
+    }
+
+    /**
+     * Reads the raw content between quotes without applying escape processing.
+     * This is used by tagged string literals that handle their own escape logic.
+     */
+    private CharSequence parseRawStringContents(boolean triple) {
+        int start = parser.position();
+
+        while (!parser.eof()) {
+            char next = parser.peek();
+            if (next == '"' && (!triple || (parser.peek(1) == '"' && parser.peek(2) == '"'))) {
+                break;
+            }
+            parser.skip();
+            if (next == '\\') {
+                parser.skip();
+            }
+        }
+
+        CharSequence result = parser.borrowSliceFrom(start);
+        parser.expect('"');
+
+        if (triple) {
+            parser.expect('"');
+            parser.expect('"');
+        }
+
+        return result;
     }
 
     private IdlToken parseString() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlModelLoader.java
@@ -303,6 +303,7 @@ final class IdlModelLoader {
 
         emittedVersion = true;
         modelVersion = resolvedVersion;
+        tokenizer.setVersion(resolvedVersion);
         addOperation(new LoadOperation.ModelVersion(modelVersion, value.getSourceLocation()));
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlStringLexer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlStringLexer.java
@@ -271,7 +271,19 @@ final class IdlStringLexer {
         return endPosition >= startPosition ? line.subSequence(startPosition, endPosition + 1) : null;
     }
 
-    private static boolean isValidNormalCharacter(char c, boolean isTextBlock) {
+    /**
+     * Normalizes line endings and formats text blocks without applying escape processing.
+     * Used by tagged string literals that handle their own escape logic.
+     */
+    static CharSequence normalizeAndFormat(CharSequence lexeme, boolean isTextBlock) {
+        lexeme = normalizeLineEndings(lexeme);
+        if (isTextBlock) {
+            lexeme = formatTextBlock(lexeme);
+        }
+        return lexeme;
+    }
+
+    static boolean isValidNormalCharacter(char c, boolean isTextBlock) {
         // Valid normal characters are the unescaped characters defined in the
         // QuotedChar grammar:
         // https://smithy.io/2.0/spec/idl.html#grammar-token-smithy-QuotedChar

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/IdlTokenizer.java
@@ -31,7 +31,9 @@ public interface IdlTokenizer extends Iterator<IdlToken> {
      * @return         Returns the tokenizer.
      */
     static IdlTokenizer create(String filename, CharSequence model) {
-        return new DefaultTokenizer(filename, model);
+        DefaultTokenizer tokenizer = new DefaultTokenizer(filename, model);
+        tokenizer.setVersion(Version.detectFromModel(model));
+        return tokenizer;
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TaggedStringLiteral.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TaggedStringLiteral.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.loader;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Handles tagged string literals in the Smithy IDL.
+ *
+ * <p>A tagged string literal is a string prefixed with {@code #tag} that changes
+ * how the string content is interpreted. The result can be a string or number token.
+ */
+final class TaggedStringLiteral {
+
+    /**
+     * The result of scanning a tagged string literal.
+     */
+    static final class Result {
+        final IdlToken token;
+        final CharSequence stringValue;
+        final Number numberValue;
+
+        private Result(IdlToken token, CharSequence stringValue, Number numberValue) {
+            this.token = token;
+            this.stringValue = stringValue;
+            this.numberValue = numberValue;
+        }
+
+        static Result ofString(CharSequence value) {
+            return new Result(IdlToken.STRING, value, null);
+        }
+
+        static Result ofNumber(Number value) {
+            return new Result(IdlToken.NUMBER, null, value);
+        }
+    }
+
+    private static final Map<String, Function<CharSequence, Result>> HANDLERS = new HashMap<>();
+
+    static {
+        HANDLERS.put("re", TaggedStringLiteral::scanRegexContents);
+        HANDLERS.put("b", TaggedStringLiteral::scanBinaryContents);
+        HANDLERS.put("timestamp", TaggedStringLiteral::scanTimestampContents);
+        HANDLERS.put("hex", TaggedStringLiteral::scanHexContents);
+    }
+
+    private TaggedStringLiteral() {}
+
+    static boolean hasHandler(String tag) {
+        return HANDLERS.containsKey(tag);
+    }
+
+    static Result scan(String tag, CharSequence lexeme, boolean isTextBlock) {
+        lexeme = IdlStringLexer.normalizeAndFormat(lexeme, isTextBlock);
+        return HANDLERS.get(tag).apply(lexeme);
+    }
+
+    /**
+     * Scans regex string contents. Backslash sequences are passed through literally
+     * except for {@code \"} and {@code \\}.
+     */
+    private static Result scanRegexContents(CharSequence lexeme) {
+        StringBuilder result = new StringBuilder(lexeme.length());
+        for (int i = 0; i < lexeme.length(); i++) {
+            char c = lexeme.charAt(i);
+            if (c == '\\' && i + 1 < lexeme.length()) {
+                char next = lexeme.charAt(i + 1);
+                if (next == '"') {
+                    result.append('"');
+                    i++;
+                } else if (next == '\\') {
+                    result.append('\\');
+                    i++;
+                } else if (next == '\n') {
+                    i++;
+                } else {
+                    result.append(c);
+                    result.append(next);
+                    i++;
+                }
+            } else {
+                if (!IdlStringLexer.isValidNormalCharacter(c, true)) {
+                    throw new RuntimeException("Invalid string character: `" + c + "`");
+                }
+                result.append(c);
+            }
+        }
+        return Result.ofString(result);
+    }
+
+    /**
+     * Scans binary string contents like Python's {@code b'...'} syntax.
+     * The resulting bytes are base64-encoded.
+     */
+    private static Result scanBinaryContents(CharSequence lexeme) {
+        byte[] buffer = new byte[lexeme.length()];
+        int length = 0;
+        for (int i = 0; i < lexeme.length(); i++) {
+            char c = lexeme.charAt(i);
+            if (c == '\\' && i + 1 < lexeme.length()) {
+                char next = lexeme.charAt(i + 1);
+                switch (next) {
+                    case 'x':
+                        if (i + 3 >= lexeme.length()) {
+                            throw new RuntimeException("Incomplete \\x escape in binary string");
+                        }
+                        int hi = hexDigit(lexeme.charAt(i + 2));
+                        int lo = hexDigit(lexeme.charAt(i + 3));
+                        buffer[length++] = (byte) ((hi << 4) | lo);
+                        i += 3;
+                        break;
+                    case '\\':
+                        buffer[length++] = (byte) '\\';
+                        i++;
+                        break;
+                    case '"':
+                        buffer[length++] = (byte) '"';
+                        i++;
+                        break;
+                    case 'a':
+                        buffer[length++] = (byte) 0x07;
+                        i++;
+                        break;
+                    case 'b':
+                        buffer[length++] = (byte) 0x08;
+                        i++;
+                        break;
+                    case 'f':
+                        buffer[length++] = (byte) 0x0C;
+                        i++;
+                        break;
+                    case 'n':
+                        buffer[length++] = (byte) '\n';
+                        i++;
+                        break;
+                    case 'r':
+                        buffer[length++] = (byte) '\r';
+                        i++;
+                        break;
+                    case 't':
+                        buffer[length++] = (byte) '\t';
+                        i++;
+                        break;
+                    case 'v':
+                        buffer[length++] = (byte) 0x0B;
+                        i++;
+                        break;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                        // Octal escape: 1-3 octal digits.
+                        int octal = next - '0';
+                        int octalChars = 1;
+                        while (octalChars < 3 && i + 1 + octalChars < lexeme.length()) {
+                            char oc = lexeme.charAt(i + 1 + octalChars);
+                            if (oc < '0' || oc > '7') {
+                                break;
+                            }
+                            octal = (octal << 3) | (oc - '0');
+                            octalChars++;
+                        }
+                        if (octal > 0xFF) {
+                            throw new RuntimeException("Octal escape value \\" + Integer.toOctalString(octal)
+                                    + " exceeds byte range");
+                        }
+                        buffer[length++] = (byte) octal;
+                        i += octalChars;
+                        break;
+                    case '\n':
+                        i++;
+                        break;
+                    default:
+                        throw new RuntimeException("Invalid escape in binary string: `\\" + next + "`");
+                }
+            } else {
+                if (c <= 0x7F) {
+                    buffer[length++] = (byte) c;
+                } else {
+                    byte[] utf8 = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+                    System.arraycopy(utf8, 0, buffer, length, utf8.length);
+                    length += utf8.length;
+                }
+            }
+        }
+        byte[] result = new byte[length];
+        System.arraycopy(buffer, 0, result, 0, length);
+        return Result.ofString(Base64.getEncoder().encodeToString(result));
+    }
+
+    /**
+     * Parses an ISO-8601 timestamp string and returns epoch seconds as a number.
+     * E.g., {@code #timestamp "2026-04-14T01:40:23.657Z"} produces {@code 1776130823.657}.
+     */
+    private static Result scanTimestampContents(CharSequence lexeme) {
+        try {
+            Instant instant = Instant.parse(lexeme);
+            long epochSecond = instant.getEpochSecond();
+            int nanos = instant.getNano();
+            if (nanos == 0) {
+                return Result.ofNumber(epochSecond);
+            }
+            // Combine seconds and fractional part into a double.
+            double value = epochSecond + nanos / 1_000_000_000.0;
+            return Result.ofNumber(value);
+        } catch (DateTimeParseException e) {
+            throw new RuntimeException("Invalid ISO-8601 timestamp: " + lexeme);
+        }
+    }
+
+    /**
+     * Parses hex-encoded bytes: strips comments ({@code #} to end of line)
+     * and whitespace, decodes the remaining hex digits, and returns base64.
+     */
+    private static Result scanHexContents(CharSequence lexeme) {
+        // First pass: strip comments and collect hex chars.
+        StringBuilder hex = new StringBuilder(lexeme.length());
+        boolean inComment = false;
+        for (int i = 0; i < lexeme.length(); i++) {
+            char c = lexeme.charAt(i);
+            if (inComment) {
+                if (c == '\n') {
+                    inComment = false;
+                }
+            } else if (c == '#') {
+                inComment = true;
+            } else if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+                hex.append(c);
+            } else if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+                throw new RuntimeException("Invalid character in annotated CBOR: `" + c + "`");
+            }
+        }
+        if (hex.length() % 2 != 0) {
+            throw new RuntimeException("Odd number of hex digits in annotated CBOR");
+        }
+        byte[] bytes = new byte[hex.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) ((hexDigit(hex.charAt(i * 2)) << 4) | hexDigit(hex.charAt(i * 2 + 1)));
+        }
+        return Result.ofString(Base64.getEncoder().encodeToString(bytes));
+    }
+
+    private static int hexDigit(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+            return 10 + c - 'a';
+        } else if (c >= 'A' && c <= 'F') {
+            return 10 + c - 'A';
+        }
+        throw new RuntimeException("Invalid hex digit in \\x escape: `" + c + "`");
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Version.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Version.java
@@ -57,6 +57,11 @@ enum Version {
         }
 
         @Override
+        boolean supportsTaggedLiterals() {
+            return true;
+        }
+
+        @Override
         ValidationEvent validateVersionedTrait(ShapeId target, ShapeId traitId, Node value) {
             return null;
         }
@@ -183,6 +188,54 @@ enum Version {
 
             return null;
         }
+    },
+
+    VERSION_2_1 {
+        @Override
+        public String toString() {
+            return "2.1";
+        }
+
+        @Override
+        boolean supportsMixins() {
+            return true;
+        }
+
+        @Override
+        boolean supportsInlineOperationIO() {
+            return true;
+        }
+
+        @Override
+        boolean supportsTargetElision() {
+            return true;
+        }
+
+        @Override
+        boolean isDefaultSupported() {
+            return true;
+        }
+
+        @Override
+        boolean isShapeTypeSupported(ShapeType shapeType) {
+            return shapeType != ShapeType.SET;
+        }
+
+        @Override
+        boolean isDeprecated() {
+            return false;
+        }
+
+        @Override
+        boolean supportsTaggedLiterals() {
+            return true;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        ValidationEvent validateVersionedTrait(ShapeId target, ShapeId traitId, Node value) {
+            return VERSION_2_0.validateVersionedTrait(target, traitId, value);
+        }
     };
 
     /**
@@ -200,9 +253,38 @@ enum Version {
             case "2":
             case "2.0":
                 return VERSION_2_0;
+            case "2.1":
+                return VERSION_2_1;
             default:
                 return null;
         }
+    }
+
+    /**
+     * Detects the IDL version from model text by scanning for the $version control statement.
+     *
+     * @param model Model text to scan.
+     * @return Returns the detected version, or null if not found.
+     */
+    static Version detectFromModel(CharSequence model) {
+        String text = model.toString();
+        int idx = text.indexOf("$version:");
+        if (idx == -1) {
+            idx = text.indexOf("$version :");
+        }
+        if (idx == -1) {
+            return null;
+        }
+        int colon = text.indexOf(':', idx);
+        int quote1 = text.indexOf('"', colon);
+        if (quote1 == -1) {
+            return null;
+        }
+        int quote2 = text.indexOf('"', quote1 + 1);
+        if (quote2 == -1) {
+            return null;
+        }
+        return fromString(text.substring(quote1 + 1, quote2));
     }
 
     /**
@@ -211,7 +293,16 @@ enum Version {
      * @return Returns true if this version supports resource properties.
      */
     boolean supportsResourceProperties() {
-        return this == VERSION_2_0;
+        return this == VERSION_2_0 || this == VERSION_2_1;
+    }
+
+    /**
+     * Checks if this version of the IDL supports tagged string literals.
+     *
+     * @return Returns true if this version supports tagged string literals.
+     */
+    boolean supportsTaggedLiterals() {
+        return false;
     }
 
     /**

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TaggedStringLiteralTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TaggedStringLiteralTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Base64;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TaggedStringLiteralTest {
+
+    private static IdlInternalTokenizer tokenizerV21(String model) {
+        IdlInternalTokenizer tokenizer = new IdlInternalTokenizer("a.smithy", model);
+        tokenizer.setVersion(Version.VERSION_2_1);
+        return tokenizer;
+    }
+
+    // --- #re tag tests ---
+
+    public static Stream<Arguments> reTagTests() {
+        return Stream.of(
+                Arguments.of("#re \"^\\d{5}$\"", "^\\d{5}$"),
+                Arguments.of("#re \"\\w+\\s\\d\"", "\\w+\\s\\d"),
+                Arguments.of("#re \"\\\\\"", "\\"),
+                Arguments.of("#re \"\\\"\"", "\""),
+                Arguments.of("#re \"hello\"", "hello"),
+                Arguments.of("#re \"\"", ""),
+                Arguments.of("#re \"[a-z]+\\.(\\d{1,3}\\.){3}\\d{1,3}\"", "[a-z]+\\.(\\d{1,3}\\.){3}\\d{1,3}"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("reTagTests")
+    public void parsesReTaggedStrings(String model, String expected) {
+        IdlInternalTokenizer tokenizer = tokenizerV21(model);
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.STRING));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(), equalTo(expected));
+    }
+
+    @Test
+    public void parsesReTaggedTextBlock() {
+        String model = "#re \"\"\"\n"
+                + "    ^\\d{5}$\n"
+                + "    \"\"\"";
+        IdlInternalTokenizer tokenizer = tokenizerV21(model);
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.TEXT_BLOCK));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(), equalTo("^\\d{5}$\n"));
+    }
+
+    // --- #b tag tests ---
+
+    public static Stream<Arguments> bTagTests() {
+        return Stream.of(
+                Arguments.of("#b \"Hello world\"", base64("Hello world")),
+                Arguments.of("#b \"\\xaa\"", base64((byte) 0xaa)),
+                Arguments.of("#b \"A\\x42C\"", base64((byte) 'A', (byte) 0x42, (byte) 'C')),
+                Arguments.of("#b \"\\n\"", base64((byte) '\n')),
+                Arguments.of("#b \"\\t\"", base64((byte) '\t')),
+                Arguments.of("#b \"\\r\"", base64((byte) '\r')),
+                Arguments.of("#b \"\\\\\"", base64((byte) '\\')),
+                Arguments.of("#b \"\\0\"", base64((byte) 0)),
+                // Python-compatible escapes
+                Arguments.of("#b \"\\a\"", base64((byte) 0x07)),
+                Arguments.of("#b \"\\b\"", base64((byte) 0x08)),
+                Arguments.of("#b \"\\f\"", base64((byte) 0x0C)),
+                Arguments.of("#b \"\\v\"", base64((byte) 0x0B)),
+                // Octal escapes
+                Arguments.of("#b \"\\101\"", base64((byte) 'A')), // 0101 = 65 = 'A'
+                Arguments.of("#b \"\\377\"", base64((byte) 0xFF)), // max single byte
+                Arguments.of("#b \"\\7\"", base64((byte) 7)), // single octal digit
+                Arguments.of("#b \"\\77\"", base64((byte) 63)), // two octal digits
+                Arguments.of("#b \"\"", base64()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("bTagTests")
+    public void parsesBTaggedStrings(String model, String expected) {
+        IdlInternalTokenizer tokenizer = tokenizerV21(model);
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.STRING));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(), equalTo(expected));
+    }
+
+    @Test
+    public void parsesBTaggedTextBlock() {
+        String model = "#b \"\"\"\n"
+                + "    \\x48\\x69\n"
+                + "    \"\"\"";
+        IdlInternalTokenizer tokenizer = tokenizerV21(model);
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.TEXT_BLOCK));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(),
+                equalTo(base64((byte) 'H', (byte) 'i', (byte) '\n')));
+    }
+
+    // --- Disambiguation and version gating ---
+
+    @Test
+    public void poundStillWorksForShapeIds() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.POUND));
+    }
+
+    @Test
+    public void unknownTagFallsBackToPound() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#foo \"bar\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.POUND));
+    }
+
+    @Test
+    public void tagWithoutStringFallsBackToPound() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#re foo");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.POUND));
+    }
+
+    @Test
+    public void tagWithSpacesBeforeString() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#re   \"\\d+\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.STRING));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(), equalTo("\\d+"));
+    }
+
+    @Test
+    public void taggedLiteralsNotParsedInVersion20() {
+        IdlInternalTokenizer tokenizer = new IdlInternalTokenizer("a.smithy", "#re \"\\d+\"");
+        tokenizer.setVersion(Version.VERSION_2_0);
+        // Should be POUND, not STRING — tagged literals require 2.1
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.POUND));
+    }
+
+    @Test
+    public void taggedLiteralsNotParsedWithoutVersion() {
+        IdlInternalTokenizer tokenizer = new IdlInternalTokenizer("a.smithy", "#re \"\\d+\"");
+        // No version set — should be POUND
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.POUND));
+    }
+
+    // --- #timestamp tag tests ---
+
+    @Test
+    public void parsesTimestampWithFractionalSeconds() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#timestamp \"2026-04-14T01:40:23.657Z\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.NUMBER));
+        assertThat(tokenizer.getCurrentTokenNumberValue().doubleValue(), equalTo(1776130823.657));
+    }
+
+    @Test
+    public void parsesTimestampWholeSeconds() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#timestamp \"2026-04-14T01:40:23Z\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.NUMBER));
+        assertThat(tokenizer.getCurrentTokenNumberValue().longValue(), equalTo(1776130823L));
+    }
+
+    @Test
+    public void parsesTimestampEpoch() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#timestamp \"1970-01-01T00:00:00Z\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.NUMBER));
+        assertThat(tokenizer.getCurrentTokenNumberValue().longValue(), equalTo(0L));
+    }
+
+    @Test
+    public void invalidTimestampProducesError() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#timestamp \"not-a-timestamp\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.ERROR));
+    }
+
+    // --- #hex tag tests ---
+
+    @Test
+    public void parsesAnnotatedCborSimpleHex() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#hex \"81c1\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.STRING));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(),
+                equalTo(base64((byte) 0x81, (byte) 0xc1)));
+    }
+
+    @Test
+    public void parsesAnnotatedCborWithCommentsAndWhitespace() {
+        String model = "#hex \"\"\"\n"
+                + "    81                        # array(1)\n"
+                + "       c1                     #   tag(1)\n"
+                + "          fb 41d9ad970f9b4396 #     float\n"
+                + "    \"\"\"";
+        IdlInternalTokenizer tokenizer = tokenizerV21(model);
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.TEXT_BLOCK));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(),
+                equalTo(base64((byte) 0x81,
+                        (byte) 0xc1,
+                        (byte) 0xfb,
+                        (byte) 0x41,
+                        (byte) 0xd9,
+                        (byte) 0xad,
+                        (byte) 0x97,
+                        (byte) 0x0f,
+                        (byte) 0x9b,
+                        (byte) 0x43,
+                        (byte) 0x96)));
+    }
+
+    @Test
+    public void parsesAnnotatedCborCommentOnlyLines() {
+        String model = "#hex \"\"\"\n"
+                + "    # This is a comment-only line\n"
+                + "    ff\n"
+                + "    \"\"\"";
+        IdlInternalTokenizer tokenizer = tokenizerV21(model);
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.TEXT_BLOCK));
+        assertThat(tokenizer.getCurrentTokenStringSlice().toString(),
+                equalTo(base64((byte) 0xff)));
+    }
+
+    @Test
+    public void hexOddHexDigitsProducesError() {
+        IdlInternalTokenizer tokenizer = tokenizerV21("#hex \"abc\"");
+        assertThat(tokenizer.getCurrentToken(), is(IdlToken.ERROR));
+    }
+
+    // --- Helpers ---
+
+    private static String base64(String s) {
+        return Base64.getEncoder().encodeToString(s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static String base64(byte... bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+}

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
@@ -453,16 +453,24 @@ final class FormatVisitor {
             }
 
             case TEXT_BLOCK: {
+                CapturedToken textBlockToken = cursor.getTree()
+                        .tokens()
+                        .findFirst()
+                        .orElseThrow(() -> new RuntimeException("TEXT_BLOCK cursor does not have an IDL token"));
+
+                // Tagged text blocks (e.g., #re """...""") are preserved as-is since their
+                // string contents have been transformed and can't be used to rebuild the block.
+                CharSequence lexeme = textBlockToken.getLexeme();
+                if (lexeme.length() > 0 && lexeme.charAt(0) == '#') {
+                    return Doc.text(tree.concatTokens());
+                }
+
                 // Dispersing the lines of the text block preserves any indentation applied from formatting parent
                 // nodes.
 
                 // We need to rebuild the text block to remove any incidental leading whitespace. The easiest way to
                 // do that is to use the already parsed and resolved value from the lexer.
-                String stringValue = cursor.getTree()
-                        .tokens()
-                        .findFirst()
-                        .orElseThrow(() -> new RuntimeException("TEXT_BLOCK cursor does not have an IDL token"))
-                        .getStringContents();
+                String stringValue = textBlockToken.getStringContents();
 
                 // If the last character is a newline, then the closing triple quote must be on the next line.
                 boolean endQuoteOnNextLine = stringValue.endsWith("\n") || stringValue.endsWith("\r");

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeTypeTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TreeTypeTest.java
@@ -1868,8 +1868,47 @@ public class TreeTypeTest {
         }
     }
 
+    @Test
+    public void taggedStringLiteralQuotedText() {
+        String tagged = "#re \"^\\\\d{5}$\"";
+        TokenTree tree = getTreeV21(TreeType.NODE_VALUE, tagged);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
+                TreeType.NODE_VALUE,
+                TreeType.NODE_STRING_VALUE);
+    }
+
+    @Test
+    public void taggedStringLiteralTextBlock() {
+        String tagged = "#re \"\"\"\n    ^\\\\d{5}$\n    \"\"\"";
+        TokenTree tree = getTreeV21(TreeType.NODE_VALUE, tagged);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
+                TreeType.NODE_VALUE,
+                TreeType.NODE_STRING_VALUE);
+    }
+
+    @Test
+    public void taggedBinaryLiteral() {
+        String tagged = "#b \"\\\\x48\\\\x69\"";
+        TokenTree tree = getTreeV21(TreeType.NODE_VALUE, tagged);
+        assertTreeIsValid(tree);
+        rootAndChildTypesEqual(tree,
+                TreeType.NODE_VALUE,
+                TreeType.NODE_STRING_VALUE);
+    }
+
     private static TokenTree getTree(TreeType type, String forText) {
         IdlTokenizer tokenizer = IdlTokenizer.create(forText);
         return TokenTree.of(tokenizer, type);
+    }
+
+    private static TokenTree getTreeV21(TreeType type, String forText) {
+        IdlTokenizer tokenizer = IdlTokenizer.create("$version: \"2.1\"\n" + forText);
+        CapturingTokenizer capturingTokenizer = new CapturingTokenizer(tokenizer);
+        // Skip past the control section tokens to get to the actual content.
+        TreeType.CONTROL_SECTION.parse(capturingTokenizer);
+        type.parse(capturingTokenizer);
+        return capturingTokenizer.getRoot().getChildren().get(1);
     }
 }

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/tagged-string-literals.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/tagged-string-literals.smithy
@@ -1,0 +1,9 @@
+$version: "2.1"
+
+namespace smithy.example
+
+@pattern(#re "^\d{3}-\d{2}-\d{4}$")
+string SSNFormat
+
+@pattern(#re "^\d+$")
+string DigitsOnly


### PR DESCRIPTION
#### Background

These changes are expected to be part of the IDL 2.1 changes planed. For now, it adds support for "tagged literals" which allows a literal to be prefixed with a tag that will modify the way the literal is parsed and the resulting token. This change implements:

* `#b <string>` Similar to b-strings in Python signals that the string contains binary data that can be composed by hex or octal escapes or literal values. The resulting token will be the string base64 encoded.
* `#hex <string>` Similar to a hex dump string that contains hexadecimal values, spaces are ignored and strings starting with `#` are consider comments and ignored until the end of line.
* `#timestamp <string>` This tag converts that given ISO encoded date to Smithy's epoch second with millis precision.
* `#re <string>` Takes backslashes as literal chars instead of escape sequences allowing writing regular expressions with character classes without having to escape the slashes.

A model that uses all of that is shown below:

```smithy
$version: "2.1"

structure Example {

    @default(#timestamp "1994-07-05T00:00:00Z")
    startDate: Timestamp

    @pattern(#re "^\d{3}-\d{2}-\d{4}$")
    founderSsn: String

    @default(#b ".PNG\x0D\x0A\x1A\x0A")
    avatar: Blob

    @default(#hex """
          # The first 4 hex values are the literal .PNG, the magic value for PNG images
          89 50 4E 47 0D 0A 1A 0A
          """)
    bigAvatar: Blob
}
    

* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
