### PR TITLE
Add providerARNs to authorizer definition

### DIFF
--- a/.changes/next-release/feature-e79b3baeb6376740db141d38436fabdd20796222.json
+++ b/.changes/next-release/feature-e79b3baeb6376740db141d38436fabdd20796222.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Add providerARNs field to aws.apigateway#authorizers trait",
+  "description": "Added a `providerARNs` field to the `aws.apigateway#authorizers` trait",
   "pull_requests": [
     "[#3085](https://github.com/smithy-lang/smithy/pull/3085)"
   ]

--- a/.changes/next-release/feature-e79b3baeb6376740db141d38436fabdd20796222.json
+++ b/.changes/next-release/feature-e79b3baeb6376740db141d38436fabdd20796222.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Add providerARNs field to aws.apigateway#authorizers trait",
+  "pull_requests": [
+    "[#3085](https://github.com/smithy-lang/smithy/pull/3085)"
+  ]
+}

--- a/docs/source-2.0/aws/amazon-apigateway.rst
+++ b/docs/source-2.0/aws/amazon-apigateway.rst
@@ -178,7 +178,7 @@ An *authorizer* definition is a structure that supports the following members:
         Lambda authorizer function returns a Boolean value.
     * - providerARNs
       - ``list`` of ``string``
-      - A list of the Amazon Cognito user pool ARNs for the
+      - A list of the `Amazon Cognito user pool`_ ARNs for the
         ``COGNITO_USER_POOLS`` authorizer.
 
 .. code-block:: smithy
@@ -895,3 +895,4 @@ integration response to two ``header`` parameters of the method response.
 .. _IntegrationResponse: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration-response/
 .. _mapping templates: https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings
 .. _Lambda Authorizers Payload Format: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.payload-format
+.. _Amazon Cognito user pool: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html

--- a/docs/source-2.0/aws/amazon-apigateway.rst
+++ b/docs/source-2.0/aws/amazon-apigateway.rst
@@ -176,6 +176,10 @@ An *authorizer* definition is a structure that supports the following members:
         Boolean value or an IAM policy. Supported only for authorizers
         with an ``authorizerPayloadFormatVersion`` of 2.0. If enabled, the
         Lambda authorizer function returns a Boolean value.
+    * - providerARNs
+      - ``list`` of ``string``
+      - A list of the Amazon Cognito user pool ARNs for the
+        ``COGNITO_USER_POOLS`` authorizer.
 
 .. code-block:: smithy
 

--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -1916,6 +1916,10 @@ attach to authentication schemes defined on a service. Authorizers are
 first defined on a service, and then attached to the service, resources,
 or operations using the ``aws.apigateway#authorizer-trait``.
 
+When an authorizer definition includes ``providerARNs``, the list of
+Amazon Cognito user pool ARNs is included in the generated
+``x-amazon-apigateway-authorizer`` extension.
+
 The following Smithy model:
 
 .. code-block:: smithy

--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -1917,7 +1917,7 @@ first defined on a service, and then attached to the service, resources,
 or operations using the ``aws.apigateway#authorizer-trait``.
 
 When an authorizer definition includes ``providerARNs``, the list of
-Amazon Cognito user pool ARNs is included in the generated
+`Amazon Cognito user pool`_ ARNs is included in the generated
 ``x-amazon-apigateway-authorizer`` extension.
 
 The following Smithy model:
@@ -2296,3 +2296,4 @@ The conversion process is highly extensible through
 .. _OpenAPI specification extension: https://spec.openapis.org/oas/v3.1.0#specification-extensions
 .. _integration's passthroughBehavior: https://docs.aws.amazon.com/apigateway/latest/developerguide/integration-passthrough-behaviors.html
 .. _gradle installed: https://gradle.org/install/
+.. _Amazon Cognito user pool: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizers.java
@@ -211,6 +211,8 @@ final class AddAuthorizers implements ApiGatewayMapper {
                         authorizer.getAuthorizerPayloadFormatVersion().map(Node::from))
                 .withOptionalMember("enableSimpleResponses",
                         authorizer.getEnableSimpleResponses().map(Node::from))
