### PR TITLE
Fix CLI dependency cache for multiple configs

### DIFF
--- a/.changes/next-release/bugfix-64f2d54aae177e3b8290c9309e873954749ee3d3.json
+++ b/.changes/next-release/bugfix-64f2d54aae177e3b8290c9309e873954749ee3d3.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fix CLI dependency cache for multiple configs building to the same directory",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3061](https://github.com/smithy-lang/smithy/pull/3061)"
+  ]
 }

--- a/.changes/next-release/bugfix-64f2d54aae177e3b8290c9309e873954749ee3d3.json
+++ b/.changes/next-release/bugfix-64f2d54aae177e3b8290c9309e873954749ee3d3.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fix CLI dependency cache for multiple configs building to the same directory",
+  "pull_requests": []
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ClasspathAction.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ClasspathAction.java
@@ -124,18 +124,22 @@ class ClasspathAction implements CommandAction {
         DependencyResolver baseResolver = dependencyResolverFactory.create(smithyBuildConfig, env);
         long lastModified = smithyBuildConfig.getLastModifiedInMillis();
         DependencyResolver delegate = new FilterCliVersionResolver(SmithyCli.getVersion(), baseResolver);
-        DependencyResolver resolver = new FileCacheResolver(getCacheFile(buildOptions, smithyBuildConfig),
-                lastModified,
-                delegate);
 
         Set<MavenRepository> repositories = ConfigurationUtils.getConfiguredMavenRepos(smithyBuildConfig);
+        int configHash = ConfigurationUtils.configHash(maven.getDependencies(), repositories);
+
+        DependencyResolver resolver = new FileCacheResolver(getCacheFile(buildOptions, smithyBuildConfig),
+                lastModified,
+                configHash,
+                delegate);
+
         repositories.forEach(resolver::addRepository);
 
         // Use the pinned lockfile dependencies if a lockfile exists otherwise use the configured dependencies
         Optional<LockFile> lockFileOptional = LockFile.load();
         if (lockFileOptional.isPresent()) {
             LockFile lockFile = lockFileOptional.get();
-            if (lockFile.getConfigHash() != ConfigurationUtils.configHash(maven.getDependencies(), repositories)) {
+            if (lockFile.getConfigHash() != configHash) {
                 throw new CliError(
                         "`smithy-lock.json` does not match configured dependencies. "
                                 + "Re-lock dependencies using the `lock` command or revert changes.");

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/FileCacheResolver.java
@@ -37,16 +37,33 @@ public final class FileCacheResolver implements DependencyResolver {
     private final DependencyResolver delegate;
     private final File location;
     private final long referenceTimeInMillis;
+    private final int configHash;
+
+    /**
+     * @param location The location to the cache.
+     * @param referenceTimeInMillis Invalidate cache items if this time is newer than the cache item time.
+     * @param configHash A hash of the dependency configuration (artifacts and repositories) used to detect
+     *                   when different configs share the same cache file location. A value of 0 disables
+     *                   hash-based invalidation (used by the deprecated constructor for backward compatibility).
+     * @param delegate Resolver to delegate to when dependencies aren't cached.
+     */
+    public FileCacheResolver(File location, long referenceTimeInMillis, int configHash, DependencyResolver delegate) {
+        this.location = location;
+        this.referenceTimeInMillis = referenceTimeInMillis;
+        this.configHash = configHash;
+        this.delegate = delegate;
+    }
 
     /**
      * @param location The location to the cache.
      * @param referenceTimeInMillis Invalidate cache items if this time is newer than the cache item time.
      * @param delegate Resolver to delegate to when dependencies aren't cached.
+     * @deprecated Use {@link #FileCacheResolver(File, long, int, DependencyResolver)} to include a config hash
+     *             for correct cache invalidation when different configs share the same output directory.
      */
+    @Deprecated
     public FileCacheResolver(File location, long referenceTimeInMillis, DependencyResolver delegate) {
-        this.location = location;
-        this.referenceTimeInMillis = referenceTimeInMillis;
-        this.delegate = delegate;
+        this(location, referenceTimeInMillis, 0, delegate);
     }
 
     @Override
@@ -111,6 +128,18 @@ public final class FileCacheResolver implements DependencyResolver {
             return Collections.emptyList();
         }
 
+        // Invalidate if the config hash (dependencies + repositories) has changed, which happens
+        // when different --config files resolve to the same output directory.
+        if (configHash != 0) {
+            int cachedHash = node.getNumberMemberOrDefault("configHash", 0).intValue();
+            if (cachedHash != configHash) {
+                LOGGER.fine("Invalidating dependency cache: config hash mismatch (cached: "
+                        + cachedHash + ", current: " + configHash + ")");
+                invalidate();
+                return Collections.emptyList();
+            }
+        }
+
         ObjectNode artifactNode = node.expectObjectMember("artifacts");
         List<ResolvedArtifact> result = new ArrayList<>(artifactNode.getStringMap().size());
         for (Map.Entry<String, Node> entry : artifactNode.getStringMap().entrySet()) {
@@ -139,6 +168,7 @@ public final class FileCacheResolver implements DependencyResolver {
             Files.createDirectories(parent);
             ObjectNode.Builder builder = Node.objectNodeBuilder();
             builder.withMember("version", CURRENT_CACHE_FILE_VERSION);
+            builder.withMember("configHash", configHash);
             ObjectNode.Builder artifactNodeBuilder = Node.objectNodeBuilder();
             for (ResolvedArtifact artifact : result) {
                 artifactNodeBuilder.withMember(artifact.getCoordinates(), artifact.toNode());

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.MavenRepository;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -129,6 +131,81 @@ public class FileCacheResolverTest {
 
         // The cache will be invalidated here and reloaded from source, resulting in an empty result.
         assertThat(cachingResolver.resolve(), empty());
+    }
+
+    @Test
+    public void usesCacheWhenConfigHashMatches() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".jar");
+        Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
+
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
+        List<ResolvedArtifact> result = new ArrayList<>();
+        result.add(artifact);
+
+        int hash = 12345;
+        Mock mock = new Mock(result);
+        DependencyResolver cachingResolver = new FileCacheResolver(cache, jar.lastModified(), hash, mock);
+        List<ResolvedArtifact> resolved = cachingResolver.resolve();
+
+        assertThat(resolved, contains(artifact));
+        ObjectNode cacheNode = Node.parse(IoUtils.readUtf8File(cache.toPath())).expectObjectNode();
+        assertThat(cacheNode.expectNumberMember("configHash").getValue().intValue(), is(hash));
+
+        // Clear the mock so a cache miss would return empty.
+        result.clear();
+
+        // A second resolver with the same hash should get a cache hit.
+        DependencyResolver secondResolver = new FileCacheResolver(cache, jar.lastModified(), hash, new Mock(result));
+        assertThat(secondResolver.resolve(), contains(artifact));
+    }
+
+    @Test
+    public void invalidatesCacheWhenConfigHashDiffers() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".jar");
+        Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
+
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
+        List<ResolvedArtifact> result = new ArrayList<>();
+        result.add(artifact);
+
+        // Write the cache with hash A.
+        Mock mock = new Mock(result);
+        DependencyResolver firstResolver = new FileCacheResolver(cache, jar.lastModified(), 111, mock);
+        assertThat(firstResolver.resolve(), contains(artifact));
+
+        // A second resolver with hash B should invalidate and re-resolve via its delegate.
+        List<ResolvedArtifact> secondResult = new ArrayList<>();
+        Mock secondMock = new Mock(secondResult);
+        DependencyResolver secondResolver = new FileCacheResolver(cache, jar.lastModified(), 222, secondMock);
+        assertThat(secondResolver.resolve(), empty());
+    }
+
+    @Test
+    public void invalidatesCacheWhenOldCacheFileLacksConfigHash() throws IOException {
+        File cache = File.createTempFile("classpath", ".json");
+        File jar = File.createTempFile("foo", ".jar");
+        Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
+
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
+        List<ResolvedArtifact> result = new ArrayList<>();
+        result.add(artifact);
+
+        // Write the cache using the deprecated constructor (configHash=0), simulating an old cache file.
+        Mock mock = new Mock(result);
+        DependencyResolver oldResolver = new FileCacheResolver(cache, jar.lastModified(), mock);
+        assertThat(oldResolver.resolve(), contains(artifact));
+
+        // The cache file should have configHash 0.
+        ObjectNode cacheNode = Node.parse(IoUtils.readUtf8File(cache.toPath())).expectObjectNode();
+        assertThat(cacheNode.expectNumberMember("configHash").getValue().intValue(), is(0));
+
+        // A new resolver with a non-zero hash should invalidate the old cache.
+        List<ResolvedArtifact> newResult = new ArrayList<>();
+        Mock newMock = new Mock(newResult);
+        DependencyResolver newResolver = new FileCacheResolver(cache, jar.lastModified(), 99999, newMock);
+        assertThat(newResolver.resolve(), empty());
     }
 
     @Test


### PR DESCRIPTION
The `smithy ast` command cached resolved maven dependencies to a single `classpath.json` keyed only by the output directory. When different `--config` files shared the same output directory, the second invocation reused the first's cached dependencies.

`FileCacheResolver` now stores a hash of the dependency configuration in the cache file and invalidates on mismatch, reusing the existing `ConfigurationUtils.configHash` method. This keeps regular builds caching while resolving this issue.

## Testing

Manually verified end-to-end by creating two smithy-build configs
pulling different dependencies (`smithy-rules-engine` vs
`smithy-protocol-traits`) with corresponding model files that
use traits from each. Running `smithy ast` with the first config
then the second against the installed 1.65.0 CLI reproduces the
bug: the second invocation fails with `Unable to resolve trait
smithy.protocols#rpcv2Cbor`. Running the same sequence against
the locally built image, both invocations succeed.

Resolves #2537 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
