### PR TITLE
Fix selector parsing with errant break tokens

### DIFF
--- a/.changes/next-release/bugfix-d3f8cb56f24737e46d719b83f7f8bff142c3c705.json
+++ b/.changes/next-release/bugfix-d3f8cb56f24737e46d719b83f7f8bff142c3c705.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fixed selector parsing to properly handle extraneous BREAK_TOKENS (',', ']', ')') in a selector. This manifested in silently dropping contents in the comma case (\"structure, string\" was effectively just \"structure\"). For the closing brace/paren, the characters were silently ignored as seen in the additional fixed tests.",
+  "pull_requests": []
+}

--- a/.changes/next-release/bugfix-d3f8cb56f24737e46d719b83f7f8bff142c3c705.json
+++ b/.changes/next-release/bugfix-d3f8cb56f24737e46d719b83f7f8bff142c3c705.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fixed selector parsing to properly handle extraneous BREAK_TOKENS (',', ']', ')') in a selector. This manifested in silently dropping contents in the comma case (\"structure, string\" was effectively just \"structure\"). For the closing brace/paren, the characters were silently ignored as seen in the additional fixed tests.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3063](https://github.com/smithy-lang/smithy/pull/3063)"
+  ]
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -47,7 +47,12 @@ final class SelectorParser extends SimpleParser {
     }
 
     List<InternalSelector> parse() {
-        return recursiveParse();
+        List<InternalSelector> result = recursiveParse();
+        ws();
+        if (!eof()) {
+            throw syntax("Unexpected selector character: " + peek());
+        }
+        return result;
     }
 
     private List<InternalSelector> recursiveParse() {

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -901,7 +901,7 @@ public class SelectorTest {
                         + "~>\n"
                         + "operation\n"
                         + "[trait|auth]"
-                        + ":not([@: @{trait|auth|(values)} {<} @{var|authTraits|id}]))");
+                        + ":not([@: @{trait|auth|(values)} {<} @{var|authTraits|id}])");
 
         List<Pair<Shape, Map<String, Set<Shape>>>> results = new ArrayList<>();
         selector.runner().model(result).selectMatches((s, vars) -> results.add(Pair.of(s, vars)));
@@ -1194,5 +1194,29 @@ public class SelectorTest {
     @Test
     public void rootRequiresOneSelector() {
         Assertions.assertThrows(SelectorSyntaxException.class, () -> Selector.parse(":root()"));
+    }
+
+    @Test
+    public void rejectsTopLevelComma() {
+        SelectorSyntaxException e = Assertions.assertThrows(
+                SelectorSyntaxException.class,
+                () -> Selector.parse("string, integer"));
+        assertThat(e.getMessage(), containsString(","));
+    }
+
+    @Test
+    public void rejectsUnmatchedTopLevelCloseBracket() {
+        SelectorSyntaxException e = Assertions.assertThrows(
+                SelectorSyntaxException.class,
+                () -> Selector.parse("string ] extra"));
+        assertThat(e.getMessage(), containsString("]"));
+    }
+
+    @Test
+    public void rejectsUnmatchedTopLevelCloseParen() {
+        SelectorSyntaxException e = Assertions.assertThrows(
+                SelectorSyntaxException.class,
+                () -> Selector.parse("string ) extra"));
+        assertThat(e.getMessage(), containsString(")"));
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/traitValidators/find-incompatible-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/traitValidators/find-incompatible-shapes.smithy
@@ -10,7 +10,7 @@ namespace com.amazonaws.simple
         message: "Document types are not supported"
     }
     "com.amazonaws.simple.myProtocol.NoEventStreams": {
-        selector: "~> operation -[input, output]-> :test(> member > union [trait|streaming]))"
+        selector: "~> operation -[input, output]-> :test(> member > union [trait|streaming])"
         message: "Event streams are not supported"
     }
     "com.amazonaws.simple.myProtocol.NoErrors": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/variables.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/variables.smithy
@@ -26,7 +26,7 @@ metadata selectorTests = [
         ~>
         operation
         [trait|auth]
-        :not([@: @{trait|auth|(values)} {<} @{var|authTraits|id}]))
+        :not([@: @{trait|auth|(values)} {<} @{var|authTraits|id}])
         """
         matches: [
             smithy.example#HasDigestAuth


### PR DESCRIPTION
This commit fixes an issue where the top-level `parse()` method did not properly handle extraneous BREAK_TOKENS (',', ']', ')') in a selector. This manifested in silently dropping contents in the comma case ("structure, string" was effectively just "structure"). For the closing brace/paren, the characters were silently ignored as seen in the additional fixed tests.

Fixes #2578 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
