### PR TITLE
Constrain plexus-utils to 3.6.1

### DIFF
--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -30,6 +30,14 @@ val imageJreVersion = "17"
 val correttoRoot = "https://corretto.aws/downloads/latest/amazon-corretto-$imageJreVersion"
 
 dependencies {
+    constraints {
+        implementation("org.codehaus.plexus:plexus-utils:3.6.1") {
+            because(
+                "CVE-2025-67030: directory traversal in Expand.extractFile (CVSS 8.8), fixed in 3.6.1 via https://github.com/codehaus-plexus/plexus-utils/pull/304",
+            )
+        }
+    }
+
     // Keeps these as exported transitive dependencies.
     implementation(project(":smithy-model"))
     implementation(project(":smithy-build"))


### PR DESCRIPTION
Do this while waiting for `maven-resolver-provider` to release with the updated dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
