### PR TITLE
Optimize chained :root selector evaluation

### DIFF
--- a/.changes/next-release/bugfix-572c733fb40f7b2b3e44e99603b7033f56ee8d34.json
+++ b/.changes/next-release/bugfix-572c733fb40f7b2b3e44e99603b7033f56ee8d34.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Optimize chained :root selector evaluation by updating IntermediateAndSelector to only push to input-independent selectors one time",
+  "pull_requests": [
+    "[#3054](https://github.com/smithy-lang/smithy/pull/3054)"
+  ]
+}

--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
@@ -37,6 +37,7 @@ public class Selectors {
         public Model model;
         public Selector suboptimalHttpBindingSelector = createSuboptimalHttpBindingIncompatibilitySelector();
         public Selector httpBindingSelector = createHttpBindingIncompatibilitySelector();
+        public Selector doubleRootSelector = createDoubleRootSelector();
         public String testIdlModelLocation = "test-model.smithy";
         public String testJsonModelLocation = "test-model.json";
 
@@ -63,6 +64,10 @@ public class Selectors {
                     + ":test(${operations}[trait|http])\n"
                     + "${operations}\n"
                     + ":not([trait|http])");
+        }
+
+        private Selector createDoubleRootSelector() {
+            return Selector.parse(":root(*):root(*)");
         }
     }
 
@@ -127,5 +132,11 @@ public class Selectors {
             return operations.stream().filter(shape -> !shape.hasTrait(HttpTrait.ID));
         })
                 .collect(Collectors.toSet());
+    }
+
+    // Benchmarks evaluating the :root(*):root(*) selector against the model.
+    @Benchmark
+    public Set<Shape> evaluateDoubleRootSelector(SelectorState state) {
+        return state.doubleRootSelector.select(state.model);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
@@ -50,7 +50,21 @@ final class AndSelector {
 
         @Override
         public Response push(Context ctx, Shape shape, Receiver next) {
+            // When the right selector is input-shape-independent (e.g., RootSelector), its
+            // output is the same regardless of which shape is pushed into it. Check if the
+            // left emits anything, and if so, call the right selector exactly once.
+            if (rightSelector.isInputShapeIndependent()) {
+                if (ctx.receivedShapes(shape, leftSelector)) {
+                    return rightSelector.push(ctx, shape, next);
+                }
+                return Response.CONTINUE;
+            }
             return leftSelector.push(ctx, shape, (c, s) -> rightSelector.push(c, s, next));
+        }
+
+        @Override
+        public boolean isInputShapeIndependent() {
+            return leftSelector.isInputShapeIndependent() && rightSelector.isInputShapeIndependent();
         }
 
         @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
@@ -111,6 +111,19 @@ interface InternalSelector {
     }
 
     /**
+     * Returns true if this selector's output is independent of the input shape passed to {@link #push}.
+     *
+     * <p>Selectors like {@link RootSelector} always emit the same set of shapes regardless of the input shape,
+     * because they draw from a pre-computed root result. This allows optimizations in selector chaining to avoid
+     * redundant evaluations when an input-independent selector appears downstream of a multi-emitting selector.
+     *
+     * @return Returns true if the selector ignores the input shape parameter.
+     */
+    default boolean isInputShapeIndependent() {
+        return false;
+    }
+
+    /**
      * Receives shapes from an InternalSelector.
      */
     interface Receiver {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/RootSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/RootSelector.java
@@ -39,4 +39,9 @@ final class RootSelector implements InternalSelector {
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
         return context.getRootResult(id).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public boolean isInputShapeIndependent() {
+        return true;
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -1153,6 +1153,30 @@ public class SelectorTest {
     }
 
     @Test
+    public void chainedRootsDoNotCauseExponentialBlowup() {
+        // Regression test for https://github.com/smithy-lang/smithy/issues/2701
+        // Chaining :root selectors previously caused a cross-product blowup (N^(K+1) operations).
+        // With the fix, this completes in linear time.
+        Selector selector = Selector.parse(":root(*):root(*):root(*)");
+        Set<Shape> result = selector.select(resourceModel);
+
+        assertThat(result, equalTo(resourceModel.toSet()));
+    }
+
+    @Test
+    public void chainedRootsWithDifferentFilters() {
+        // :root(string):root(integer) should produce only integer shapes (the right root's result),
+        // because :root ignores its input shape and emits its pre-computed result.
+        Selector selector = Selector.parse(":root(string):root(integer)");
+        Set<Shape> result = selector.select(resourceModel);
+
+        Selector integerOnly = Selector.parse(":root(integer)");
+        Set<Shape> expected = integerOnly.select(resourceModel);
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
     public void inDoesNotSupportMoreThanOneSelector() {
         Assertions.assertThrows(SelectorSyntaxException.class, () -> Selector.parse(":in(*, *)"));
     }


### PR DESCRIPTION
Chaining multiple `:root()` selectors previously caused an N^(K+1) cross-product setup because `IntermediateAndSelector` pushed every shape emitted by the left selector into the right selector, even when the right selector's output was identical regardless of input.

`InternalSelector` now exposes an `isInputShapeIndependent()` hook that `RootSelector` overrides to return true. When `IntermediateAndSelector` detects an input-independent right side, it checks whether the left emits anything and then calls the right exactly once, reducing chained roots from exponential to linear.

Also adds regression tests for chained roots and a JMH benchmark for this case.

Fixes #2701 

---

| Benchmark | Baseline (us/op) | With Fix (us/op) | Change |
|---|---|---|---|
| evaluateDoubleRootSelector | 69,360 ± 5,142 | 325 ± 51 | **213x faster** |
| evaluateHttpBindingSelector | 0.496 ± 0.107 | 0.472 ± 0.048 | within noise |
| evaluateHttpBindingManually | 0.144 ± 0.005 | 0.137 ± 0.011 | within noise |
| evaluateSuboptimalHttpBindingSelector | 10.7 ± 2.8 | 13.221 ±  0.681 | within noise |
| loadsIdlModelWithValidation | 383 ± 36 | 380 ± 33 | within noise |

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
