### PR TITLE
Ignore JARs without a Smithy manifest

### DIFF
--- a/.changes/next-release/feature-6dc2e6dcfbad136a8cffecc102b0f02214cd9e46.json
+++ b/.changes/next-release/feature-6dc2e6dcfbad136a8cffecc102b0f02214cd9e46.json
@@ -1,5 +1,7 @@
 {
   "type": "feature",
   "description": "Ignore JARs without a Smithy manifest to allow Smithy model packages to have non-Smithy dependencies",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3055](https://github.com/smithy-lang/smithy/pull/3055)"
+  ]
 }

--- a/.changes/next-release/feature-6dc2e6dcfbad136a8cffecc102b0f02214cd9e46.json
+++ b/.changes/next-release/feature-6dc2e6dcfbad136a8cffecc102b0f02214cd9e46.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Ignore JARs without a Smithy manifest to allow Smithy model packages to have non-Smithy dependencies",
+  "pull_requests": []
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
@@ -4,10 +4,12 @@
  */
 package software.amazon.smithy.model.loader;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -118,7 +120,18 @@ final class ModelLoader {
         URL manifestUrl = ModelDiscovery.createSmithyJarManifestUrl(filename);
         LOGGER.fine(() -> "Loading Smithy model imports from JAR: " + manifestUrl);
 
-        for (URL model : ModelDiscovery.findModels(manifestUrl)) {
+        List<URL> models;
+        try {
+            models = ModelDiscovery.findModels(manifestUrl);
+        } catch (ModelManifestException e) {
+            if (e.getCause() instanceof FileNotFoundException) {
+                LOGGER.info(() -> "Ignoring JAR without Smithy manifest: " + filename);
+                return;
+            }
+            throw e;
+        }
+
+        for (URL model : models) {
             try {
                 URLConnection connection = model.openConnection();
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -1348,6 +1348,16 @@ public class ModelAssemblerTest {
     }
 
     @Test
+    public void ignoresJarWithoutSmithyManifest() throws URISyntaxException, IOException {
+        Path jar = JarUtils.createJarFromDir(
+                Paths.get(getClass().getResource("assembler-no-manifest-jar").toURI()));
+
+        ValidatedResult<Model> result = Model.assembler().addImport(jar).assemble();
+
+        assertFalse(result.isBroken());
+    }
+
+    @Test
     public void doesNotThrowOnInvalidSuppression() {
         ObjectNode node = Node.objectNode()
                 .withMember("smithy", "1.0")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-no-manifest-jar/META-INF/MANIFEST.MF
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-no-manifest-jar/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Manifest-Version: 1.0


### PR DESCRIPTION
This commit logs when a JAR is encountered with a missing manifest instead of throwing, allowing for libraries that bring in Smithy models to have dependencies on non-Smithy packages.

Fixes #2581 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
