### PR TITLE
Check smithy-build by default in formatter

### DIFF
--- a/.changes/next-release/feature-e9097de591c134f9ac7eb44efd86aaacc987cd6b.json
+++ b/.changes/next-release/feature-e9097de591c134f9ac7eb44efd86aaacc987cd6b.json
@@ -1,0 +1,6 @@
+{
+  "type": "feature",
+  "description": "The `smithy format` CLI command now falls back to the `sources` defined in `smithy-build.json` when no positional arguments are provided, allowing it to be run with no arguments inside a configured Smithy project.",
+  "pull_requests": [
+  ]
+}

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/FormatCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/FormatCommandTest.java
@@ -98,4 +98,58 @@ public class FormatCommandTest {
             assertThat(checked.getExitCode(), equalTo(0));
         });
     }
+
+    @Test
+    public void formatsSourcesFromSmithyBuildConfig() {
+        IntegUtils.run("format-from-config", ListUtils.of("format"), result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+
+            String main = result.getFile("model/main.smithy");
+            assertThat(main,
+                    equalTo(String.format("$version: \"2.0\"%n"
+                            + "%n"
+                            + "metadata this_is_a_long_string = {%n"
+                            + "    this_is_a_long_string1: \"a\"%n"
+                            + "    this_is_a_long_string2: \"b\"%n"
+                            + "    this_is_a_long_string3: \"c\"%n"
+                            + "    this_is_a_long_string4: \"d\"%n"
+                            + "}%n")));
+
+            String other = result.getFile("model/other.smithy");
+            assertThat(other,
+                    equalTo(String.format("$version: \"2.0\"%n"
+                            + "%n"
+                            + "namespace smithy.example%n"
+                            + "%n"
+                            + "string MyString%n"
+                            + "%n"
+                            + "string MyString2%n")));
+
+            String vendored = result.getFile("vendored/vendored.smithy");
+            assertThat(vendored,
+                    equalTo(String.format("$version: \"2.0\"%n"
+                            + "namespace smithy.vendored%n"
+                            + "string VendoredString%n")));
+        });
+    }
+
+    @Test
+    public void failsWhenBothModelsAndConfigGiven() {
+        IntegUtils.run("format-from-config",
+                ListUtils.of("format", "--config", "smithy-build.json", "model"),
+                result -> {
+                    assertThat(result.getExitCode(), equalTo(1));
+                    assertThat(result.getOutput(),
+                            containsString("Cannot combine --config with positional model arguments"));
+                });
+    }
+
+    @Test
+    public void failsWhenNoArgsAndNoConfigFlag() {
+        IntegUtils.run("format-from-config", ListUtils.of("format", "--no-config"), result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+            assertThat(result.getOutput(),
+                    containsString("No .smithy model or directory was provided as a positional argument"));
+        });
+    }
 }

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/model/main.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/model/main.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+
+metadata this_is_a_long_string = {this_is_a_long_string1: "a", this_is_a_long_string2: "b",
+                                  this_is_a_long_string3: "c", this_is_a_long_string4: "d"}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/model/other.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/model/other.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+namespace smithy.example
+string MyString
+string MyString2

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/smithy-build.json
@@ -1,0 +1,5 @@
+{
+    "version": "1.0",
+    "sources": ["model"],
+    "imports": ["vendored"]
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/vendored/vendored.smithy
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/format-from-config/vendored/vendored.smithy
@@ -1,0 +1,3 @@
+$version: "2.0"
+namespace smithy.vendored
+string VendoredString

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ConfigOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ConfigOptions.java
@@ -61,6 +61,10 @@ final class ConfigOptions implements ArgumentReceiver {
         this.root = root;
     }
 
+    boolean hasExplicitConfig() {
+        return !config.isEmpty();
+    }
+
     List<String> config() {
         List<String> config = this.config;
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/FormatCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/FormatCommand.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.CliError;
@@ -62,12 +63,14 @@ final class FormatCommand implements Command {
                     null,
                     "Exit with a non-zero status if any files would be reformatted, without modifying them.");
             printer.positional("<MODELS>",
-                    "`.smithy` model files and directories of model files to recursively format.");
+                    "`.smithy` model files and directories of model files to recursively format. "
+                            + "If omitted, the `sources` from smithy-build.json are formatted.");
         }
     }
 
     @Override
     public int execute(Arguments arguments, Env env) {
+        arguments.addReceiver(new ConfigOptions());
         arguments.addReceiver(new Options());
 
         CommandAction action = HelpActionWrapper.fromCommand(this, parentCommandName, c -> {
@@ -76,6 +79,7 @@ final class FormatCommand implements Command {
             buffer.println("   smithy format model-file.smithy", ColorTheme.LITERAL);
             buffer.println("   smithy format model/", ColorTheme.LITERAL);
             buffer.println("   smithy format model-file.smithy model/", ColorTheme.LITERAL);
+            buffer.println("   smithy format  # uses sources from smithy-build.json", ColorTheme.LITERAL);
             buffer.println("   smithy format --check model/", ColorTheme.LITERAL);
             return buffer.toString();
         }, this::run);
@@ -83,14 +87,12 @@ final class FormatCommand implements Command {
     }
 
     private int run(Arguments arguments, Env env) {
-        if (arguments.getPositional().isEmpty()) {
-            throw new CliError("No .smithy model or directory was provided as a positional argument");
-        }
+        List<String> filenames = resolveFilenames(arguments);
 
         Options options = arguments.getReceiver(Options.class);
 
-        List<Path> paths = new ArrayList<>(arguments.getPositional().size());
-        for (String filename : arguments.getPositional()) {
+        List<Path> paths = new ArrayList<>(filenames.size());
+        for (String filename : filenames) {
             Path path = Paths.get(filename);
             paths.add(path);
 
@@ -115,6 +117,31 @@ final class FormatCommand implements Command {
             throw new CliError(message.toString());
         }
         return 0;
+    }
+
+    private List<String> resolveFilenames(Arguments arguments) {
+        ConfigOptions configOptions = arguments.getReceiver(ConfigOptions.class);
+        List<String> positional = arguments.getPositional();
+
+        if (!positional.isEmpty()) {
+            if (configOptions.hasExplicitConfig()) {
+                throw new CliError("Cannot combine --config with positional model arguments. "
+                        + "Provide either model paths or --config, not both.");
+            }
+            return positional;
+        }
+
+        // Fall back to `sources` from smithy-build.json so `smithy format` can be run
+        // with no arguments in a configured project. `imports` is intentionally
+        // excluded: imports often point to vendored or generated content that the
+        // current project does not own and should not reformat in place.
+        SmithyBuildConfig config = configOptions.createSmithyBuildConfig();
+        List<String> sources = config.getSources();
+        if (sources.isEmpty()) {
+            throw new CliError("No .smithy model or directory was provided as a positional argument, "
+                    + "and no sources were found in smithy-build.json");
+        }
+        return sources;
     }
 
     private void visit(Path file, Options options, List<Path> needsFormat) {


### PR DESCRIPTION
This updates smithy-format to check `smithy-build.json` in the current working directory if no explicit models are supplied. This also allows explicitly targeting one or more configs to be consistent with other build-like tasks.

This does not format imports, since they may not be "owned" by the project.

Resolves #2498

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