+                .withOptionalMember("providerARNs",
+                        authorizer.getProviderARNs().map(Node::fromStrings))
                 .build();
         if (authorizerNode.size() != 0) {
             schemeBuilder.putExtension(EXTENSION_NAME, authorizerNode);

--- a/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
+++ b/smithy-aws-apigateway-openapi/src/test/java/software/amazon/smithy/aws/apigateway/openapi/AddAuthorizersTest.java
@@ -169,4 +169,31 @@ public class AddAuthorizersTest {
         assertThat(result.getPaths().get("/operationB").getGet().get().getSecurity(),
                 is(Optional.of(ListUtils.of(MapUtils.of("baz", ListUtils.of())))));
     }
+
+    @Test
+    public void addsProviderArnsToSecurityScheme() {
+        Model model = Model.assembler()
+                .discoverModels(getClass().getClassLoader())
+                .addImport(getClass().getResource("cognito-authorizer-provider-arns.smithy"))
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        OpenApi result = OpenApiConverter.create()
+                .config(config)
+                .classLoader(getClass().getClassLoader())
+                .convert(model);
+
+        SecurityScheme scheme = result.getComponents().getSecuritySchemes().get("my-cognito-auth");
+        assertThat(scheme.getType(), equalTo("apiKey"));
+        ObjectNode authorizerExt = scheme.getExtension("x-amazon-apigateway-authorizer")
+                .get()
+                .expectObjectNode();
+        assertThat(authorizerExt.getStringMember("type").get().getValue(),
+                equalTo("cognito_user_pools"));
+        assertThat(
+                authorizerExt.expectArrayMember("providerARNs")
+                        .getElementsAs(n -> n.expectStringNode().getValue()),
+                contains("arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123"));
+    }
 }

--- a/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cognito-authorizer-provider-arns.smithy
+++ b/smithy-aws-apigateway-openapi/src/test/resources/software/amazon/smithy/aws/apigateway/openapi/cognito-authorizer-provider-arns.smithy
@@ -1,0 +1,26 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use aws.apigateway#authorizer
+use aws.apigateway#authorizers
+use aws.auth#sigv4
+use aws.protocols#restJson1
+
+@restJson1
+@sigv4(name: "service")
+@authorizer("my-cognito-auth")
+@authorizers(
+    "my-cognito-auth": {
+        scheme: "aws.auth#sigv4"
+        type: "cognito_user_pools"
+        providerARNs: ["arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123"]
+    }
+)
+service Service {
+    version: "2006-03-01"
+    operations: [Operation1]
+}
+
+@http(uri: "/1", method: "GET")
+operation Operation1 {}

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizerDefinition.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizerDefinition.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.aws.apigateway.traits;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
@@ -33,6 +34,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
     private final Integer resultTtlInSeconds;
     private final String authorizerPayloadFormatVersion;
     private final Boolean enableSimpleResponses;
+    private final List<String> providerARNs;
 
     private AuthorizerDefinition(Builder builder) {
         scheme = SmithyBuilder.requiredState(SCHEME_KEY, builder.scheme);
@@ -44,6 +46,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         resultTtlInSeconds = builder.resultTtlInSeconds;
         authorizerPayloadFormatVersion = builder.authorizerPayloadFormatVersion;
         enableSimpleResponses = builder.enableSimpleResponses;
+        providerARNs = builder.providerARNs;
 
         if (builder.customAuthType != null) {
             customAuthType = builder.customAuthType;
@@ -174,6 +177,16 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         return Optional.ofNullable(enableSimpleResponses);
     }
 
+    /**
+     * Gets the list of Amazon Cognito user pool ARNs for the
+     * COGNITO_USER_POOLS authorizer.
+     *
+     * @return Returns the optional list of provider ARNs.
+     */
+    public Optional<List<String>> getProviderARNs() {
+        return Optional.ofNullable(providerARNs);
+    }
+
     @Override
     public Builder toBuilder() {
         return builder()
@@ -186,7 +199,8 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
                 .identityValidationExpression(identityValidationExpression)
                 .resultTtlInSeconds(resultTtlInSeconds)
                 .authorizerPayloadFormatVersion(authorizerPayloadFormatVersion)
-                .enableSimpleResponses(enableSimpleResponses);
+                .enableSimpleResponses(enableSimpleResponses)
+                .providerARNs(providerARNs);
     }
 
     @Override
@@ -214,7 +228,8 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
                 && Objects.equals(identityValidationExpression, that.identityValidationExpression)
                 && Objects.equals(resultTtlInSeconds, that.resultTtlInSeconds)
                 && Objects.equals(authorizerPayloadFormatVersion, that.authorizerPayloadFormatVersion)
-                && Objects.equals(enableSimpleResponses, that.enableSimpleResponses);
+                && Objects.equals(enableSimpleResponses, that.enableSimpleResponses)
+                && Objects.equals(providerARNs, that.providerARNs);
     }
 
     @Override
@@ -236,6 +251,7 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
         private Integer resultTtlInSeconds;
         private String authorizerPayloadFormatVersion;
         private Boolean enableSimpleResponses;
