### PR TITLE
Added test cases for errors in AWS JSON protocols using different namespaces

### DIFF
--- a/.changes/next-release/feature-115f276aaf230e5e0b9502b6d0bcc9594962b529.json
+++ b/.changes/next-release/feature-115f276aaf230e5e0b9502b6d0bcc9594962b529.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Add test cases for AWS JSON protocols using different namespaces",
+  "pull_requests": [
+    "[#3157](https://github.com/smithy-lang/smithy/pull/3157)"
+  ]
+}

--- a/.changes/next-release/feature-115f276aaf230e5e0b9502b6d0bcc9594962b529.json
+++ b/.changes/next-release/feature-115f276aaf230e5e0b9502b6d0bcc9594962b529.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Add test cases for AWS JSON protocols using different namespaces",
+  "description": "Added test cases for errors in AWS JSON protocols using different namespaces",
   "pull_requests": [
     "[#3157](https://github.com/smithy-lang/smithy/pull/3157)"
   ]

--- a/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
@@ -222,6 +222,21 @@ apply FooError @httpResponseTests([
         appliesTo: "client"
     }
     {
+        id: "AwsJson10FooErrorWithDunderTypeAndDifferentNamespace"
+        documentation: """
+            Because only the part after '#' is considered, an unrecognized namespace should \
+            not make a difference."""
+        protocol: awsJson1_0
+        code: 500
+        headers: { "Content-Type": "application/x-amz-json-1.0" }
+        body: """
+            {
+                "__type": "aws.different.namespace#FooError"
+            }"""
+        bodyMediaType: "application/json"
+        appliesTo: "client"
+    }
+    {
         id: "AwsJson10FooErrorWithDunderTypeUriAndNamespace"
         documentation: """
             Some services serialize errors using __type, and it might contain a namespace. It also might \

--- a/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
@@ -214,6 +214,21 @@ apply FooError @httpResponseTests([
         appliesTo: "client"
     }
     {
+        id: "AwsJson11FooErrorWithDunderTypeAndDifferentNamespace"
+        documentation: """
+            Because only the part after '#' is considered, an unrecognized namespace should \
+            not make a difference."""
+        protocol: awsJson1_1
+        code: 500
+        headers: { "Content-Type": "application/x-amz-json-1.1" }
+        body: """
+            {
+                "__type": "aws.different.namespace#FooError"
+            }"""
+        bodyMediaType: "application/json"
+        appliesTo: "client"
+    }
+    {
         id: "AwsJson11FooErrorWithDunderTypeUriAndNamespace"
         documentation: """
             Some services serialize errors using __type, and it might contain a namespace. It also might \

--- a/smithy-aws-protocol-tests/model/restJson1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/errors.smithy
@@ -178,6 +178,16 @@ apply FooError @httpResponseTests([
         appliesTo: "client"
     }
     {
+        id: "RestJsonFooErrorUsingXAmznErrorTypeWithUriAndDifferentNamespace"
+        documentation: """
+            Because namespace and URL are ignored, an unrecognized namespace should \
+            not make a difference."""
+        protocol: restJson1
+        code: 500
+        headers: { "X-Amzn-Errortype": "aws.different.namespace#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/" }
+        appliesTo: "client"
+    }
+    {
         id: "RestJsonFooErrorUsingCode"
         documentation: """
             This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some \


### PR DESCRIPTION
#### Background
Adds test cases for the AWS JSON protocols that cover the case where service returned error identifier namespace is different from those in the SDK's known model.

The AWS SDK for JS had a bug caused by my misunderstanding of the protocol spec detailed in https://github.com/aws/aws-sdk-js-v3/pull/8031.

That bug made JSON 1.0 error parsing not strip the namespace when performing error lookup. Because the test namespace is the same as the SDK's model namespace, this did not fail in protocol tests, which only assert that a particular error type was resolved.

In practice, most JSON 1.0 services return a different namespace than what exists in their models.

#### Testing
Tested by generating AWS protocol tests for the AWS SDK JSv3, which passed.

#### Links
* Bugfix in JSv3 https://github.com/aws/aws-sdk-js-v3/pull/8031
* Error parsing https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
