### PR TITLE
Add a new query test for empty output with response metadata

### DIFF
--- a/.changes/next-release/other-9bd6d84413f9cd31f5b4b7f98c2e69f3dc9db3b4.json
+++ b/.changes/next-release/other-9bd6d84413f9cd31f5b4b7f98c2e69f3dc9db3b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "other",
+  "description": "Added a new protocol test for query operations with no output that can include `ResponseMetadata`. No assertions are done but protocol test runners should be able to handle the metadata without choking.",
+  "pull_requests": [
+    "[#3106](https://github.com/smithy-lang/smithy/pull/3106)"
+  ]
+}

--- a/smithy-aws-protocol-tests/build.gradle.kts
+++ b/smithy-aws-protocol-tests/build.gradle.kts
@@ -28,3 +28,7 @@ smithy {
     format.set(false)
     smithyBuildConfigs.set(project.files())
 }
+
+java.sourceSets["main"].java {
+    srcDirs("model", "src/main/smithy")
+}

--- a/smithy-aws-protocol-tests/model/awsQuery/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/awsQuery/empty-input-output.smithy
@@ -37,6 +37,19 @@ apply NoInputAndNoOutput @httpResponseTests([
        protocol: awsQuery,
        code: 200,
    }
+   {
+       id: "QueryNoInputAndNoOutputWithResponseMetadata",
+       documentation: "Empty output, but the server returns ResponseMetadata.",
+       protocol: awsQuery,
+       code: 200,
+       body: """
+       <NoInputAndNoOutputResponse>
+           <ResponseMetadata>
+               <RequestId>abc-123</RequestId>
+           </ResponseMetadata>
+       </NoInputAndNoOutputResponse>
+       """
+   }
 ])
 
 /// The example tests how requests and responses are serialized when there's


### PR DESCRIPTION
#### Background

Operations of AWS services using query targeting `smithy.api#Unit` as response might still return the `ResponseMetadata` element. This protocol tests doesn't have any new assertions but the runners should be able to ignore or handle the `ResponseMetadata` present in the body.

One example of such operation is [Neptune `AddTagsToResource`](https://github.com/aws/api-models-aws/blob/main/models/neptune/service/2014-10-31/neptune-2014-10-31.json#L143-L149). This service response looks like

```
  <AddTagsToResourceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
    <ResponseMetadata>
      <RequestId>abc-123</RequestId>
    </ResponseMetadata>
  </AddTagsToResourceResponse>
```

#### Testing
N/A

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
