### PR TITLE
Add Version 2.1

### DIFF
--- a/.changes/next-release/feature-c890ed1da437b16c254ed65140f1e343b551d1ce.json
+++ b/.changes/next-release/feature-c890ed1da437b16c254ed65140f1e343b551d1ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Bumped the IDL version to 2.1.",
+  "pull_requests": [
+    "[#3059](https://github.com/smithy-lang/smithy/pull/3059)"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, "idl-2.1"]
   pull_request:
-    branches: [main]
+    branches: [main, "idl-2.1"]
 
 permissions:
   contents: read

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -65,7 +65,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final class Model implements ToSmithyBuilder<Model> {
 
     /** Specifies the highest supported version of the IDL. */
-    public static final String MODEL_VERSION = "2.0";
+    public static final String MODEL_VERSION = "2.1";
 
     /** The map of metadata keys to their "node" values. */
     private final Map<String, Node> metadata;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelInteropTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelInteropTransformer.java
@@ -83,7 +83,8 @@ final class ModelInteropTransformer {
                             upgradeV1Member(member, target);
                         });
                     }
-                } else if (fileToVersion.apply(struct) == Version.VERSION_2_0) {
+                } else if (fileToVersion.apply(struct) == Version.VERSION_2_0
+                        || fileToVersion.apply(struct) == Version.VERSION_2_1) {
                     // Patch v2 based members with the box trait when necessary in order for v1 based tooling to
                     // correctly interpret a v2 model.
                     for (MemberShape member : struct.getAllMembers().values()) {
@@ -201,7 +202,7 @@ final class ModelInteropTransformer {
                 DefaultTrait syntheticDefault = new DefaultTrait(defaultZeroValue);
                 builder.addTrait(syntheticDefault);
             }
-        } else if (defineShape.version == Version.VERSION_2_0) {
+        } else if (defineShape.version == Version.VERSION_2_0 || defineShape.version == Version.VERSION_2_1) {
             // Add the box trait to root level shapes not marked with the default trait, or that are marked with
             // the default trait, and it isn't set to the zero value of a v1 type.
             Trait defaultTrait = builder.getAllTraits().get(DefaultTrait.ID);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Version.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Version.java
@@ -161,27 +161,50 @@ enum Version {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         ValidationEvent validateVersionedTrait(ShapeId target, ShapeId traitId, Node value) {
-            if (traitId.equals(BoxTrait.ID)) {
-                return ValidationEvent.builder()
-                        .id(Validator.MODEL_ERROR)
-                        .severity(Severity.ERROR)
-                        .shapeId(target)
-                        .sourceLocation(value)
-                        .message("@box is not supported in Smithy IDL 2.0")
-                        .build();
-            } else if (traitId.equals(EnumTrait.ID)) {
-                return ValidationEvent.builder()
-                        .id(Validator.MODEL_DEPRECATION)
-                        .severity(Severity.WARNING)
-                        .shapeId(target)
-                        .sourceLocation(value)
-                        .message("The enum trait is deprecated. Smithy 2.0 models should use the enum shape.")
-                        .build();
-            }
+            return validateV2VersionedTrait(target, traitId, value, this);
+        }
+    },
 
-            return null;
+    VERSION_2_1 {
+        @Override
+        public String toString() {
+            return "2.1";
+        }
+
+        @Override
+        boolean supportsMixins() {
+            return true;
+        }
+
+        @Override
+        boolean supportsInlineOperationIO() {
+            return true;
+        }
+
+        @Override
+        boolean supportsTargetElision() {
+            return true;
+        }
+
+        @Override
+        boolean isDefaultSupported() {
+            return true;
+        }
+
+        @Override
+        boolean isShapeTypeSupported(ShapeType shapeType) {
+            return shapeType != ShapeType.SET;
+        }
+
+        @Override
+        boolean isDeprecated() {
+            return false;
+        }
+
+        @Override
+        ValidationEvent validateVersionedTrait(ShapeId target, ShapeId traitId, Node value) {
+            return validateV2VersionedTrait(target, traitId, value, this);
         }
     };
 
@@ -200,6 +223,8 @@ enum Version {
             case "2":
             case "2.0":
                 return VERSION_2_0;
+            case "2.1":
+                return VERSION_2_1;
             default:
                 return null;
         }
@@ -211,7 +236,39 @@ enum Version {
      * @return Returns true if this version supports resource properties.
      */
     boolean supportsResourceProperties() {
-        return this == VERSION_2_0;
+        return this == VERSION_2_0 || this == VERSION_2_1;
+    }
+
+    /**
+     * Shared trait validation logic for Smithy 2.x versions.
+     */
+    @SuppressWarnings("deprecation")
+    private static ValidationEvent validateV2VersionedTrait(
+            ShapeId target,
+            ShapeId traitId,
+            Node value,
+            Version version
+    ) {
+        if (traitId.equals(BoxTrait.ID)) {
+            return ValidationEvent.builder()
+                    .id(Validator.MODEL_ERROR)
+                    .severity(Severity.ERROR)
+                    .shapeId(target)
+                    .sourceLocation(value)
+                    .message("@box is not supported in Smithy IDL " + version)
+                    .build();
+        } else if (traitId.equals(EnumTrait.ID)) {
+            return ValidationEvent.builder()
+                    .id(Validator.MODEL_DEPRECATION)
+                    .severity(Severity.WARNING)
+                    .shapeId(target)
+                    .sourceLocation(value)
+                    .message("The enum trait is deprecated. Smithy " + version
+                            + " models should use the enum shape.")
+                    .build();
+        }
+
+        return null;
     }
 
     /**
@@ -243,7 +300,7 @@ enum Version {
 
     /**
      * Checks if the default trait is supported.
-     * @return Returns true if supported (i.e., IDL 2.0 or UNKNOWN).
+     * @return Returns true if supported (i.e., IDL 2.0+, or UNKNOWN).
      */
     abstract boolean isDefaultSupported();
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ModelSerializer.java
@@ -162,7 +162,7 @@ public final class ModelSerializer {
         private Predicate<Shape> shapeFilter = FunctionalUtils.alwaysTrue();
         private boolean includePrelude = false;
         private Predicate<Trait> traitFilter = FunctionalUtils.alwaysTrue();
-        private String version = "2.0";
+        private String version = "2.1";
 
         private Builder() {}
 
@@ -225,7 +225,7 @@ public final class ModelSerializer {
          *
          * <p>Version "1.0" serialization cannot be used with {@link #includePrelude}.
          *
-         * @param version IDL version to set. Can be "1", "1.0", "2", or "2.0".
+         * @param version IDL version to set. Can be "1", "1.0", "2", "2.0", or "2.1".
          *                "1" and "2" are normalized to "1.0" and "2.0".
          * @return Returns the builder.
          */
@@ -234,6 +234,9 @@ public final class ModelSerializer {
                 case "2":
                 case "2.0":
                     this.version = "2.0";
+                    break;
+                case "2.1":
+                    this.version = "2.1";
                     break;
                 case "1":
                 case "1.0":

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ModelSerializerTest.java
@@ -284,7 +284,7 @@ public class ModelSerializerTest {
                 .build();
         Model model = Model.builder().addShape(shape).build();
         Node node = ModelSerializer.builder().build().serialize(model);
-        Node expectedNode = Node.parse("{\"smithy\":\"2.0\",\"shapes\":{\"ns.foo#Bar\":" +
+        Node expectedNode = Node.parse("{\"smithy\":\"2.1\",\"shapes\":{\"ns.foo#Bar\":" +
                 "{\"type\":\"resource\",\"properties\":{\"fooProperty\":{\"target\":\"ns.foo#Shape\"}}}}}");
         Node.assertEquals(node, expectedNode);
     }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/enums.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/enums.json
@@ -1,0 +1,74 @@
+{
+    "smithy": "2.1",
+    "shapes": {
+        "smithy.example#Suit": {
+            "type": "enum",
+            "members": {
+                "CLUB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CLUB"
+                    }
+                },
+                "DIAMOND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DIAMOND"
+                    }
+                },
+                "HEART": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HEART"
+                    }
+                },
+                "SPADE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SPADE"
+                    }
+                }
+            }
+        },
+        "smithy.example#SuitWithValues": {
+            "type": "enum",
+            "members": {
+                "CLUB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "clubs"
+                    }
+                },
+                "DIAMOND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "diamonds"
+                    }
+                }
+            }
+        },
+        "smithy.example#Priority": {
+            "type": "intEnum",
+            "members": {
+                "LOW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": 1
+                    }
+                },
+                "MEDIUM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": 2
+                    }
+                },
+                "HIGH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": 3
+                    }
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/enums.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/enums.smithy
@@ -1,0 +1,24 @@
+$version: "2.1"
+
+namespace smithy.example
+
+enum Suit {
+    CLUB
+    DIAMOND
+    HEART
+    SPADE
+}
+
+enum SuitWithValues {
+    @enumValue("clubs")
+    CLUB
+
+    @enumValue("diamonds")
+    DIAMOND
+}
+
+intEnum Priority {
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/inline-io.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/inline-io.json
@@ -1,0 +1,39 @@
+{
+    "smithy": "2.1",
+    "shapes": {
+        "smithy.example#GetWidget": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.example#GetWidgetInput"
+            },
+            "output": {
+                "target": "smithy.example#GetWidgetOutput"
+            }
+        },
+        "smithy.example#GetWidgetInput": {
+            "type": "structure",
+            "members": {
+                "widgetId": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "smithy.example#GetWidgetOutput": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String"
+                },
+                "description": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/inline-io.smithy
@@ -1,0 +1,13 @@
+$version: "2.1"
+
+namespace smithy.example
+
+operation GetWidget {
+    input := {
+        widgetId: String
+    }
+    output := {
+        name: String
+        description: String
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/mixins.json
@@ -1,0 +1,42 @@
+{
+    "smithy": "2.1",
+    "shapes": {
+        "smithy.example#BaseMixin": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "smithy.api#String"
+                },
+                "name": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#UsesBase": {
+            "type": "structure",
+            "members": {
+                "description": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "mixins": [
+                {"target": "smithy.example#BaseMixin"}
+            ]
+        },
+        "smithy.example#StringMixin": {
+            "type": "string",
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "smithy.example#MixedString": {
+            "type": "string",
+            "mixins": [
+                {"target": "smithy.example#StringMixin"}
+            ]
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/mixins.smithy
@@ -1,0 +1,18 @@
+$version: "2.1"
+
+namespace smithy.example
+
+@mixin
+structure BaseMixin {
+    id: String
+    name: String
+}
+
+structure UsesBase with [BaseMixin] {
+    description: String
+}
+
+@mixin
+string StringMixin
+
+string MixedString with [StringMixin]

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/resource-properties.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/resource-properties.json
@@ -1,0 +1,58 @@
+{
+    "smithy": "2.1",
+    "shapes": {
+        "smithy.example#Widget": {
+            "type": "resource",
+            "identifiers": {
+                "widgetId": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "properties": {
+                "name": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "read": {
+                "target": "smithy.example#GetWidget"
+            }
+        },
+        "smithy.example#GetWidget": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.example#GetWidgetInput"
+            },
+            "output": {
+                "target": "smithy.example#GetWidgetOutput"
+            },
+            "traits": {
+                "smithy.api#readonly": {}
+            }
+        },
+        "smithy.example#GetWidgetInput": {
+            "type": "structure",
+            "members": {
+                "widgetId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "smithy.example#GetWidgetOutput": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/resource-properties.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/resource-properties.smithy
@@ -1,0 +1,24 @@
+$version: "2.1"
+
+namespace smithy.example
+
+resource Widget {
+    identifiers: {
+        widgetId: String
+    }
+    properties: {
+        name: String
+    }
+    read: GetWidget
+}
+
+@readonly
+operation GetWidget {
+    input := {
+        @required
+        widgetId: String
+    }
+    output := {
+        name: String
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/simple-shapes.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/simple-shapes.json
@@ -1,0 +1,78 @@
+{
+    "smithy": "2.1",
+    "shapes": {
+        "smithy.example#MyString": {
+            "type": "string"
+        },
+        "smithy.example#MyBoolean": {
+            "type": "boolean"
+        },
+        "smithy.example#MyBlob": {
+            "type": "blob"
+        },
+        "smithy.example#MyShort": {
+            "type": "short"
+        },
+        "smithy.example#MyByte": {
+            "type": "byte"
+        },
+        "smithy.example#MyInteger": {
+            "type": "integer"
+        },
+        "smithy.example#MyLong": {
+            "type": "long"
+        },
+        "smithy.example#MyFloat": {
+            "type": "float"
+        },
+        "smithy.example#MyDouble": {
+            "type": "double"
+        },
+        "smithy.example#MyBigDecimal": {
+            "type": "bigDecimal"
+        },
+        "smithy.example#MyBigInteger": {
+            "type": "bigInteger"
+        },
+        "smithy.example#MyTimestamp": {
+            "type": "timestamp"
+        },
+        "smithy.example#MyList": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String"
+            }
+        },
+        "smithy.example#MyMap": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
+            }
+        },
+        "smithy.example#MyStruct": {
+            "type": "structure",
+            "members": {
+                "foo": {
+                    "target": "smithy.api#String"
+                },
+                "bar": {
+                    "target": "smithy.api#Integer"
+                }
+            }
+        },
+        "smithy.example#MyUnion": {
+            "type": "union",
+            "members": {
+                "a": {
+                    "target": "smithy.api#String"
+                },
+                "b": {
+                    "target": "smithy.api#Integer"
+                }
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/simple-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/valid/2.1/simple-shapes.smithy
@@ -1,0 +1,46 @@
+$version: "2.1"
+
+namespace smithy.example
+
+string MyString
+
+byte MyByte
+
+short MyShort
+
+integer MyInteger
+
+long MyLong
+
+float MyFloat
+
+double MyDouble
+
+bigInteger MyBigInteger
+
+bigDecimal MyBigDecimal
+
+boolean MyBoolean
+
+blob MyBlob
+
+timestamp MyTimestamp
+
+list MyList {
+    member: String
+}
+
+map MyMap {
+    key: String
+    value: String
+}
+
+structure MyStruct {
+    foo: String
+    bar: Integer
+}
+
+union MyUnion {
+    a: String
+    b: Integer
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v1/1.0-box-member.2.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v1/1.0-box-member.2.0.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#BoxedBoolean": {
             "type": "boolean"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v1/1.0-box-root.2.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v1/1.0-box-root.2.0.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#BoxedBoolean": {
             "type": "boolean"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v1/1.0-enums.2.0.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v1/1.0-enums.2.0.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#IntEnum": {
             "type": "integer",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/data-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/data-mixins.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#A": {
             "type": "structure",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/enums.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/enums.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#StringEnum": {
             "type": "enum",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/operation-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/operation-mixins.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#MixinError": {
             "type": "structure",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/resource-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/resource-mixins.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#MixinResource": {
             "type": "resource",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/service-mixins-with-overrides.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/service-mixins-with-overrides.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#MixedService": {
             "type": "service",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/service-mixins.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/cases/v2/service-mixins.json
@@ -1,5 +1,5 @@
 {
-    "smithy": "2.0",
+    "smithy": "2.1",
     "shapes": {
         "smithy.example#ShapeToRename": {
             "type": "string"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/out-of-order-errors.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/ast-serialization/out-of-order-errors.json
@@ -1,5 +1,5 @@
 {
-  "smithy": "2.0",
+  "smithy": "2.1",
   "shapes": {
     "smithy.example#ErrorA": {
       "type": "structure",

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/after.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/before.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 metadata zoo = "test"
 metadata foo = "hi"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/metadata.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 metadata foo = "hi"
 metadata zoo = "test"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/boolean-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/boolean-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/collection-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/collection-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/data-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/data-mixins.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace smithy.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/default-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/default-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/document-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/document-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/documentation-trait.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/enums.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/enums.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/inline-io.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/metadata.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 metadata CaseSensitive = true
 metadata bool2 = false

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/mixins.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace smithy.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/number-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/number-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/object-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/object-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/operation-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/operation-mixins.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace smithy.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/optional-namespaces-are-stripped.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/optional-namespaces-are-stripped.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/resource-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/resource-mixins.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace smithy.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-errors.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-errors.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-mixins-with-merging.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-mixins-with-merging.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace smithy.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-mixins.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-mixins.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace smithy.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/service-shapes.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/simple-shapes.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/string-traits.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/string-traits.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/trailing-space-in-docs.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/cases/trailing-space-in-docs.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/after.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 $operationInputSuffix: "Request"
 $operationOutputSuffix: "Response"
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/before.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/custom-inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/custom-inline-io.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 $operationInputSuffix: "Request"
 $operationOutputSuffix: "Response"
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-input.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-input.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-output.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-output.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.foo
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/default.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/default.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/main.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/main.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/mixed.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/mixed.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/shared.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/shared.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 $operationInputSuffix: "Request"
 $operationOutputSuffix: "Response"
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/metadata.smithy
@@ -1,3 +1,3 @@
-$version: "2.0"
+$version: "2.1"
 
 metadata shared = true

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.primitives
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace ns.structures
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/out-of-order.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/out-of-order.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "2.1"
 
 namespace com.example
 


### PR DESCRIPTION
This adds the 2.1 version to Smithy. Currently there is no difference between 2.0 and 2.1, this is just to get the process started.

The default version is now 2.1, so serialized models will reflect that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
