### PR TITLE
docs(apigateway): Fix stale and mismatched reference link targets

### DIFF
--- a/.changes/next-release/documentation-ad9fca5e56b93e78e4780644c8e4d5c9d07f8939.json
+++ b/.changes/next-release/documentation-ad9fca5e56b93e78e4780644c8e4d5c9d07f8939.json
@@ -1,5 +1,7 @@
 {
   "type": "documentation",
   "description": "Fix stale and mismatched AWS API Gateway reference link targets",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3077](https://github.com/smithy-lang/smithy/pull/3077)"
+  ]
 }

--- a/.changes/next-release/documentation-ad9fca5e56b93e78e4780644c8e4d5c9d07f8939.json
+++ b/.changes/next-release/documentation-ad9fca5e56b93e78e4780644c8e4d5c9d07f8939.json
@@ -1,0 +1,5 @@
+{
+  "type": "documentation",
+  "description": "Fix stale and mismatched AWS API Gateway reference link targets",
+  "pull_requests": []
+}

--- a/docs/source-1.0/spec/aws/amazon-apigateway.rst
+++ b/docs/source-1.0/spec/aws/amazon-apigateway.rst
@@ -889,17 +889,17 @@ integration response to two ``header`` parameters of the method response.
 
 
 .. _Enable Request Validation in API Gateway: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html
-.. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.requestValidator.html
+.. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validator.html
 .. _x-amazon-apigateway-request-validators: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html
 .. _Granting Permissions Using a Resource Policy: https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#intro-permission-model-access-policy
-.. _Integration.passthroughBehavior: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/#passthroughBehavior
-.. _VpcLink: https://docs.aws.amazon.com/apigateway/api-reference/resource/vpc-link/
+.. _Integration.passthroughBehavior: https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html#passthroughBehavior
+.. _VpcLink: https://docs.aws.amazon.com/apigateway/latest/api/API_VpcLink.html
 .. _x-amazon-apigateway-integration: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration.html
-.. _API Gateway integration: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
+.. _API Gateway integration: https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html
 .. _Lambda authorizers: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html
 .. _x-amazon-apigateway-authtype: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authtype.html
 .. _Create and Use Usage Plans with API Keys: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html
 .. _Choose an API Key Source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html
 .. _x-amazon-apigateway-api-key-source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-api-key-source.html
-.. _IntegrationResponse: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration-response/
+.. _IntegrationResponse: https://docs.aws.amazon.com/apigateway/latest/api/API_IntegrationResponse.html
 .. _mapping templates: https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings

--- a/docs/source-2.0/aws/amazon-apigateway.rst
+++ b/docs/source-2.0/aws/amazon-apigateway.rst
@@ -876,18 +876,18 @@ integration response to two ``header`` parameters of the method response.
 
 
 .. _Enable Request Validation in API Gateway: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html
-.. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.requestValidator.html
+.. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validator.html
 .. _x-amazon-apigateway-request-validators: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html
 .. _Granting Permissions Using a Resource Policy: https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#intro-permission-model-access-policy
-.. _Integration.passthroughBehavior: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/#passthroughBehavior
-.. _VpcLink: https://docs.aws.amazon.com/apigateway/api-reference/resource/vpc-link/
+.. _Integration.passthroughBehavior: https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html#passthroughBehavior
+.. _VpcLink: https://docs.aws.amazon.com/apigateway/latest/api/API_VpcLink.html
 .. _x-amazon-apigateway-integration: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration.html
-.. _API Gateway integration: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
+.. _API Gateway integration: https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html
 .. _Lambda authorizers: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html
 .. _x-amazon-apigateway-authtype: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authtype.html
 .. _Create and Use Usage Plans with API Keys: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html
 .. _Choose an API Key Source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html
 .. _x-amazon-apigateway-api-key-source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-api-key-source.html
-.. _IntegrationResponse: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration-response/
+.. _IntegrationResponse: https://docs.aws.amazon.com/apigateway/latest/api/API_IntegrationResponse.html
 .. _mapping templates: https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings
 .. _Lambda Authorizers Payload Format: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.payload-format


### PR DESCRIPTION
Update link targets in source-1.0 and source-2.0 amazon-apigateway.rst:

- Repoint retired `/apigateway/api-reference/resource/<name>/` URLs to their current `/apigateway/latest/api/API_<Name>.html` replacements:
  - `Integration.passthroughBehavior`
  - `VpcLink`
  - `API Gateway integration`
  - `IntegrationResponse`
- Correct the `x-amazon-apigateway-request-validator` label to point at the singular top-level extension page rather than the nested object schema page.

#### Background

* What do these changes do?
  * Update five link targets in `docs/source-1.0/spec/aws/amazon-apigateway.rst` and `docs/source-2.0/aws/amazon-apigateway.rst` that were either stale or mismatched.
  * Four targets used the retired `/apigateway/api-reference/resource/<name>/` URL pattern, which AWS now redirects to a generic Actions index page. They've been repointed at the corresponding `/apigateway/latest/api/API_<Name>.html` pages.
  * The `x-amazon-apigateway-request-validator` label was pointing at `api-gateway-swagger-extensions-request-validators.requestValidator.html`, which is the nested schema object inside the plural-map extension. It now points at `api-gateway-swagger-extensions-request-validator.html`, the page that actually documents the singular top-level extension the label names.
* Why are they important?
  * Readers following these links previously landed on a page that didn't match what the surrounding prose described.
  * `source-1.0/guides/converting-to-openapi.rst` and `source-2.0/guides/model-translations/converting-to-openapi.rst` already use the correct URLs for the same labels, so this brings the API Gateway traits pages in line with the rest of the docs.

#### Testing

* How did you test these changes?
  * Verified each updated URL by fetching the page and confirming it loads the expected AWS documentation content.
  * Confirmed no usages of the retired `/apigateway/api-reference/resource/` URL pattern remain in any `.rst` file under `docs/`.
  * Grep confirms all four `.rst` files (`source-1.0/spec/aws/amazon-apigateway.rst`, `source-2.0/aws/amazon-apigateway.rst`, `source-1.0/guides/converting-to-openapi.rst`, `source-2.0/guides/model-translations/converting-to-openapi.rst`) now agree on the correct URL for `x-amazon-apigateway-request-validator`.

#### Links

* [AWS API Gateway `Integration` API reference](https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html)
* [AWS API Gateway `IntegrationResponse` API reference](https://docs.aws.amazon.com/apigateway/latest/api/API_IntegrationResponse.html)
* [AWS API Gateway `VpcLink` API reference](https://docs.aws.amazon.com/apigateway/latest/api/API_VpcLink.html)
* [`x-amazon-apigateway-request-validator` extension](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validator.html)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

