### PR TITLE
Fixed trait codegen to generate more specific return type for trait provider

### DIFF
--- a/.changes/next-release/feature-2abbbb589bd53cb39804f4df52e06a7773a7c038.json
+++ b/.changes/next-release/feature-2abbbb589bd53cb39804f4df52e06a7773a7c038.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Fixed trait codegen to generate more specific return type for trait provider",
+  "pull_requests": [
+    "[#3087](https://github.com/smithy-lang/smithy/pull/3087)"
+  ]
+}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ProviderGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ProviderGenerator.java
@@ -22,7 +22,6 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.StringListTrait;
 import software.amazon.smithy.model.traits.StringTrait;
-import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.traitcodegen.TraitCodegenUtils;
 import software.amazon.smithy.traitcodegen.writer.TraitCodegenWriter;
 
@@ -75,7 +74,7 @@ final class ProviderGenerator implements Runnable {
                         writer.override();
                         writer.openBlock("public $T createTrait($T target, $T value) {",
                                 "}",
-                                Trait.class,
+                                traitSymbol,
                                 ShapeId.class,
                                 Node.class,
                                 () -> writer.write("return new $T(value);", traitSymbol));
@@ -157,7 +156,7 @@ final class ProviderGenerator implements Runnable {
                         writer.override();
                         writer.openBlock("public $T createTrait($T target, $T value) {",
                                 "}",
-                                Trait.class,
+                                traitSymbol,
                                 ShapeId.class,
                                 Node.class,
                                 () -> {
@@ -181,7 +180,7 @@ final class ProviderGenerator implements Runnable {
                         writer.override();
                         writer.openBlock("public $T createTrait($T target, $T value) {",
                                 "}",
-                                Trait.class,
+                                traitSymbol,
                                 ShapeId.class,
                                 Node.class,
                                 () -> writer.write("return new $1T($2C, value.getSourceLocation());",

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.traitcodegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,6 +68,18 @@ public class TraitCodegenPluginTest {
         assertThat(fileList,
                 hasItem(
                         Paths.get("/com/example/traits/nested/NestedNamespaceStruct.java").toString()));
+
+        assertThat(
+                manifest.getFileString("/com/example/traits/nested/NestedNamespaceTrait.java").get(),
+                containsString("public NestedNamespaceTrait createTrait(ShapeId target, Node value) {"));
+
+        assertThat(
+                manifest.getFileString("/com/example/traits/documents/DocumentTrait.java").get(),
+                containsString("public DocumentTrait createTrait(ShapeId target, Node value) {"));
+
+        assertThat(
+                manifest.getFileString("/com/example/traits/numbers/IntegerTrait.java").get(),
+                containsString("public IntegerTrait createTrait(ShapeId target, Node value) {"));
     }
 
     @Test


### PR DESCRIPTION
#### Background

Currently, if you have a trait for custom protocol, when you run the trait-codegen for it the provider for such trait will be generated with `public Trait createTrait(ShapeId target, Node value)` signature. This is generally fine, but when you integrate this trait into smithy-java client codegen, the compilation fails because when [it generates `protocolTrait` property](https://github.com/smithy-lang/smithy-java/blob/016a777697023e90f7899275bc91aa7103bf3feb/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java#L451) by default [it is using provider](https://github.com/smithy-lang/smithy-java/blob/91afa891651dd3cccab4418ba04c165703f7815c/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/GenericTraitInitializer.java#L40-L43) that essentially gets resolved into something like this:

```java
        private static final CustomTrait protocolTrait = new CustomTrait.Provider().createTrait(
            ShapeId.from("customTraitShapeId"),
            Node.objectNode()
        );
```

Where `CustomTrait.Provider().createTrait` currently returns `Trait` and the compilation fails.

This change changes the return type so that the signature now looks like `public CustomTrait createTrait(ShapeId target, Node value)`.

#### Testing

- Added tests to validate the provider's signature.
- Tested locally with internal traits I have that the generated code is correct

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
