### PR TITLE
Fix several formatter issues moving docs/comments

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FixBadDocComments.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FixBadDocComments.java
@@ -67,17 +67,54 @@ final class FixBadDocComments implements Function<TokenTree, TokenTree> {
             // Find BRs in shape statements and look at the next sibling.
             for (TreeCursor br : shapeStatements.getChildrenByType(TreeType.BR)) {
                 TreeCursor nextSibling = br.getNextSibling();
-                if (nextSibling == null || nextSibling.getFirstChild(TreeType.APPLY_STATEMENT) != null) {
+                if (nextSibling == null
+                        || nextSibling.getFirstChild(TreeType.APPLY_STATEMENT) != null
+                        || hasBlankLineBeforeNextStatement(br, nextSibling)) {
                     updateNestedChildren(br);
                 }
             }
-            // Fix any trailing doc comments in shape bodies
-            for (TreeCursor members : shapeStatements.findChildrenByType(TreeType.SHAPE_MEMBERS)) {
+            // Fix any trailing doc comments in member bodies (structures, enums, and operations).
+            for (TreeCursor members : shapeStatements.findChildrenByType(
+                    TreeType.SHAPE_MEMBERS,
+                    TreeType.ENUM_SHAPE_MEMBERS,
+                    TreeType.OPERATION_BODY)) {
                 TreeCursor closeBrace = members.getLastChild();
-                if (closeBrace != null) {
-                    TreeCursor possibleTrailingWs = closeBrace.getPreviousSibling();
-                    if (possibleTrailingWs != null && possibleTrailingWs.getTree().getType() == TreeType.WS) {
-                        updateDirectChildren(possibleTrailingWs);
+                List<TreeCursor> wsNodes = members.getChildrenByType(TreeType.WS);
+                for (TreeCursor ws : wsNodes) {
+                    // Trailing WS right before closing brace: all doc comments are invalid.
+                    if (closeBrace != null && ws.getNextSibling() != null
+                            && ws.getNextSibling().getTree() == closeBrace.getTree()) {
+                        updateDirectChildren(ws);
+                        continue;
+                    }
+                    // Between-member WS: only same-line trailing doc comments are invalid.
+                    // Use the NODE_VALUE end line for members with VALUE_ASSIGNMENT to avoid
+                    // the BR's NEWLINE token inflating the member's end line.
+                    TreeCursor prevSibling = ws.getPreviousSibling();
+                    if (prevSibling != null) {
+                        int prevEndLine = FormatUtils.valueEndLine(prevSibling);
+                        for (TreeCursor comment : ws.getChildrenByType(TreeType.COMMENT)) {
+                            if (comment.getTree().getStartLine() == prevEndLine && isDocComment(comment)) {
+                                updateComment(comment);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fix same-line trailing doc comments inside VALUE_ASSIGNMENT BR nodes
+            // (e.g., `a: String = "" /// comment`). Non-inline comments have already been
+            // relocated to WS siblings by RelocateMemberComments, so only same-line comments
+            // remain in the BR.
+            for (TreeCursor valueAssignment : shapeStatements.findChildrenByType(TreeType.VALUE_ASSIGNMENT)) {
+                TreeCursor nodeValue = valueAssignment.getFirstChild(TreeType.NODE_VALUE);
+                if (nodeValue == null) {
+                    continue;
+                }
+                int valueEndLine = nodeValue.getTree().getEndLine();
+                for (TreeCursor comment : valueAssignment.findChildrenByType(TreeType.COMMENT)) {
+                    if (isDocComment(comment) && comment.getTree().getStartLine() == valueEndLine) {
+                        updateComment(comment);
                     }
                 }
             }
@@ -114,12 +151,73 @@ final class FixBadDocComments implements Function<TokenTree, TokenTree> {
                 .isPresent();
     }
 
+    // A banner is a comment whose lexeme begins with 4 or more slashes (e.g., `//////` or
+    // `////// Shapes`). Banners are visual section dividers; their extra slashes are content,
+    // not prefix, and must survive demotion intact.
+    private static boolean isBannerLexeme(CharSequence lexeme) {
+        return lexeme.length() >= 4
+                && lexeme.charAt(0) == '/'
+                && lexeme.charAt(1) == '/'
+                && lexeme.charAt(2) == '/'
+                && lexeme.charAt(3) == '/';
+    }
+
+    // True iff the cursor wraps a DOC_COMMENT token whose lexeme is a banner.
+    private boolean isBannerDocComment(TreeCursor cursor) {
+        if (!isDocComment(cursor)) {
+            return false;
+        }
+        return cursor.getTree().tokens().findFirst().map(t -> isBannerLexeme(t.getLexeme())).orElse(false);
+    }
+
+    // Detect a blank line between a doc-comment block in a BR and the start of the next shape
+    // statement, and decide whether the block should be demoted. The rule is asymmetric:
+    //
+    //   - A standard `///` doc comment separated from its shape by a blank line is still a
+    //     doc comment for that shape; the formatter normalizes the blank line elsewhere and the
+    //     doc comment survives.
+    //
+    //   - A banner doc comment (`////` or longer) separated from its shape by a blank line is
+    //     a section divider, not documentation. Section dividers can't span blank-line gaps, so
+    //     the entire block of doc comments preceding that gap is demoted to regular comments.
+    //
+    // This method returns true when both conditions hold: a blank line exists between the BR's
+    // last comment and the next shape, AND at least one of the BR's doc comments is a banner.
+    private boolean hasBlankLineBeforeNextStatement(TreeCursor br, TreeCursor nextStatement) {
+        List<TreeCursor> comments = br.findChildrenByType(TreeType.COMMENT);
+        if (comments.isEmpty()) {
+            return false;
+        }
+        // A comment lexeme includes its trailing newline, so a comment on source line N has
+        // end line N+1. The strict greater-than therefore fires only when the next statement
+        // starts at N+2 or later, i.e., when there is at least one blank source line between
+        // the last comment and the next statement.
+        int lastCommentEndLine = comments.get(comments.size() - 1).getTree().getEndLine();
+        if (nextStatement.getTree().getStartLine() <= lastCommentEndLine) {
+            return false;
+        }
+        for (TreeCursor comment : comments) {
+            if (isBannerDocComment(comment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void updateComment(TreeCursor cursor) {
         cursor.getTree().tokens().findFirst().ifPresent(token -> {
-            CapturedToken updatedToken = token.toBuilder()
-                    // Trim the first "/" from the lexeme. Note that this does make the spans inaccurate.
-                    .lexeme(token.getLexeme().subSequence(1, token.getLexeme().length()))
-                    .build();
+            CharSequence lexeme = token.getLexeme();
+            // Banners (4+ leading slashes like `////// Banner`) preserve their full lexeme so the
+            // extra slashes survive demotion as content of a regular comment. The renderer keys
+            // off the IdlToken type, so we mark the comment as COMMENT and let the formatter
+            // produce `// <rest of lexeme>`. Standard `/// X` doc comments still drop one slash
+            // here, producing the conventional `// X` lexeme expected by the rest of the pipeline.
+            CapturedToken.Builder builder = token.toBuilder().token(IdlToken.COMMENT);
+            if (!isBannerLexeme(lexeme)) {
+                // Trim the first "/" from the lexeme. Note that this does make the spans inaccurate.
+                builder.lexeme(lexeme.subSequence(1, lexeme.length()));
+            }
+            CapturedToken updatedToken = builder.build();
             TokenTree updatedTree = TokenTree.of(TreeType.COMMENT);
             updatedTree.appendChild(TokenTree.of(updatedToken));
             cursor.getParent().getTree().replaceChild(cursor.getTree(), updatedTree);

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatUtils.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.syntax;
+
+/**
+ * Shared tree-navigation helpers used by the formatter pipeline passes.
+ */
+final class FormatUtils {
+
+    private FormatUtils() {}
+
+    /**
+     * Get the end line of a member's visible value content for same-line comment detection.
+     *
+     * <p>For members with a VALUE_ASSIGNMENT, the BR production's NEWLINE token can inflate
+     * {@code getEndLine()} past the actual value line (because the NEWLINE spans to the next
+     * line). This method returns the NODE_VALUE's end line instead, giving the line where the
+     * member's visible content actually ends. For members without a VALUE_ASSIGNMENT, this is
+     * just the cursor's own end line.
+     *
+     * @param cursor the cursor to inspect, or null.
+     * @return the value end line, or -1 if cursor is null.
+     */
+    static int valueEndLine(TreeCursor cursor) {
+        if (cursor == null) {
+            return -1;
+        }
+        TreeCursor va = cursor.getFirstChild(TreeType.VALUE_ASSIGNMENT);
+        if (va != null) {
+            TreeCursor nodeValue = va.getFirstChild(TreeType.NODE_VALUE);
+            if (nodeValue != null) {
+                return nodeValue.getTree().getEndLine();
+            }
+        }
+        return cursor.getTree().getEndLine();
+    }
+
+    /**
+     * Check whether a member cursor is the last member in its container before the closing brace.
+     *
+     * <p>Walks the cursor's subsequent siblings, skipping WS nodes. Returns true when the next
+     * non-WS sibling is the container's closing brace token (TOKEN type) or there is no next
+     * sibling at all.
+     *
+     * @param cursor the member cursor to inspect.
+     * @return true if no further member follows in the container.
+     */
+    static boolean isLastMemberBeforeBrace(TreeCursor cursor) {
+        TreeCursor next = cursor.getNextSibling();
+        while (next != null && next.getTree().getType() == TreeType.WS) {
+            next = next.getNextSibling();
+        }
+        return next == null || next.getTree().getType() == TreeType.TOKEN;
+    }
+}

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import software.amazon.smithy.model.loader.IdlToken;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -513,15 +514,18 @@ final class FormatVisitor {
             }
 
             case COMMENT: {
-                // Ensure comments have a single space before their content.
+                // Render comments based on their token type so banners (4+ slashes like `//////`)
+                // are preserved as content rather than re-segmented. Plain comments use the `//`
+                // prefix; doc comments use `///`. In both cases we trim trailing whitespace and
+                // ensure exactly one space follows the prefix when the original had none. Doc
+                // comments additionally preserve banner content (a `/` immediately after `///`)
+                // verbatim, since those slashes are part of the banner the user wrote.
                 String contents = tree.concatTokens().trim();
-                if (contents.startsWith("/// ") || contents.startsWith("// ")) {
-                    return Doc.text(contents);
-                } else if (contents.startsWith("///")) {
-                    return Doc.text("/// " + contents.substring(3));
-                } else {
-                    return Doc.text("// " + contents.substring(2));
+                IdlToken tokenType = tree.tokens().findFirst().map(CapturedToken::getIdlToken).orElse(null);
+                if (tokenType == IdlToken.DOC_COMMENT) {
+                    return Doc.text(normalizeCommentSpacing(contents, "///", true));
                 }
+                return Doc.text(normalizeCommentSpacing(contents, "//", false));
             }
 
             case WS: {
@@ -535,9 +539,26 @@ final class FormatVisitor {
                 pendingComments = Doc.empty();
                 Doc result = Doc.empty();
                 List<TreeCursor> comments = getComments(cursor);
+                int brStartLine = tree.getStartLine();
+                // Plain comments contiguous with the BR's owning construct stick to that
+                // construct when the BR sits between top-level shape statements. This keeps
+                // comments after a structure that just closed pinned there instead of being
+                // pushed down to the next shape. Doc comments always defer forward because
+                // they are documentation for what follows. Other BR contexts (use, metadata,
+                // namespace) keep the historical defer-forward behavior so that a comment
+                // between two use statements still attaches to the next one.
+                boolean stickContiguous = isBetweenShapeStatements(cursor);
+                int prevContentLine = brStartLine;
                 for (TreeCursor comment : comments) {
-                    if (comment.getTree().getStartLine() == tree.getStartLine()) {
+                    int commentLine = comment.getTree().getStartLine();
+                    if (commentLine == brStartLine) {
                         result = result.append(Formatter.SPACE.append(visit(comment)));
+                        prevContentLine = commentLine;
+                    } else if (stickContiguous
+                            && !isDocComment(comment)
+                            && commentLine == prevContentLine + 1) {
+                        result = result.append(Doc.line()).append(visit(comment));
+                        prevContentLine = commentLine;
                     } else {
                         pendingComments = pendingComments.append(visit(comment)).append(Doc.line());
                     }
@@ -579,6 +600,70 @@ final class FormatVisitor {
         return !getComments(cursor).isEmpty();
     }
 
+    // Check if a comment is inside a VALUE_ASSIGNMENT's BR node. These are same-line trailing
+    // comments that should not trigger double-line separation.
+    private static boolean isInsideValueAssignmentBr(TreeCursor comment, TreeCursor boundary) {
+        // After RelocateMemberComments runs, the only comments still nested inside a
+        // VALUE_ASSIGNMENT > BR subtree are same-line trailing comments (those on the same
+        // source line as the value). Non-inline comments have already been relocated to the
+        // member's sibling WS by the time the formatter visits this tree, so a positive return
+        // here always means "this is the value's same-line trailing comment, don't promote it
+        // to a standalone annotation."
+        TreeCursor parent = comment.getParent();
+        TokenTree boundaryTree = boundary.getTree();
+        while (parent != null && parent.getTree() != boundaryTree) {
+            if (parent.getTree().getType() == TreeType.BR) {
+                TreeCursor grandparent = parent.getParent();
+                if (grandparent != null && grandparent.getTree().getType() == TreeType.VALUE_ASSIGNMENT) {
+                    return true;
+                }
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+
+    // True when the BR sits directly inside SHAPE_STATEMENTS, i.e., the gap between (or after)
+    // shape and apply statements at the top level. This is where contiguous trailing comments
+    // should stick to the previous statement rather than defer to the next one.
+    private static boolean isBetweenShapeStatements(TreeCursor brCursor) {
+        TreeCursor parent = brCursor.getParent();
+        return parent != null && parent.getTree().getType() == TreeType.SHAPE_STATEMENTS;
+    }
+
+    // Whether a COMMENT cursor wraps a `///` doc-comment token. Doc comments always defer
+    // forward to the next statement because they document it; only plain `//` comments are
+    // candidates for sticking to the preceding construct.
+    private static boolean isDocComment(TreeCursor commentCursor) {
+        return commentCursor.getTree()
+                .tokens()
+                .findFirst()
+                .map(token -> token.getIdlToken() == IdlToken.DOC_COMMENT)
+                .orElse(false);
+    }
+
+    // Normalize the comment spacing for either a `//` plain comment or a `///` doc comment. The
+    // prefix argument is the literal slashes that introduce the comment; the content is
+    // everything after. When {@code preserveBanner} is true (used for doc comments), a content
+    // that begins with another slash is left alone, so `////// Shapes` round-trips verbatim and
+    // banner doc comments are not re-segmented. Otherwise, a content that lacks a leading space
+    // gets exactly one inserted, so `///foo` becomes `/// foo` and `//////` demoted to a regular
+    // comment renders as `// ////` (prefix `//` + space + four-slash content).
+    private static String normalizeCommentSpacing(String contents, String prefix, boolean preserveBanner) {
+        String content = contents.substring(prefix.length());
+        if (content.isEmpty()) {
+            return prefix;
+        }
+        char first = content.charAt(0);
+        if (first == ' ' || first == '\t') {
+            return prefix + content;
+        }
+        if (preserveBanner && first == '/') {
+            return prefix + content;
+        }
+        return prefix + " " + content;
+    }
+
     // Get direct child comments from a cursor, or from direct WS children that have comments.
     private static List<TreeCursor> getComments(TreeCursor cursor) {
         List<TreeCursor> result = new ArrayList<>();
@@ -603,16 +688,66 @@ final class FormatVisitor {
         return (leadingLine ? Doc.line() : Doc.empty()).append(Doc.fold(docs, Doc::append));
     }
 
+    // Determines whether double-line separation is needed between members. Returns true if the
+    // container has traits or standalone comments (comments not trailing inline on a member).
+    private static boolean hasNonInlineAnnotations(TreeCursor container, TreeType memberType) {
+        if (!container.findChildrenByType(TreeType.TRAIT).isEmpty()) {
+            return true;
+        }
+
+        // Check for standalone comments in WS nodes between members that are NOT
+        // on the same line as the previous member. Comments on the immediately next line after
+        // a member with a VALUE_ASSIGNMENT are excluded because they were relocated from the
+        // VALUE_ASSIGNMENT's BR by RelocateMemberComments and are trailing annotations, not
+        // standalone section dividers.
+        for (TreeCursor ws : container.getChildrenByType(TreeType.WS)) {
+            TreeCursor prevSibling = ws.getPreviousSibling();
+            int prevEndLine = FormatUtils.valueEndLine(prevSibling);
+            for (TreeCursor c : ws.getChildrenByType(TreeType.COMMENT)) {
+                int commentLine = c.getTree().getStartLine();
+                if (commentLine != prevEndLine) {
+                    // Exclude comments on the immediately next line after a member with a
+                    // VALUE_ASSIGNMENT (these are relocated trailing annotations). This is a
+                    // deliberate semantic choice: a comment on the line immediately after a value
+                    // assignment is always treated as a trailing annotation of that member, not a
+                    // standalone section divider. The VALUE_ASSIGNMENT check ensures this exclusion
+                    // only applies to members that had value assignments (where RelocateMemberComments
+                    // would have relocated the comment from the BR); members without VALUE_ASSIGNMENT
+                    // are not affected.
+                    if (prevSibling != null
+                            && prevSibling.getTree().getType() == memberType
+                            && prevSibling.getFirstChild(TreeType.VALUE_ASSIGNMENT) != null
+                            && commentLine == prevEndLine + 1) {
+                        continue;
+                    }
+                    return true;
+                }
+            }
+        }
+
+        // Check for comments inside members (e.g., doc comments on inline shapes, comments in traits).
+        // Exclude same-line trailing comments inside VALUE_ASSIGNMENT BR nodes, as these are
+        // inline annotations that should not trigger double-line separation.
+        for (TreeCursor memberCursor : container.getChildrenByType(memberType)) {
+            for (TreeCursor mc : memberCursor.findChildrenByType(TreeType.COMMENT)) {
+                if (!isInsideValueAssignmentBr(mc, memberCursor)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     // Renders "members" in braces, grouping related comments and members together.
     private Doc renderMembers(TreeCursor container, TreeType memberType) {
-        boolean noComments = container.findChildrenByType(TreeType.COMMENT, TreeType.TRAIT).isEmpty();
-        // Separate members by a single line if none have traits or docs, and two lines if any do.
-        Doc separator = noComments ? Doc.line() : Doc.line().append(Doc.line());
+        boolean useDoubleLineSeparator = hasNonInlineAnnotations(container, memberType);
+        Doc separator = useDoubleLineSeparator ? Doc.line().append(Doc.line()) : Doc.line();
         List<TreeCursor> members = container.getChildrenByType(memberType, TreeType.WS);
         // Remove WS we don't care about.
         members.removeIf(c -> c.getTree().getType() == TreeType.WS && !hasComment(c));
         // Empty structures render as "{}".
-        if (noComments && members.isEmpty()) {
+        if (!useDoubleLineSeparator && members.isEmpty()) {
             return Doc.group(Formatter.LINE_OR_SPACE.append(Doc.text("{}")));
         }
 
@@ -624,8 +759,38 @@ final class FormatVisitor {
 
         for (TreeCursor member : members) {
             if (member.getTree().getType() == TreeType.WS) {
-                newLineNeededAfterComment = true;
-                current = current.append(visit(member));
+                // Check if any comments in this WS were on the same line as the previous member.
+                // If so, and the previous member is not the last member, keep them inline.
+                List<TreeCursor> wsComments = member.getChildrenByType(TreeType.COMMENT);
+                TreeCursor prevSibling = member.getPreviousSibling();
+                // Use the value end line of the previous member for same-line detection.
+                // For members with VALUE_ASSIGNMENT, the BR's NEWLINE token can inflate getEndLine()
+                // past the actual value line, so use the NODE_VALUE's end line instead.
+                int prevEndLine = FormatUtils.valueEndLine(prevSibling);
+
+                // Determine if there's a next non-WS member after this WS node.
+                boolean hasNextMember = !FormatUtils.isLastMemberBeforeBrace(member);
+
+                for (TreeCursor c : wsComments) {
+                    boolean isSameLineAsPrev = prevSibling != null
+                            && c.getTree().getStartLine() == prevEndLine;
+                    // Inline a same-line trailing comment when there's a next member. For the last
+                    // member, only inline when using single-line separation (no traits or standalone
+                    // comments in the structure). With double-line separation, last-member trailing
+                    // comments are placed on their own lines before the closing brace.
+                    if (isSameLineAsPrev
+                            && (hasNextMember || !useDoubleLineSeparator)
+                            && !memberDocs.isEmpty()) {
+                        Doc lastDoc = memberDocs.remove(memberDocs.size() - 1);
+                        memberDocs.add(lastDoc.append(Formatter.SPACE).append(visit(c)));
+                    } else {
+                        if (newLineNeededAfterComment) {
+                            current = current.append(Doc.line());
+                        }
+                        newLineNeededAfterComment = true;
+                        current = current.append(visit(c));
+                    }
+                }
             } else {
                 if (newLineNeededAfterComment) {
                     current = current.append(Doc.line());

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/Formatter.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/Formatter.java
@@ -56,7 +56,12 @@ public final class Formatter {
                     errors.get(0));
         }
 
+        // Pipeline ordering matters: RelocateMemberComments must run before FixBadDocComments
+        // (which depends on non-inline comments having been relocated out of VALUE_ASSIGNMENT BR
+        // nodes) and before FormatVisitor (whose hasNonInlineAnnotations heuristic assumes
+        // relocated comments are in WS siblings, not BR nodes).
         root = new SortUseStatements().apply(root);
+        root = new RelocateMemberComments().apply(root);
         root = new FixBadDocComments().apply(root);
         root = new RemoveUnusedUseStatements().apply(root);
 

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RelocateMemberComments.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RelocateMemberComments.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.syntax;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import software.amazon.smithy.utils.Pair;
+
+/**
+ * Moves non-inline comments from VALUE_ASSIGNMENT BR nodes into sibling WS nodes in the enclosing member container.
+ *
+ * <p>The parser's BR production greedily consumes all trailing whitespace including comments. When a member has a
+ * value assignment (e.g., {@code a: String = ""}), any comments on subsequent lines get captured inside the
+ * VALUE_ASSIGNMENT's BR child, even when they semantically belong between members or before the closing brace.
+ * This pass relocates those comments so that FormatVisitor can treat all inter-member comments uniformly as
+ * WS-contained siblings rather than needing special handling for BR-trapped comments.
+ *
+ * <p>Same-line trailing comments (comments on the same line as the value) are left in the BR because the
+ * FormatVisitor's BR visitor already handles them inline.
+ */
+final class RelocateMemberComments implements Function<TokenTree, TokenTree> {
+    @Override
+    public TokenTree apply(TokenTree tree) {
+        TreeCursor root = tree.zipper();
+        TreeCursor shapeSection = root.getFirstChild(TreeType.SHAPE_SECTION);
+        if (shapeSection == null) {
+            return tree;
+        }
+
+        TreeCursor shapeStatements = shapeSection.getFirstChild(TreeType.SHAPE_STATEMENTS);
+        if (shapeStatements == null) {
+            return tree;
+        }
+
+        // Process all member containers that can contain VALUE_ASSIGNMENT members. OPERATION_BODY
+        // is intentionally excluded: its OPERATION_PROPERTY children parse to OPERATION_INPUT,
+        // OPERATION_OUTPUT, or OPERATION_ERRORS, none of which produce VALUE_ASSIGNMENTs. Inline
+        // operation inputs and outputs (e.g., `input := { ... }`) are reached recursively via
+        // findChildrenByType when their nested SHAPE_MEMBERS container is visited.
+        for (TreeCursor members : shapeStatements.findChildrenByType(
+                TreeType.SHAPE_MEMBERS,
+                TreeType.ENUM_SHAPE_MEMBERS)) {
+            relocateInContainer(members);
+        }
+
+        return tree;
+    }
+
+    private void relocateInContainer(TreeCursor container) {
+        // Determine the member type for this container.
+        TreeType memberType;
+        switch (container.getTree().getType()) {
+            case SHAPE_MEMBERS:
+                memberType = TreeType.SHAPE_MEMBER;
+                break;
+            case ENUM_SHAPE_MEMBERS:
+                memberType = TreeType.ENUM_SHAPE_MEMBER;
+                break;
+            default:
+                return;
+        }
+
+        for (TreeCursor member : container.getChildrenByType(memberType)) {
+            TreeCursor va = member.getFirstChild(TreeType.VALUE_ASSIGNMENT);
+            if (va == null) {
+                continue;
+            }
+            TreeCursor br = va.getFirstChild(TreeType.BR);
+            if (br == null) {
+                continue;
+            }
+
+            // Collect non-inline comments from the BR node (comments on a different line than the BR start).
+            // Each entry pairs the comment's immediate parent (left) with the comment itself (right) so the
+            // detach step can remove from the recorded parent directly instead of re-searching the BR subtree.
+            List<Pair<TokenTree, TokenTree>> toRelocate = new ArrayList<>();
+            int brStartLine = br.getTree().getStartLine();
+            // Comments may be direct children of BR or nested inside a WS child of BR.
+            collectNonInlineComments(br, brStartLine, toRelocate);
+
+            if (toRelocate.isEmpty()) {
+                continue;
+            }
+
+            // Detach each comment from its recorded parent. Because the parent reference is captured at
+            // collection time, removal cannot fail to locate the node and we never risk attaching the
+            // same comment to two parents. A failed remove indicates the tree shape changed underneath us.
+            for (Pair<TokenTree, TokenTree> entry : toRelocate) {
+                if (!entry.getLeft().removeChild(entry.getRight())) {
+                    throw new IllegalStateException(
+                            "RelocateMemberComments could not detach comment from its recorded parent: "
+                                    + entry.getRight().concatTokens());
+                }
+            }
+
+            // Clean up residual whitespace in the BR after removing comments. If the BR's WS child
+            // no longer contains any COMMENT children (only SP/NEWLINE/COMMA tokens remain), remove
+            // it entirely. This prevents the residual tokens from inflating the member's getEndLine(),
+            // which would corrupt line-number heuristics in FormatVisitor.
+            cleanupBrWhitespace(br.getTree());
+
+            // Find or create the WS node that follows this member in the container.
+            // The member's next sibling should be a WS node (inter-member whitespace) or the closing brace.
+            TreeCursor nextSibling = member.getNextSibling();
+            TokenTree wsTarget;
+            if (nextSibling != null && nextSibling.getTree().getType() == TreeType.WS) {
+                wsTarget = nextSibling.getTree();
+            } else {
+                // No WS sibling exists; create one and insert it after the member.
+                wsTarget = TokenTree.of(TreeType.WS);
+                insertAfter(container.getTree(), member.getTree(), wsTarget);
+            }
+
+            // Prepend the relocated comments to the WS node (before any existing content).
+            // Insert in reverse order at position 0 to preserve original comment ordering.
+            List<TokenTree> existingChildren = new ArrayList<>(wsTarget.getChildren());
+            // Clear and rebuild: relocated comments first, then existing children.
+            for (TokenTree child : existingChildren) {
+                wsTarget.removeChild(child);
+            }
+            for (Pair<TokenTree, TokenTree> entry : toRelocate) {
+                wsTarget.appendChild(entry.getRight());
+            }
+            for (TokenTree child : existingChildren) {
+                wsTarget.appendChild(child);
+            }
+        }
+    }
+
+    private void collectNonInlineComments(
+            TreeCursor brCursor,
+            int brStartLine,
+            List<Pair<TokenTree, TokenTree>> result
+    ) {
+        // The BR's start line equals the value's last line in both newline-led and comment-led
+        // BR branches (the parser anchors BR at the position right after the value, then consumes
+        // the trailing newline plus any optional WS). Comments whose start line differs from the
+        // BR start line are therefore not on the same source line as the value and are candidates
+        // for relocation. Same-line trailing comments are left in the BR for FixBadDocComments
+        // and FormatVisitor's BR visitor to handle inline.
+        TokenTree brTree = brCursor.getTree();
+        for (TokenTree child : brTree.getChildren()) {
+            if (child.getType() == TreeType.COMMENT && child.getStartLine() != brStartLine) {
+                result.add(Pair.of(brTree, child));
+            } else if (child.getType() == TreeType.WS) {
+                // Comments inside a WS child of BR.
+                for (TokenTree wsChild : child.getChildren()) {
+                    if (wsChild.getType() == TreeType.COMMENT && wsChild.getStartLine() != brStartLine) {
+                        result.add(Pair.of(child, wsChild));
+                    }
+                }
+            }
+        }
+    }
+
+    // Remove WS children of BR that no longer contain any COMMENT nodes. This is safe because
+    // downstream passes (FixBadDocComments, FormatVisitor) do not depend on BR WS structure for
+    // non-comment tokens; they only inspect BR for comments via getComments() or findChildrenByType.
+    private void cleanupBrWhitespace(TokenTree brTree) {
+        List<TokenTree> wsChildren = new ArrayList<>();
+        for (TokenTree child : brTree.getChildren()) {
+            if (child.getType() == TreeType.WS) {
+                wsChildren.add(child);
+            }
+        }
+        for (TokenTree ws : wsChildren) {
+            boolean hasComment = false;
+            for (TokenTree wsChild : ws.getChildren()) {
+                if (wsChild.getType() == TreeType.COMMENT) {
+                    hasComment = true;
+                    break;
+                }
+            }
+            if (!hasComment) {
+                brTree.removeChild(ws);
+            }
+        }
+    }
+
+    private void insertAfter(TokenTree parent, TokenTree target, TokenTree toInsert) {
+        // TokenTree has no indexed insert API (only appendChild), so we snapshot the children,
+        // clear the parent, and rebuild with the new node inserted at the correct position.
+        List<TokenTree> snapshot = new ArrayList<>(parent.getChildren());
+        int index = -1;
+        for (int i = 0; i < snapshot.size(); i++) {
+            if (snapshot.get(i) == target) {
+                index = i;
+                break;
+            }
+        }
+        if (index == -1) {
+            parent.appendChild(toInsert);
+            return;
+        }
+        // Clear and rebuild with the insertion.
+        for (int i = snapshot.size() - 1; i >= 0; i--) {
+            parent.removeChild(snapshot.get(i));
+        }
+        for (int i = 0; i < snapshot.size(); i++) {
+            parent.appendChild(snapshot.get(i));
+            if (i == index) {
+                parent.appendChild(toInsert);
+            }
+        }
+    }
+}

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/ParseAndFormatTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/ParseAndFormatTest.java
@@ -58,6 +58,12 @@ public class ParseAndFormatTest {
         String expected = IoUtils.readUtf8File(formattedFile);
 
         assertEquals(expected, formatted);
+
+        // Formatting must be idempotent: re-formatting the expected output produces the same output.
+        IdlTokenizer reTokenizer = IdlTokenizer.create(formattedFile.toString(), expected);
+        TokenTree reTree = TokenTree.of(reTokenizer);
+        String reformatted = Formatter.format(reTree, 120);
+        assertEquals(expected, reformatted, "Formatter is not idempotent for " + formattedFile);
     }
 
     public static List<Path> tests() throws Exception {

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.formatted.smithy
@@ -105,9 +105,8 @@ integer MyInteger2
 structure MyStruct {
     // b
     // c
-    a: String
+    a: String // d
 
-    // d
     // e
     // f
     b: String
@@ -115,8 +114,8 @@ structure MyStruct {
     // g
     // h
 } // i
-
 // j
+
 structure MyStructure2 {
     // k
     // l
@@ -127,3 +126,23 @@ structure MyStructure2 {
     // m
 } // n
 // o
+
+// ///+ lines are doc comments when followed immediately by a shape.
+// They must be preserved as-is rather than rewritten to //.
+////// Shapes
+structure MyStructure3 {}
+
+//////
+/// Number
+//////
+integer MyInteger3
+
+// ///+ lines are regular comments when NOT followed immediately by a shape.
+// They must be rewritten to //.
+// //// Banner 1
+integer MyInteger4
+
+// ////
+// Banner 2
+// ////
+integer MyInteger5

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/awkward-comments.smithy
@@ -91,3 +91,26 @@ structure MyStructure2 { //k
     l: Long // m
 } // n
 // o
+
+// ///+ lines are doc comments when followed immediately by a shape.
+// They must be preserved as-is rather than rewritten to //.
+////// Shapes
+structure MyStructure3 {}
+
+//////
+/// Number
+//////
+integer MyInteger3
+
+// ///+ lines are regular comments when NOT followed immediately by a shape.
+// They must be rewritten to //.
+
+////// Banner 1
+
+integer MyInteger4
+
+//////
+// Banner 2
+//////
+
+integer MyInteger5

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.formatted.smithy
@@ -39,8 +39,7 @@ structure Foo {
     @length(min: 1)
     baz: String = ""
 
-    /// 18 (TODO: Fix trailing comment after VALUE_ASSIGNMENT)
-
+    // 18 (change)
 }
 
 // 19 (change)

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.smithy
@@ -39,7 +39,7 @@ structure Foo {
     @length(min: 1)
     baz: String = ""
 
-    /// 18 (TODO: Fix trailing comment after VALUE_ASSIGNMENT)
+    /// 18 (change)
 }
 
 /// 19 (change)

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/member-comment-moving.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/member-comment-moving.formatted.smithy
@@ -1,0 +1,158 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Issue 1: Trailing comment on same line as member gets moved with extra blank line.
+structure Issue1 {
+    a: String // a
+    b: String
+}
+
+// Issue 1b: Same as issue 1, but no next member.
+structure Issue1b {
+    a: String // a
+}
+
+// Issue 1c: Trailing comment between two members.
+structure Issue1c {
+    a: String // a
+    b: String // b
+    c: String
+}
+
+// Issue 2: Default value assignment with trailing comment on next line gets extra blank lines.
+structure Issue2 {
+    a: String = ""
+    // a
+    b: String
+}
+
+// Issue 2b: Same as issue 2, but no next member.
+structure Issue2b {
+    a: String = ""
+    // a
+}
+
+// Issue 2c: Default value assignment with trailing comment on same line.
+structure Issue2c {
+    a: String = "" // a
+    b: String
+}
+
+// Issue 3: Doc comment after default value assignment is not fixed to regular comment.
+structure Issue3a {
+    a: String = "" // a
+    b: String
+}
+
+// Issue 3b: doc comment on the line after a default value, with a following member.
+// `/// a` is `b`'s doc comment per Smithy IDL rules and must be preserved as-is.
+structure Issue3b {
+    a: String = ""
+    /// a
+    b: String
+}
+
+// Issue 3c: Doc comment trailing on same line as member (no default).
+structure Issue3c {
+    a: String // a
+    b: String
+}
+
+// Issue 4: Trailing comment on member with trait applied.
+structure Issue4 {
+    @required
+    a: String // a
+
+    b: String
+}
+
+// Issue 4b: Trailing comment on member with trait and default value.
+structure Issue4b {
+    @required
+    a: String = "" // a
+
+    b: String
+}
+
+// Issue 5: Enum members with value assignments and trailing comments.
+enum Issue5 {
+    A = "a" // a
+    B = "b"
+}
+
+// Issue 5b: Enum member with value assignment and comment on next line.
+enum Issue5b {
+    A = "a"
+    // a
+    B = "b"
+}
+
+// Issue 5c: Enum member with value assignment, doc comment trailing (should convert).
+enum Issue5c {
+    A = "a" // a
+    B = "b"
+}
+
+// Issue 6: Multiple consecutive comments after a VALUE_ASSIGNMENT.
+structure Issue6 {
+    a: String = ""
+
+    // comment 1
+    // comment 2
+    b: String
+}
+
+// Issue 6b: Multiple consecutive comments after VALUE_ASSIGNMENT, last member.
+structure Issue6b {
+    a: String = ""
+
+    // comment 1
+    // comment 2
+}
+
+// Issue 7: All members have VALUE_ASSIGNMENT with trailing comments, no traits.
+// Should use single-line separation (no blank lines between members).
+structure Issue7 {
+    a: String = "" // a
+    b: String = "" // b
+    c: String = ""
+}
+
+// Issue 8: Nested inline aggregate shape with member comments.
+operation Issue8 {
+    input := {
+        a: String = "" // a
+        b: String
+    }
+}
+
+// Issue 9: Elided member with trailing comment (no VALUE_ASSIGNMENT).
+@mixin
+structure Issue9Base {
+    a: String
+}
+
+structure Issue9 with [Issue9Base] {
+    $a // elided with comment
+    b: String
+}
+
+// Issue 10: Nested inline shape with doc comments on inner members.
+operation Issue10 {
+    input := {
+        /// Doc comment on inner member.
+        a: String
+
+        b: String
+    }
+}
+
+// Issue 11: Multi-line value assignment with trailing comment.
+structure Issue11 {
+    a: String = """
+    multi
+    line
+    """ // a
+    b: String
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/member-comment-moving.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/member-comment-moving.smithy
@@ -1,0 +1,153 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Issue 1: Trailing comment on same line as member gets moved with extra blank line.
+structure Issue1 {
+    a: String // a
+    b: String
+}
+
+// Issue 1b: Same as issue 1, but no next member.
+structure Issue1b {
+    a: String // a
+}
+
+// Issue 1c: Trailing comment between two members.
+structure Issue1c {
+    a: String // a
+    b: String // b
+    c: String
+}
+
+// Issue 2: Default value assignment with trailing comment on next line gets extra blank lines.
+structure Issue2 {
+    a: String = ""
+    // a
+    b: String
+}
+
+// Issue 2b: Same as issue 2, but no next member.
+structure Issue2b {
+    a: String = ""
+    // a
+}
+
+// Issue 2c: Default value assignment with trailing comment on same line.
+structure Issue2c {
+    a: String = "" // a
+    b: String
+}
+
+// Issue 3: Doc comment after default value assignment is not fixed to regular comment.
+structure Issue3a {
+    a: String = "" /// a
+    b: String
+}
+
+// Issue 3b: doc comment on the line after a default value, with a following member.
+// `/// a` is `b`'s doc comment per Smithy IDL rules and must be preserved as-is.
+structure Issue3b {
+    a: String = ""
+    /// a
+    b: String
+}
+
+// Issue 3c: Doc comment trailing on same line as member (no default).
+structure Issue3c {
+    a: String /// a
+    b: String
+}
+
+// Issue 4: Trailing comment on member with trait applied.
+structure Issue4 {
+    @required
+    a: String // a
+    b: String
+}
+
+// Issue 4b: Trailing comment on member with trait and default value.
+structure Issue4b {
+    @required
+    a: String = "" // a
+    b: String
+}
+
+// Issue 5: Enum members with value assignments and trailing comments.
+enum Issue5 {
+    A = "a" // a
+    B = "b"
+}
+
+// Issue 5b: Enum member with value assignment and comment on next line.
+enum Issue5b {
+    A = "a"
+    // a
+    B = "b"
+}
+
+// Issue 5c: Enum member with value assignment, doc comment trailing (should convert).
+enum Issue5c {
+    A = "a" /// a
+    B = "b"
+}
+
+// Issue 6: Multiple consecutive comments after a VALUE_ASSIGNMENT.
+structure Issue6 {
+    a: String = ""
+    // comment 1
+    // comment 2
+    b: String
+}
+
+// Issue 6b: Multiple consecutive comments after VALUE_ASSIGNMENT, last member.
+structure Issue6b {
+    a: String = ""
+    // comment 1
+    // comment 2
+}
+
+// Issue 7: All members have VALUE_ASSIGNMENT with trailing comments, no traits.
+// Should use single-line separation (no blank lines between members).
+structure Issue7 {
+    a: String = "" // a
+    b: String = "" // b
+    c: String = ""
+}
+
+// Issue 8: Nested inline aggregate shape with member comments.
+operation Issue8 {
+    input := {
+        a: String = "" // a
+        b: String
+    }
+}
+
+// Issue 9: Elided member with trailing comment (no VALUE_ASSIGNMENT).
+@mixin
+structure Issue9Base {
+    a: String
+}
+
+structure Issue9 with [Issue9Base] {
+    $a // elided with comment
+    b: String
+}
+
+// Issue 10: Nested inline shape with doc comments on inner members.
+operation Issue10 {
+    input := {
+        /// Doc comment on inner member.
+        a: String
+        b: String
+    }
+}
+
+// Issue 11: Multi-line value assignment with trailing comment.
+structure Issue11 {
+    a: String = """
+        multi
+        line
+        """ // a
+    b: String
+}


### PR DESCRIPTION
The IDL formatter mishandled comments around members with default value assignments and around shape boundaries: trailing comments were hoisted to their own lines, doc comments after default values kept their `///` prefix even when the position was structurally invalid, banner-style doc comments (4+ leading slashes) were re-segmented, and trailing top-level comments were always reattached to the next shape even when they read as commentary on the closing brace above them.

A new `RelocateMemberComments` pipeline pass moves non-inline comments out of `VALUE_ASSIGNMENT > BR` subtrees and into the surrounding member container's whitespace before the rest of the formatter runs, so the downstream passes only see comments in their structurally meaningful positions. `FixBadDocComments` is extended to demote same-line trailing doc comments inside `VALUE_ASSIGNMENT` and to demote banner-bearing doc-comment blocks separated from their target shape by a blank line. `FormatVisitor` now keys comment rendering off the IDL token type rather than the lexeme prefix, with a banner-preserving mode for doc comments and a banner-aware demotion path for plain comments. The BR visitor distributes top-level shape-statement comments three ways: same-line trailing inline, plain comments contiguous with the previous construct sticking to it, and everything else deferring forward.

A new `FormatUtils` collects shared tree-navigation helpers used across the pipeline, including a value-end-line helper that compensates for the BR newline token inflating member end lines. The `ParseAndFormatTest` corpus runner now asserts idempotency by re-formatting each expected output and confirming it is a fixed point across all 162 fixtures.

Fixes #2279 
Fixes #2643 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
