### PR TITLE
Fix trait/validator loading with discoverModels

### DIFF
--- a/.changes/next-release/bugfix-55db376e5c6cd40ec745a2f5dbce93d0ea94b9bd.json
+++ b/.changes/next-release/bugfix-55db376e5c6cd40ec745a2f5dbce93d0ea94b9bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fix trait/validator loading with discoverModels",
+  "pull_requests": [
+    "[#3049](https://github.com/smithy-lang/smithy/pull/3049)"
+  ]
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -393,18 +393,28 @@ public final class ModelAssembler {
     }
 
     /**
-     * Discovers models by merging in all models returns by {@link ModelDiscovery}
+     * Discovers models by merging in all models returned by {@link ModelDiscovery}
      * manifests using the provided {@code ClassLoader}.
+     *
+     * <p>This method also configures the assembler to use the provided
+     * {@code ClassLoader} for discovering trait and validator service
+     * providers if they have not already been explicitly configured.
      *
      * @param loader Class loader to use to discover models.
      * @return Returns the model assembler.
      */
     public ModelAssembler discoverModels(ClassLoader loader) {
+        if (traitFactory == null) {
+            traitFactory = TraitFactory.createServiceFactory(loader);
+        }
+        if (validatorFactory == null) {
+            validatorFactory = ValidatorFactory.createServiceFactory(loader);
+        }
         return addDiscoveredModels(ModelDiscovery.findModels(loader));
     }
 
     /**
-     * Discovers models by merging in all models returns by {@link ModelDiscovery}
+     * Discovers models by merging in all models returned by {@link ModelDiscovery}
      * manifests using the thread context {@code ClassLoader}.
      *
      * @return Returns the model assembler.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -641,6 +641,35 @@ public class ModelAssemblerTest {
         assertTrue(reloadedModel.getShape(ShapeId.from("smithy.test#test")).isPresent());
     }
 
+    // Regression test for https://github.com/smithy-lang/smithy/issues/2596.
+    // When discoverModels(ClassLoader) is called without first configuring a
+    // traitFactory, the assembler should use the provided classloader for trait
+    // SPI discovery so that traits resolve to their concrete classes rather
+    // than falling back to DynamicTrait.
+    @Test
+    public void discoverModelsWithClassLoaderConfiguresTraitFactory() {
+        URL jar = getClass().getResource("jar-traits-import.jar");
+        URL file = getClass().getResource("loads-jar-traits.smithy");
+        URLClassLoader urlClassLoader = new URLClassLoader(new URL[] {jar});
+
+        // Use a plain Model.assembler() call (not Model.assembler(classLoader))
+        // to reproduce the scenario where no explicit traitFactory is set.
+        Model model = Model.assembler()
+                .discoverModels(urlClassLoader)
+                .addImport(file)
+                .assemble()
+                .unwrap();
+
+        ShapeId traitId = ShapeId.from("smithy.test#test");
+        assertTrue(model.getShape(traitId).isPresent());
+
+        // The trait definition shape itself should be present and not a DynamicTrait
+        // on the service that uses it.
+        Shape weatherService = model.expectShape(ShapeId.from("ns.test#Weather"));
+        assertTrue(weatherService.hasTrait(traitId));
+        assertThat(weatherService.findTrait(traitId).get(), not(instanceOf(DynamicTrait.class)));
+    }
+
     @Test
     public void canDisableValidation() {
         String document = "namespace foo.baz\n"


### PR DESCRIPTION
When `discoverModels(ClassLoader)` is called on a bare `Model.assembler()` (not via `Model.assembler(ClassLoader)`), the provided `ClassLoader` is used for model discovery but not for trait/validator factory creation, so traits from models that are only on the `discoverModels`' classpath fall back to `DynamicTrait` instead as the `TraitFactory` instance on the assembler uses the default classpath.

This commit configures the `traitFactory` and `validatorFactory` from the provided `ClassLoader` when they have not already been set.

Fixes #2596 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
