### PR TITLE
Fix Windows PATH issue in install.bat

### DIFF
--- a/.changes/next-release/bugfix-fab9cf64f935850c592eca38cab212cba6579149.json
+++ b/.changes/next-release/bugfix-fab9cf64f935850c592eca38cab212cba6579149.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fix Windows user PATH corruption in install.bat caused by setx silently truncating values over 1024 characters",
+  "pull_requests": [
+    "[#3117](https://github.com/smithy-lang/smithy/pull/3117)"
+  ]
+}

--- a/smithy-cli/configuration/install.bat
+++ b/smithy-cli/configuration/install.bat
@@ -32,7 +32,7 @@ xcopy /i /h /e /k "%installer_path%*" "%choice_path%\"
 set "smithy_install_dir=%choice_path%"
 powershell -Command "& { $installDir = $env:smithy_install_dir; $userPath = [Environment]::GetEnvironmentVariable('PATH','User'); if ([string]::IsNullOrEmpty($userPath)) { [Environment]::SetEnvironmentVariable('PATH', $installDir, 'User') } elseif (-not $userPath.Contains($installDir)) { [Environment]::SetEnvironmentVariable('PATH', $userPath.TrimEnd(';') + ';' + $installDir, 'User') } }"
 if %ERRORLEVEL% neq 0 (
-  echo Failed to update PATH. You may need to add %choice_path%\bin to your PATH manually.
+  echo Failed to update PATH. You may need to add %choice_path% to your PATH manually.
   goto done
 )
 call "%choice_path%\bin\%exe_name%" warmup

--- a/smithy-cli/configuration/install.bat
+++ b/smithy-cli/configuration/install.bat
@@ -29,8 +29,13 @@ if exist "%choice_path%" goto upgrade
 
 :: Copy the installation
 xcopy /i /h /e /k "%installer_path%*" "%choice_path%\"
-setx path "%path%;%choice_path%\;"
-call %exe_name% warmup
+set "smithy_install_dir=%choice_path%"
+powershell -Command "& { $installDir = $env:smithy_install_dir; $userPath = [Environment]::GetEnvironmentVariable('PATH','User'); if ([string]::IsNullOrEmpty($userPath)) { [Environment]::SetEnvironmentVariable('PATH', $installDir, 'User') } elseif (-not $userPath.Contains($installDir)) { [Environment]::SetEnvironmentVariable('PATH', $userPath.TrimEnd(';') + ';' + $installDir, 'User') } }"
+if %ERRORLEVEL% neq 0 (
+  echo Failed to update PATH. You may need to add %choice_path%\bin to your PATH manually.
+  goto done
+)
+call "%choice_path%\bin\%exe_name%" warmup
 echo You may now run '%exe_name% --version'
 goto done
 


### PR DESCRIPTION
I was trying to install the Smithy CLI on my Windows laptop earlier today, but ran into an issue since `setx` (which the previous script used) reads from the session %PATH% (system + user combined) and silently truncates at 1024 characters.

So I replaced that with PowerShell's `SetEnvironmentVariable`, which reads and writes only the user PATH from the registry without a length limit. Also added some extra validation such as preventing duplicates on re-installs and checking the exit code in case updating the path fails.

This shouldn't impact the Scoop installation method since it manages updating the `PATH` separately (via https://github.com/smithy-lang/scoop-bucket/blob/main/bucket/smithy-cli.json#L9).

#### Testing
* How did you test these changes?
Followed the manual steps for Windows (from https://smithy.io/2.0/guides/smithy-cli/cli_installation.html) after replacing the `install.bat` file with the content from my fork. On my Workspace, confirmed the path was appended correctly and I could invoke `smithy --version`.

Before:
```
PS> [Environment]::GetEnvironmentVariable('PATH', 'User')
D:\Users\dspin\AppData\Local\Microsoft\WindowsApps; 
```

After:
```
PS> [Environment]::GetEnvironmentVariable('PATH', 'User')
D:\Users\dspin\AppData\Local\Microsoft\WindowsApps;D:\Program Files\Smithy
PS> smithy --version
1.70.0
```

#### Links
N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
