### PR TITLE
Add additional shape type selectors

### DIFF
--- a/.changes/next-release/feature-bea96a571b157d1286e56e7c59abdee25c031d79.json
+++ b/.changes/next-release/feature-bea96a571b157d1286e56e7c59abdee25c031d79.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Added three new shape type selectors\n\n* `aggregateType` selects lists, structures, unions, and maps.\n* `serviceType` selects services, resources, and operations.\n* `dataType` selects aggregate types and simple types.",
+  "pull_requests": [
+    "[#3070](https://github.com/smithy-lang/smithy/pull/3070)"
+  ]
+}

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -74,6 +74,16 @@ Shapes can be matched by type using the following tokens:
         ``double``, ``bigDecimal``, and ``bigInteger`` shapes
     * - ``simpleType``
       - Matches all :ref:`simple types <simple-types>`
+    * - ``aggregateType``
+      - Matches all :ref:`aggregate types <aggregate-types>` (``list``,
+        ``map``, ``structure``, and ``union``)
+    * - ``dataType``
+      - Matches all :ref:`simple types <simple-types>` and
+        :ref:`aggregate types <aggregate-types>`. This is an alias of
+        ``:is(simpleType, aggregateType)``.
+    * - ``serviceType``
+      - Matches all :ref:`service types <service-types>` (``service``,
+        ``operation``, and ``resource``)
     * - ``collection``
       - Deprecated: An alias of ``list``. Also matches ``set`` shapes in Smithy IDL 1.0.
     * - ``blob``

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -44,7 +44,9 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
@@ -75,6 +77,9 @@ public final class Model implements ToSmithyBuilder<Model> {
 
     /** A cache of shapes of a specific type. */
     private final Map<Class<? extends Shape>, Set<? extends Shape>> cachedTypes = new ConcurrentHashMap<>();
+
+    /** A cache of shapes of a specific category. */
+    private final Map<ShapeType.Category, Set<? extends Shape>> cachedCategories = new ConcurrentHashMap<>();
 
     /** Cache of computed {@link KnowledgeIndex} instances. */
     private final Map<String, KnowledgeIndex> blackboard = new ConcurrentSkipListMap<>();
@@ -751,6 +756,31 @@ public final class Model implements ToSmithyBuilder<Model> {
      */
     public <T extends Shape> Stream<T> shapes(Class<T> shapeType) {
         return toSet(shapeType).stream();
+    }
+
+    /**
+     * Gets an immutable Set of shapes of a specific category.
+     *
+     * @param shapeCategory The category of shape to get a set of.
+     * @return Returns an unmodifiable set of shapes.
+     */
+    public Set<? extends Shape> toSet(ShapeType.Category shapeCategory) {
+        switch (shapeCategory) {
+            case SIMPLE:
+                return toSet(SimpleShape.class);
+            case MEMBER:
+                return toSet(MemberShape.class);
+            default:
+                return cachedCategories.computeIfAbsent(shapeCategory, c -> {
+                    Set<Shape> result = new HashSet<>();
+                    for (Shape shape : shapeMap.values()) {
+                        if (shape.getType().getCategory() == shapeCategory) {
+                            result.add(shape);
+                        }
+                    }
+                    return Collections.unmodifiableSet(result);
+                });
+        }
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -15,7 +16,6 @@ import software.amazon.smithy.model.neighbor.RelationshipType;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.ShapeType;
-import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SimpleParser;
 
@@ -133,9 +133,17 @@ final class SelectorParser extends SimpleParser {
                         case "number":
                             return new ShapeTypeCategorySelector(NumberShape.class);
                         case "simpleType":
-                            return new ShapeTypeCategorySelector(SimpleShape.class);
+                            return new ShapeTypeCategoryEnumSelector(ShapeType.Category.SIMPLE);
                         case "collection":
                             return new ShapeTypeCategorySelector(CollectionShape.class);
+                        case "aggregateType":
+                            return new ShapeTypeCategoryEnumSelector(ShapeType.Category.AGGREGATE);
+                        case "serviceType":
+                            return new ShapeTypeCategoryEnumSelector(ShapeType.Category.SERVICE);
+                        case "dataType":
+                            return IsSelector.of(Arrays.asList(
+                                    new ShapeTypeCategoryEnumSelector(ShapeType.Category.SIMPLE),
+                                    new ShapeTypeCategoryEnumSelector(ShapeType.Category.AGGREGATE)));
                         default:
                             ShapeType shape = ShapeType.fromString(identifier)
                                     .orElseThrow(() -> syntax("Unknown shape type: " + identifier));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.selector;
+
+import java.util.Collection;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+/**
+ * Matches shapes whose {@link ShapeType.Category} equals a given category.
+ *
+ * <p>This complements {@link ShapeTypeCategorySelector}, which keys off of a shared
+ * Java base class. A class-based check is not possible for the AGGREGATE and SERVICE
+ * categories because their shape types do not share a common Java superclass.
+ */
+final class ShapeTypeCategoryEnumSelector implements InternalSelector {
+    private final ShapeType.Category category;
+
+    ShapeTypeCategoryEnumSelector(ShapeType.Category category) {
+        this.category = category;
+    }
+
+    @Override
+    public Response push(Context ctx, Shape shape, Receiver next) {
+        if (shape.getType().getCategory() == category) {
+            return next.apply(ctx, shape);
+        }
+        return Response.CONTINUE;
+    }
+
+    @Override
+    public Collection<? extends Shape> getStartingShapes(Model model) {
+        return model.toSet(category);
+    }
+
+    @Override
+    public ContainsShape containsShapeOptimization(Context context, Shape shape) {
+        return shape.getType().getCategory() == category ? ContainsShape.YES : ContainsShape.NO;
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
@@ -58,8 +58,34 @@ public enum ShapeType {
     RESOURCE("resource", ResourceShape.class, Category.SERVICE),
     OPERATION("operation", OperationShape.class, Category.SERVICE);
 
+    /**
+     * Top-level grouping of {@link ShapeType} values as defined in the Smithy specification.
+     *
+     * <p>Categories are useful when a piece of code needs to distinguish between broad kinds
+     * of shapes without enumerating each individual type.
+     */
     public enum Category {
-        SIMPLE, AGGREGATE, SERVICE, MEMBER
+        /**
+         * Simple types that model basic data values.
+         */
+        SIMPLE,
+
+        /**
+         * Aggregate types that compose other shapes (lists, maps, structures, and unions).
+         *
+         * <p>The deprecated {@code set} type also falls into this category.
+         */
+        AGGREGATE,
+
+        /**
+         * Service types that define a service-level interface (services, resources, and operations).
+         */
+        SERVICE,
+
+        /**
+         * The special {@code member} type, which references another shape from inside an aggregate shape.
+         */
+        MEMBER
     }
 
     private final String stringValue;
@@ -87,8 +113,9 @@ public enum ShapeType {
     }
 
     /**
-     * Returns the category of the shape type, as defined in the Smithy
-     * specification (one of SIMPLE, AGGREGATE, or SERVICE).
+     * Returns the category of the shape type, as defined in the Smithy specification
+     * (one of {@link Category#SIMPLE}, {@link Category#AGGREGATE}, {@link Category#SERVICE},
+     * or {@link Category#MEMBER}).
      *
      * @return Returns the category of the type.
      */

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
@@ -234,6 +234,29 @@ public class ModelTest {
     }
 
     @Test
+    public void toSetWithCategoryReturnsShapesOfCategory() {
+        StringShape string = StringShape.builder().id("ns.foo#Str").build();
+        IntegerShape integer = IntegerShape.builder().id("ns.foo#Int").build();
+        ListShape list = ListShape.builder()
+                .id("ns.foo#List")
+                .member(string.getId())
+                .build();
+        StructureShape structure = StructureShape.builder().id("ns.foo#Struct").build();
+        OperationShape operation = OperationShape.builder().id("ns.foo#Op").build();
+        ServiceShape service = ServiceShape.builder()
+                .id("ns.foo#Service")
+                .version("1")
+                .addOperation(operation)
+                .build();
+        Model model = Model.builder().addShapes(string, integer, list, structure, operation, service).build();
+
+        assertThat(model.toSet(ShapeType.Category.SIMPLE), containsInAnyOrder(string, integer));
+        assertThat(model.toSet(ShapeType.Category.AGGREGATE), containsInAnyOrder(list, structure));
+        assertThat(model.toSet(ShapeType.Category.SERVICE), containsInAnyOrder(service, operation));
+        assertThat(model.toSet(ShapeType.Category.MEMBER), containsInAnyOrder(list.getMember()));
+    }
+
+    @Test
     public void addsMembersAutomatically() {
         StringShape string = StringShape.builder().id("ns.foo#a").build();
         ListShape list = ListShape.builder()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelectorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.selector;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+
+public class ShapeTypeCategoryEnumSelectorTest {
+
+    private static Model model;
+
+    @BeforeAll
+    public static void before() {
+        model = Model.assembler()
+                .addImport(SelectorTest.class.getResource("shape-type-test.smithy"))
+                .assemble()
+                .unwrap();
+    }
+
+    @Test
+    public void simpleTypeMatchesSimpleShapes() {
+        Set<String> ids = exampleIds("simpleType");
+
+        assertThat(ids,
+                containsInAnyOrder("smithy.example#String",
+                        "smithy.example#Integer",
+                        "smithy.example#Enum",
+                        "smithy.example#IntEnum"));
+        assertThat("smithy.example#List", not(in(ids)));
+        assertThat("smithy.example#Service", not(in(ids)));
+    }
+
+    @Test
+    public void aggregateTypeMatchesAggregateShapes() {
+        Set<String> ids = exampleIds("aggregateType");
+
+        assertThat(ids,
+                containsInAnyOrder(
+                        "smithy.example#List",
+                        "smithy.example#Map",
+                        "smithy.example#Structure",
+                        "smithy.example#Union",
+                        "smithy.example#OperationInput",
+                        "smithy.example#OperationOutput"));
+        assertThat("smithy.example#String", not(in(ids)));
+        assertThat("smithy.example#Service", not(in(ids)));
+    }
+
+    @Test
+    public void serviceTypeMatchesServiceShapes() {
+        Set<String> ids = exampleIds("serviceType");
+
+        assertThat(ids,
+                containsInAnyOrder(
+                        "smithy.example#Service",
+                        "smithy.example#Operation",
+                        "smithy.example#Resource"));
+    }
+
+    @Test
+    public void dataTypeMatchesAggregateAndSimpleShapes() {
+        Set<String> ids = exampleIds("dataType");
+
+        assertThat(ids,
+                containsInAnyOrder(
+                        "smithy.example#String",
+                        "smithy.example#Integer",
+                        "smithy.example#Enum",
+                        "smithy.example#IntEnum",
+                        "smithy.example#List",
+                        "smithy.example#Map",
+                        "smithy.example#Structure",
+                        "smithy.example#OperationInput",
+                        "smithy.example#OperationOutput",
+                        "smithy.example#Union"));
+
+        // Service shapes are excluded.
+        assertThat("smithy.example#Service", not(in(ids)));
+        assertThat("smithy.example#Operation", not(in(ids)));
+        assertThat("smithy.example#Resource", not(in(ids)));
+
+        // Member shapes are excluded
+        assertThat("smithy.example#List$member", not(in(ids)));
+    }
+
+    private static Set<String> exampleIds(String typeSelector) {
+        return SelectorTest.ids(model, typeSelector + " [id|namespace = smithy.example]");
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/shape-type-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/shape-type-test.smithy
@@ -14,3 +14,36 @@ intEnum IntEnum {
 }
 
 integer Integer
+
+list List {
+    member: String
+}
+
+map Map {
+    key: String
+    value: String
+}
+
+structure Structure {
+    member: String
+}
+
+union Union {
+    a: String
+    b: Integer
+}
+
+service Service {
+    version: "1"
+    operations: [Operation]
+    resources: [Resource]
+}
+
+operation Operation {
+    input := {}
+    output := {}
+}
+
+resource Resource {
+    identifiers: { id: String }
+}


### PR DESCRIPTION
This adds three new shape type selectors:

* `aggregateType` selects lists, unions, structures, and maps.
* `serviceType` selects services, operations, and resources.
* `dataType` selects aggregate types and simple types.

This also adds a new `toSet` override that takes a shape category and returns a cached set of shapes in that category.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
