### PR TITLE
Optimize model scoping in JsonSchemaConverter

### DIFF
--- a/.changes/next-release/feature-1c0cbaf67ed3623cce686b3fd4419737fc146fae.json
+++ b/.changes/next-release/feature-1c0cbaf67ed3623cce686b3fd4419737fc146fae.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Optimized model scoping in JsonSchemaConverter by constructing through a Model.Builder instead of filtering shapes.",
+  "pull_requests": [
+    "[#3111](https://github.com/smithy-lang/smithy/pull/3111)"
+  ]
+}

--- a/smithy-jsonschema/build.gradle.kts
+++ b/smithy-jsonschema/build.gradle.kts
@@ -4,6 +4,7 @@
  */
 plugins {
     id("smithy.module-conventions")
+    id("smithy.profiling-conventions")
 }
 
 description = "This module contains support for converting a Smithy model to JSON Schema."

--- a/smithy-jsonschema/src/jmh/java/software/amazon/smithy/jsonschema/jmh/JsonSchemaConversion.java
+++ b/smithy-jsonschema/src/jmh/java/software/amazon/smithy/jsonschema/jmh/JsonSchemaConversion.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.jsonschema.jmh;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import software.amazon.smithy.jsonschema.JsonSchemaConfig;
+import software.amazon.smithy.jsonschema.JsonSchemaConverter;
+import software.amazon.smithy.jsonschema.SchemaDocument;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.InputTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
+import software.amazon.smithy.model.traits.OutputTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.traits.TraitDefinition;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, timeUnit = TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+public class JsonSchemaConversion {
+
+    @State(Scope.Thread)
+    public static class ConversionState {
+
+        @Param({"5", "50", "200"})
+        public int operationCount;
+
+        @Param({"1", "5", "50"})
+        public int serviceCount;
+
+        public Model model;
+        public JsonSchemaConfig config;
+
+        @Setup
+        public void prepare() {
+            model = buildModel(operationCount, serviceCount);
+            config = new JsonSchemaConfig();
+            config.setService(ShapeId.from("smithy.benchmark.s0#BenchmarkService0"));
+        }
+
+        private static Model buildModel(int numOperations, int numServices) {
+            ModelAssembler assembler = new ModelAssembler();
+
+            // Mixin structure that all inputs/outputs will use
+            StructureShape commonMixin = StructureShape.builder()
+                    .id("smithy.benchmark#CommonFields")
+                    .addTrait(MixinTrait.builder().build())
+                    .addMember("requestId", ShapeId.from("smithy.api#String"))
+                    .addMember("timestamp", ShapeId.from("smithy.api#String"))
+                    .build();
+            assembler.addShape(commonMixin);
+
+            // Trait definition (gets scrubbed during conversion)
+            StructureShape traitDef = StructureShape.builder()
+                    .id("smithy.benchmark#customTag")
+                    .addTrait(TraitDefinition.builder().build())
+                    .addMember("value", ShapeId.from("smithy.api#String"))
+                    .build();
+            assembler.addShape(traitDef);
+
+            for (int s = 0; s < numServices; s++) {
+                String ns = "smithy.benchmark.s" + s;
+                ServiceShape.Builder serviceBuilder = ServiceShape.builder()
+                        .id(ns + "#BenchmarkService" + s)
+                        .version("2024-01-01");
+
+                for (int i = 0; i < numOperations; i++) {
+                    String opName = "Operation" + i;
+                    ShapeId inputId = ShapeId.fromParts(ns, opName + "Input");
+                    ShapeId outputId = ShapeId.fromParts(ns, opName + "Output");
+                    ShapeId nestedId = ShapeId.fromParts(ns, opName + "Nested");
+                    ShapeId itemListId = ShapeId.fromParts(ns, opName + "ItemList");
+                    ShapeId itemId = ShapeId.fromParts(ns, opName + "Item");
+                    ShapeId errorId = ShapeId.fromParts(ns, opName + "Error");
+                    ShapeId opId = ShapeId.fromParts(ns, opName);
+
+                    // Nested structure
+                    StructureShape nested = StructureShape.builder()
+                            .id(nestedId)
+                            .addMember("value0", ShapeId.from("smithy.api#Integer"))
+                            .addMember("value1", ShapeId.from("smithy.api#Integer"))
+                            .addMember("value2", ShapeId.from("smithy.api#Integer"))
+                            .build();
+                    assembler.addShape(nested);
+
+                    // Input structure with mixin
+                    StructureShape input = StructureShape.builder()
+                            .id(inputId)
+                            .addTrait(new InputTrait())
+                            .addMixin(commonMixin)
+                            .addMember("id",
+                                    ShapeId.from("smithy.api#String"),
+                                    b -> b.addTrait(new RequiredTrait()))
+                            .addMember("field0", ShapeId.from("smithy.api#String"))
+                            .addMember("field1", ShapeId.from("smithy.api#String"))
+                            .addMember("field2", ShapeId.from("smithy.api#String"))
+                            .addMember("nested", nestedId)
+                            .build();
+                    assembler.addShape(input);
+
+                    // Item structure for list
+                    StructureShape item = StructureShape.builder()
+                            .id(itemId)
+                            .addMember("name", ShapeId.from("smithy.api#String"))
+                            .addMember("value", ShapeId.from("smithy.api#String"))
+                            .build();
+                    assembler.addShape(item);
+
+                    // List shape
+                    ListShape itemList = ListShape.builder()
+                            .id(itemListId)
+                            .member(MemberShape.builder()
+                                    .id(itemListId.withMember("member"))
+                                    .target(itemId)
+                                    .build())
+                            .build();
+                    assembler.addShape(itemList);
+
+                    // Output structure with mixin
+                    StructureShape output = StructureShape.builder()
+                            .id(outputId)
+                            .addTrait(new OutputTrait())
+                            .addMixin(commonMixin)
+                            .addMember("result", ShapeId.from("smithy.api#String"))
+                            .addMember("items", itemListId)
+                            .build();
+                    assembler.addShape(output);
+
+                    // Error structure
+                    StructureShape error = StructureShape.builder()
+                            .id(errorId)
+                            .addTrait(new ErrorTrait("client"))
+                            .addMember("message",
+                                    ShapeId.from("smithy.api#String"),
+                                    b -> b.addTrait(new RequiredTrait()))
+                            .build();
+                    assembler.addShape(error);
+
+                    // Operation
+                    OperationShape operation = OperationShape.builder()
+                            .id(opId)
+                            .input(inputId)
+                            .output(outputId)
+                            .addError(errorId)
+                            .build();
+                    assembler.addShape(operation);
+
+                    serviceBuilder.addOperation(opId);
+                }
+
+                assembler.addShape(serviceBuilder.build());
+            }
+
+            return assembler.disableValidation().assemble().unwrap();
+        }
+    }
+
+    @Benchmark
+    public SchemaDocument convertFullService(ConversionState state) {
+        JsonSchemaConverter converter = JsonSchemaConverter.builder()
+                .model(state.model)
+                .config(state.config)
+                .rootShape(ShapeId.from("smithy.benchmark.s0#BenchmarkService0"))
+                .build();
+        return converter.convert();
+    }
+}

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConverter.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConverter.java
@@ -6,9 +6,9 @@ package software.amazon.smithy.jsonschema;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -83,7 +83,7 @@ public final class JsonSchemaConverter implements ToSmithyBuilder<JsonSchemaConv
         LOGGER.fine("Creating JSON ref strategy");
         Model refModel = config.isEnableOutOfServiceReferences()
                 ? this.model
