### PR TITLE
Add validation for not-bound required rules engine params

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetParameterValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetParameterValidator.java
@@ -77,6 +77,8 @@ public final class RuleSetParameterValidator extends AbstractValidator {
         Map<String, Parameter> modelParams = validateAndExtractParameters(errors, model, service, operations);
         // Make sure parameters align across Params <-> RuleSet transitions.
         validateParametersMatching(errors, service, sourceLocation, parameters, modelParams);
+        // Check that all required parameters are bound by each operation.
+        validateRequiredParametersPerOperation(errors, model, service, parameters, operations);
         // Check that tests declare required parameters, only defined parameters, etc.
         if (service.hasTrait(EndpointTestsTrait.ID)) {
             validateTestsParameters(errors, service, service.expectTrait(EndpointTestsTrait.class), parameters);
@@ -185,6 +187,60 @@ public final class RuleSetParameterValidator extends AbstractValidator {
         }
 
         return endpointParams;
+    }
+
+    private void validateRequiredParametersPerOperation(
+            List<ValidationEvent> errors,
+            Model model,
+            ServiceShape service,
+            Iterable<Parameter> ruleSetParams,
+            Set<OperationShape> operations
+    ) {
+        // Collect required params that must be bound per-operation (no default, not built-in).
+        Set<String> requiredParams = new HashSet<>();
+        for (Parameter param : ruleSetParams) {
+            if (param.isRequired() && !param.getDefault().isPresent() && !param.isBuiltIn()) {
+                requiredParams.add(param.getName().toString());
+            }
+        }
+        if (requiredParams.isEmpty()) {
+            return;
+        }
+
+        // Service-level ClientContextParams satisfy requirements for all operations.
+        Set<String> serviceLevel = new HashSet<>();
+        if (service.hasTrait(ClientContextParamsTrait.ID)) {
+            serviceLevel.addAll(service.expectTrait(ClientContextParamsTrait.class).getParameters().keySet());
+        }
+
+        for (OperationShape operation : operations) {
+            Set<String> boundParams = new HashSet<>(serviceLevel);
+
+            if (operation.hasTrait(StaticContextParamsTrait.ID)) {
+                boundParams.addAll(operation.expectTrait(StaticContextParamsTrait.class).getParameters().keySet());
+            }
+            if (operation.hasTrait(OperationContextParamsTrait.ID)) {
+                boundParams.addAll(operation.expectTrait(OperationContextParamsTrait.class).getParameters().keySet());
+            }
+
+            StructureShape input = model.expectShape(operation.getInputShape(), StructureShape.class);
+            for (MemberShape member : input.members()) {
+                if (member.hasTrait(ContextParamTrait.ID)) {
+                    boundParams.add(member.expectTrait(ContextParamTrait.class).getName());
+                }
+            }
+
+            for (String required : requiredParams) {
+                if (!boundParams.contains(required)) {
+                    errors.add(parameterError(operation,
+                            operation,
+                            "Operation.RequiredMissing",
+                            String.format("Required parameter `%s` is not bound by operation `%s`",
+                                    required,
+                                    operation.getId().getName())));
+                }
+            }
+        }
     }
 
     private void validateParametersMatching(

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/required-params-missing.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/required-params-missing.errors
@@ -1,0 +1,4 @@
+[WARNING] example#MyService: This shape applies a trait that is unstable: smithy.rules#clientContextParams | UnstableTrait
+[WARNING] example#MyService: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
+[WARNING] example#HasBucket: This shape applies a trait that is unstable: smithy.rules#staticContextParams | UnstableTrait.smithy.rules#staticContextParams
+[ERROR] example#MissingBucket: Required parameter `Bucket` is not bound by operation `MissingBucket` | RuleSetParameter.Operation.RequiredMissing

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/required-params-missing.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/required-params-missing.smithy
@@ -1,0 +1,40 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#clientContextParams
+use smithy.rules#endpointRuleSet
+use smithy.rules#staticContextParams
+
+@endpointRuleSet({
+    version: "1.3"
+    parameters: {
+        Region: { type: "string", required: true, documentation: "docs" }
+        Bucket: { type: "string", required: true, documentation: "docs" }
+    }
+    rules: []
+})
+@clientContextParams(
+    Region: { type: "string", documentation: "docs" }
+)
+service MyService {
+    operations: [
+        HasBucket
+        MissingBucket
+    ]
+}
+
+@staticContextParams(
+    Bucket: { value: "my-bucket" }
+)
+operation HasBucket {
+    input: HasBucketInput
+}
+
+structure HasBucketInput {}
+
+operation MissingBucket {
+    input: MissingBucketInput
+}
+
+structure MissingBucketInput {}


### PR DESCRIPTION
#### Background
* Adds per-operation validation of required endpoint ruleset parameters in `RuleSetParameterValidator`.
* Previously, the validator only checked that required params existed *somewhere* across all operations. This allowed services to be released where some operations didn't bind required params, causing SDK build failures.
* The new check ensures every operation binds all required parameters (those with `required: true`, no default, and not built-in) via `ClientContextParams`, `StaticContextParams`, `OperationContextParams`, or `ContextParam`.

#### Testing
* Added `required-params-missing.smithy` errorfile test validating the new `RuleSetParameter.Operation.RequiredMissing` error is emitted.
* Existing tests (`default-values.smithy` with required+default params, `valid-model.smithy`) confirm no false positives.
* Full `smithy-rules-engine` test suite passes.

#### Links

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
