### PR TITLE
fix exponential performance issue in validator

### DIFF
--- a/.changes/next-release/bugfix-98e5ece84cd6114ac90e6752ad6fea9e8d5d5966.json
+++ b/.changes/next-release/bugfix-98e5ece84cd6114ac90e6752ad6fea9e8d5d5966.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fixes an issue with exponential performance on graph traversal in MemberShouldReferenceResourceValidator",
+  "pull_requests": [
+    "[#3149](https://github.com/smithy-lang/smithy/pull/3149)"
+  ]
+}

--- a/.changes/next-release/bugfix-98e5ece84cd6114ac90e6752ad6fea9e8d5d5966.json
+++ b/.changes/next-release/bugfix-98e5ece84cd6114ac90e6752ad6fea9e8d5d5966.json
@@ -1,6 +1,6 @@
 {
   "type": "bugfix",
-  "description": "Fixes an issue with exponential performance on graph traversal in MemberShouldReferenceResourceValidator",
+  "description": "Fixed an exponential search space growth in MemberShouldReferenceResourceValidator",
   "pull_requests": [
     "[#3149](https://github.com/smithy-lang/smithy/pull/3149)"
   ]

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
@@ -124,7 +124,7 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
      * runs in {@code O(V + E)}. It intentionally mirrors the directed-relationship traversal that
      * {@link software.amazon.smithy.model.selector.PathFinder} performs, but without enumerating
      * every simple path between each resource and the member ... that enumeration is exponential
-     * on recursive or highly-connected models and previously caused this validator to hang.
+     * on recursive or highly-connected models and can cause this validator to hang.
      */
     private Set<ShapeId> findBindingResources(NeighborProvider reverseProvider, MemberShape member) {
         Set<ShapeId> boundResources = new HashSet<>();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
@@ -6,13 +6,18 @@ package software.amazon.smithy.model.validation.validators;
 
 import static java.lang.String.format;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.selector.PathFinder;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Relationship;
+import software.amazon.smithy.model.neighbor.RelationshipDirection;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -38,6 +43,10 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
             return ListUtils.of();
         }
 
+        // Reverse (predecessor) neighbors are used to discover which resources a member is
+        // already bound to. This index is cached on the model and reused for every member.
+        NeighborProvider reverseProvider = NeighborProviderIndex.of(model).getReverseProvider();
+
         // Check every member to see if it's a potential reference.
         List<ValidationEvent> events = new ArrayList<>();
         for (MemberShape member : model.getMemberShapes()) {
@@ -50,7 +59,7 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
                 continue;
             }
 
-            Set<ShapeId> potentialReferences = computePotentialReferences(model, member);
+            Set<ShapeId> potentialReferences = computePotentialReferences(model, reverseProvider, member);
             if (!potentialReferences.isEmpty()) {
                 events.add(warning(member,
                         format("This member appears to reference the following resources without "
@@ -70,18 +79,25 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
         return identifierNames;
     }
 
-    private Set<ShapeId> computePotentialReferences(Model model, MemberShape member) {
+    private Set<ShapeId> computePotentialReferences(Model model, NeighborProvider reverseProvider, MemberShape member) {
         // Exclude any resources already in `@references` on the member or container structure.
         Set<ShapeId> resourcesToIgnore = new HashSet<>();
         ignoreReferencedResources(member, resourcesToIgnore);
         ignoreReferencedResources(model.expectShape(member.getContainer()), resourcesToIgnore);
 
+        // Exclude resources the member is already bound to (i.e., the member is reachable from
+        // the resource through the model graph), including the other resources in those
+        // hierarchies. Resources on a `resource -> ... -> member` path are exactly the resources
+        // from which the member is reachable, so a single reverse-reachability walk from the
+        // member finds all of them at once.
+        for (ShapeId boundResource : findBindingResources(reverseProvider, member)) {
+            resourcesToIgnore.add(boundResource);
+            resourcesToIgnore.addAll(model.expectShape(boundResource, ResourceShape.class).getResources());
+        }
+
         // Check each resource in the model for something missed.
         Set<ShapeId> potentialResources = new HashSet<>();
         for (ResourceShape resource : model.getResourceShapes()) {
-            // We'll want to ignore some resources based on the member -> resource path.
-            computeResourcesToIgnore(model, member, resource, resourcesToIgnore);
-
             // Exclude members bound to resource hierarchies from generating events,
             // including for resources that are within the same hierarchy.
             if (resourcesToIgnore.contains(resource.getId())) {
@@ -99,29 +115,42 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
         return potentialResources;
     }
 
-    private void computeResourcesToIgnore(
-            Model model,
-            MemberShape member,
-            ResourceShape resource,
-            Set<ShapeId> resourcesToIgnore
-    ) {
-        // Exclude actually bound members via searching with a PathFinder.
-        List<PathFinder.Path> resourceMemberPaths = PathFinder.create(model)
-                .search(resource, ListUtils.of(member));
-        if (!resourceMemberPaths.isEmpty()) {
-            // This member is already bound to a resource, so we don't need a references trait for it.
-            // In addition, we should not tell users to add a references trait for other resources that
-            // are children in that hierarchy - any parent resources or other children of those parents.
-            for (PathFinder.Path path : resourceMemberPaths) {
-                for (Shape pathShape : path.getShapes()) {
-                    if (pathShape.isResourceShape()) {
-                        ResourceShape resourceShape = (ResourceShape) pathShape;
-                        resourcesToIgnore.add(resourceShape.getId());
-                        resourcesToIgnore.addAll(resourceShape.getResources());
+    /**
+     * Finds every resource from which the given member is reachable by traversing directed
+     * relationships, i.e., the resources the member is effectively bound to.
+     *
+     * <p>This walks the reverse (predecessor) neighbor graph starting from the member using a
+     * permanent visited set, so each shape and relationship is visited at most once and the walk
+     * runs in {@code O(V + E)}. It intentionally mirrors the directed-relationship traversal that
+     * {@link software.amazon.smithy.model.selector.PathFinder} performs, but without enumerating
+     * every simple path between each resource and the member ... that enumeration is exponential
+     * on recursive or highly-connected models and previously caused this validator to hang.
+     */
+    private Set<ShapeId> findBindingResources(NeighborProvider reverseProvider, MemberShape member) {
+        Set<ShapeId> boundResources = new HashSet<>();
+        Set<ShapeId> visited = new HashSet<>();
+        Deque<Shape> frontier = new ArrayDeque<>();
+        visited.add(member.getId());
+        frontier.push(member);
+
+        while (!frontier.isEmpty()) {
+            Shape current = frontier.pop();
+            for (Relationship relationship : reverseProvider.getNeighbors(current)) {
+                // Match PathFinder, which only walks directed relationships.
+                if (relationship.getDirection() != RelationshipDirection.DIRECTED) {
+                    continue;
+                }
+                Shape predecessor = relationship.getShape();
+                if (visited.add(predecessor.getId())) {
+                    if (predecessor.isResourceShape()) {
+                        boundResources.add(predecessor.getId());
                     }
+                    frontier.push(predecessor);
                 }
             }
         }
+
+        return boundResources;
     }
 
     private void ignoreReferencedResources(Shape shape, Set<ShapeId> resourcesToIgnore) {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/recursive-member-references.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/recursive-member-references.errors
@@ -1,0 +1,1 @@
+[WARNING] ns.recursive#N1$id: This member appears to reference the following resources without being included in a `@references` trait: [`ns.recursive#FooResource`] | MemberShouldReferenceResource

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/recursive-member-references.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/references/recursive-member-references.smithy
@@ -1,0 +1,287 @@
+// Regression test for MemberShouldReferenceResource: the validator used to call
+// PathFinder.search (which enumerates EVERY simple path) once per resource. On a
+// densely connected, recursive shape graph the number of simple paths is factorial,
+// so validation effectively hangs. N0..N14 form a near-complete digraph (each
+// structure references every other), disconnected from FooResource. Validating N1$id
+// used to enumerate the ~e*14! simple paths through that graph; it must now complete
+// quickly and still flag the unbound identifier member while leaving the
+// resource-bound GetFooInput$id alone.
+$version: "2.0"
+
+namespace ns.recursive
+
+resource FooResource {
+    identifiers: {
+        id: String
+    }
+    read: GetFoo
+}
+
+@readonly
+operation GetFoo {
+    input := {
+        // Bound to FooResource through its `read` lifecycle, so this matching
+        // identifier member must be ignored (it is reachable from the resource).
+        @required
+        id: String
+    }
+    output := {}
+}
+
+// Near-complete, recursive digraph disconnected from any resource. N1 carries an
+// identifier member that is NOT bound to a resource and should therefore be flagged.
+structure N0 {
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N1 {
+    id: String
+    m0: N0
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N2 {
+    m0: N0
+    m1: N1
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N3 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N4 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N5 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N6 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N7 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N8 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N9 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N10 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m11: N11
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N11 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m12: N12
+    m13: N13
+    m14: N14
+}
+
+structure N12 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m13: N13
+    m14: N14
+}
+
+structure N13 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m14: N14
+}
+
+structure N14 {
+    m0: N0
+    m1: N1
+    m2: N2
+    m3: N3
+    m4: N4
+    m5: N5
+    m6: N6
+    m7: N7
+    m8: N8
+    m9: N9
+    m10: N10
+    m11: N11
+    m12: N12
+    m13: N13
+}


### PR DESCRIPTION
#### Background
* What do these changes do? 
* Why are they important?

We are running into an issue internally with a specification that is highly recursive in nature causing the `MemberShouldReferenceResourceValidator` to hang. This PR introduces a reproduction of the issue in a test, and proposes a potential fix which changes the algorithm to be completed in linear time as opposed to exponential.

#### Testing
* How did you test these changes?

See included unit test that was added, when run prior to the fix it hangs, with the fix it completes in seconds.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

I admittedly have not spent much time on this fix so much as I did on tracing down what the issue was. I had claude help me propose this as a fix, but if you want to solve the issue in a different way, that's of course totally fine.
