### PR TITLE
Add integration trait fields and compression docs

### DIFF
--- a/docs/source-2.0/aws/amazon-apigateway.rst
+++ b/docs/source-2.0/aws/amazon-apigateway.rst
@@ -616,6 +616,25 @@ following members:
       - Defines the method's responses and specifies desired parameter
         mappings or payload mappings from integration responses to method
         responses.
+    * - tlsConfig
+      - ``structure``
+      - Specifies the TLS configuration for an integration. Supported only
+        for HTTP and HTTP_PROXY integration types. Contains the following
+        member:
+
+        - ``insecureSkipVerification`` (``boolean``): When set to ``true``,
+          API Gateway skips verification that the certificate for an
+          integration endpoint is issued by a supported certificate
+          authority.
+    * - responseTransferMode
+      - ``string``
+      - Specifies how the response payload is transferred between the
+        integration and the caller. Valid values are ``BUFFERED`` and
+        ``STREAM``.
+    * - integrationTarget
+      - ``string``
+      - The ARN of an ALB or NLB listener for private integrations using
+        VPC Links V2.
 
 The following example defines an integration that is applied to every
 operation within the service.

--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -1809,6 +1809,47 @@ collecting all of the :ref:`mediaType-trait` values for all members marked
 with :ref:`httppayload-trait`.
 
 
+Minimum compression size
+========================
+
+The minimum payload size in bytes at which compression is applied on an
+API Gateway REST API can be set using the
+:ref:`aws.apigateway#minimumCompressionSize-trait`. The value must be
+between 0 and 10485760 bytes (10 MB), inclusive. Smithy will add the
+value of the trait to the generated OpenAPI document as the top-level
+`x-amazon-apigateway-minimum-compression-size`_ extension.
+
+The following Smithy model enables compression on payloads of 1024 bytes
+or larger:
+
+.. code-block:: smithy
+
+    $version: "2"
+    namespace smithy.example
+
+    use aws.apigateway#minimumCompressionSize
+    use aws.protocols#restJson1
+
+    @restJson1
+    @minimumCompressionSize(1024)
+    service Example {
+      version: "2019-06-17"
+    }
+
+is converted to the following OpenAPI model:
+
+.. code-block:: json
+
+    {
+        "openapi": "3.0.2",
+        "info": {
+            "title": "Example",
+            "version": "2019-06-17"
+        },
+        "x-amazon-apigateway-minimum-compression-size": 1024
+    }
+
+
 .. _apigateway-request-validators:
 
 Request validators
@@ -1882,6 +1923,30 @@ applied to a resource shape, then all operations of the resource and all child
 resources inherit the applied integration. If either trait is applied to an
 operation, then the operation uses a specific integration that overrides any
 integration inherited from a resource or service.
+
+The following ``aws.apigateway#integration`` trait fields map directly to
+``x-amazon-apigateway-integration`` OpenAPI extension fields:
+
+tlsConfig
+    Maps to ``x-amazon-apigateway-integration.tlsConfig`` in the OpenAPI
+    output. Contains the ``insecureSkipVerification`` boolean member. When
+    set to ``true``, API Gateway skips verification that the certificate for
+    an integration endpoint is issued by a supported certificate authority.
+    Supported only for HTTP and HTTP_PROXY integration types.
+
+responseTransferMode
+    Maps to ``x-amazon-apigateway-integration.responseTransferMode`` in the
+    OpenAPI output. Specifies how the response payload is transferred between
+    the integration and the caller. Valid values are ``BUFFERED`` and
+    ``STREAM``.
+
+integrationTarget
+    Maps to ``x-amazon-apigateway-integration.integrationTarget`` in the
+    OpenAPI output. The ARN of an `Application Load Balancer (ALB)`_ or
+    `Network Load Balancer (NLB)`_ listener for private integrations using
+    `VPC Links V2`_. Values containing ``${...}`` syntax are automatically
+    wrapped in an `Fn::Sub`_ intrinsic function for CloudFormation
+    substitution. See :ref:`openapi-cfn-substitutions`.
 
 
 CORS functionality
@@ -2227,6 +2292,7 @@ uses the ``Fn::Sub`` variable syntax (``*`` means any value):
 - ``paths/*/*/x-amazon-apigateway-integration/connectionId``
 - ``paths/*/*/x-amazon-apigateway-integration/credentials``
 - ``paths/*/*/x-amazon-apigateway-integration/uri``
+- ``paths/*/*/x-amazon-apigateway-integration/integrationTarget``
 - ``x-amazon-apigateway-endpoint-configuration/vpcEndpointIds/*``
 
 .. note::
@@ -2626,7 +2692,7 @@ The conversion process is highly extensible through
 .. _x-amazon-apigateway-request-validators: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html
 .. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validator.html
 .. _intrinsic functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
-.. _`Fn::Sub`: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html
+.. _`Fn::Sub`: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-sub.html
 .. _x-amazon-apigateway-api-key-source: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-api-key-source.html
 .. _OpenAPI tags: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#tagObject
 .. _OpenAPI Data types: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#data-types
@@ -2645,3 +2711,6 @@ The conversion process is highly extensible through
 .. _x-amazon-apigateway-endpoint-configuration: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-endpoint-configuration.html
 .. _x-amazon-apigateway-minimum-compression-size: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-openapi-minimum-compression-size.html
 .. _x-amazon-apigateway-policy: https://docs.aws.amazon.com/apigateway/latest/developerguide/openapi-extensions-policy.html
+.. _Application Load Balancer (ALB): https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html
+.. _Network Load Balancer (NLB): https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html
+.. _VPC Links V2: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-vpc-links-v2.html


### PR DESCRIPTION


Add `tlsConfig`, `responseTransferMode`, and `integrationTarget` to the `@integration` trait table and the converting-to-openapi guide. Add the "Minimum compression size" section with a Smithy-to-OpenAPI conversion example, and add `integrationTarget` to the CloudFormation substitution paths list.

#### Background

* Adds documentation for three `@integration` trait fields (`tlsConfig`, `responseTransferMode`, `integrationTarget`) that were added in #3090 but inadvertently lost during a merge conflict resolution in #3089.
* Restores the standalone "Minimum compression size" section in the converting-to-openapi guide with its before/after code example showing the Smithy model and generated OpenAPI output.
* Adds `integrationTarget` to the CloudFormation substitution paths list since it contains ARN values that need `Fn::Sub` wrapping.
* Updates the `Fn::Sub` link reference to the current AWS documentation URL.

#### Testing

* Sphinx build passes in strict mode (`-W --keep-going -n`) with no warnings or errors.
* `./gradlew clean build` passes all tasks.

#### Links

* Relates to #3090

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.