### PR TITLE
Allow tagMap/tagsMap variants for tag member name

### DIFF
--- a/.changes/next-release/feature-d17968aca46bca4363e20d02a48b457df03623ec.json
+++ b/.changes/next-release/feature-d17968aca46bca4363e20d02a48b457df03623ec.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Allow tags member names in input/output structures to have \"map\" suffix variants.",
+  "description": "Updated tags member names validation in input/output structures to allow \"map\" suffix variants.",
   "pull_requests": [
     "[#3129](https://github.com/smithy-lang/smithy/pull/3129)"
   ]

--- a/.changes/next-release/feature-d17968aca46bca4363e20d02a48b457df03623ec.json
+++ b/.changes/next-release/feature-d17968aca46bca4363e20d02a48b457df03623ec.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Allow tags member names in input/output structures to have \"map\" suffix variants.",
+  "pull_requests": []
+}

--- a/.changes/next-release/feature-d17968aca46bca4363e20d02a48b457df03623ec.json
+++ b/.changes/next-release/feature-d17968aca46bca4363e20d02a48b457df03623ec.json
@@ -1,5 +1,7 @@
 {
   "type": "feature",
   "description": "Allow tags member names in input/output structures to have \"map\" suffix variants.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3129](https://github.com/smithy-lang/smithy/pull/3129)"
+  ]
 }

--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -1348,10 +1348,11 @@ tag associations on a resource:
 * Must have exactly one input member that targets a string shape and has a
   member name that matches ``^([R|r]esource)?([A|a]rn|ARN)$`` to accept
   the resource ARN.
-* Must have exactly one input member that targets a list shape, with list
-  member targeting a structure that consists of two members that target a
-  string shape representing the tag key or name and the tag value. This
-  member name must match: ``^[T|t]ag(s|[L|l]ist)$``
+* Must have exactly one input member that targets either a list shape (with
+  list member targeting a structure of two string members representing the
+  tag key and tag value) or a map shape with string keys and values. This
+  member name must match: ``^[T|t]ag(s|s?[M|m]ap|[L|l]ist)$`` (e.g., ``tags``,
+  ``TagList``, ``tagMap``, ``tagsMap``).
 
 The following snippet is a valid definition of a tag resource operation and
 its input:
@@ -1416,10 +1417,11 @@ resource.
 * Must have exactly one input member that targets a string shape and has a
   member name that matches: ``^([R|r]esource)?([A|a]rn|ARN)$`` to accept
   the resource ARN.
-* Must have exactly one output member that targets a list shape, with list
-  member targeting a structure that consists of two members that target a
-  string shape representing the tag key or name and the tag value. This
-  member name must match: ``^[T|t]ag(s|[L|l]ist)$``
+* Must have exactly one output member that targets either a list shape (with
+  list member targeting a structure of two string members representing the
+  tag key and tag value) or a map shape with string keys and values. This
+  member name must match: ``^[T|t]ag(s|s?[M|m]ap|[L|l]ist)$`` (e.g., ``tags``,
+  ``TagList``, ``tagMap``, ``tagsMap``).
 
 The following snippet is an example of the list tags for resource operation and
 its input:

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggingShapeUtils.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggingShapeUtils.java
@@ -29,7 +29,7 @@ final class TaggingShapeUtils {
     static final String LIST_TAGS_OPNAME = "ListTagsForResource";
 
     private static final Pattern TAG_PROPERTY_REGEX = Pattern
-            .compile("^[T|t]ag(s|[L|l]ist)$");
+            .compile("^[T|t]ag(s|s?[M|m]ap|[L|l]ist)$");
     private static final Pattern RESOURCE_ARN_REGEX = Pattern
             .compile("^([R|r]esource)?([A|a]rn|ARN)?$");
     private static final Pattern TAG_KEYS_REGEX = Pattern

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/tagging/TaggingShapeUtilsTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/tagging/TaggingShapeUtilsTest.java
@@ -36,4 +36,39 @@ public class TaggingShapeUtilsTest {
     public void isArnMemberDesiredName(String arnMember, boolean expected) {
         assertEquals(expected, TaggingShapeUtils.isArnMemberDesiredName(arnMember));
     }
+
+    public static List<Arguments> tagMembers() {
+        return ListUtils.of(
+                // accepted plural / list forms (existing)
+                Arguments.of("Tags", true),
+                Arguments.of("tags", true),
+                Arguments.of("TagList", true),
+                Arguments.of("tagList", true),
+                Arguments.of("Taglist", true),
+                Arguments.of("taglist", true),
+                // accepted map forms (new)
+                Arguments.of("TagMap", true),
+                Arguments.of("tagMap", true),
+                Arguments.of("Tagmap", true),
+                Arguments.of("tagmap", true),
+                Arguments.of("TagsMap", true),
+                Arguments.of("tagsMap", true),
+                Arguments.of("Tagsmap", true),
+                Arguments.of("tagsmap", true),
+                // rejected
+                Arguments.of("", false),
+                Arguments.of("Tag", false),
+                Arguments.of("tag", false),
+                Arguments.of("Tagger", false),
+                Arguments.of("tagging", false),
+                Arguments.of("mytags", false),
+                Arguments.of("Maptag", false),
+                Arguments.of("Maps", false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tagMembers")
+    public void isTagDesiredName(String memberName, boolean expected) {
+        assertEquals(expected, TaggingShapeUtils.isTagDesiredName(memberName));
+    }
 }


### PR DESCRIPTION
#### Background
* What do these changes do? 

Map shapes (string -> string) are already a valid representation for tags in TagResource/ListTagsForResource per verifyTagsShape, but the member-name regex only accepted Tags/TagList variants. Loosen the TAG_PROPERTY_REGEX to also accept TagMap/tagMap/TagsMap/tagsMap (and case variants), aligning name validation with the shape validation that already supports maps.

* Why are they important?

Services that may use the map shape for their tags may want to align the member names with that type for internal consistency in their API fields.

#### Testing
* How did you test these changes?

Ran all existing tests and added valid tagMembers test case.

#### Links
* Links to additional context, if necessary

N/A

* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