+        private List<String> providerARNs;
 
         @Override
         public AuthorizerDefinition build() {
@@ -371,6 +387,17 @@ public final class AuthorizerDefinition implements ToNode, ToSmithyBuilder<Autho
          */
         public Builder enableSimpleResponses(Boolean enableSimpleResponses) {
             this.enableSimpleResponses = enableSimpleResponses;
+            return this;
+        }
+
+        /**
+         * Sets the list of Amazon Cognito user pool ARNs.
+         *
+         * @param providerARNs List of Cognito user pool ARNs.
+         * @return Returns the builder.
+         */
+        public Builder providerARNs(List<String> providerARNs) {
+            this.providerARNs = providerARNs;
             return this;
         }
     }

--- a/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.smithy
+++ b/smithy-aws-apigateway-traits/src/main/resources/META-INF/smithy/aws.apigateway.smithy
@@ -186,6 +186,15 @@ structure AuthorizerDefinition {
     /// If enabled, authorizer returns a boolean. Used only by HTTP APIs.
     /// Only supported when authorizerPayloadFormatVersion is set to 2.0.
     enableSimpleResponses: Boolean
+
+    /// A list of the Amazon Cognito user pool ARNs for the
+    /// COGNITO_USER_POOLS authorizer.
+    providerARNs: ProviderARNs
+}
+
+@private
+list ProviderARNs {
+    member: String
 }
 
 /// Defines a response and specifies parameter mappings.

--- a/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTraitTest.java
+++ b/smithy-aws-apigateway-traits/src/test/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTraitTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
+import java.util.Arrays;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -37,6 +39,30 @@ public class AuthorizersTraitTest {
         Trait trait = factory.createTrait(AuthorizersTrait.ID, id, node).get();
 
         assertThat(trait, instanceOf(AuthorizersTrait.class));
+        assertThat(factory.createTrait(AuthorizersTrait.ID, id, trait.toNode()).get(), equalTo(trait));
+    }
+
+    @Test
+    public void loadsProviderARNs() {
+        TraitFactory factory = TraitFactory.createServiceFactory();
+        ShapeId id = ShapeId.from("smithy.example#Foo");
+        ObjectNode node = Node.objectNodeBuilder()
+                .withMember("cognito-auth",
+                        Node.objectNodeBuilder()
+                                .withMember("scheme", "aws.auth#sigv4")
+                                .withMember("type", "cognito_user_pools")
+                                .withMember("providerARNs",
+                                        Node.fromStrings(
+                                                "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123"))
+                                .build())
+                .build();
+        Trait trait = factory.createTrait(AuthorizersTrait.ID, id, node).get();
+        AuthorizersTrait authorizersTrait = (AuthorizersTrait) trait;
+        AuthorizerDefinition definition = authorizersTrait.getAuthorizer("cognito-auth").get();
+
+        assertThat(definition.getProviderARNs(),
+                equalTo(Optional.of(Arrays.asList(
+                        "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123"))));
         assertThat(factory.createTrait(AuthorizersTrait.ID, id, trait.toNode()).get(), equalTo(trait));
     }
 }


### PR DESCRIPTION
The `x-amazon-apigateway-authorizer` extension supports a `providerARNs` field that lists Amazon Cognito user pool ARNs for `COGNITO_USER_POOLS` authorizers. This field was missing from the Smithy `AuthorizerDefinition` structure.

Add the optional `providerARNs` list field to `AuthorizerDefinition` in both the Smithy model and Java class. The `AddAuthorizers` mapper now includes `providerARNs` in the generated OpenAPI security scheme when present.

#### Background

* **What do these changes do?**
  * Add an optional `providerARNs` field (list of string) to the `AuthorizerDefinition` structure in `smithy-aws-apigateway-traits`. This field specifies the Amazon Cognito user pool ARNs for `COGNITO_USER_POOLS` authorizers.
  * Update the `AddAuthorizers` mapper in `smithy-aws-apigateway-openapi` to include `providerARNs` in the generated `x-amazon-apigateway-authorizer` extension when the field is present.
  * Update the authorizer properties table in `amazon-apigateway.rst` and add a note in `converting-to-openapi.rst`.
* **Why are they important?**
  * Without this field, customers using Cognito user pool authorizers had no way to specify `providerARNs` in their Smithy model and had to use `jsonAdd` workarounds instead. This is the only missing field on `AuthorizerDefinition` for REST API authorizers.

#### Testing

* Unit test added to `AuthorizersTraitTest`: verifies `providerARNs` round-trips through the factory and is accessible via `getProviderARNs()`
* Integration test added to `AddAuthorizersTest`: loads a Cognito authorizer model with `providerARNs`, converts to OpenAPI, and verifies both `type: "cognito_user_pools"` and the `providerARNs` array appear in the generated `x-amazon-apigateway-authorizer` extension
* All existing authorizer tests pass with no regressions

#### Links

* [[x-amazon-apigateway-authorizer extension (providerARNs property)](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html)](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html)
* [[Integrate a REST API with an Amazon Cognito user pool](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html)](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.