### PR TITLE
Preserve comments after removed imports

### DIFF
--- a/.changes/next-release/bugfix-5f2d35bea732e5ff1cf4dba2f15b06230512985b.json
+++ b/.changes/next-release/bugfix-5f2d35bea732e5ff1cf4dba2f15b06230512985b.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fixed a bug where comments trailing unused imports were being improperly removed during formatting.",
+  "pull_requests": []
+}

--- a/.changes/next-release/bugfix-5f2d35bea732e5ff1cf4dba2f15b06230512985b.json
+++ b/.changes/next-release/bugfix-5f2d35bea732e5ff1cf4dba2f15b06230512985b.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fixed a bug where comments trailing unused imports were being improperly removed during formatting.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3152](https://github.com/smithy-lang/smithy/pull/3152)"
+  ]
 }

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatUtils.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatUtils.java
@@ -4,12 +4,69 @@
  */
 package software.amazon.smithy.syntax;
 
+import java.util.List;
+import software.amazon.smithy.utils.Pair;
+
 /**
  * Shared tree-navigation helpers used by the formatter pipeline passes.
  */
 final class FormatUtils {
 
     private FormatUtils() {}
+
+    /**
+     * Collect non-inline comments from a BR node into the given result list.
+     *
+     * <p>The parser's BR production greedily consumes all trailing whitespace including comments.
+     * Comments on a different line than the BR's start are not inline trailing comments of the BR's
+     * owning construct. They belong to whatever follows and are collected here so callers can
+     * relocate or remove them. Comments may be direct children of the BR or nested inside a WS child
+     * of the BR. Each entry pairs the comment's immediate parent (left) with the comment itself
+     * (right) so the caller can detach it from the recorded parent directly instead of re-searching
+     * the BR subtree.
+     *
+     * @param brCursor the BR cursor to inspect.
+     * @param brStartLine the BR's start line, used to distinguish inline from following comments.
+     * @param result the list to collect (parent, comment) pairs into.
+     */
+    static void collectNonInlineComments(
+            TreeCursor brCursor,
+            int brStartLine,
+            List<Pair<TokenTree, TokenTree>> result
+    ) {
+        TokenTree brTree = brCursor.getTree();
+        for (TokenTree child : brTree.getChildren()) {
+            if (child.getType() == TreeType.COMMENT && child.getStartLine() != brStartLine) {
+                result.add(Pair.of(brTree, child));
+            } else if (child.getType() == TreeType.WS) {
+                // Comments inside a WS child of BR.
+                for (TokenTree wsChild : child.getChildren()) {
+                    if (wsChild.getType() == TreeType.COMMENT && wsChild.getStartLine() != brStartLine) {
+                        result.add(Pair.of(child, wsChild));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Detach each collected comment from its recorded parent.
+     *
+     * <p>Operates on the (parent, comment) pairs produced by {@link #collectNonInlineComments}.
+     * Because the parent reference is captured at collection time, removal cannot fail to locate the
+     * node and the same comment is never attached to two parents. A failed removal indicates the
+     * tree shape changed underneath the caller and is reported as an {@link IllegalStateException}.
+     *
+     * @param comments the (parent, comment) pairs to detach.
+     */
+    static void detachCollectedComments(List<Pair<TokenTree, TokenTree>> comments) {
+        for (Pair<TokenTree, TokenTree> entry : comments) {
+            if (!entry.getLeft().removeChild(entry.getRight())) {
+                throw new IllegalStateException(
+                        "Could not detach comment from its recorded parent: " + entry.getRight().concatTokens());
+            }
+        }
+    }
 
     /**
      * Get the end line of a member's visible value content for same-line comment detection.

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RelocateMemberComments.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RelocateMemberComments.java
@@ -79,22 +79,13 @@ final class RelocateMemberComments implements Function<TokenTree, TokenTree> {
             List<Pair<TokenTree, TokenTree>> toRelocate = new ArrayList<>();
             int brStartLine = br.getTree().getStartLine();
             // Comments may be direct children of BR or nested inside a WS child of BR.
-            collectNonInlineComments(br, brStartLine, toRelocate);
+            FormatUtils.collectNonInlineComments(br, brStartLine, toRelocate);
 
             if (toRelocate.isEmpty()) {
                 continue;
             }
 
-            // Detach each comment from its recorded parent. Because the parent reference is captured at
-            // collection time, removal cannot fail to locate the node and we never risk attaching the
-            // same comment to two parents. A failed remove indicates the tree shape changed underneath us.
-            for (Pair<TokenTree, TokenTree> entry : toRelocate) {
-                if (!entry.getLeft().removeChild(entry.getRight())) {
-                    throw new IllegalStateException(
-                            "RelocateMemberComments could not detach comment from its recorded parent: "
-                                    + entry.getRight().concatTokens());
-                }
-            }
+            FormatUtils.detachCollectedComments(toRelocate);
 
             // Clean up residual whitespace in the BR after removing comments. If the BR's WS child
             // no longer contains any COMMENT children (only SP/NEWLINE/COMMA tokens remain), remove
@@ -126,32 +117,6 @@ final class RelocateMemberComments implements Function<TokenTree, TokenTree> {
             }
             for (TokenTree child : existingChildren) {
                 wsTarget.appendChild(child);
-            }
-        }
-    }
-
-    private void collectNonInlineComments(
-            TreeCursor brCursor,
-            int brStartLine,
-            List<Pair<TokenTree, TokenTree>> result
-    ) {
-        // The BR's start line equals the value's last line in both newline-led and comment-led
-        // BR branches (the parser anchors BR at the position right after the value, then consumes
-        // the trailing newline plus any optional WS). Comments whose start line differs from the
-        // BR start line are therefore not on the same source line as the value and are candidates
-        // for relocation. Same-line trailing comments are left in the BR for FixBadDocComments
-        // and FormatVisitor's BR visitor to handle inline.
-        TokenTree brTree = brCursor.getTree();
-        for (TokenTree child : brTree.getChildren()) {
-            if (child.getType() == TreeType.COMMENT && child.getStartLine() != brStartLine) {
-                result.add(Pair.of(brTree, child));
-            } else if (child.getType() == TreeType.WS) {
-                // Comments inside a WS child of BR.
-                for (TokenTree wsChild : child.getChildren()) {
-                    if (wsChild.getType() == TreeType.COMMENT && wsChild.getStartLine() != brStartLine) {
-                        result.add(Pair.of(child, wsChild));
-                    }
-                }
             }
         }
     }

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RemoveUnusedUseStatements.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/RemoveUnusedUseStatements.java
@@ -4,15 +4,20 @@
  */
 package software.amazon.smithy.syntax;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.Pair;
 
 final class RemoveUnusedUseStatements implements Function<TokenTree, TokenTree> {
 
@@ -28,13 +33,15 @@ final class RemoveUnusedUseStatements implements Function<TokenTree, TokenTree> 
         }
 
         // SHAPE_SECTION is always present at this point if there are detected use statements.
-        TreeCursor shapeStatements = Objects.requireNonNull(root.getFirstChild(TreeType.SHAPE_SECTION))
-                .getFirstChild(TreeType.SHAPE_STATEMENTS);
+        TreeCursor shapeSection = Objects.requireNonNull(root.getFirstChild(TreeType.SHAPE_SECTION));
+        TreeCursor shapeStatements = shapeSection.getFirstChild(TreeType.SHAPE_STATEMENTS);
 
         if (shapeStatements == null) {
             return tree;
         }
 
+        // Remove every shape id referenced in the model file from the map of use
+        // statements. Anything left after this loop is unreferenced.
         for (TreeCursor identifier : shapeStatements.findChildrenByType(TreeType.SHAPE_ID)) {
             String name = identifier.getTree().concatTokens();
 
@@ -51,6 +58,17 @@ final class RemoveUnusedUseStatements implements Function<TokenTree, TokenTree> 
             useShapeNames.remove(name);
         }
 
+        if (useShapeNames.isEmpty()) {
+            return tree;
+        }
+
+        // Before removing an unused use statement, we need to handle its trailing whitespace.
+        // A use statement's trailing BR greedily captures every comment written above the next
+        // statement, including any doc comments that document following shapes. Removing the
+        // statement wholesale would delete those comments and silently change the model, so the
+        // comments that belong to surviving statements are preserved before removal.
+        handleAllTrailingComments(shapeSection, useShapeNames.values());
+
         // Anything left in the map needs to be removed from the tree.
         for (TreeCursor unused : useShapeNames.values()) {
             LOGGER.fine(() -> "Removing unused use statement: "
@@ -61,6 +79,88 @@ final class RemoveUnusedUseStatements implements Function<TokenTree, TokenTree> 
         }
 
         return tree;
+    }
+
+    // Preserve or discard the comments captured by the BRs of the use statements being removed.
+    // A comment belongs to the statement directly below it, so each BR holds the comments that
+    // lead its successor (the next use statement, or the following shape for the last import).
+    private void handleAllTrailingComments(TreeCursor shapeSection, Collection<TreeCursor> removedStatements) {
+        // We already know there's a use section, or we wouldn't be here.
+        TreeCursor useSection = Objects.requireNonNull(shapeSection.getFirstChild(TreeType.USE_SECTION));
+
+        // The defer target is the trailing BR of the most recent surviving statement.
+        // This is where comments will be moved to if their holder is being removed but
+        // the comments themselves need to be kept. It starts at the namespace statement's
+        // BR, which always survives.
+        TreeCursor namespaceStatement =
+                Objects.requireNonNull(shapeSection.getFirstChild(TreeType.NAMESPACE_STATEMENT));
+        TreeCursor deferTarget = Objects.requireNonNull(namespaceStatement.getFirstChild(TreeType.BR));
+
+        // Create an identity set to be able to easily identify removed statements while
+        // iterating. An identity set in particular is used because nodes are mutable and
+        // are mutated, so their hashes can and do change.
+        Set<TreeCursor> removed = Collections.newSetFromMap(new IdentityHashMap<>());
+        removed.addAll(removedStatements);
+
+        // Go through each use statement, removing or preserving its comments as necessary.
+        TreeCursor holderBr = deferTarget;
+        boolean holderRemoved = false;
+        for (TreeCursor useStatement : useSection.getChildrenByType(TreeType.USE_STATEMENT)) {
+            boolean successorRemoved = removedStatements.contains(useStatement);
+            handleTrailingComments(holderBr, holderRemoved, successorRemoved, deferTarget);
+            if (!holderRemoved) {
+                deferTarget = holderBr;
+            }
+            holderBr = Objects.requireNonNull(useStatement.getFirstChild(TreeType.BR));
+            holderRemoved = successorRemoved;
+        }
+
+        // The last use statement's BR leads the following shape, which always survives.
+        handleTrailingComments(holderBr, holderRemoved, false, deferTarget);
+    }
+
+    private void handleTrailingComments(
+            TreeCursor holderBr,
+            boolean holderRemoved,
+            boolean successorRemoved,
+            TreeCursor deferTarget
+    ) {
+        if (holderBr == null) {
+            return;
+        }
+
+        List<Pair<TokenTree, TokenTree>> comments = new ArrayList<>();
+        FormatUtils.collectNonInlineComments(holderBr, holderBr.getTree().getStartLine(), comments);
+        if (comments.isEmpty()) {
+            return;
+        }
+
+        if (successorRemoved) {
+            // If the successor is removed, the comments that precede it also need to be removed.
+            // If the statement that those comments are attached to is also going to be removed,
+            // the comments will get removed when that whole tree is removed. If the holding
+            // statement isn't going to be removed, we need to do it manually.
+            if (!holderRemoved) {
+                FormatUtils.detachCollectedComments(comments);
+            }
+        } else if (holderRemoved) {
+            // If the successor isn't being removed, but the statement holding the comments is,
+            // we need to add those comments up to the most recent surviving statement.
+            TokenTree targetWs = findOrCreateWs(deferTarget.getTree());
+            comments.forEach(entry -> targetWs.appendChild(entry.getRight()));
+        }
+        // Otherwise the successor and its holder both survive, so the comments stay where they are.
+    }
+
+    private TokenTree findOrCreateWs(TokenTree br) {
+        for (TokenTree child : br.getChildren()) {
+            if (child.getType() == TreeType.WS) {
+                return child;
+            }
+        }
+        TokenTree ws = TokenTree.of(TreeType.WS);
+        br.appendChild(ws);
+        return ws;
     }
 
     // Create a map of shape name to the TreeCursor of the use statement.

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-consecutive-unused-imports.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-consecutive-unused-imports.formatted.smithy
@@ -1,0 +1,6 @@
+$version: "2.0"
+
+namespace smithy.example
+
+// Comment after the second unused import.
+string Foo

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-consecutive-unused-imports.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-consecutive-unused-imports.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Boolean
+// Comment after the first unused import.
+use smithy.api#Integer
+
+// Comment after the second unused import.
+string Foo

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-unused-imports.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-unused-imports.formatted.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Integer
+
+// This plain comment needs to stay.
+structure Foo {
+    bar: Integer
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-unused-imports.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-after-unused-imports.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Integer
+use smithy.api#String // This trailing note documents the import and is dropped with it.
+
+// This plain comment needs to stay.
+structure Foo {
+    bar: Integer
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-before-unused-import.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-before-unused-import.formatted.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Boolean
+
+// This comment leads the shape and is kept.
+structure Foo {
+    bar: Boolean
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-before-unused-import.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/comments-before-unused-import.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#Boolean
+
+// This comment leads the removed import and is dropped with it.
+use smithy.api#Integer
+
+// This comment leads the shape and is kept.
+structure Foo {
+    bar: Boolean
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/doc-comment-after-unused-import.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/doc-comment-after-unused-import.formatted.smithy
@@ -1,0 +1,6 @@
+$version: "1.0"
+
+namespace smithy.example
+
+/// This doc comment needs to stay.
+string Foo

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/doc-comment-after-unused-import.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/doc-comment-after-unused-import.smithy
@@ -1,0 +1,8 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use smithy.api#String
+
+/// This doc comment needs to stay.
+string Foo


### PR DESCRIPTION
This fixes a bug in smithy-syntax where comments (including doc comments) after an unused import would be removed along with the unused import. This is because those comments live in the BR tree at the end of the import tree, and that entire tree was being removed.

This updates the removal logic to preserve those comments by moving them up into the nearest surviving statement.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
