### PR TITLE
Close some gaps in private trait reference validation

### DIFF
--- a/.changes/next-release/bugfix-83a4ce16152a80b76c877e7524fdb8b93990ac73.json
+++ b/.changes/next-release/bugfix-83a4ce16152a80b76c877e7524fdb8b93990ac73.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Adds a validation event for when a private resource shape is referenced outside of its namespace using the resource target elision syntax.",
+  "pull_requests": [
+    "[#3139](https://github.com/smithy-lang/smithy/pull/3139)"
+  ]
+}

--- a/.changes/next-release/bugfix-f0192fabb1c81e31355c09d7de830b38eb3359a7.json
+++ b/.changes/next-release/bugfix-f0192fabb1c81e31355c09d7de830b38eb3359a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Adds a warning when using the private trait on a mixin member, clarifying that it does not prevent the member from being inherited or modified by inheritors.",
+  "pull_requests": [
+    "[#3139](https://github.com/smithy-lang/smithy/pull/3139)"
+  ]
+}

--- a/docs/source-2.0/spec/constraint-traits.rst
+++ b/docs/source-2.0/spec/constraint-traits.rst
@@ -276,6 +276,14 @@ The following model is invalid because it attempts to refer to
         member: PrivateString
     }
 
+.. note::
+
+    Applying the ``private`` trait to a member of a :ref:`mixin <mixins>` does
+    not prevent the member from being inherited by shapes in other namespaces,
+    nor does it prevent new traits from being applied to the inherited member.
+    To restrict cross-namespace access, apply the ``private`` trait to the
+    mixin shape itself or to the targeted shape.
+
 
 .. smithy-trait:: smithy.api#range
 .. _range-trait:

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ApplyResourceBasedTargets.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ApplyResourceBasedTargets.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -65,6 +66,51 @@ final class ApplyResourceBasedTargets implements ShapeModifier {
                 memberBuilder.target(resource.getProperties().get(name));
             }
         }
+    }
+
+    // Validate that resource being used is not a private shape from another
+    // namespace. This is generally validated by PrivateAccessValidator, but
+    // the `for` binding is not persisted as a relationship, so the validator
+    // can't discover it.
+    @Override
+    public void modifyShape(
+            AbstractShapeBuilder<?, ?> builder,
+            Map<String, MemberShape.Builder> memberBuilders,
+            Function<ShapeId, Map<ShapeId, Trait>> unclaimedTraits,
+            Function<ShapeId, Shape> shapeMap
+    ) {
+        // First, check to see if the resource is private or not.
+        Shape fromShape = shapeMap.apply(resourceId);
+        if (fromShape == null || !fromShape.hasTrait(PrivateTrait.ID)) {
+            return;
+        }
+
+        // If it is private, check to see if the current shape is in the same
+        // namespace.
+        if (resourceId.getNamespace().equals(builder.getId().getNamespace())) {
+            return;
+        }
+
+        // Emit a validation event using the same ID as PrivateAccessValidator
+        String message = String.format(
+                "This shape has an invalid for relationship that targets a private shape, `%s`, in another namespace.",
+                resourceId);
+
+        ValidationEvent event = ValidationEvent.builder()
+                .id("PrivateAccess")
+                // Severity is set to danger because this was added well after
+                // resource-based target elision, so it could break people.
+                // As a danger, it can at least be suppressed.
+                .severity(Severity.DANGER)
+                .shapeId(builder.getId())
+                .sourceLocation(builder.getSourceLocation())
+                .message(message)
+                .build();
+
+        if (events == null) {
+            events = new ArrayList<>(1);
+        }
+        events.add(event);
     }
 
     private void fromShapeIsNotResource(MemberShape.Builder memberBuilder, Shape fromShape) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateMixinMemberValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateMixinMemberValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.validation.validators;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.MixinTrait;
+import software.amazon.smithy.model.traits.PrivateTrait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Warns when a mixin member is marked with the {@code @private} trait, since
+ * the trait does not prevent the member from being inherited by shapes in
+ * other namespaces.
+ */
+public final class PrivateMixinMemberValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        for (MemberShape member : model.getMemberShapesWithTrait(PrivateTrait.class)) {
+            Shape container = model.getShape(member.getContainer()).orElse(null);
+            if (container != null && container.hasTrait(MixinTrait.ID)) {
+                events.add(warning(member,
+                        member.expectTrait(PrivateTrait.class),
+                        "The `@private` trait does not prevent a mixin member from being inherited by shapes in "
+                                + "other namespaces, nor does it prevent new traits from being added to the inherited "
+                                + "member. Apply `@private` to the mixin shape or target shape instead if "
+                                + "cross-namespace access should be restricted."));
+            }
+        }
+        return events;
+    }
+}

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -33,6 +33,7 @@ software.amazon.smithy.model.validation.validators.OperationValidator
 software.amazon.smithy.model.validation.validators.PaginatedTraitValidator
 software.amazon.smithy.model.validation.validators.PatternTraitValidator
 software.amazon.smithy.model.validation.validators.PrivateAccessValidator
