### PR TITLE
Improve deferred rendering performance

### DIFF
--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/AbstractCodeWriter.java
@@ -20,7 +20,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 /**
  * Helper class for generating code.
@@ -609,7 +608,6 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
             '_',
             '`'};
 
-    private static final Pattern LINES = Pattern.compile("\\r?\\n");
     private static final Map<Character, BiFunction<Object, String, String>> DEFAULT_FORMATTERS = MapUtils.of(
             'L',
             (s, i) -> formatLiteral(s),
@@ -621,7 +619,6 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     private boolean trailingNewline = true;
     private int trimBlankLines = -1;
     private boolean enableStackTraceComments;
-    private final List<String> deferredPlaceholders = new ArrayList<>();
     private final List<Supplier<String>> deferredSuppliers = new ArrayList<>();
     private int deferredCounter = 0;
 
@@ -788,28 +785,33 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
     public String toString() {
         String result = currentState.toString();
 
-        // Resolve any deferred values.
-        if (!deferredPlaceholders.isEmpty()) {
-            // Find all sentinel positions, then resolve in a single linear pass.
-            List<int[]> positions = new ArrayList<>();
-            for (int i = 0; i < deferredPlaceholders.size(); i++) {
-                String key = deferredPlaceholders.get(i);
-                int fromIndex = 0;
-                while ((fromIndex = result.indexOf(key, fromIndex)) != -1) {
-                    positions.add(new int[] {fromIndex, i, key.length()});
-                    fromIndex += key.length();
+        // Resolve any deferred values with a single linear scan.
+        if (deferredCounter > 0) {
+            StringBuilder resolved = new StringBuilder(result.length());
+            int pos = 0;
+            int fromIndex = 0;
+            int len = result.length();
+            while (fromIndex < len) {
+                if (result.charAt(fromIndex) == '\0' && fromIndex + 1 < len && result.charAt(fromIndex + 1) == '\0') {
+                    int idStart = fromIndex + 2;
+                    int end = result.indexOf("\0\0", idStart);
+                    if (end != -1) {
+                        int id = 0;
+                        for (int k = idStart; k < end; k++) {
+                            id = id * 10 + (result.charAt(k) - '0');
+                        }
+                        int keyLen = end + 2 - fromIndex;
+                        resolved.append(result, pos, fromIndex);
+                        resolved.append(deferredSuppliers.get(id).get());
+                        fromIndex += keyLen;
+                        pos = fromIndex;
+                        continue;
+                    }
                 }
+                fromIndex++;
             }
-            if (!positions.isEmpty()) {
-                positions.sort((a, b) -> Integer.compare(a[0], b[0]));
-                StringBuilder resolved = new StringBuilder(result.length());
-                int pos = 0;
-                for (int[] entry : positions) {
-                    resolved.append(result, pos, entry[0]);
-                    resolved.append(deferredSuppliers.get(entry[1]).get());
-                    pos = entry[0] + entry[2];
-                }
-                resolved.append(result, pos, result.length());
+            if (pos > 0) {
+                resolved.append(result, pos, len);
                 result = resolved.toString();
             }
         }
@@ -817,18 +819,32 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
         // Trim excessive blank lines.
         if (trimBlankLines > -1) {
             StringBuilder builder = new StringBuilder(result.length());
-            String[] lines = LINES.split(result);
             int blankCount = 0;
+            int start = 0;
+            int len = result.length();
+            int lastNonBlankEnd = 0;
 
-            for (String line : lines) {
-                if (!StringUtils.isBlank(line)) {
-                    builder.append(line).append(currentState.newline);
+            while (start < len) {
+                int newlineIdx = result.indexOf('\n', start);
+                int lineEnd = (newlineIdx == -1) ? len : newlineIdx;
+                // Handle \r\n
+                int lineContentEnd = (lineEnd > start && result.charAt(lineEnd - 1) == '\r')
+                        ? lineEnd - 1
+                        : lineEnd;
+
+                boolean blank = StringUtils.isBlank(result, start, lineContentEnd);
+                if (!blank) {
+                    builder.append(result, start, lineContentEnd).append(currentState.newline);
                     blankCount = 0;
+                    lastNonBlankEnd = builder.length();
                 } else if (blankCount++ < trimBlankLines) {
-                    builder.append(line).append(currentState.newline);
+                    builder.append(result, start, lineContentEnd).append(currentState.newline);
                 }
+
+                start = (newlineIdx == -1) ? len : newlineIdx + 1;
             }
 
+            builder.setLength(lastNonBlankEnd);
             result = builder.toString();
         }
 
@@ -1804,7 +1820,6 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> {
      */
     protected final String defer(Supplier<String> supplier) {
         String id = "\u0000\u0000" + (deferredCounter++) + "\u0000\u0000";
-        deferredPlaceholders.add(id);
         deferredSuppliers.add(supplier);
         return id;
     }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeFormatter.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @SmithyInternalApi
@@ -321,8 +320,6 @@ final class CodeFormatter {
     }
 
     private static final class Parser {
-        private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z]+[a-zA-Z0-9_.#$]*$");
-
         private final String template;
         private final SimpleParser parser;
         private final char expressionStart;
@@ -704,8 +701,13 @@ final class CodeFormatter {
         }
 
         private void ensureNameIsValid(String name) {
-            if (!NAME_PATTERN.matcher(name).matches()) {
+            if (name.isEmpty() || name.charAt(0) < 'a' || name.charAt(0) > 'z') {
                 throw error(String.format("Invalid format expression name `%s`", name));
+            }
+            for (int i = 1; i < name.length(); i++) {
+                if (!isNameCharacter(name.charAt(i))) {
+                    throw error(String.format("Invalid format expression name `%s`", name));
+                }
             }
         }
 

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/StringUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/StringUtils.java
@@ -163,6 +163,23 @@ public final class StringUtils {
     }
 
     /**
+     * Checks if a region of a CharSequence contains only whitespace.
+     *
+     * @param cs    the CharSequence to check, must not be null
+     * @param start the start index (inclusive)
+     * @param end   the end index (exclusive)
+     * @return {@code true} if the region is empty or contains only whitespace
+     */
+    public static boolean isBlank(final CharSequence cs, int start, int end) {
+        for (int i = start; i < end; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * <p>Checks if a CharSequence is not empty (""), not null and not whitespace only.</p>
      *
      * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>


### PR DESCRIPTION
#### Background

Second pass to improve the rendering of deferred writes. Instead of sorting the position first to access the deferred values in the correct order we scan the buffer and lookup directly the value.

While there, avoid the use of regular expressions for validating the names, the logic is straight enough that can be done in a simple loop.

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
