### PR TITLE
Add copy-on-write optimization for `toBuilder()` via `BuilderRef.setBorrowed`

### DIFF
--- a/.changes/next-release/feature-1650726abe4d825b45050491d4030cc3a0d25501.json
+++ b/.changes/next-release/feature-1650726abe4d825b45050491d4030cc3a0d25501.json
@@ -1,5 +1,7 @@
 {
   "type": "feature",
   "description": "Added copy-on-write optimization for `toBuilder()` via `BuilderRef.setBorrowed`",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3107](https://github.com/smithy-lang/smithy/pull/3107)"
+  ]
 }

--- a/.changes/next-release/feature-1650726abe4d825b45050491d4030cc3a0d25501.json
+++ b/.changes/next-release/feature-1650726abe4d825b45050491d4030cc3a0d25501.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Added copy-on-write optimization for `toBuilder()` via `BuilderRef.setBorrowed`",
+  "pull_requests": []
+}

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/AuthorizersTrait.java
@@ -91,7 +91,7 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
 
     @Override
     public Builder toBuilder() {
-        return builder().sourceLocation(getSourceLocation()).authorizers(authorizers);
+        return new Builder(this);
     }
 
     @Override
@@ -110,6 +110,13 @@ public final class AuthorizersTrait extends AbstractTrait implements ToSmithyBui
      */
     public static final class Builder extends AbstractTraitBuilder<AuthorizersTrait, Builder> {
         private final BuilderRef<Map<String, AuthorizerDefinition>> authorizers = BuilderRef.forOrderedMap();
+
+        private Builder() {}
+
+        private Builder(AuthorizersTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.authorizers.setBorrowed(trait.authorizers);
+        }
 
         @Override
         public AuthorizersTrait build() {

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/GatewayResponsesTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/GatewayResponsesTrait.java
@@ -73,9 +73,7 @@ public final class GatewayResponsesTrait extends AbstractTrait implements ToSmit
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder().sourceLocation(getSourceLocation());
-        builder.responses(responses);
-        return builder;
+        return new Builder(this);
     }
 
     @Override
@@ -93,6 +91,13 @@ public final class GatewayResponsesTrait extends AbstractTrait implements ToSmit
      */
     public static final class Builder extends AbstractTraitBuilder<GatewayResponsesTrait, Builder> {
         private final BuilderRef<Map<String, GatewayResponse>> responses = BuilderRef.forOrderedMap();
+
+        private Builder() {}
+
+        private Builder(GatewayResponsesTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.responses.setBorrowed(trait.responses);
+        }
 
         @Override
         public GatewayResponsesTrait build() {

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/IntegrationTrait.java
@@ -372,26 +372,7 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(getSourceLocation())
-                .type(type)
-                .uri(uri)
-                .credentials(credentials)
-                .httpMethod(httpMethod)
-                .passThroughBehavior(passThroughBehavior)
-                .contentHandling(contentHandling)
-                .timeoutInMillis(timeoutInMillis)
-                .connectionId(connectionId)
-                .connectionType(connectionType)
-                .cacheNamespace(cacheNamespace)
-                .payloadFormatVersion(payloadFormatVersion)
-                .requestParameters(requestParameters)
-                .requestTemplates(requestTemplates)
-                .responses(responses)
-                .cacheKeyParameters(cacheKeyParameters)
-                .tlsConfig(tlsConfig)
-                .responseTransferMode(responseTransferMode)
-                .integrationTarget(integrationTarget);
+        return new Builder(this);
     }
 
     public static final class Builder extends AbstractTraitBuilder<IntegrationTrait, Builder> {
@@ -413,6 +394,30 @@ public final class IntegrationTrait extends AbstractTrait implements ToSmithyBui
         private TlsConfig tlsConfig;
         private String responseTransferMode;
         private String integrationTarget;
+
+        private Builder() {}
+
+        private Builder(IntegrationTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.type = trait.type;
+            this.uri = trait.uri;
+            this.credentials = trait.credentials;
+            this.httpMethod = trait.httpMethod;
+            this.passThroughBehavior = trait.passThroughBehavior;
+            this.contentHandling = trait.contentHandling;
+            this.timeoutInMillis = trait.timeoutInMillis;
+            this.connectionId = trait.connectionId;
+            this.connectionType = trait.connectionType;
+            this.cacheNamespace = trait.cacheNamespace;
+            this.payloadFormatVersion = trait.payloadFormatVersion;
+            this.tlsConfig = trait.tlsConfig;
+            this.responseTransferMode = trait.responseTransferMode;
+            this.integrationTarget = trait.integrationTarget;
+            this.cacheKeyParameters.setBorrowed(trait.cacheKeyParameters);
+            this.requestParameters.setBorrowed(trait.requestParameters);
+            this.requestTemplates.setBorrowed(trait.requestTemplates);
+            this.responses.setBorrowed(trait.responses);
+        }
 
         @Override
         public IntegrationTrait build() {

--- a/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
+++ b/smithy-aws-apigateway-traits/src/main/java/software/amazon/smithy/aws/apigateway/traits/MockIntegrationTrait.java
@@ -152,13 +152,7 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(getSourceLocation())
-                .passThroughBehavior(passThroughBehavior)
-                .contentHandling(contentHandling)
-                .requestParameters(requestParameters)
-                .requestTemplates(requestTemplates)
-                .responses(responses);
+        return new Builder(this);
     }
 
     public static final class Builder extends AbstractTraitBuilder<MockIntegrationTrait, Builder> {
@@ -167,6 +161,17 @@ public final class MockIntegrationTrait extends AbstractTrait implements ToSmith
         private final BuilderRef<Map<String, String>> requestParameters = BuilderRef.forOrderedMap();
         private final BuilderRef<Map<String, String>> requestTemplates = BuilderRef.forOrderedMap();
         private final BuilderRef<Map<String, IntegrationResponse>> responses = BuilderRef.forOrderedMap();
+
+        private Builder() {}
+
+        private Builder(MockIntegrationTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.passThroughBehavior = trait.passThroughBehavior;
+            this.contentHandling = trait.contentHandling;
+            this.requestParameters.setBorrowed(trait.requestParameters);
+            this.requestTemplates.setBorrowed(trait.requestTemplates);
+            this.responses.setBorrowed(trait.responses);
+        }
 
         @Override
         public MockIntegrationTrait build() {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
@@ -64,12 +64,7 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
 
     @Override
     public Builder toBuilder() {
-        return new Builder()
-                .sourceLocation(getSourceLocation())
-                .requestChecksumRequired(requestChecksumRequired)
-                .requestAlgorithmMember(requestAlgorithmMember)
-                .requestValidationModeMember(requestValidationModeMember)
-                .responseAlgorithms(responseAlgorithms);
+        return new Builder(this);
     }
 
     /**
@@ -176,6 +171,14 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
         private final BuilderRef<List<String>> responseAlgorithms = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(HttpChecksumTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.requestChecksumRequired = trait.requestChecksumRequired;
+            this.requestAlgorithmMember = trait.requestAlgorithmMember;
+            this.requestValidationModeMember = trait.requestValidationModeMember;
+            this.responseAlgorithms.setBorrowed(trait.responseAlgorithms);
+        }
 
         @Override
         public HttpChecksumTrait build() {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/auth/CognitoUserPoolsTrait.java
@@ -66,7 +66,7 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
 
     @Override
     public Builder toBuilder() {
-        return builder().sourceLocation(getSourceLocation()).providerArns(providerArns);
+        return new Builder(this);
     }
 
     @Override
@@ -82,6 +82,11 @@ public final class CognitoUserPoolsTrait extends AbstractTrait implements ToSmit
         private final BuilderRef<List<String>> providerArns = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(CognitoUserPoolsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.providerArns.setBorrowed(trait.providerArns);
+        }
 
         @Override
         public CognitoUserPoolsTrait build() {

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/LockFile.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/LockFile.java
@@ -165,10 +165,7 @@ final class LockFile implements ToSmithyBuilder<LockFile>, ToNode {
 
     @Override
     public LockFile.Builder toBuilder() {
-        return builder().repositories(repositories)
-                .artifacts(artifacts)
-                .version(version)
-                .configHash(configHash);
+        return new Builder(this);
     }
 
     public static final class Builder implements SmithyBuilder<LockFile> {
@@ -176,6 +173,15 @@ final class LockFile implements ToSmithyBuilder<LockFile>, ToNode {
         private final BuilderRef<Set<String>> repositories = BuilderRef.forOrderedSet();
         private String version = DEFAULT_VERSION;
         private int configHash;
+
+        private Builder() {}
+
+        private Builder(LockFile lockFile) {
+            this.version = lockFile.version;
+            this.configHash = lockFile.configHash;
+            this.artifacts.setBorrowed(lockFile.artifacts);
+            this.repositories.setBorrowed(lockFile.repositories);
+        }
 
         public LockFile.Builder artifacts(Map<String, LockedArtifact> artifacts) {
             this.artifacts.clear();

--- a/smithy-contract-traits/src/main/java/software/amazon/smithy/contracts/ConditionsTrait.java
+++ b/smithy-contract-traits/src/main/java/software/amazon/smithy/contracts/ConditionsTrait.java
@@ -71,8 +71,7 @@ public final class ConditionsTrait extends AbstractTrait implements ToSmithyBuil
      * Converts this trait to a builder used to build an equivalent {@link ConditionsTrait}.
      */
     public SmithyBuilder<ConditionsTrait> toBuilder() {
-        return builder().sourceLocation(getSourceLocation())
-                .conditions(getConditions());
+        return new Builder(this);
     }
 
     /**
@@ -89,6 +88,11 @@ public final class ConditionsTrait extends AbstractTrait implements ToSmithyBuil
         private final BuilderRef<Map<String, Condition>> conditions = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(ConditionsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.conditions.setBorrowed(trait.conditions);
+        }
 
         public Builder conditions(Map<String, Condition> conditions) {
             clearConditions();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -861,9 +861,7 @@ public final class Model implements ToSmithyBuilder<Model> {
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .metadata(getMetadata())
-                .addShapes(this);
+        return new Builder(this);
     }
 
     /**
@@ -926,6 +924,11 @@ public final class Model implements ToSmithyBuilder<Model> {
         private final BuilderRef<Map<ShapeId, Shape>> shapeMap = BuilderRef.forUnorderedMap();
 
         private Builder() {}
+
+        private Builder(Model model) {
+            this.shapeMap.setBorrowed(model.shapeMap);
+            this.metadata.setBorrowed(model.metadata);
+        }
 
         public Builder metadata(Map<String, Node> metadata) {
             clearMetadata();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/OperationShape.java
@@ -66,10 +66,7 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
 
     @Override
     public Builder toBuilder() {
-        return updateBuilder(builder())
-                .input(input)
-                .output(output)
-                .errors(getIntroducedErrorsSet());
+        return new Builder(this);
     }
 
     @Override
@@ -212,6 +209,15 @@ public final class OperationShape extends Shape implements ToSmithyBuilder<Opera
         private ShapeId input = UnitTypeTrait.UNIT;
         private ShapeId output = UnitTypeTrait.UNIT;
         private final BuilderRef<Set<ShapeId>> errors = BuilderRef.forOrderedSet();
+
+        private Builder() {}
+
+        private Builder(OperationShape shape) {
+            shape.updateBuilder(this);
+            this.input = shape.input;
+            this.output = shape.output;
+            this.errors.setBorrowed(shape.introducedErrors);
+        }
 
         @Override
         public ShapeType getShapeType() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ResourceShape.java
@@ -75,19 +75,7 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
 
     @Override
     public Builder toBuilder() {
-        Builder builder = updateBuilder(builder())
-                .identifiers(getIdentifiers())
-                .properties(properties)
-                .put(put)
-                .create(create)
-                .read(read)
-                .update(update)
-                .delete(delete)
-                .list(list);
-        getOperations().forEach(builder::addOperation);
-        getCollectionOperations().forEach(builder::addCollectionOperation);
-        getResources().forEach(builder::addResource);
-        return builder;
+        return new Builder(this);
     }
 
     @Override
@@ -231,6 +219,23 @@ public final class ResourceShape extends EntityShape implements ToSmithyBuilder<
         private ShapeId update;
         private ShapeId delete;
         private ShapeId list;
+
+        private Builder() {}
+
+        private Builder(ResourceShape shape) {
+            shape.updateBuilder(this);
+            this.put = shape.put;
+            this.create = shape.create;
+            this.read = shape.read;
+            this.update = shape.update;
+            this.delete = shape.delete;
+            this.list = shape.list;
+            this.identifiers.setBorrowed(shape.identifiers);
+            this.properties.setBorrowed(shape.properties);
+            this.collectionOperations.setBorrowed(shape.collectionOperations);
+            operations(shape.getOperations());
+            resources(shape.getResources());
+        }
 
         @Override
         public ResourceShape build() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ServiceShape.java
@@ -77,12 +77,7 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
 
     @Override
     public Builder toBuilder() {
-        return updateBuilder(builder())
-                .version(introducedVersion)
-                .errors(introducedErrors)
-                .rename(introducedRename)
-                .operations(getIntroducedOperations())
-                .resources(getIntroducedResources());
+        return new Builder(this);
     }
 
     @Override
@@ -215,6 +210,17 @@ public final class ServiceShape extends EntityShape implements ToSmithyBuilder<S
         private String version = "";
         private final BuilderRef<Map<ShapeId, String>> rename = BuilderRef.forOrderedMap();
         private final BuilderRef<Set<ShapeId>> errors = BuilderRef.forOrderedSet();
+
+        public Builder() {}
+
+        private Builder(ServiceShape shape) {
+            shape.updateBuilder(this);
+            this.version = shape.introducedVersion;
+            this.rename.setBorrowed(shape.introducedRename);
+            this.errors.setBorrowed(shape.introducedErrors);
+            operations(shape.getIntroducedOperations());
+            resources(shape.getIntroducedResources());
+        }
 
         @Override
         public ServiceShape build() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/AuthDefinitionTrait.java
@@ -55,7 +55,7 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
 
     @Override
     public Builder toBuilder() {
-        return builder().sourceLocation(getSourceLocation()).traits(traits);
+        return new Builder(this);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -75,6 +75,13 @@ public final class AuthDefinitionTrait extends AbstractTrait implements ToSmithy
 
     public static final class Builder extends AbstractTraitBuilder<AuthDefinitionTrait, Builder> {
         private final BuilderRef<List<ShapeId>> traits = BuilderRef.forList();
+
+        private Builder() {}
+
+        private Builder(AuthDefinitionTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.traits.setBorrowed(trait.traits);
+        }
 
         @Override
         public AuthDefinitionTrait build() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/CorsTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/CorsTrait.java
@@ -134,16 +134,7 @@ public final class CorsTrait extends AbstractTrait implements ToSmithyBuilder<Co
 
     @Override
     public Builder toBuilder() {
-        Builder b = builder()
-                .sourceLocation(getSourceLocation())
-                .origins(origins)
-                .maxAge(maxAge)
-                .additionalAllowedHeaders(additionalAllowedHeaders)
-                .additionalExposedHeaders(additionalExposedHeaders);
-        if (specifiedOrigin != null) {
-            b.origin(specifiedOrigin);
-        }
-        return b;
+        return new Builder(this);
     }
 
     @Override
@@ -208,6 +199,15 @@ public final class CorsTrait extends AbstractTrait implements ToSmithyBuilder<Co
                 BuilderRef.forSortedSet(String.CASE_INSENSITIVE_ORDER);
 
         private Builder() {}
+
+        private Builder(CorsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.origin = trait.specifiedOrigin;
+            this.maxAge = trait.maxAge;
+            this.origins.setBorrowed(trait.origins);
+            this.additionalAllowedHeaders.setBorrowed(trait.additionalAllowedHeaders);
+            this.additionalExposedHeaders.setBorrowed(trait.additionalExposedHeaders);
+        }
 
         public Builder origin(String origin) {
             this.origin = Objects.requireNonNull(origin);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumTrait.java
@@ -93,11 +93,7 @@ public class EnumTrait extends AbstractTrait implements ToSmithyBuilder<EnumTrai
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder().sourceLocation(getSourceLocation());
-        for (EnumDefinition definition : definitions) {
-            builder.addEnum(definition);
-        }
-        return builder;
+        return new Builder(this);
     }
 
     /**
@@ -112,6 +108,13 @@ public class EnumTrait extends AbstractTrait implements ToSmithyBuilder<EnumTrai
      */
     public static class Builder extends AbstractTraitBuilder<EnumTrait, Builder> {
         private final BuilderRef<List<EnumDefinition>> definitions = BuilderRef.forList();
+
+        protected Builder() {}
+
+        private Builder(EnumTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.definitions.setBorrowed(trait.definitions);
+        }
 
         public Builder addEnum(EnumDefinition value) {
             definitions.get().add(value);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ProtocolDefinitionTrait.java
@@ -71,10 +71,7 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(getSourceLocation())
-                .traits(traits)
-                .noInlineDocumentSupport(noInlineDocumentSupport);
+        return new Builder(this);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -97,6 +94,14 @@ public final class ProtocolDefinitionTrait extends AbstractTrait implements ToSm
     public static final class Builder extends AbstractTraitBuilder<ProtocolDefinitionTrait, Builder> {
         private final BuilderRef<List<ShapeId>> traits = BuilderRef.forList();
         private boolean noInlineDocumentSupport;
+
+        private Builder() {}
+
+        private Builder(ProtocolDefinitionTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.noInlineDocumentSupport = trait.noInlineDocumentSupport;
+            this.traits.setBorrowed(trait.traits);
+        }
 
         @Override
         public ProtocolDefinitionTrait build() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequestCompressionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequestCompressionTrait.java
@@ -74,9 +74,7 @@ public final class RequestCompressionTrait extends AbstractTrait implements ToSm
 
     @Override
     public Builder toBuilder() {
-        return new Builder()
-                .sourceLocation(getSourceLocation())
-                .encodings(encodings);
+        return new Builder(this);
     }
 
     public static final class Builder
@@ -84,6 +82,11 @@ public final class RequestCompressionTrait extends AbstractTrait implements ToSm
         private final BuilderRef<List<String>> encodings = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(RequestCompressionTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.encodings.setBorrowed(trait.encodings);
+        }
 
         @Override
         public RequestCompressionTrait build() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitDefinition.java
@@ -211,13 +211,7 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
-                .sourceLocation(getSourceLocation())
-                .selector(selector)
-                .structurallyExclusive(structurallyExclusive)
-                .breakingChanges(breakingChanges);
-        conflicts.forEach(builder::addConflict);
-        return builder;
+        return new Builder(this);
     }
 
     /**
@@ -327,6 +321,14 @@ public final class TraitDefinition extends AbstractTrait implements ToSmithyBuil
         private final BuilderRef<List<BreakingChangeRule>> breakingChanges = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(TraitDefinition trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.selector = trait.selector;
+            this.structurallyExclusive = trait.structurallyExclusive;
+            this.conflicts.setBorrowed(trait.conflicts);
+            this.breakingChanges.setBorrowed(trait.breakingChanges);
+        }
 
         public Builder selector(Selector selector) {
             this.selector = selector;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitValidatorsTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitValidatorsTrait.java
@@ -45,9 +45,7 @@ public final class TraitValidatorsTrait extends AbstractTrait implements ToSmith
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder().sourceLocation(getSourceLocation());
-        validators.forEach(builder::putValidator);
-        return builder;
+        return new Builder(this);
     }
 
     /**
@@ -133,6 +131,11 @@ public final class TraitValidatorsTrait extends AbstractTrait implements ToSmith
         private final BuilderRef<Map<String, Validator>> validators = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(TraitValidatorsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.validators.setBorrowed(trait.validators);
+        }
 
         @Override
         public TraitValidatorsTrait build() {

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestDefinition.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestDefinition.java
@@ -118,15 +118,7 @@ public final class HttpMalformedRequestDefinition implements ToNode, ToSmithyBui
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
-                .headers(getHeaders())
-                .method(getMethod())
-                .queryParams(getQueryParams());
-        getBody().ifPresent(builder::body);
-        getBodyMediaType().ifPresent(builder::bodyMediaType);
-        getHost().ifPresent(builder::host);
-        getUri().ifPresent(builder::uri);
-        return builder;
+        return new Builder(this);
     }
 
     public static Builder builder() {
@@ -147,6 +139,16 @@ public final class HttpMalformedRequestDefinition implements ToNode, ToSmithyBui
         private String uri;
 
         private Builder() {}
+
+        private Builder(HttpMalformedRequestDefinition def) {
+            this.body = def.body;
+            this.bodyMediaType = def.bodyMediaType;
+            this.host = def.host;
+            this.method = def.method;
+            this.uri = def.uri;
+            this.headers.setBorrowed(def.headers);
+            this.queryParams.setBorrowed(def.queryParams);
+        }
 
         public Builder body(String body) {
             this.body = body;

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestCase.java
@@ -68,14 +68,7 @@ public final class HttpMalformedRequestTestCase implements Tagged, ToSmithyBuild
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
-                .id(getId())
-                .protocol(getProtocol())
-                .request(getRequest())
-                .response(getResponse())
-                .tags(getTags());
-        getDocumentation().ifPresent(builder::documentation);
-        return builder;
+        return new Builder(this);
     }
 
     public static Builder builder() {
@@ -95,6 +88,15 @@ public final class HttpMalformedRequestTestCase implements Tagged, ToSmithyBuild
         private final BuilderRef<List<String>> tags = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(HttpMalformedRequestTestCase testCase) {
+            this.documentation = testCase.documentation;
+            this.id = testCase.id;
+            this.protocol = testCase.protocol;
+            this.request = testCase.request;
+            this.response = testCase.response;
+            this.tags.setBorrowed(testCase.tags);
+        }
 
         public Builder documentation(String documentation) {
             this.documentation = documentation;

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedResponseDefinition.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedResponseDefinition.java
@@ -71,11 +71,7 @@ public final class HttpMalformedResponseDefinition implements ToNode, ToSmithyBu
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
-                .headers(getHeaders())
-                .code(getCode());
-        getBody().ifPresent(builder::body);
-        return builder;
+        return new Builder(this);
     }
 
     public static Builder builder() {
@@ -92,6 +88,12 @@ public final class HttpMalformedResponseDefinition implements ToNode, ToSmithyBu
         private final BuilderRef<Map<String, String>> headers = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(HttpMalformedResponseDefinition def) {
+            this.body = def.body;
+            this.code = def.code;
+            this.headers.setBorrowed(def.headers);
+        }
 
         public Builder body(HttpMalformedResponseBodyDefinition body) {
             this.body = body;

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ParameterizedHttpMalformedRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ParameterizedHttpMalformedRequestTestCase.java
@@ -211,15 +211,7 @@ final class ParameterizedHttpMalformedRequestTestCase
 
     @Override
     public Builder toBuilder() {
-        Builder builder = builder()
-                .id(getId())
-                .protocol(getProtocol())
-                .request(getRequest())
-                .response(getResponse())
-                .tags(getTags())
-                .testParameters(getTestParameters());
-        getDocumentation().ifPresent(builder::documentation);
-        return builder;
+        return new Builder(this);
     }
 
     public static Builder builder() {
@@ -240,6 +232,16 @@ final class ParameterizedHttpMalformedRequestTestCase
         private final BuilderRef<Map<String, List<String>>> testParameters = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(ParameterizedHttpMalformedRequestTestCase testCase) {
+            this.documentation = testCase.documentation;
+            this.id = testCase.id;
+            this.protocol = testCase.protocol;
+            this.request = testCase.request;
+            this.response = testCase.response;
+            this.tags.setBorrowed(testCase.tags);
+            this.testParameters.setBorrowed(testCase.testParameters);
+        }
 
         public Builder documentation(String documentation) {
             this.documentation = documentation;

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/Event.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/Event.java
@@ -167,17 +167,7 @@ public final class Event implements ToSmithyBuilder<Event> {
 
     @Override
     public SmithyBuilder<Event> toBuilder() {
-        return new Builder()
-                .type(type)
-                .params(params)
-                .headers(headers)
-                .forbidHeaders(forbidHeaders)
-                .requireHeaders(requireHeaders)
-                .body(body)
-                .bodyMediaType(bodyMediaType)
-                .bytes(bytes)
-                .vendorParams(vendorParams)
-                .vendorParamsShape(vendorParamsShape);
+        return new Builder(this);
     }
 
     /**
@@ -232,6 +222,21 @@ public final class Event implements ToSmithyBuilder<Event> {
         private byte[] bytes;
         private ObjectNode vendorParams;
         private ShapeId vendorParamsShape;
+
+        private Builder() {}
+
+        private Builder(Event event) {
+            this.type = event.type;
+            this.params = event.params;
+            this.body = event.body;
+            this.bodyMediaType = event.bodyMediaType;
+            this.bytes = event.bytes;
+            this.vendorParams = event.vendorParams;
+            this.vendorParamsShape = event.vendorParamsShape;
+            this.headers.setBorrowed(event.headers);
+            this.forbidHeaders.setBorrowed(event.forbidHeaders);
+            this.requireHeaders.setBorrowed(event.requireHeaders);
+        }
 
         @Override
         public Event build() {

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/EventStreamTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/eventstream/EventStreamTestCase.java
@@ -179,21 +179,7 @@ public final class EventStreamTestCase implements ToSmithyBuilder<EventStreamTes
      */
     @Override
     public Builder toBuilder() {
-        return builder()
-                .id(id)
-                .protocol(protocol)
-                .initialRequestParams(initialRequestParams)
-                .initialRequest(initialRequest)
-                .initialRequestShape(initialRequestShape)
-                .initialResponseParams(initialResponseParams)
-                .initialResponse(initialResponse)
-                .initialResponseShape(initialResponseShape)
-                .events(events)
-                .expectation(expectation)
-                .vendorParams(vendorParams)
-                .vendorParamsShape(vendorParamsShape)
-                .documentation(documentation)
-                .appliesTo(appliesTo);
+        return new Builder(this);
     }
 
     /**
@@ -263,6 +249,26 @@ public final class EventStreamTestCase implements ToSmithyBuilder<EventStreamTes
         private String documentation;
         private AppliesTo appliesTo;
         private final BuilderRef<List<String>> tags = BuilderRef.forList();
+
+        private Builder() {}
+
+        private Builder(EventStreamTestCase testCase) {
+            this.id = testCase.id;
+            this.protocol = testCase.protocol;
+            this.initialRequestParams = testCase.initialRequestParams;
+            this.initialRequest = testCase.initialRequest;
+            this.initialRequestShape = testCase.initialRequestShape;
+            this.initialResponseParams = testCase.initialResponseParams;
+            this.initialResponse = testCase.initialResponse;
+            this.initialResponseShape = testCase.initialResponseShape;
+            this.expectation = testCase.expectation;
+            this.vendorParams = testCase.vendorParams;
+            this.vendorParamsShape = testCase.vendorParamsShape;
+            this.documentation = testCase.documentation;
+            this.appliesTo = testCase.appliesTo;
+            this.events.setBorrowed(testCase.events);
+            this.tags.setBorrowed(testCase.tags);
+        }
 
         @Override
         public EventStreamTestCase build() {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/Endpoint.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/Endpoint.java
@@ -160,7 +160,7 @@ public final class Endpoint implements FromSourceLocation, ToNode, ToSmithyBuild
 
     @Override
     public Builder toBuilder() {
-        return builder().sourceLocation(sourceLocation).url(url).headers(headers).properties(properties);
+        return new Builder(this);
     }
 
     @Override
@@ -261,6 +261,13 @@ public final class Endpoint implements FromSourceLocation, ToNode, ToSmithyBuild
 
         public Builder(FromSourceLocation sourceLocation) {
             super(sourceLocation);
+        }
+
+        private Builder(Endpoint endpoint) {
+            super(endpoint.sourceLocation);
+            this.url = endpoint.url;
+            this.headers.setBorrowed(endpoint.headers);
+            this.properties.setBorrowed(endpoint.properties);
         }
 
         public Builder url(Expression url) {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/EndpointRuleSet.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/EndpointRuleSet.java
@@ -158,11 +158,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(getSourceLocation())
-                .parameters(parameters)
-                .rules(rules)
-                .version(version);
+        return new Builder(this);
     }
 
     @Override
@@ -261,6 +257,13 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
          */
         public Builder(FromSourceLocation sourceLocation) {
             super(sourceLocation);
+        }
+
+        private Builder(EndpointRuleSet ruleSet) {
+            super(ruleSet.sourceLocation);
+            this.parameters = ruleSet.parameters;
+            this.version = ruleSet.version;
+            this.rules.setBorrowed(ruleSet.rules);
         }
 
         /**

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamsTrait.java
@@ -47,9 +47,7 @@ public final class ClientContextParamsTrait extends AbstractTrait implements ToS
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(getSourceLocation())
-                .parameters(getParameters());
+        return new Builder(this);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -79,6 +77,11 @@ public final class ClientContextParamsTrait extends AbstractTrait implements ToS
         private final BuilderRef<Map<String, ClientContextParamDefinition>> parameters = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(ClientContextParamsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.parameters.setBorrowed(trait.parameters);
+        }
 
         public Builder parameters(Map<String, ClientContextParamDefinition> parameters) {
             this.parameters.clear();

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestCase.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestCase.java
@@ -61,12 +61,7 @@ public final class EndpointTestCase implements FromSourceLocation, ToSmithyBuild
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(sourceLocation)
-                .documentation(documentation)
-                .params(params)
-                .operationInputs(operationInputs)
-                .expect(expect);
+        return new Builder(this);
     }
 
     @Override
@@ -97,6 +92,14 @@ public final class EndpointTestCase implements FromSourceLocation, ToSmithyBuild
         private EndpointTestExpectation expect;
 
         private Builder() {}
+
+        private Builder(EndpointTestCase testCase) {
+            this.sourceLocation = testCase.sourceLocation;
+            this.documentation = testCase.documentation;
+            this.params = testCase.params;
+            this.expect = testCase.expect;
+            this.operationInputs.setBorrowed(testCase.operationInputs);
+        }
 
         public Builder sourceLocation(FromSourceLocation sourceLocation) {
             this.sourceLocation = sourceLocation.getSourceLocation();

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTrait.java
@@ -61,10 +61,7 @@ public final class EndpointTestsTrait extends AbstractTrait implements ToSmithyB
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(getSourceLocation())
-                .version(version)
-                .testCases(testCases);
+        return new Builder(this);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -83,6 +80,12 @@ public final class EndpointTestsTrait extends AbstractTrait implements ToSmithyB
         private String version;
 
         private Builder() {}
+
+        private Builder(EndpointTestsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.version = trait.version;
+            this.testCases.setBorrowed(trait.testCases);
+        }
 
         public Builder version(String version) {
             this.version = version;

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
@@ -56,11 +56,7 @@ public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuild
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .sourceLocation(sourceLocation)
-                .url(url)
-                .headers(headers)
-                .properties(properties);
+        return new Builder(this);
     }
 
     @Override
@@ -109,6 +105,13 @@ public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuild
         private String url;
 
         private Builder() {}
+
+        private Builder(ExpectedEndpoint endpoint) {
+            this.sourceLocation = endpoint.sourceLocation;
+            this.url = endpoint.url;
+            this.headers.setBorrowed(endpoint.headers);
+            this.properties.setBorrowed(endpoint.properties);
+        }
 
         public Builder sourceLocation(FromSourceLocation fromSourceLocation) {
             this.sourceLocation = fromSourceLocation.getSourceLocation();

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamsTrait.java
@@ -48,9 +48,7 @@ public final class OperationContextParamsTrait extends AbstractTrait
 
     @Override
     public Builder toBuilder() {
-        return new Builder()
-                .sourceLocation(getSourceLocation())
-                .parameters(parameters);
+        return new Builder(this);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -78,6 +76,11 @@ public final class OperationContextParamsTrait extends AbstractTrait
         private final BuilderRef<Map<String, OperationContextParamDefinition>> parameters = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(OperationContextParamsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.parameters.setBorrowed(trait.parameters);
+        }
 
         public Builder parameters(Map<String, OperationContextParamDefinition> parameters) {
             this.parameters.clear();

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/StaticContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/StaticContextParamsTrait.java
@@ -47,9 +47,7 @@ public final class StaticContextParamsTrait extends AbstractTrait implements ToS
 
     @Override
     public Builder toBuilder() {
-        return new Builder()
-                .sourceLocation(getSourceLocation())
-                .parameters(parameters);
+        return new Builder(this);
     }
 
     public static final class Provider extends AbstractTrait.Provider {
@@ -77,6 +75,11 @@ public final class StaticContextParamsTrait extends AbstractTrait implements ToS
         private final BuilderRef<Map<String, StaticContextParamDefinition>> parameters = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(StaticContextParamsTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.parameters.setBorrowed(trait.parameters);
+        }
 
         public Builder parameters(Map<String, StaticContextParamDefinition> parameters) {
             this.parameters.clear();

--- a/smithy-smoke-test-traits/src/main/java/software/amazon/smithy/smoketests/traits/SmokeTestCase.java
+++ b/smithy-smoke-test-traits/src/main/java/software/amazon/smithy/smoketests/traits/SmokeTestCase.java
@@ -140,13 +140,7 @@ public final class SmokeTestCase implements Tagged, ToNode, ToSmithyBuilder<Smok
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .id(this.getId())
-                .params(this.getParams().orElse(null))
-                .vendorParams(this.getVendorParams().orElse(null))
-                .vendorParamsShape(this.getVendorParamsShape().orElse(null))
-                .expectation(this.getExpectation())
-                .tags(this.getTags());
+        return new Builder(this);
     }
 
     @Override
@@ -192,6 +186,15 @@ public final class SmokeTestCase implements Tagged, ToNode, ToSmithyBuilder<Smok
         private final BuilderRef<List<String>> tags = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(SmokeTestCase testCase) {
+            this.id = testCase.id;
+            this.params = testCase.params;
+            this.vendorParams = testCase.vendorParams;
+            this.vendorParamsShape = testCase.vendorParamsShape;
+            this.expectation = testCase.expectation;
+            this.tags.setBorrowed(testCase.tags);
+        }
 
         /**
          * Sets the smoke test case ID.

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/BuilderRef.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/BuilderRef.java
@@ -81,6 +81,20 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
     void clear();
 
     /**
+     * Sets a borrowed (immutable) value directly, clearing any owned state.
+     *
+     * <p>This enables the {@code toBuilder()} optimization: when creating a
+     * builder from an existing built object, the already-immutable collections
+     * can be set directly without copying. A copy will only be made if the
+     * builder actually mutates the value via {@link #get()}.
+     *
+     * @param value The immutable value to borrow. May be {@code null} to clear.
+     */
+    default void setBorrowed(T value) {
+        throw new UnsupportedOperationException("setBorrowed");
+    }
+
+    /**
      * Creates a builder reference to an unordered map.
      *
      * @param <K> Type of key of the map.
@@ -89,7 +103,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <K, V> BuilderRef<Map<K, V>> forUnorderedMap() {
         return new DefaultBuilderRef<>(HashMap::new,
-                HashMap::new,
+                source -> {
+                    Map<K, V> copy = new HashMap<>((int) (source.size() / 0.75f + 1));
+                    for (Map.Entry<K, V> entry : source.entrySet()) {
+                        copy.put(entry.getKey(), entry.getValue());
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableMap,
                 Collections::emptyMap);
     }
@@ -103,7 +123,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <K, V> BuilderRef<Map<K, V>> forOrderedMap() {
         return new DefaultBuilderRef<>(LinkedHashMap::new,
-                LinkedHashMap::new,
+                source -> {
+                    Map<K, V> copy = new LinkedHashMap<>((int) (source.size() / 0.75f + 1));
+                    for (Map.Entry<K, V> entry : source.entrySet()) {
+                        copy.put(entry.getKey(), entry.getValue());
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableMap,
                 Collections::emptyMap);
     }
@@ -117,7 +143,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <K, V> BuilderRef<Map<K, V>> forSortedMap() {
         return new DefaultBuilderRef<>(TreeMap::new,
-                TreeMap::new,
+                source -> {
+                    Map<K, V> copy = new TreeMap<>();
+                    for (Map.Entry<K, V> entry : source.entrySet()) {
+                        copy.put(entry.getKey(), entry.getValue());
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableMap,
                 Collections::emptyMap);
     }
@@ -135,7 +167,9 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
                 () -> new TreeMap<>(comparator),
                 source -> {
                     Map<K, V> copy = new TreeMap<>(comparator);
-                    copy.putAll(source);
+                    for (Map.Entry<K, V> entry : source.entrySet()) {
+                        copy.put(entry.getKey(), entry.getValue());
+                    }
                     return copy;
                 },
                 Collections::unmodifiableMap,
@@ -150,7 +184,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <T> BuilderRef<List<T>> forList() {
         return new DefaultBuilderRef<>(ArrayList::new,
-                ArrayList::new,
+                source -> {
+                    List<T> copy = new ArrayList<>(source.size());
+                    for (T item : source) {
+                        copy.add(item);
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableList,
                 Collections::emptyList);
     }
@@ -163,7 +203,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <T> BuilderRef<Set<T>> forUnorderedSet() {
         return new DefaultBuilderRef<>(HashSet::new,
-                HashSet::new,
+                source -> {
+                    Set<T> copy = new HashSet<>((int) (source.size() / 0.75f + 1));
+                    for (T item : source) {
+                        copy.add(item);
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableSet,
                 Collections::emptySet);
     }
@@ -176,7 +222,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <T> BuilderRef<Set<T>> forOrderedSet() {
         return new DefaultBuilderRef<>(LinkedHashSet::new,
-                LinkedHashSet::new,
+                source -> {
+                    Set<T> copy = new LinkedHashSet<>((int) (source.size() / 0.75f + 1));
+                    for (T item : source) {
+                        copy.add(item);
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableSet,
                 Collections::emptySet);
     }
@@ -189,7 +241,13 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
      */
     static <T> BuilderRef<Set<T>> forSortedSet() {
         return new DefaultBuilderRef<>(TreeSet::new,
-                TreeSet::new,
+                source -> {
+                    Set<T> copy = new TreeSet<>();
+                    for (T item : source) {
+                        copy.add(item);
+                    }
+                    return copy;
+                },
                 Collections::unmodifiableSet,
                 Collections::emptySet);
     }
@@ -206,7 +264,9 @@ public interface BuilderRef<T> extends CopyOnWriteRef<T> {
                 () -> new TreeSet<>(comparator),
                 source -> {
                     Set<T> copy = new TreeSet<>(comparator);
-                    copy.addAll(source);
+                    for (T item : source) {
+                        copy.add(item);
+                    }
                     return copy;
                 },
                 Collections::unmodifiableSet,

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/DefaultBuilderRef.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/DefaultBuilderRef.java
@@ -81,8 +81,8 @@ public final class DefaultBuilderRef<T> implements BuilderRef<T> {
             borrowed = result;
             return result;
         } else if (borrowed != null) {
-            // Copy the borrowed value and make it immutable.
-            return applyImmutableWrapper(applyCopyCtor(borrowed));
+            // The borrowed value is already immutable, return it directly.
+            return borrowed;
         } else if (emptyCtorOptimization != null) {
             // The value is empty and was never created, so call the empty ctor supplier if available.
             return applyEmptyCtorOptimization();
@@ -101,6 +101,13 @@ public final class DefaultBuilderRef<T> implements BuilderRef<T> {
     @Override
     public void clear() {
         setOwned(null);
+    }
+
+    @Override
+    public void setBorrowed(T value) {
+        this.owned = null;
+        this.immutableOwned = null;
+        this.borrowed = value;
     }
 
     private T setOwned(T value) {

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/BuilderRefTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/BuilderRefTest.java
@@ -120,4 +120,115 @@ public class BuilderRefTest {
         sortedSet.get().add("a");
         assertThat(sortedSet.peek(), containsInRelativeOrder("a", "B"));
     }
+
+    @Test
+    public void setBorrowedAllowsPeekWithoutCopy() {
+        List<String> immutable = ListUtils.of("a", "b");
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.setBorrowed(immutable);
+
+        // peek returns the borrowed value directly
+        assertThat(ref.peek(), equalTo(immutable));
+        assertThat(ref.hasValue(), equalTo(true));
+    }
+
+    @Test
+    public void setBorrowedCopiesOnGet() {
+        List<String> immutable = ListUtils.of("a", "b");
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.setBorrowed(immutable);
+
+        // get() triggers a copy so we can mutate
+        List<String> mutable = ref.get();
+        mutable.add("c");
+
+        // original is unchanged
+        assertThat(immutable.size(), equalTo(2));
+        // ref now has the mutated copy
+        assertThat(ref.peek(), contains("a", "b", "c"));
+    }
+
+    @Test
+    public void setBorrowedClearsOwnedState() {
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.get().add("x");
+
+        // setBorrowed replaces owned state
+        List<String> immutable = ListUtils.of("a", "b");
+        ref.setBorrowed(immutable);
+
+        assertThat(ref.peek(), equalTo(immutable));
+        assertThat(ref.peek(), contains("a", "b"));
+    }
+
+    @Test
+    public void setBorrowedWithNullClearsState() {
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.get().add("x");
+
+        ref.setBorrowed(null);
+
+        assertThat(ref.hasValue(), equalTo(false));
+    }
+
+    @Test
+    public void setBorrowedCopyReturnsBorrowedValue() {
+        List<String> immutable = ListUtils.of("a", "b");
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.setBorrowed(immutable);
+
+        // copy() on a borrowed value copies it and wraps immutably
+        List<String> copied = ref.copy();
+        assertThat(copied, contains("a", "b"));
+    }
+
+    @Test
+    public void setBorrowedEnablesToBuilderPattern() {
+        // Simulates the toBuilder() optimization:
+        // 1. Build an object with copy()
+        BuilderRef<Map<String, String>> ref = BuilderRef.forOrderedMap();
+        ref.get().put("key", "value");
+        Map<String, String> built = ref.copy(); // immutable
+
+        // 2. Create a new builder and setBorrowed (simulates toBuilder)
+        BuilderRef<Map<String, String>> ref2 = BuilderRef.forOrderedMap();
+        ref2.setBorrowed(built);
+
+        // 3. peek() returns the borrowed value without copy
+        assertThat(ref2.peek(), equalTo(built));
+
+        // 4. Mutating via get() doesn't affect the original
+        ref2.get().put("key2", "value2");
+        assertThat(built.size(), equalTo(1));
+        assertThat(ref2.peek().size(), equalTo(2));
+    }
+
+    @Test
+    public void copyReturnsSameInstanceWhenNotMutatedAfterSetBorrowed() {
+        // The key optimization: if setBorrowed is called and no mutation happens,
+        // copy() returns the exact same instance (no copy at all).
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.get().add("a");
+        List<String> original = ref.copy();
+
+        // Simulate toBuilder: setBorrowed with the immutable collection
+        BuilderRef<List<String>> ref2 = BuilderRef.forList();
+        ref2.setBorrowed(original);
+
+        // copy() without any mutation should return the same instance
+        List<String> result = ref2.copy();
+        assertThat(result == original, equalTo(true));
+    }
+
+    @Test
+    public void copyReturnsSameInstanceOnRepeatedCopyCalls() {
+        // Even without setBorrowed, repeated copy() calls should reuse the same instance
+        BuilderRef<List<String>> ref = BuilderRef.forList();
+        ref.get().add("a");
+
+        List<String> first = ref.copy();
+        List<String> second = ref.copy();
+
+        assertThat(first == second, equalTo(true));
+    }
 }

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
@@ -36,7 +36,7 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
 
     @Override
     public Builder toBuilder() {
-        return new Builder().sourceLocation(getSourceLocation()).replace(waiters);
+        return new Builder(this);
     }
 
     /**
@@ -63,6 +63,11 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
         private final BuilderRef<Map<String, Waiter>> waiters = BuilderRef.forOrderedMap();
 
         private Builder() {}
+
+        private Builder(WaitableTrait trait) {
+            sourceLocation(trait.getSourceLocation());
+            this.waiters.setBorrowed(trait.waiters);
+        }
 
         @Override
         public WaitableTrait build() {

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/Waiter.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/Waiter.java
@@ -64,13 +64,7 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
 
     @Override
     public Builder toBuilder() {
-        return builder()
-                .documentation(getDocumentation().orElse(null))
-                .acceptors(getAcceptors())
-                .minDelay(getMinDelay())
-                .maxDelay(getMaxDelay())
-                .tags(tags)
-                .deprecated(deprecated);
+        return new Builder(this);
     }
 
     /**
@@ -207,6 +201,15 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
         private final BuilderRef<List<String>> tags = BuilderRef.forList();
 
         private Builder() {}
+
+        private Builder(Waiter waiter) {
+            this.documentation = waiter.documentation;
+            this.minDelay = waiter.minDelay;
+            this.maxDelay = waiter.maxDelay;
+            this.deprecated = waiter.deprecated;
+            this.acceptors.setBorrowed(waiter.acceptors);
+            this.tags.setBorrowed(waiter.tags);
+        }
 
         @Override
         public Waiter build() {


### PR DESCRIPTION
## Summary

Adds a `setBorrowed(T)` method to `BuilderRef` that enables zero-copy `toBuilder()` calls. When a builder is created from an existing built object, the already-immutable collections are borrowed directly instead of being copied through setter methods. A copy only occurs if the builder actually mutates the collection.

## Motivation

Previously, calling `toBuilder()` on any built object would copy every collection field, even if the resulting builder was never mutated or only a single field was changed. For objects with many collection fields (like `ServiceShape`, `Model`, `IntegrationTrait`), this meant multiple unnecessary allocations on every `toBuilder()` call.

## Changes

**`BuilderRef` interface**, Added `default void setBorrowed(T value)` with a default implementation that throws `UnsupportedOperationException` for backwards compatibility.

**`DefaultBuilderRef`**, Implemented `setBorrowed` to set the borrowed (immutable) reference directly, clearing any owned state. Also optimized `copy()` to return the borrowed value directly when no mutation has occurred, avoiding a redundant copy+wrap cycle.

**30 classes across the project**, Added private `Builder(BuiltObject)` constructors that use `setBorrowed` for collection fields, and simplified `toBuilder()` to `return new Builder(this)`.

## Performance characteristics

| Scenario | Before | After |
|----------|--------|-------|
| `toBuilder()` call | O(n) copy per collection field | O(1), just sets a reference |
| `toBuilder()` then `build()` (no mutation) | 2× O(n) copies per field | Zero copies, same instance reused |
| `toBuilder()`, mutate one field, `build()` | 2× O(n) copies for ALL fields | O(n) copy only for the mutated field |

## Backwards compatibility

- The existing `BuilderRef` API (`get`, `peek`, `copy`, `hasValue`, `clear`) is unchanged.
- `setBorrowed` has a default implementation that throws, so external implementations of `BuilderRef` are not broken.
- The `copy()` optimization (returning borrowed directly) is safe because `borrowed` is always immutable in all codepaths.

## Megamorphic call site fix

Replaced all collection copy constructors (`new HashMap<>(map)`, `new ArrayList<>(list)`, etc.) in `BuilderRef` factory methods with explicit for-each iteration. This avoids the megamorphic performance penalty described in [JDK-8368292](https://bugs.openjdk.org/browse/JDK-8368292), where bulk methods like `putAll`/`addAll` suffer from (3 + 4n) virtual method calls that the JIT cannot inline due to the many different collection types flowing through these paths (HashMap, TreeMap, LinkedHashMap, unmodifiableMap, emptyMap, etc.).
