### PR TITLE
Preserve typed traits when renaming shapes

### DIFF
--- a/.changes/next-release/bugfix-02fe7a562eb287afa32967a77ee5d80a33419e15.json
+++ b/.changes/next-release/bugfix-02fe7a562eb287afa32967a77ee5d80a33419e15.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Preserve typed traits when renaming shapes",
+  "pull_requests": [
+    "[#3086](https://github.com/smithy-lang/smithy/pull/3086)"
+  ]
+}

--- a/.changes/next-release/bugfix-02fe7a562eb287afa32967a77ee5d80a33419e15.json
+++ b/.changes/next-release/bugfix-02fe7a562eb287afa32967a77ee5d80a33419e15.json
@@ -1,6 +1,6 @@
 {
   "type": "bugfix",
-  "description": "Preserve typed traits when renaming shapes",
+  "description": "Fixed an issue where traits would lose their types, reverting to DynamicTrait, when renaming shapes",
   "pull_requests": [
     "[#3086](https://github.com/smithy-lang/smithy/pull/3086)"
   ]

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/RenameShapes.java
@@ -11,7 +11,6 @@ import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeIdSyntaxException;
-import software.amazon.smithy.model.transform.ModelTransformer;
 
 /**
  * {@code renameShapes} updates a model by renaming shapes. When
@@ -62,7 +61,7 @@ public final class RenameShapes extends ConfigurableProjectionTransformer<Rename
         }
         Model model = context.getModel();
 
-        return ModelTransformer.create().renameShapes(model, getShapeIdsToRename(config, model));
+        return context.getTransformer().renameShapes(model, getShapeIdsToRename(config, model));
     }
 
     @Override

--- a/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RenameShapesTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/transforms/RenameShapesTest.java
@@ -6,8 +6,10 @@ package software.amazon.smithy.build.transforms;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
+import java.net.URLClassLoader;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,6 +22,12 @@ import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.DynamicTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.FunctionalUtils;
 
 public class RenameShapesTest {
@@ -108,6 +116,32 @@ public class RenameShapesTest {
                 .settings(config)
                 .build();
         Assertions.assertThrows(SmithyBuildException.class, () -> new RenameShapes().transform(context));
+    }
+
+    @Test
+    public void renameShapesUsesContextTransformer() {
+        ShapeId from = ShapeId.from("ns.foo#MyString");
+        ShapeId to = ShapeId.from("ns.foo#NewString");
+        StringShape stringShape = StringShape.builder()
+                .id(from)
+                .addTrait(DeprecatedTrait.builder().build())
+                .build();
+        Model model = Model.builder().addShape(stringShape).build();
+
+        ClassLoader empty = new URLClassLoader(new java.net.URL[] {}, null);
+        ModelTransformer customTransformer = ModelTransformer.createWithServiceProviders(empty);
+
+        ObjectNode renamed = Node.objectNode().withMember(from.toString(), to.toString());
+        ObjectNode config = Node.objectNode().withMember("renamed", renamed);
+        TransformContext context = TransformContext.builder()
+                .model(model)
+                .settings(config)
+                .transformer(customTransformer)
+                .build();
+
+        Model result = new RenameShapes().transform(context);
+        Trait raw = result.expectShape(to).getAllTraits().get(DeprecatedTrait.ID);
+        assertThat(raw.getClass().getName(), equalTo(DynamicTrait.class.getName()));
     }
 
     @Test

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -38,9 +38,15 @@ import software.amazon.smithy.utils.ListUtils;
  */
 public final class ModelTransformer {
     private final List<ModelTransformerPlugin> plugins;
+    private final ClassLoader classLoader;
 
     private ModelTransformer(List<ModelTransformerPlugin> plugins) {
+        this(plugins, null);
+    }
+
+    private ModelTransformer(List<ModelTransformerPlugin> plugins, ClassLoader classLoader) {
         this.plugins = ListUtils.copyOf(plugins);
+        this.classLoader = classLoader;
     }
 
     /**
@@ -83,7 +89,11 @@ public final class ModelTransformer {
      * @return Returns the created ModelTransformer.
      */
     public static ModelTransformer createWithServiceProviders(ClassLoader classLoader) {
-        return createWithServiceLoader(ServiceLoader.load(ModelTransformerPlugin.class, classLoader));
+        ServiceLoader<ModelTransformerPlugin> serviceLoader =
+                ServiceLoader.load(ModelTransformerPlugin.class, classLoader);
+        List<ModelTransformerPlugin> plugins = new ArrayList<>();
+        serviceLoader.forEach(plugins::add);
+        return new ModelTransformer(plugins, classLoader);
     }
 
     /**
@@ -145,7 +155,10 @@ public final class ModelTransformer {
             Model model,
             Map<ShapeId, ShapeId> renamed
     ) {
-        return this.renameShapes(model, renamed, () -> Model.assembler().disableValidation());
+        Supplier<ModelAssembler> supplier = classLoader == null
+                ? () -> Model.assembler().disableValidation()
+                : () -> Model.assembler(classLoader).disableValidation();
+        return this.renameShapes(model, renamed, supplier);
     }
 
     /**

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/RenameShapesTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,8 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.DynamicTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -423,5 +426,28 @@ public class RenameShapesTest {
 
         assertThat(model2.expectShape(originalBoxedId).getAllTraits(),
                 equalTo(model1.expectShape(originalBoxedId).getAllTraits()));
+    }
+
+    @Test
+    public void renameShapesUsesStoredClassLoaderForTraitResolution() {
+        ShapeId from = ShapeId.from("ns.foo#MyString");
+        ShapeId to = ShapeId.from("ns.foo#NewString");
+        StringShape stringShape = StringShape.builder()
+                .id(from)
+                .addTrait(DeprecatedTrait.builder().build())
+                .build();
+        Model model = Model.builder().addShape(stringShape).build();
+
+        // Sanity check: the trait is initially the typed class.
+        assertTrue(model.expectShape(from).getTrait(DeprecatedTrait.class).isPresent());
+
+        // An empty class loader (null parent) sees no TraitService providers.
+        ClassLoader empty = new URLClassLoader(new java.net.URL[] {}, null);
+        ModelTransformer transformer = ModelTransformer.createWithServiceProviders(empty);
+
+        Model result = transformer.renameShapes(model, Collections.singletonMap(from, to));
+
+        Trait raw = result.expectShape(to).getAllTraits().get(DeprecatedTrait.ID);
+        assertThat(raw.getClass().getName(), equalTo(DynamicTrait.class.getName()));
     }
 }


### PR DESCRIPTION
The `renameShapes` projection transform downgrades typed traits to `DynamicTrait`. After running `renameShapes`, `operation.getTrait(SomeTrait.class)` returns empty even though the trait is still on the shape, because what's stored is now an untyped `DynamicTrait`.

  I hit this from the smithy-typescript codegen path: with `renameShapes` in the projection, lookups for `@staticContextParams` returned empty, so the generated client emitted incomplete endpoint instructions, and endpoint resolution failed at runtime.



#### Background
Two issues contribute here:

1. `smithy-build/transforms/RenameShapes` calls `ModelTransformer.create()` instead of using `context.getTransformer()`. Every other transform in smithy-build/transforms/ already uses the context's transformer; `RenameShapes` seems to be the lone holdout?

2. `smithy-model/transform/ModelTransformer` even when callers construct a transformer via `createWithServiceProviders(cl)`, the classloader is used to discover plugins and then thrown away. The 2-arg `renameShapes(model, renamed)` overload calls `Model.assembler()` with no classloader, so trait reassembly uses smithy-model's classloader and providers from sibling jars (e.g. rules-engine traits) are never found. Anything not in smithy-model itself falls through to `DynamicTrait`.


#### Testing

Adds a regression test in each module: an empty URLClassLoader (no providers) is passed to the transformer/context, and we assert that a typed DeprecatedTrait becomes a DynamicTrait after renameShapes. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