-                : scopeModelToService(model, config.getService());
+                : scopeModelToShape(model, config.getService());
 
         unitTargetedByUnion = refModel.shapes(UnionShape.class)
                 .anyMatch(u -> u.members().stream().anyMatch(m -> m.getTarget().equals(UnitTypeTrait.UNIT)));
@@ -120,12 +120,7 @@ public final class JsonSchemaConverter implements ToSmithyBuilder<JsonSchemaConv
 
         if (rootShape != null) {
             LOGGER.fine(() -> "Filtering out shapes that are not connected to " + rootShape);
-            Set<Shape> connected = new Walker(model).walkShapes(rootShape);
-            LOGGER.fine(() -> "Only generating the following JSON schema shapes: " + connected.stream()
-                    .map(Shape::getId)
-                    .map(ShapeId::toString)
-                    .collect(Collectors.joining(", ")));
-            model = transformer.filterShapes(model, connected::contains);
+            model = scopeModelToShape(model, rootShape.toShapeId());
         }
 
         model = transformer.filterShapes(model, predicate);
@@ -136,12 +131,18 @@ public final class JsonSchemaConverter implements ToSmithyBuilder<JsonSchemaConv
         return model;
     }
 
-    private static Model scopeModelToService(Model model, ShapeId serviceId) {
-        if (serviceId == null) {
+    private static Model scopeModelToShape(Model model, ShapeId shapeId) {
+        if (shapeId == null) {
             return model;
         }
-        Set<Shape> connected = new Walker(model).walkShapes(model.expectShape(serviceId));
-        return ModelTransformer.create().filterShapes(model, connected::contains);
+        Iterator<Shape> connected = new Walker(model).iterateShapes(model.expectShape(shapeId));
+        Model.Builder builder = Model.builder().metadata(model.getMetadata());
+
+        while (connected.hasNext()) {
+            builder.addShape(connected.next());
+        }
+
+        return builder.build();
     }
 
     private static int countSegments(String pointer) {


### PR DESCRIPTION
Scoping models when converting to JSON Schema no longer routes through filterShapes, instead constructing a model piecemeal via Model.Builder. This, combined with using the iterator directly, produces a 40-80% improvement in the speed of converting to JSON Schema.

The two paths that performed this work are now consolidated and a JMH benchmark is added.

Fixes #2556 

### Old

| Benchmark                             | operationCount | serviceCount | Mode | Cnt | Score       | Error          | Units |
| ------------------------------------- | -------------: | -----------: | ---- | --: | ----------: | -------------: | ----- |
| `JsonSchemaConversion.convertFullService` |              5 |            1 | avgt |   5 |     590.689 |     ±   13.645 | us/op |
| `JsonSchemaConversion.convertFullService` |              5 |            5 | avgt |   5 |    1283.085 |     ±   28.705 | us/op |
| `JsonSchemaConversion.convertFullService` |              5 |           50 | avgt |   5 |   10129.960 |     ±  368.544 | us/op |
| `JsonSchemaConversion.convertFullService` |             50 |            1 | avgt |   5 |    3953.793 |     ± 1748.429 | us/op |
| `JsonSchemaConversion.convertFullService` |             50 |            5 | avgt |   5 |   14850.451 |     ±  651.051 | us/op |
| `JsonSchemaConversion.convertFullService` |             50 |           50 | avgt |   5 |  240286.486 |   ± 218849.555 | us/op |
| `JsonSchemaConversion.convertFullService` |            200 |            1 | avgt |   5 |   15543.877 |     ± 1002.197 | us/op |
| `JsonSchemaConversion.convertFullService` |            200 |            5 | avgt |   5 |   54535.699 |     ± 2298.536 | us/op |
| `JsonSchemaConversion.convertFullService` |            200 |           50 | avgt |   5 | 1181416.415 |   ± 103688.124 | us/op |

### New

| Benchmark                             | operationCount | serviceCount | Mode | Cnt | Score      | Error       | Units |
| ------------------------------------- | -------------: | -----------: | ---- | --: | ---------: | ----------: | ----- |
| `JsonSchemaConversion.convertFullService` |              5 |            1 | avgt |   5 |    156.115 |  ±    2.557 | us/op |
| `JsonSchemaConversion.convertFullService` |              5 |            5 | avgt |   5 |    273.269 |  ±    7.763 | us/op |
| `JsonSchemaConversion.convertFullService` |              5 |           50 | avgt |   5 |   1668.706 |  ±   62.961 | us/op |
| `JsonSchemaConversion.convertFullService` |             50 |            1 | avgt |   5 |   1769.331 |  ±   37.957 | us/op |
| `JsonSchemaConversion.convertFullService` |             50 |            5 | avgt |   5 |   3865.549 |  ± 1297.786 | us/op |
| `JsonSchemaConversion.convertFullService` |             50 |           50 | avgt |   5 |  42499.379 |  ± 3164.557 | us/op |
| `JsonSchemaConversion.convertFullService` |            200 |            1 | avgt |   5 |   9448.042 |  ±  645.092 | us/op |
| `JsonSchemaConversion.convertFullService` |            200 |            5 | avgt |   5 |  19588.177 |  ± 5678.761 | us/op |
| `JsonSchemaConversion.convertFullService` |            200 |           50 | avgt |   5 | 196389.030 |  ± 16907.118 | us/op |

### Summary: Percent Improvement (New vs Old)

| operationCount | serviceCount | Old (us/op) | New (us/op) | Improvement |
| -------------: | -----------: | ----------: | ----------: | ----------: |
|              5 |            1 |     590.689 |     156.115 |      73.57% |
|              5 |            5 |    1283.085 |     273.269 |      78.70% |
|              5 |           50 |   10129.960 |    1668.706 |      83.53% |
|             50 |            1 |    3953.793 |    1769.331 |      55.25% |
|             50 |            5 |   14850.451 |    3865.549 |      73.97% |
|             50 |           50 |  240286.486 |   42499.379 |      82.31% |
|            200 |            1 |   15543.877 |    9448.042 |      39.22% |
|            200 |            5 |   54535.699 |   19588.177 |      64.08% |
|            200 |           50 | 1181416.415 |  196389.030 |      83.38% |


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
