### PR TITLE
Add --check flag to smithy format

### DIFF
--- a/.changes/next-release/feature-724e469c16006c185a55e7ca13910734f84c55d0.json
+++ b/.changes/next-release/feature-724e469c16006c185a55e7ca13910734f84c55d0.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Add `--check` flag to `smithy format` that validates files are formatted without modifying them. Exits with code 2 if any files would be changed.",
+  "pull_requests": []
+}

--- a/.changes/next-release/feature-724e469c16006c185a55e7ca13910734f84c55d0.json
+++ b/.changes/next-release/feature-724e469c16006c185a55e7ca13910734f84c55d0.json
@@ -1,5 +1,7 @@
 {
   "type": "feature",
   "description": "Add `--check` flag to `smithy format` that validates files are formatted without modifying them. Exits with code 2 if any files would be changed.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3094](https://github.com/smithy-lang/smithy/pull/3094)"
+  ]
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/FormatCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/FormatCommandTest.java
@@ -75,4 +75,33 @@ public class FormatCommandTest {
                             + "string MyString2%n")));
         });
     }
+
+    @Test
+    public void checkFormattedFile() {
+        // Format the files first, then run --check on the same project copy.
+        IntegUtils.withProject("bad-formatting", path -> {
+            RunResult formatResult = IntegUtils.run(path, ListUtils.of("format", "model"));
+            assertThat(formatResult.getExitCode(), equalTo(0));
+
+            RunResult checkResult = IntegUtils.run(path, ListUtils.of("format", "--check", "model"));
+            assertThat(checkResult.getExitCode(), equalTo(0));
+        });
+    }
+
+    @Test
+    public void checkUnformattedFile() {
+        IntegUtils.run("bad-formatting", ListUtils.of("format", "--check", "model"), result -> {
+            assertThat(result.getExitCode(), equalTo(2));
+            assertThat(result.getOutput(), containsString("not formatted"));
+        });
+    }
+
+    @Test
+    public void checkNoArgs() {
+        IntegUtils.run("bad-formatting", ListUtils.of("format", "--check"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(),
+                    containsString("No .smithy model or directory was provided as a positional argument"));
+        });
+    }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/FormatCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/FormatCommand.java
@@ -13,6 +13,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
@@ -44,10 +46,26 @@ final class FormatCommand implements Command {
     }
 
     private static final class Options implements ArgumentReceiver {
+        private boolean check;
+
+        @Override
+        public boolean testOption(String name) {
+            switch (name) {
+                case "--check":
+                    check = true;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         @Override
         public void registerHelp(HelpPrinter printer) {
             printer.positional("<MODELS>",
                     "`.smithy` model files and directories of model files to recursively format.");
+            printer.option("--check",
+                    null,
+                    "Checks if model files are formatted. Exits with code 2 if any files would be changed.");
         }
     }
 
@@ -61,12 +79,15 @@ final class FormatCommand implements Command {
             buffer.println("   smithy format model-file.smithy", ColorTheme.LITERAL);
             buffer.println("   smithy format model/", ColorTheme.LITERAL);
             buffer.println("   smithy format model-file.smithy model/", ColorTheme.LITERAL);
+            buffer.println("   smithy format --check model/", ColorTheme.LITERAL);
             return buffer.toString();
         }, this::run);
         return action.apply(arguments, env);
     }
 
     private int run(Arguments arguments, Env env) {
+        Options options = arguments.getReceiver(Options.class);
+
         if (arguments.getPositional().isEmpty()) {
             throw new CliError("No .smithy model or directory was provided as a positional argument");
         }
@@ -85,31 +106,62 @@ final class FormatCommand implements Command {
             }
         }
 
-        paths.forEach(this::formatFile);
+        if (options.check) {
+            List<Path> violations = new ArrayList<>();
+            for (Path p : paths) {
+                checkFile(p, violations);
+            }
+            if (!violations.isEmpty()) {
+                StringBuilder msg = new StringBuilder("The following files are not formatted:\n");
+                for (Path v : violations) {
+                    msg.append("  ").append(v).append("\n");
+                }
+                throw new CliError(msg.toString(), 2);
+            }
+        } else {
+            for (Path p : paths) {
+                formatFile(p);
+            }
+        }
+
         return 0;
     }
 
-    private void formatFile(Path file) {
-        if (Files.isDirectory(file)) {
-            try {
-                Files.find(file, 100, (p, a) -> a.isRegularFile()).forEach(this::formatFile);
+    private void walkSmithyFiles(Path path, Consumer<Path> action) {
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> files = Files.find(path,
+                    100,
+                    (p, a) -> a.isRegularFile() && p.toString().endsWith(".smithy"))) {
+                files.forEach(action);
             } catch (IOException e) {
-                throw new CliError("Error formatting " + file + " (directory): " + e.getMessage());
+                throw new CliError("Error walking " + path + ": " + e.getMessage());
             }
-        } else if (Files.isRegularFile(file) && file.toString().endsWith(".smithy")) {
-            TokenTree tree = parse(file);
-            String formatted = Formatter.format(tree);
-            try (OutputStream s = Files.newOutputStream(file, StandardOpenOption.TRUNCATE_EXISTING)) {
-                s.write(formatted.getBytes(StandardCharsets.UTF_8));
-            } catch (IOException e) {
-                throw new CliError("Error formatting " + file + " (file): " + e.getMessage());
-            }
+        } else if (Files.isRegularFile(path) && path.toString().endsWith(".smithy")) {
+            action.accept(path);
         }
     }
 
-    private TokenTree parse(Path file) {
-        String contents = IoUtils.readUtf8File(file);
-        IdlTokenizer tokenizer = IdlTokenizer.create(file.toString(), contents);
-        return TokenTree.of(tokenizer);
+    private void checkFile(Path file, List<Path> violations) {
+        walkSmithyFiles(file, p -> {
+            String original = IoUtils.readUtf8File(p);
+            TokenTree tree = TokenTree.of(IdlTokenizer.create(p.toString(), original));
+            String formatted = Formatter.format(tree);
+            if (!original.equals(formatted)) {
+                violations.add(p);
+            }
+        });
+    }
+
+    private void formatFile(Path file) {
+        walkSmithyFiles(file, p -> {
+            String contents = IoUtils.readUtf8File(p);
+            TokenTree tree = TokenTree.of(IdlTokenizer.create(p.toString(), contents));
+            String formatted = Formatter.format(tree);
+            try (OutputStream s = Files.newOutputStream(p, StandardOpenOption.TRUNCATE_EXISTING)) {
+                s.write(formatted.getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new CliError("Error formatting " + p + ": " + e.getMessage());
+            }
+        });
     }
 }


### PR DESCRIPTION
The `smithy format` command previously only supported in-place formatting, with no way to verify formatting without modifying files. This made CI enforcement impossible without risking unintended writes in read-only pipelines.

Add a `--check` mode that compares each file's current content against its formatted output and exits with code 2 if any files differ. Refactor the file-walking logic into a shared `walkSmithyFiles` helper used by both `formatFile` and the new `checkFile`, fixing a `Files.find` stream leak with try-with-resources in the process.

Fixes #2317 


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
