### PR TITLE
make the blob params in the event stream tests not b64

### DIFF
--- a/.changes/next-release/bugfix-56887e7be8e96d3b96972b0367992984eb7f71e4.json
+++ b/.changes/next-release/bugfix-56887e7be8e96d3b96972b0367992984eb7f71e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fix base64 blobs in event stream test params.",
+  "pull_requests": [
+    "[#3121](https://github.com/smithy-lang/smithy/pull/3121)"
+  ]
+}

--- a/smithy-aws-protocol-tests/model/restJson1/event-stream.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/event-stream.smithy
@@ -192,7 +192,7 @@ structure ErrorEvent {
             {
                 type: "request"
                 params: {
-                    headers: { blobHeader: "Zm9v" }
+                    headers: { blobHeader: "foo" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -246,7 +246,7 @@ structure ErrorEvent {
             {
                 type: "request"
                 params: {
-                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "YmFy" }
+                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "bar" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -684,7 +684,7 @@ operation InputStream {
             {
                 type: "response"
                 params: {
-                    headers: { blobHeader: "Zm9v" }
+                    headers: { blobHeader: "foo" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -738,7 +738,7 @@ operation InputStream {
             {
                 type: "response"
                 params: {
-                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "YmFy" }
+                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "bar" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -1217,7 +1217,7 @@ structure ServiceUnavailableError {
             {
                 type: "request"
                 params: {
-                    headers: { blobHeader: "Zm9v" }
+                    headers: { blobHeader: "foo" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -1271,7 +1271,7 @@ structure ServiceUnavailableError {
             {
                 type: "request"
                 params: {
-                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "YmFy" }
+                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "bar" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -1699,7 +1699,7 @@ structure ServiceUnavailableError {
             {
                 type: "response"
                 params: {
-                    headers: { blobHeader: "Zm9v" }
+                    headers: { blobHeader: "foo" }
                 }
                 headers: {
                     ":message-type": { string: "event" }
@@ -1753,7 +1753,7 @@ structure ServiceUnavailableError {
             {
                 type: "response"
                 params: {
-                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "YmFy" }
+                    headers: { booleanHeader: true, stringHeader: "foo", blobHeader: "bar" }
                 }
                 headers: {
                     ":message-type": { string: "event" }


### PR DESCRIPTION
#### Background
* What do these changes do? 
  * All of the blob params in our protocoltests are plaintext, but some in the new eventstream ones were b64
* Why are they important?
  * consistency

#### Testing
* How did you test these changes?
  * Ran the event stream tests in smithy-go

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