+software.amazon.smithy.model.validation.validators.PrivateMixinMemberValidator
 software.amazon.smithy.model.validation.validators.RangeTraitValidator
 software.amazon.smithy.model.validation.validators.ReferencesTraitValidator
 software.amazon.smithy.model.validation.validators.RequestCompressionTraitValidator

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ApplyResourceBasedTargetsTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ApplyResourceBasedTargetsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.ShapeMatcher;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class ApplyResourceBasedTargetsTest {
+
+    @Test
+    public void detectsPrivateResourceTargetElisionForStructure() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("private-resource-elision/private-resource.smithy"))
+                .addImport(getClass().getResource("private-resource-elision/cross-namespace-structure.smithy"))
+                .assemble();
+
+        assertThat(ShapeId.from("smithy.example#InvalidElidedStructure"),
+                ShapeMatcher.hasEvent(result, "PrivateAccess", Severity.DANGER, "smithy.private#PrivateResource"));
+    }
+
+    @Test
+    public void allowsPrivateResourceTargetElisionWithinSameNamespace() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("private-resource-elision/same-namespace-structure.smithy"))
+                .assemble();
+
+        assertThat(privateAccessEventIds(result), is(empty()));
+    }
+
+    @Test
+    public void allowsCrossNamespaceTargetElisionForPublicResource() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("private-resource-elision/public-resource.smithy"))
+                .addImport(getClass().getResource("private-resource-elision/cross-namespace-public.smithy"))
+                .assemble();
+
+        assertThat(privateAccessEventIds(result), is(empty()));
+    }
+
+    private static List<ValidationEvent> privateAccessEventIds(ValidatedResult<Model> result) {
+        return result.getValidationEvents()
+                .stream()
+                .filter(e -> e.getId().equals("PrivateAccess"))
+                .collect(Collectors.toList());
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-mixin-member.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-mixin-member.errors
@@ -1,0 +1,1 @@
+[WARNING] smithy.example#MixinWithPrivateMember$sensitiveField: The `@private` trait does not prevent a mixin member from being inherited by shapes in other namespaces, nor does it prevent new traits from being added to the inherited member. Apply `@private` to the mixin shape or target shape instead if cross-namespace access should be restricted. | PrivateMixinMember

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-mixin-member.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/private-mixin-member.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@mixin
+structure MixinWithPrivateMember {
+    @private
+    sensitiveField: String
+}
+
+structure ConsumerSameNamespace with [MixinWithPrivateMember] {
+    @required
+    $sensitiveField
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/cross-namespace-public.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/cross-namespace-public.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure ElidedStructure for smithy.public#PublicResource {
+    $id
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/cross-namespace-structure.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/cross-namespace-structure.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure InvalidElidedStructure for smithy.private#PrivateResource {
+    $id
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/private-resource.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/private-resource.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+namespace smithy.private
+
+@private
+resource PrivateResource {
+    identifiers: { id: String }
+    properties: { value: String }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/public-resource.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/public-resource.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace smithy.public
+
+resource PublicResource {
+    identifiers: { id: String }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/same-namespace-structure.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/private-resource-elision/same-namespace-structure.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace smithy.private
+
+@private
+resource PrivateResource {
+    identifiers: { id: String }
+    properties: { value: String }
+}
+
+structure InternalElidedStructure for PrivateResource {
+    $id
+}


### PR DESCRIPTION
This adds a validation event to stop users from using the resource target elision syntax on resources that are private and in a different namespace. This was a gap when the feature was initially implemented.

The event is a DANGER so that it can be suppressed since we don't want to hard break people who are already doing this.

A theoretical alternative would be to add a new relationship type, but there's no way to persist that in the AST without introducing version-bump-requiring changes.

This also adds a warning when mixins have members with the private trait, as the trait does not prevent the members from being inherited or modified by shapes that use the mixin.


Resolves #1407

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
