### PR TITLE
Skip clientOptional members in AddedRequiredMember

### DIFF
--- a/.changes/next-release/bugfix-f5f810abf0f6986480e08df52c82c8201eb20f42.json
+++ b/.changes/next-release/bugfix-f5f810abf0f6986480e08df52c82c8201eb20f42.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fixed the `AddedRequiredMember` diff evaluator so that it no longer flags new members marked with the `@clientOptional` trait, which is the sanctioned way to add a `@required` member without breaking generated client code.",
+  "pull_requests": []
+}

--- a/.changes/next-release/bugfix-f5f810abf0f6986480e08df52c82c8201eb20f42.json
+++ b/.changes/next-release/bugfix-f5f810abf0f6986480e08df52c82c8201eb20f42.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fixed the `AddedRequiredMember` diff evaluator so that it no longer flags new members marked with the `@clientOptional` trait, which is the sanctioned way to add a `@required` member without breaking generated client code.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3166](https://github.com/smithy-lang/smithy/pull/3166)"
+  ]
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedRequiredMember.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedRequiredMember.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.validation.Severity;
@@ -36,6 +37,9 @@ public class AddedRequiredMember extends AbstractDiffEvaluator {
                         .stream()
                         .filter(newMember -> newMember.hasTrait(RequiredTrait.ID)
                                 && !newMember.hasTrait(DefaultTrait.ID)
+                                // A member marked @clientOptional is treated as optional by clients, so the
+                                // service reserves the right to add @required without breaking generated code.
+                                && !newMember.hasTrait(ClientOptionalTrait.ID)
                                 // Members that did not exist before
                                 && change.getOldShape().getAllMembers().get(newMember.getMemberName()) == null));
     }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedRequiredMemberTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedRequiredMemberTest.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.validation.Severity;
@@ -89,6 +90,26 @@ public class AddedRequiredMemberTest {
                 .addMember("foo",
                         s.getId(),
                         b2 -> b2.addTrait(new RequiredTrait()))
+                .build();
+        Model model1 = Model.builder().addShapes(s, a).build();
+        Model model2 = Model.builder().addShapes(s, b).build();
+        ModelDiff.Result result = ModelDiff.builder().oldModel(model1).newModel(model2).compare();
+
+        assertThat(TestHelper.findEvents(result.getDiffEvents(), "AddedRequiredMember").size(), equalTo(0));
+    }
+
+    @Test
+    public void addingRequiredTraitWithClientOptionalIsOk() {
+        StringShape s = StringShape.builder().id("smithy.example#Str").build();
+        StructureShape a = StructureShape.builder()
+                .id("smithy.example#A")
+                .build();
+        StructureShape b = StructureShape.builder()
+                .id("smithy.example#A")
+                .addMember("foo", s.getId(), b2 -> {
+                    b2.addTrait(new RequiredTrait());
+                    b2.addTrait(new ClientOptionalTrait());
+                })
                 .build();
         Model model1 = Model.builder().addShapes(s, a).build();
         Model model2 = Model.builder().addShapes(s, b).build();


### PR DESCRIPTION


#### Background

The AddedRequiredMember evaluator flagged any net-new member carrying `@required` without `@default` as backwards-incompatible, even when the member was also marked `@clientOptional`. That contradicts the model evolution design: `@clientOptional` is the sanctioned escape hatch for adding a `@required `member, since clients treat the member as optional and the service owns validation.

The sibling ChangedNullability evaluator already exempts @clientOptional members; AddedRequiredMember now does the same so the two agree on what counts as a safe nullability change.

#### Testing

- Added AddedRequiredMemberTest.addingRequiredTraitWithClientOptionalIsOk() (TDD: failed before fix, passed after).
- Full :smithy-diff:test suite green, including ChangedNullabilityTest — no regression.

#### Links

- Design: [defaults-and-model-evolution.md](https://github.com/smithy-lang/smithy/blob/main/designs/defaults-and-model-evolution.md)
- Original evaluator: #1923

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
