### PR TITLE
Fix onErrorStatusConflict set via updateDefaultSettings

### DIFF
--- a/.changes/next-release/bugfix-926d46230ef307376fd27dc3e9efba97b8e97b82.json
+++ b/.changes/next-release/bugfix-926d46230ef307376fd27dc3e9efba97b8e97b82.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fixed a bug in OpenAPI conversions where onErrorStatusConflict from mappers/protocols wasn't being respected.",
+  "pull_requests": [
+    "[#3123](https://github.com/smithy-lang/smithy/pull/3123)"
+  ]
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -187,13 +187,7 @@ public final class OpenApiConverter {
         // Remove mixins from the model.
         model = ModelTransformer.create().flattenAndRemoveMixins(model);
 
-        // Dejjjqconflict errors that share the same status code.
-        if (OpenApiConfig.ErrorStatusConflictHandlingStrategy.ONE_OF == config.getOnErrorStatusConflict()) {
-            model = ModelTransformer.create().deconflictErrorsWithSharedStatusCode(model, service);
-        }
-
         JsonSchemaConverter.Builder jsonSchemaConverterBuilder = JsonSchemaConverter.builder();
-        jsonSchemaConverterBuilder.model(model);
 
         // Discover OpenAPI extensions.
         List<Smithy2OpenApiExtension> extensions = new ArrayList<>();
@@ -217,6 +211,14 @@ public final class OpenApiConverter {
 
         // Update with protocol default values.
         openApiProtocol.updateDefaultSettings(model, config);
+
+        // Deconflict errors that share the same status code. This must happen after
+        // updateDefaultSettings so that protocols can set onErrorStatusConflict.
+        if (OpenApiConfig.ErrorStatusConflictHandlingStrategy.ONE_OF == config.getOnErrorStatusConflict()) {
+            model = ModelTransformer.create().deconflictErrorsWithSharedStatusCode(model, service);
+        }
+
+        jsonSchemaConverterBuilder.model(model);
         jsonSchemaConverterBuilder.config(config);
 
         // Only convert shapes in the closure of the targeted service.

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -464,6 +464,32 @@ public class OpenApiConverterTest {
         assertThat(config.getExtensions().getMember("hello"), not(Optional.empty()));
     }
 
+    // Setting onErrorStatusConflict via updateDefaultSettings (rather than
+    // directly on the config) triggers error deconflicting in the output.
+    @Test
+    public void errorConflictStrategySetViaUpdateDefaultSettingsIsRespected() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("protocols/error-code-collision-test.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("example#Example"));
+        ObjectNode result = OpenApiConverter.create()
+                .config(config)
+                .addOpenApiMapper(new OpenApiMapper() {
+                    @Override
+                    public void updateDefaultSettings(Model m, OpenApiConfig c) {
+                        c.setOnErrorStatusConflict(
+                                OpenApiConfig.ErrorStatusConflictHandlingStrategy.ONE_OF);
+                    }
+                })
+                .convertToNode(model);
+
+        String json = Node.printJson(result);
+        assertThat(json, containsString("oneOf"));
+    }
+
     // The input structure needs a synthesized content structure. Since the
     // path property is a "parameter" the synthesized structure must not list
     // it as required because it is not part of the payload.


### PR DESCRIPTION
The error deconflicting logic in `OpenApiConverter` read `config.getOnErrorStatusConflict()` before either
`composedMapper.updateDefaultSettings` or
`openApiProtocol.updateDefaultSettings` was called. This made it impossible for protocols or mappers to set the strategy.

Move the deconflict block to after both `updateDefaultSettings` calls, and set the model and config on the JSON schema converter builder afterward so they reflect the final state.

Fixes #3120 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
