### PR TITLE
Ensure javadoc uses utf-8

### DIFF
--- a/.changes/next-release/other-a053668ff799b09ec464ea9abe561bc4ca182fcf.json
+++ b/.changes/next-release/other-a053668ff799b09ec464ea9abe561bc4ca182fcf.json
@@ -1,0 +1,5 @@
+{
+  "type": "other",
+  "description": "Ensures javadoc uses UTF-8 encoding",
+  "pull_requests": []
+}

--- a/.changes/next-release/other-a053668ff799b09ec464ea9abe561bc4ca182fcf.json
+++ b/.changes/next-release/other-a053668ff799b09ec464ea9abe561bc4ca182fcf.json
@@ -1,5 +1,7 @@
 {
   "type": "other",
   "description": "Ensures javadoc uses UTF-8 encoding",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3057](https://github.com/smithy-lang/smithy/pull/3057)"
+  ]
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ afterEvaluate {
 
             source(provider { subprojects.map { project -> project.sourceSets.main.get().allJava } })
 
+            options.encoding = "UTF-8"
             (options as StandardJavadocDocletOptions).apply {
                 addStringOption("Xdoclint:-html", "-quiet")
             }

--- a/buildSrc/src/main/kotlin/smithy.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy.java-conventions.gradle.kts
@@ -44,6 +44,7 @@ tasks {
     }
 
     javadoc {
+        options.encoding = "UTF-8"
         // Disable HTML doclint to work around heading tag sequence validation
         // inconsistencies between JDK15 and earlier Java versions.
         (options as StandardJavadocDocletOptions).apply {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
