### PR TITLE
Wrap large trait values that exceed the line width

### DIFF
--- a/.changes/next-release/bugfix-95f15010c55a9599f518c1a17079bf493f7d087d.json
+++ b/.changes/next-release/bugfix-95f15010c55a9599f518c1a17079bf493f7d087d.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fixes a formatter bug where some trait/node values weren't spread across multiple lines",
+  "pull_requests": [
+    "[#3140](https://github.com/smithy-lang/smithy/pull/3140)"
+  ]
+}

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/BracketFormatter.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/BracketFormatter.java
@@ -124,6 +124,23 @@ final class BracketFormatter {
         return this;
     }
 
+    BracketFormatter detectHardLinesOrTooWide(TreeCursor hardLineSubject, int maxWidth) {
+        return detectHardLines(hardLineSubject).forceLineBreaksIfTooWide(maxWidth);
+    }
+
+    BracketFormatter forceLineBreaksIfTooWide(int maxWidth) {
+        if (forceLineBreaks || children.isEmpty()) {
+            return this;
+        }
+        // Render the candidate flat form at huge width to test if line breaks are needed.
+        Doc flatCandidate = Doc.intersperse(Formatter.LINE_OR_COMMA, children)
+                .bracket(0, getBracketLineBreakDoc(), open, close);
+        if (flatCandidate.render(Integer.MAX_VALUE).length() > maxWidth) {
+            forceLineBreaks = true;
+        }
+        return this;
+    }
+
     // Don't force line breaks and don't indent inside brackets
     BracketFormatter forceInline() {
         forceInline = true;

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
@@ -331,7 +331,7 @@ final class FormatVisitor {
                                 }
                                 return Stream.empty();
                             }))
-                            .detectHardLines(cursor)
+                            .detectHardLinesOrTooWide(cursor, width)
                             .write();
                 } else if (cursor.getFirstChild(TreeType.TRAIT_NODE) != null) {
                     TreeCursor traitNode = cursor.getFirstChild(TreeType.TRAIT_NODE);
@@ -418,7 +418,7 @@ final class FormatVisitor {
                         .open(Formatter.LBRACKET)
                         .close(Formatter.RBRACKET)
                         .extractChildren(cursor, BracketFormatter.extractByType(TreeType.NODE_VALUE, this::visit))
-                        .detectHardLines(cursor)
+                        .detectHardLinesOrTooWide(cursor, width)
                         .write();
             }
 
@@ -431,7 +431,7 @@ final class FormatVisitor {
                     // Always break objects inside arrays if not empty
                     formatter.forceLineBreaksIfNotEmpty();
                 } else {
-                    formatter.detectHardLines(cursor);
+                    formatter.detectHardLinesOrTooWide(cursor, width);
                 }
                 return formatter.write();
 

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/line-length-overflow.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/line-length-overflow.formatted.smithy
@@ -1,0 +1,33 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Site 1: NODE_ARRAY whose flat width exceeds 120 columns.
+@tags([
+    "AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA"
+    "BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB"
+    "CcccccccccccccccccccccccccccccccccccccccccccC"
+])
+string ArrayOfStrings
+
+// Site 2: NODE_OBJECT whose flat width exceeds 120 columns, nested inside a trait-applied
+// outer NODE_OBJECT.
+@authorizers({
+    SomeAuthorizer: {
+        scheme: "httpBearerAuth"
+        type: "request"
+        identitySource: "method.request.header.Authorization"
+        uri: "${someAuthorizerInvokeArn}"
+        resultTtlInSeconds: 1000
+    }
+})
+service SomeService { version: "2024-01-01" }
+
+// Site 3: TRAIT_BODY structured-body collapsed onto one line, no nested objects or arrays.
+@externalDocumentation(
+    aaaaaaa: "http://aaaaaaaaaaaaaa.com"
+    bbbbbbb: "http://bbbbbbbbbbbbbb.com"
+    ccccccc: "http://cccccccccccccc.com"
+    ddddddd: "http://dddddddddddddd.com"
+)
+string ExternalDocsCollapsed

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/line-length-overflow.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/line-length-overflow.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Site 1: NODE_ARRAY whose flat width exceeds 120 columns.
+@tags(["AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA", "BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB", "CcccccccccccccccccccccccccccccccccccccccccccC"])
+string ArrayOfStrings
+
+// Site 2: NODE_OBJECT whose flat width exceeds 120 columns, nested inside a trait-applied
+// outer NODE_OBJECT.
+@authorizers({SomeAuthorizer: {scheme: "httpBearerAuth", type: "request", identitySource: "method.request.header.Authorization", uri: "${someAuthorizerInvokeArn}", resultTtlInSeconds: 1000}})
+service SomeService { version: "2024-01-01" }
+
+// Site 3: TRAIT_BODY structured-body collapsed onto one line, no nested objects or arrays.
+@externalDocumentation(aaaaaaa: "http://aaaaaaaaaaaaaa.com", bbbbbbb: "http://bbbbbbbbbbbbbb.com", ccccccc: "http://cccccccccccccc.com", ddddddd: "http://dddddddddddddd.com")
+string ExternalDocsCollapsed


### PR DESCRIPTION
The Smithy formatter can leave trait-applied object and array values on a single line that far exceeds the configured maximum width, producing output where a single trait spans hundreds of columns.

This adds `forceLineBreaksIfTooWide(maxWidth)` which renders the flat form at infinite width, measures its length, and sets `forceLineBreaks` when the width exceeds its max. This is wired through a new `detectHardLinesOrTooWide` combinator at `NODE_ARRAY`, `NODE_OBJECT`, and `TRAIT_BODY` paths.

Fixes #3136 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
