### PR TITLE
Fix init failure on corrupted template cache

### DIFF
--- a/.changes/next-release/bugfix-c1510aafd5f0e0a3e77cb355a0c70b114c67ccf4.json
+++ b/.changes/next-release/bugfix-c1510aafd5f0e0a3e77cb355a0c70b114c67ccf4.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fix init failure on corrupted template cache",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3051](https://github.com/smithy-lang/smithy/pull/3051)"
+  ]
 }

--- a/.changes/next-release/bugfix-c1510aafd5f0e0a3e77cb355a0c70b114c67ccf4.json
+++ b/.changes/next-release/bugfix-c1510aafd5f0e0a3e77cb355a0c70b114c67ccf4.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fix init failure on corrupted template cache",
+  "pull_requests": []
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -81,6 +81,17 @@ final class InitCommand implements Command {
         boolean isLocalRepo = isLocalRepo(options.repositoryUrl);
         Path templateRepoDirPath = getTemplateRepoDirPath(options.repositoryUrl, isLocalRepo);
 
+        // If the cache directory exists but is not a valid git repo, remove it so it can be re-cloned.
+        // Do this only for the external repo, as a non-git local repo is allowed.
+        //
+        // This case is guarded because the remote checkout is done in a temp directory, subject
+        // to system level cleanup, that can leave it in an inconsistent state for init's use.
+        if (!isLocalRepo
+                && Files.exists(templateRepoDirPath)
+                && !Files.exists(templateRepoDirPath.resolve(".git"))) {
+            IoUtils.rmdir(templateRepoDirPath);
+        }
+
         // If the cache directory does not exist, create it
         if (!Files.exists(templateRepoDirPath)) {
             try (ProgressTracker t = new ProgressTracker(env,


### PR DESCRIPTION
The `smithy init` command caches the template repository in the system temp directory. On subsequent runs it skips the clone and runs `git fetch --depth 1` to check for updates. If the cache directory exists but is not a valid git repo (e.g. from an interrupted clone or system-level temp cleanup), the fetch fails with "fatal: not a git repository".

This commit fixes this by testing for a `.git` for non-local repos and removing the folder if not, proceeding to do a fresh clone.

Fixes #2493 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
