### PR TITLE
Optimize selectors by avoiding hashmaps

### DIFF
--- a/.changes/next-release/feature-59c595d730f7bc66028aeb4973de37d40af617ae.json
+++ b/.changes/next-release/feature-59c595d730f7bc66028aeb4973de37d40af617ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Optimize selector parsing",
+  "pull_requests": [
+    "[#3175](https://github.com/smithy-lang/smithy/pull/3175)"
+  ]
+}

--- a/.changes/next-release/feature-59c595d730f7bc66028aeb4973de37d40af617ae.json
+++ b/.changes/next-release/feature-59c595d730f7bc66028aeb4973de37d40af617ae.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Optimize selector parsing",
+  "description": "Optimized selector parsing",
   "pull_requests": [
     "[#3175](https://github.com/smithy-lang/smithy/pull/3175)"
   ]

--- a/.changes/next-release/feature-bf3f6e8f4b7da8b3b10f42d1a606c6ac1ce41a42.json
+++ b/.changes/next-release/feature-bf3f6e8f4b7da8b3b10f42d1a606c6ac1ce41a42.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Optimize selectors",
+  "description": "Optimized selectors",
   "pull_requests": [
     "[#3171](https://github.com/smithy-lang/smithy/pull/3171)"
   ]

--- a/.changes/next-release/feature-bf3f6e8f4b7da8b3b10f42d1a606c6ac1ce41a42.json
+++ b/.changes/next-release/feature-bf3f6e8f4b7da8b3b10f42d1a606c6ac1ce41a42.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Optimize selectors",
+  "pull_requests": [
+    "[#3171](https://github.com/smithy-lang/smithy/pull/3171)"
+  ]
+}

--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
@@ -13,6 +13,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -138,5 +139,92 @@ public class Selectors {
     @Benchmark
     public Set<Shape> evaluateDoubleRootSelector(SelectorState state) {
         return state.doubleRootSelector.select(state.model);
+    }
+
+    // ==============================================================================
+    // Realistic model benchmarks: exercises real-world selector patterns from the
+    // prelude, validators, and AWS traits on a ~300+ shape model.
+    // ==============================================================================
+
+    @State(Scope.Thread)
+    public static class RealisticState {
+
+        public Model model;
+
+        // Trait existence: the simplest and most common pattern.
+        public Selector traitError = Selector.parse("structure [trait|error]");
+        // Negated trait: very common in validators (e.g., :not([trait|input])).
+        public Selector notTrait = Selector.parse("structure :not([trait|input]) :not([trait|output])");
+        // Multi-type union filter (:is).
+        public Selector isMultiType = Selector.parse(":is(service, operation, resource)");
+        // Neighbor + type filter: exercises forward neighbor traversal.
+        public Selector structureMembers = Selector.parse("structure > member");
+        // Recursive neighbor + type filter: the deep traversal pattern.
+        public Selector recursiveToOperation = Selector.parse("service ~> operation");
+        // :test with nested navigation.
+        public Selector testNestedStructure = Selector.parse(
+                "operation -[input, output]-> structure > member :test(> structure)");
+        // Compound validator pattern from the prelude.
+        public Selector preludeDataType = Selector.parse(
+                "structure :not([trait|input]) :not([trait|output]) > member :test(> integer)");
+        // The trait existence + attribute comparison (exercises AttributeSelector with comparator).
+        public Selector traitWithValue = Selector.parse("structure [trait|error = \"client\"]");
+
+        @Setup
+        public void prepare() {
+            model = Model.assembler()
+                    .addImport(Selectors.class.getResource("realistic-model.smithy"))
+                    .assemble()
+                    .getResult()
+                    .get();
+        }
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> traitExistence(RealisticState state) {
+        return state.traitError.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> notTrait(RealisticState state) {
+        return state.notTrait.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> isMultiType(RealisticState state) {
+        return state.isMultiType.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> structureMembers(RealisticState state) {
+        return state.structureMembers.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> recursiveToOperation(RealisticState state) {
+        return state.recursiveToOperation.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> testNestedStructure(RealisticState state) {
+        return state.testNestedStructure.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> preludeDataType(RealisticState state) {
+        return state.preludeDataType.select(state.model);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Set<Shape> traitWithValue(RealisticState state) {
+        return state.traitWithValue.select(state.model);
     }
 }

--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
@@ -104,6 +104,18 @@ public class Selectors {
         return state.createHttpBindingIncompatibilitySelector();
     }
 
+    // Parses a selector that heavily exercises the variadic expect(...) paths: directed forward/reverse neighbors
+    // with multiple relationship types, the attribute operator set, projection comparators, and the dataType keyword.
+    @Benchmark
+    public Selector parseVariadicHeavySelector() {
+        return Selector.parse(
+                "operation -[input, output]-> structure > member"
+                        + " :test(<-[member]-)"
+                        + " :is(dataType, structure)"
+                        + " [trait|range|min >= 1]"
+                        + " [@: @{trait|tags|(values)} {<} @{trait|tags|(values)}]");
+    }
+
     // The selector based version of evaluateHttpBindingManually.
     @Benchmark
     public Set<Shape> evaluateHttpBindingSelector(SelectorState state) {

--- a/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/realistic-model.smithy
+++ b/smithy-model/src/jmh/resources/software/amazon/smithy/model/jmh/realistic-model.smithy
@@ -1,0 +1,382 @@
+$version: "2"
+namespace smithy.example
+
+use smithy.api#required
+use smithy.api#documentation
+use smithy.api#paginated
+use smithy.api#readonly
+use smithy.api#idempotent
+use smithy.api#http
+use smithy.api#httpLabel
+use smithy.api#httpQuery
+use smithy.api#error
+use smithy.api#retryable
+use smithy.api#sensitive
+use smithy.api#deprecated
+
+@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "maxResults")
+service RealisticService {
+    version: "2024-01-01"
+    operations: [
+        ListThings
+        GetThing
+        CreateThing
+        UpdateThing
+        DeleteThing
+        BatchGetThings
+        SearchThings
+    ]
+    resources: [ThingResource, WidgetResource]
+}
+
+resource ThingResource {
+    identifiers: { thingId: ThingId }
+    properties: { name: String, status: ThingStatus }
+    read: GetThing
+    create: CreateThing
+    update: UpdateThing
+    delete: DeleteThing
+    list: ListThings
+    operations: [ArchiveThing, RestoreThing]
+}
+
+resource WidgetResource {
+    identifiers: { widgetId: WidgetId }
+    properties: { label: String, size: Integer }
+    read: GetWidget
+    create: CreateWidget
+    update: UpdateWidget
+    delete: DeleteWidget
+    list: ListWidgets
+}
+
+string ThingId
+string WidgetId
+
+enum ThingStatus {
+    ACTIVE
+    INACTIVE
+    ARCHIVED
+}
+
+// --- Thing operations ---
+
+@readonly
+@http(uri: "/things/{thingId}", method: "GET")
+operation GetThing {
+    input := {
+        @required @httpLabel
+        thingId: ThingId
+    }
+    output := {
+        @required
+        thingId: ThingId
+        @required
+        name: String
+        status: ThingStatus
+        metadata: ThingMetadata
+        tags: TagList
+        createdAt: Timestamp
+    }
+    errors: [ThingNotFound, AccessDenied]
+}
+
+@http(uri: "/things", method: "POST")
+operation CreateThing {
+    input := {
+        @required
+        name: String
+        status: ThingStatus
+        tags: TagList
+        @sensitive
+        secret: String
+        metadata: ThingMetadata
+    }
+    output := {
+        @required
+        thingId: ThingId
+        @required
+        name: String
+    }
+    errors: [ValidationError, ConflictError, AccessDenied]
+}
+
+@idempotent
+@http(uri: "/things/{thingId}", method: "PUT")
+operation UpdateThing {
+    input := {
+        @required @httpLabel
+        thingId: ThingId
+        name: String
+        status: ThingStatus
+        tags: TagList
+    }
+    output := {
+        @required
+        thingId: ThingId
+        name: String
+        status: ThingStatus
+    }
+    errors: [ThingNotFound, ValidationError, AccessDenied]
+}
+
+@idempotent
+@http(uri: "/things/{thingId}", method: "DELETE")
+operation DeleteThing {
+    input := {
+        @required @httpLabel
+        thingId: ThingId
+    }
+    errors: [ThingNotFound, AccessDenied]
+}
+
+@readonly
+@paginated
+@http(uri: "/things", method: "GET")
+operation ListThings {
+    input := {
+        @httpQuery("maxResults")
+        maxResults: Integer
+        @httpQuery("nextToken")
+        nextToken: String
+        @httpQuery("status")
+        statusFilter: ThingStatus
+    }
+    output := {
+        @required
+        items: ThingList
+        nextToken: String
+    }
+}
+
+@readonly
+@http(uri: "/things/batch", method: "POST")
+operation BatchGetThings {
+    input := {
+        @required
+        ids: ThingIdList
+    }
+    output := {
+        @required
+        items: ThingList
+        failedIds: ThingIdList
+    }
+}
+
+@readonly
+@http(uri: "/things/search", method: "POST")
+operation SearchThings {
+    input := {
+        @required
+        query: String
+        maxResults: Integer
+        nextToken: String
+        filters: FilterMap
+    }
+    output := {
+        @required
+        items: ThingList
+        nextToken: String
+        totalCount: Long
+    }
+}
+
+@http(uri: "/things/{thingId}/archive", method: "POST")
+operation ArchiveThing {
+    input := {
+        @required @httpLabel
+        thingId: ThingId
+        reason: String
+    }
+    errors: [ThingNotFound, AccessDenied]
+}
+
+@http(uri: "/things/{thingId}/restore", method: "POST")
+operation RestoreThing {
+    input := {
+        @required @httpLabel
+        thingId: ThingId
+    }
+    errors: [ThingNotFound, AccessDenied]
+}
+
+// --- Widget operations ---
+
+@readonly
+@http(uri: "/widgets/{widgetId}", method: "GET")
+operation GetWidget {
+    input := {
+        @required @httpLabel
+        widgetId: WidgetId
+    }
+    output := {
+        @required
+        widgetId: WidgetId
+        @required
+        label: String
+        size: Integer
+        tags: TagList
+    }
+    errors: [WidgetNotFound]
+}
+
+@http(uri: "/widgets", method: "POST")
+operation CreateWidget {
+    input := {
+        @required
+        label: String
+        size: Integer
+        tags: TagList
+    }
+    output := {
+        @required
+        widgetId: WidgetId
+    }
+    errors: [ValidationError]
+}
+
+@idempotent
+@http(uri: "/widgets/{widgetId}", method: "PUT")
+operation UpdateWidget {
+    input := {
+        @required @httpLabel
+        widgetId: WidgetId
+        label: String
+        size: Integer
+    }
+    output := {
+        @required
+        widgetId: WidgetId
+        label: String
+    }
+    errors: [WidgetNotFound, ValidationError]
+}
+
+@idempotent
+@http(uri: "/widgets/{widgetId}", method: "DELETE")
+operation DeleteWidget {
+    input := {
+        @required @httpLabel
+        widgetId: WidgetId
+    }
+    errors: [WidgetNotFound]
+}
+
+@readonly
+@paginated
+@http(uri: "/widgets", method: "GET")
+operation ListWidgets {
+    input := {
+        @httpQuery("maxResults")
+        maxResults: Integer
+        @httpQuery("nextToken")
+        nextToken: String
+    }
+    output := {
+        @required
+        items: WidgetList
+        nextToken: String
+    }
+}
+
+// --- Shared shapes ---
+
+structure ThingMetadata {
+    region: String
+    account: String
+    @deprecated
+    legacyField: String
+}
+
+list ThingList {
+    member: ThingSummary
+}
+
+list ThingIdList {
+    member: ThingId
+}
+
+list WidgetList {
+    member: WidgetSummary
+}
+
+list TagList {
+    member: Tag
+}
+
+map FilterMap {
+    key: String
+    value: FilterValues
+}
+
+list FilterValues {
+    member: String
+}
+
+structure ThingSummary {
+    @required
+    thingId: ThingId
+    @required
+    name: String
+    status: ThingStatus
+}
+
+structure WidgetSummary {
+    @required
+    widgetId: WidgetId
+    @required
+    label: String
+}
+
+structure Tag {
+    @required
+    key: String
+    value: String
+}
+
+// --- Errors ---
+
+@error("client")
+@retryable
+structure ThingNotFound {
+    @required
+    message: String
+    thingId: ThingId
+}
+
+@error("client")
+structure WidgetNotFound {
+    @required
+    message: String
+    widgetId: WidgetId
+}
+
+@error("client")
+structure ValidationError {
+    @required
+    message: String
+    fieldList: ValidationFieldList
+}
+
+list ValidationFieldList {
+    member: ValidationField
+}
+
+structure ValidationField {
+    @required
+    path: String
+    @required
+    message: String
+}
+
+@error("client")
+structure ConflictError {
+    @required
+    message: String
+}
+
+@error("client")
+structure AccessDenied {
+    @required
+    message: String
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ParserUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ParserUtils.java
@@ -147,8 +147,12 @@ public final class ParserUtils {
         // Parse identifier_start
         char c = parser.peek();
         if (c == '_') {
-            parser.consumeWhile(next -> next == '_');
-            if (!ParserUtils.isValidIdentifierCharacter(parser.peek())) {
+            do {
+                parser.skipNonNewline();
+                c = parser.peek();
+            } while (c == '_');
+
+            if (!ParserUtils.isValidIdentifierCharacter(c)) {
                 throw invalidIdentifier(parser);
             }
         } else if (!isAlphabetic(c)) {
@@ -156,10 +160,12 @@ public final class ParserUtils {
         }
 
         // Skip the first character since it's known to be valid.
-        parser.skip();
+        parser.skipNonNewline();
 
         // Parse identifier_chars
-        parser.consumeWhile(ParserUtils::isValidIdentifierCharacter);
+        while (isValidIdentifierCharacter(parser.peek())) {
+            parser.skipNonNewline();
+        }
     }
 
     private static RuntimeException invalidIdentifier(SimpleParser parser) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
@@ -55,9 +55,6 @@ final class AndSelector {
 
         @Override
         public Response push(Context ctx, Shape shape, Receiver next) {
-            // When the right selector is input-shape-independent (e.g., RootSelector), its
-            // output is the same regardless of which shape is pushed into it. Check if the
-            // left emits anything, and if so, call the right selector exactly once.
             if (rightInputShapeIndependent) {
                 if (ctx.receivedShapes(shape, leftSelector)) {
                     return rightSelector.push(ctx, shape, next);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
@@ -42,10 +42,15 @@ final class AndSelector {
     static final class IntermediateAndSelector implements InternalSelector {
         private final InternalSelector leftSelector;
         private final InternalSelector rightSelector;
+        // Precompute these flags once: the AST is immutable, so recomputing them per push() is wasted work.
+        private final boolean rightInputShapeIndependent;
+        private final boolean inputShapeIndependent;
 
         IntermediateAndSelector(InternalSelector leftSelector, InternalSelector rightSelector) {
             this.leftSelector = leftSelector;
             this.rightSelector = rightSelector;
+            this.rightInputShapeIndependent = rightSelector.isInputShapeIndependent();
+            this.inputShapeIndependent = leftSelector.isInputShapeIndependent() && rightInputShapeIndependent;
         }
 
         @Override
@@ -53,7 +58,7 @@ final class AndSelector {
             // When the right selector is input-shape-independent (e.g., RootSelector), its
             // output is the same regardless of which shape is pushed into it. Check if the
             // left emits anything, and if so, call the right selector exactly once.
-            if (rightSelector.isInputShapeIndependent()) {
+            if (rightInputShapeIndependent) {
                 if (ctx.receivedShapes(shape, leftSelector)) {
                     return rightSelector.push(ctx, shape, next);
                 }
@@ -64,7 +69,7 @@ final class AndSelector {
 
         @Override
         public boolean isInputShapeIndependent() {
-            return leftSelector.isInputShapeIndependent() && rightSelector.isInputShapeIndependent();
+            return inputShapeIndependent;
         }
 
         @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributePathExtractor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributePathExtractor.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.selector;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
+
+/**
+ * A precompiled extraction pipeline that resolves an attribute path from a shape to an {@link AttributeValue}.
+ */
+@FunctionalInterface
+interface AttributePathExtractor {
+    /**
+     * Extracts the attribute value from a shape.
+     *
+     * @param shape The shape to extract from.
+     * @param vars The current variable bindings (needed for {@code [var|name]} access).
+     * @return The resolved attribute value, or {@link AttributeValueImpl#EMPTY} if not present.
+     */
+    AttributeValue extract(Shape shape, Map<String, Set<Shape>> vars);
+
+    /**
+     * Compiles a path into a precompiled extractor.
+     *
+     * @param path The attribute path segments.
+     * @return A precompiled extractor (never null).
+     */
+    static AttributePathExtractor compile(List<String> path) {
+        if (path.isEmpty()) {
+            return AttributeValue::shape;
+        }
+
+        switch (path.get(0)) {
+            case "trait": {
+                AttributePathExtractor specialized = compileTrait(path);
+                if (specialized != null) {
+                    return specialized;
+                }
+                break;
+            }
+            case "id": {
+                AttributePathExtractor specialized = compileId(path);
+                if (specialized != null) {
+                    return specialized;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        // Generic fallback: walks the path at runtime via the AttributeValue chain.
+        return (shape, vars) -> AttributeValue.shape(shape, vars).getPath(path);
+    }
+
+    static AttributePathExtractor compileTrait(List<String> path) {
+        if (path.size() < 2) {
+            // Bare [trait]: checking if a shape has any traits at all is rare, so fall back.
+            return null;
+        }
+
+        String traitName = path.get(1);
+        if (traitName.startsWith("(")) {
+            // Projection: (keys), (values), (length). These allocate lists; compile as direct calls.
+            return null;
+        }
+
+        // Resolve the trait ShapeId once.
+        ShapeId traitId = ShapeId.from(Trait.makeAbsoluteName(traitName));
+
+        if (path.size() == 2) {
+            // [trait|X] with a comparator: extract the trait's node value.
+            return (shape, vars) -> {
+                Trait trait = shape.findTrait(traitId).orElse(null);
+                return trait == null
+                        ? AttributeValueImpl.EMPTY
+                        : AttributeValue.node(trait.toNode());
+            };
+        }
+
+        // [trait|X|property|...]: if all remaining segments are plain member names (no pseudo-properties),
+        // walk the raw Node tree directly without intermediate AttributeValue allocations.
+        List<String> remainingPath = path.subList(2, path.size());
+        if (remainingPath.stream().noneMatch(s -> s.startsWith("("))) {
+            return (shape, vars) -> {
+                Trait trait = shape.findTrait(traitId).orElse(null);
+                if (trait == null) {
+                    return AttributeValueImpl.EMPTY;
+                }
+                Node current = trait.toNode();
+                for (String segment : remainingPath) {
+                    if (!current.isObjectNode()) {
+                        return AttributeValueImpl.EMPTY;
+                    }
+                    current = current.expectObjectNode().getMember(segment).orElse(null);
+                    if (current == null) {
+                        return AttributeValueImpl.EMPTY;
+                    }
+                }
+                return AttributeValue.node(current);
+            };
+        }
+
+        // Remaining path has pseudo-properties, so fall back to AttributeValue chain for projections/length.
+        return (shape, vars) -> {
+            Trait trait = shape.findTrait(traitId).orElse(null);
+            if (trait == null) {
+                return AttributeValueImpl.EMPTY;
+            }
+            AttributeValue current = AttributeValue.node(trait.toNode());
+            for (String segment : remainingPath) {
+                current = current.getProperty(segment);
+                if (!current.isPresent()) {
+                    return AttributeValueImpl.EMPTY;
+                }
+            }
+            return current;
+        };
+    }
+
+    static AttributePathExtractor compileId(List<String> path) {
+        if (path.size() == 1) {
+            // [id]
+            return (shape, vars) -> AttributeValue.id(shape.getId());
+        } else if (path.size() > 2) {
+            // [id|name|...]: invalid, properties don't have sub-properties, fall back.
+            return null;
+        }
+
+        String property = path.get(1);
+        switch (property) {
+            case "name":
+                return (shape, vars) -> AttributeValue.literal(shape.getId().getName());
+            case "namespace":
+                return (shape, vars) -> AttributeValue.literal(shape.getId().getNamespace());
+            case "member":
+                return (shape, vars) -> shape.getId()
+                        .getMember()
+                        .map(AttributeValue::literal)
+                        .orElse(AttributeValueImpl.EMPTY);
+            default:
+                // Includes (length) or other unknown property, fall back to generic.
+                return null;
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
@@ -25,6 +25,11 @@ final class AttributeSelector implements InternalSelector {
     private final boolean caseInsensitive;
     private final Function<Model, Collection<? extends Shape>> optimizer;
 
+    // When this selector is a plain "[trait|<name>]" existence check, the trait's ShapeId is resolved once here at
+    // parse time. The hot path can then test the shape directly instead of rebuilding the absolute name and looking
+    // the ShapeId up in a cache on every shape. Null when the fast path does not apply.
+    private final ShapeId traitExistenceId;
+
     AttributeSelector(
             List<String> path,
             List<String> expected,
@@ -52,14 +57,16 @@ final class AttributeSelector implements InternalSelector {
                 && path.size() >= 2
                 && path.get(0).equals("trait") // only match on traits
                 && !path.get(1).startsWith("(")) { // don't match projections
-            optimizer = model -> {
-                // The trait name might be relative to the prelude, so ensure it's absolute.
-                String absoluteShapeId = Trait.makeAbsoluteName(path.get(1));
-                ShapeId trait = ShapeId.from(absoluteShapeId);
-                return model.getShapesWithTrait(trait);
-            };
+            // The trait name might be relative to the prelude, so ensure it's absolute.
+            ShapeId trait = ShapeId.from(Trait.makeAbsoluteName(path.get(1)));
+            optimizer = model -> model.getShapesWithTrait(trait);
+            // The per-shape existence fast path only applies when the path stops at the trait itself
+            // (e.g., "[trait|http]"). Deeper paths (e.g., "[trait|range|min]") still need to walk into
+            // the trait's node value.
+            this.traitExistenceId = path.size() == 2 ? trait : null;
         } else {
             optimizer = Model::toSet;
+            this.traitExistenceId = null;
         }
     }
 
@@ -82,6 +89,14 @@ final class AttributeSelector implements InternalSelector {
     }
 
     private boolean matchesAttribute(Shape shape, Context stack) {
+        // Fast path for plain "[trait|<name>]" existence checks: avoids rebuilding the trait ShapeId and
+        // allocating the AttributeValue path chain on every shape. This mirrors the semantics of resolving the
+        // path to a trait NodeValue, which is considered present only when the trait's node is not a null node.
+        if (traitExistenceId != null) {
+            Trait trait = shape.findTrait(traitExistenceId).orElse(null);
+            return trait != null && !trait.toNode().isNullNode();
+        }
+
         AttributeValue lhs = AttributeValue.shape(shape, stack.getVars()).getPath(path);
 
         if (comparator == null) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
@@ -19,59 +19,77 @@ import software.amazon.smithy.model.traits.Trait;
  */
 final class AttributeSelector implements InternalSelector {
 
-    private final List<String> path;
     private final List<AttributeValue> expected;
     private final AttributeComparator comparator;
     private final boolean caseInsensitive;
     private final Function<Model, Collection<? extends Shape>> optimizer;
+    private final AttributePathExtractor extractor;
 
-    // When this selector is a plain "[trait|<name>]" existence check, the trait's ShapeId is resolved once here at
-    // parse time. The hot path can then test the shape directly instead of rebuilding the absolute name and looking
-    // the ShapeId up in a cache on every shape. Null when the fast path does not apply.
-    private final ShapeId traitExistenceId;
+    private AttributeSelector(
+            List<AttributeValue> expected,
+            AttributeComparator comparator,
+            boolean caseInsensitive,
+            Function<Model, Collection<? extends Shape>> optimizer,
+            AttributePathExtractor extractor
+    ) {
+        this.expected = expected;
+        this.comparator = comparator;
+        this.caseInsensitive = caseInsensitive;
+        this.optimizer = optimizer;
+        this.extractor = extractor;
+    }
 
-    AttributeSelector(
+    /**
+     * Single factory for creating the best selector for an attribute expression.
+     *
+     * <p>This consolidates all the "is this a trait path?" logic into one place. For the common
+     * {@code [trait|X]} existence check (no comparator, path depth 2), it returns a
+     * {@link TraitExistenceSelector} that uses a direct {@code hasTrait} call. For comparator cases
+     * targeting a trait, it precompiles the ShapeId and uses a starting-shape optimizer. Everything
+     * else falls back to the generic path-walking machinery.
+     *
+     * @param path The parsed attribute path segments.
+     * @param values The expected comparison values (null for existence checks).
+     * @param comparator The comparator (null for existence checks).
+     * @param caseInsensitive Whether the comparison is case-insensitive.
+     * @return The best InternalSelector for this attribute expression.
+     */
+    static InternalSelector create(
             List<String> path,
-            List<String> expected,
+            List<String> values,
             AttributeComparator comparator,
             boolean caseInsensitive
     ) {
-        this.path = path;
-        this.caseInsensitive = caseInsensitive;
-        this.comparator = comparator;
+        boolean isTraitPath = path.size() >= 2 && path.get(0).equals("trait") && !path.get(1).startsWith("(");
 
-        // Create the valid values of the expected selector.
-        if (expected == null) {
-            this.expected = Collections.emptyList();
+        // Plain [trait|X] existence check has specialized node with direct hasTrait.
+        if (comparator == null && isTraitPath && path.size() == 2) {
+            return new TraitExistenceSelector(ShapeId.from(Trait.makeAbsoluteName(path.get(1))));
+        }
+
+        // Build the expected AttributeValues for comparator cases.
+        List<AttributeValue> expectedValues;
+        if (values == null) {
+            expectedValues = Collections.emptyList();
         } else {
-            this.expected = new ArrayList<>(expected.size());
-            for (String validValue : expected) {
-                this.expected.add(AttributeValue.literal(validValue));
+            expectedValues = new ArrayList<>(values.size());
+            for (String v : values) {
+                expectedValues.add(AttributeValue.literal(v));
             }
         }
 
-        // Optimization for loading shapes with a specific trait.
-        // This optimization can only be applied when there's no comparator,
-        // and it doesn't matter how deep into the trait the selector descends.
-        if (comparator == null
-                && path.size() >= 2
-                && path.get(0).equals("trait") // only match on traits
-                && !path.get(1).startsWith("(")) { // don't match projections
-            // The trait name might be relative to the prelude, so ensure it's absolute.
+        // Determine starting-shape optimizer.
+        Function<Model, Collection<? extends Shape>> optimizer;
+        if (comparator == null && isTraitPath) {
             ShapeId trait = ShapeId.from(Trait.makeAbsoluteName(path.get(1)));
             optimizer = model -> model.getShapesWithTrait(trait);
-            // The per-shape existence fast path only applies when the path stops at the trait itself
-            // (e.g., "[trait|http]"). Deeper paths (e.g., "[trait|range|min]") still need to walk into
-            // the trait's node value.
-            this.traitExistenceId = path.size() == 2 ? trait : null;
         } else {
             optimizer = Model::toSet;
-            this.traitExistenceId = null;
         }
-    }
 
-    static AttributeSelector existence(List<String> path) {
-        return new AttributeSelector(path, null, null, false);
+        // Precompile path extraction.
+        AttributePathExtractor extractor = AttributePathExtractor.compile(path);
+        return new AttributeSelector(expectedValues, comparator, caseInsensitive, optimizer, extractor);
     }
 
     @Override
@@ -89,15 +107,7 @@ final class AttributeSelector implements InternalSelector {
     }
 
     private boolean matchesAttribute(Shape shape, Context stack) {
-        // Fast path for plain "[trait|<name>]" existence checks: avoids rebuilding the trait ShapeId and
-        // allocating the AttributeValue path chain on every shape. This mirrors the semantics of resolving the
-        // path to a trait NodeValue, which is considered present only when the trait's node is not a null node.
-        if (traitExistenceId != null) {
-            Trait trait = shape.findTrait(traitExistenceId).orElse(null);
-            return trait != null && !trait.toNode().isNullNode();
-        }
-
-        AttributeValue lhs = AttributeValue.shape(shape, stack.getVars()).getPath(path);
+        AttributeValue lhs = extractor.extract(shape, stack.getVars());
 
         if (comparator == null) {
             return lhs.isPresent();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -35,7 +35,7 @@ final class Context {
     private VarMap varsView;
 
     // Pre-allocated Holder stack to avoid per-call allocation in receivedShapes. Handles reentrancy through growth.
-    private Holder[] holders = new Holder[] { new Holder(), new Holder() };
+    private Holder[] holders = new Holder[] {new Holder(), new Holder()};
     private int holderDepth;
 
     @SuppressWarnings("unchecked")

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -219,6 +219,27 @@ final class Context {
      * @return Returns true if the {@code predicate} matches the {@code shape}.
      */
     boolean receivedShapes(Shape shape, InternalSelector predicate) {
+        // Short-circuit side-effect-free predicates that can answer without a full push.
+        switch (predicate.emitsAnyOptimization(this, shape)) {
+            case YES:
+                return true;
+            case NO:
+                return false;
+            case MAYBE:
+            default:
+                break;
+        }
+
+        Holder h = getHolder();
+        try {
+            predicate.push(this, shape, h);
+            return h.set;
+        } finally {
+            holderDepth--;
+        }
+    }
+
+    private Holder getHolder() {
         if (holderDepth >= holders.length) {
             Holder[] grown = new Holder[holders.length * 2];
             System.arraycopy(holders, 0, grown, 0, holders.length);
@@ -231,11 +252,6 @@ final class Context {
 
         Holder h = holders[holderDepth++];
         h.set = false;
-        try {
-            predicate.push(this, shape, h);
-            return h.set;
-        } finally {
-            holderDepth--;
-        }
+        return h;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -4,9 +4,14 @@
  */
 package software.amazon.smithy.model.selector;
 
-import java.util.HashMap;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
@@ -19,22 +24,74 @@ final class Context {
 
     NeighborProviderIndex neighborIndex;
     private final Model model;
-    private final Map<String, Set<Shape>> variables = new HashMap<>();
     private final List<Set<Shape>> roots;
 
-    Context(Model model, NeighborProviderIndex neighborIndex, List<Set<Shape>> roots) {
+    // Selector variables are addressed by a dense integer slot assigned at parse time rather than by name. This lets
+    // the hot path (storing and getting variables) use plain array indexing instead of hash map lookups, and lets the
+    // per-shape variable reset be an array fill instead of a HashMap.clear(). The map-based view is only materialized
+    // lazily for the public, name-keyed API surface (ShapeMatch and [var|name] access).
+    private final Map<String, Integer> variableIndices;
+    private final Set<Shape>[] variableSlots;
+    private VarMap varsView;
+
+    @SuppressWarnings("unchecked")
+    Context(
+            Model model,
+            NeighborProviderIndex neighborIndex,
+            List<Set<Shape>> roots,
+            Map<String, Integer> variableIndices
+    ) {
         this.model = model;
         this.neighborIndex = neighborIndex;
         this.roots = roots;
+        this.variableIndices = variableIndices;
+        this.variableSlots = (Set<Shape>[]) new Set<?>[variableIndices.size()];
     }
 
     /**
-     * Gets the mutable map of captured variables.
+     * Gets the variables stored in the given slot, or an empty set if unset.
+     *
+     * @param slot Slot index assigned to the variable at parse time.
+     * @return Returns the captured shapes (never null).
+     */
+    Set<Shape> getVariable(int slot) {
+        Set<Shape> result = variableSlots[slot];
+        return result == null ? Collections.emptySet() : result;
+    }
+
+    /**
+     * Stores variables in the given slot.
+     *
+     * @param slot Slot index assigned to the variable at parse time.
+     * @param value Captured shapes to store.
+     */
+    void setVariable(int slot, Set<Shape> value) {
+        variableSlots[slot] = value;
+    }
+
+    /**
+     * Clears all captured variables. This is called between starting shapes.
+     */
+    void clearVariables() {
+        Arrays.fill(variableSlots, null);
+    }
+
+    /**
+     * Gets a mutable map view of the captured variables.
+     *
+     * <p>This is used by the name-keyed API surface (e.g., {@link Selector.ShapeMatch} and {@code [var|name]}
+     * attribute access). The map is a view over the underlying variable slots, so reads and writes go directly
+     * to the slots.
      *
      * @return Returns the captured variables.
      */
     Map<String, Set<Shape>> getVars() {
-        return variables;
+        VarMap result = varsView;
+        if (result == null) {
+            result = new VarMap();
+            varsView = result;
+        }
+        return result;
     }
 
     Set<Shape> getRootResult(int index) {
@@ -43,6 +100,96 @@ final class Context {
 
     Model getModel() {
         return model;
+    }
+
+    /**
+     * A {@link Map} view over the variable slots, keyed by variable name.
+     */
+    private final class VarMap extends AbstractMap<String, Set<Shape>> {
+        @Override
+        public Set<Shape> get(Object key) {
+            Integer slot = variableIndices.get(key);
+            return slot == null ? null : variableSlots[slot];
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            Integer slot = variableIndices.get(key);
+            return slot != null && variableSlots[slot] != null;
+        }
+
+        @Override
+        public Set<Shape> put(String key, Set<Shape> value) {
+            Integer slot = variableIndices.get(key);
+            if (slot == null) {
+                throw new IllegalArgumentException("Unknown selector variable: " + key);
+            }
+            Set<Shape> previous = variableSlots[slot];
+            variableSlots[slot] = value;
+            return previous;
+        }
+
+        @Override
+        public void clear() {
+            clearVariables();
+        }
+
+        @Override
+        public Set<Entry<String, Set<Shape>>> entrySet() {
+            return new AbstractSet<Entry<String, Set<Shape>>>() {
+                @Override
+                public Iterator<Entry<String, Set<Shape>>> iterator() {
+                    return new VarEntryIterator();
+                }
+
+                @Override
+                public int size() {
+                    int count = 0;
+                    for (Set<Shape> slot : variableSlots) {
+                        if (slot != null) {
+                            count++;
+                        }
+                    }
+                    return count;
+                }
+            };
+        }
+    }
+
+    private final class VarEntryIterator implements Iterator<Map.Entry<String, Set<Shape>>> {
+        private final Iterator<Map.Entry<String, Integer>> indices = variableIndices.entrySet().iterator();
+        private Map.Entry<String, Integer> next;
+
+        VarEntryIterator() {
+            advance();
+        }
+
+        private void advance() {
+            next = null;
+            while (indices.hasNext()) {
+                Map.Entry<String, Integer> candidate = indices.next();
+                if (variableSlots[candidate.getValue()] != null) {
+                    next = candidate;
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public Map.Entry<String, Set<Shape>> next() {
+            if (next == null) {
+                throw new NoSuchElementException();
+            }
+            String name = next.getKey();
+            Set<Shape> value = variableSlots[next.getValue()];
+            advance();
+            return new AbstractMap.SimpleImmutableEntry<>(name, value);
+        }
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -34,6 +34,10 @@ final class Context {
     private final Set<Shape>[] variableSlots;
     private VarMap varsView;
 
+    // Pre-allocated Holder stack to avoid per-call allocation in receivedShapes. Handles reentrancy through growth.
+    private Holder[] holders = new Holder[] { new Holder(), new Holder() };
+    private int holderDepth;
+
     @SuppressWarnings("unchecked")
     Context(
             Model model,
@@ -215,8 +219,23 @@ final class Context {
      * @return Returns true if the {@code predicate} matches the {@code shape}.
      */
     boolean receivedShapes(Shape shape, InternalSelector predicate) {
-        Holder holder = new Holder();
-        predicate.push(this, shape, holder);
-        return holder.set;
+        if (holderDepth >= holders.length) {
+            Holder[] grown = new Holder[holders.length * 2];
+            System.arraycopy(holders, 0, grown, 0, holders.length);
+            // Allocate the new part of the list.
+            for (int i = holders.length; i < grown.length; i++) {
+                grown[i] = new Holder();
+            }
+            holders = grown;
+        }
+
+        Holder h = holders[holderDepth++];
+        h.set = false;
+        try {
+            predicate.push(this, shape, h);
+            return h.set;
+        } finally {
+            holderDepth--;
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
@@ -111,6 +111,27 @@ interface InternalSelector {
     }
 
     /**
+     * Quickly determines whether this selector emits at least one shape when given {@code input}, without performing
+     * a full push.
+     *
+     * <p>This differs from {@link #containsShapeOptimization}: that method asks "is this <em>specific</em> shape in
+     * the selector's output?", whereas this asks "does the selector emit <em>anything at all</em> for this input?".
+     * The answers diverge for emitting selectors like {@code :root(...)}, {@code ${var}}, and neighbors, which can
+     * emit shapes other than the input.
+     *
+     * <p>Implementations MUST only return YES or NO when they have no side effects (e.g., variable stores). A selector
+     * that could store a variable as part of being pushed MUST return MAYBE so the full push runs and the side effect
+     * occurs.
+     *
+     * @param context Evaluation context.
+     * @param input Shape that would be pushed into the selector.
+     * @return YES if the selector definitely emits something, NO if it definitely emits nothing, MAYBE if unknown.
+     */
+    default ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return ContainsShape.MAYBE;
+    }
+
+    /**
      * Returns true if this selector's output is independent of the input shape passed to {@link #push}.
      *
      * <p>Selectors like {@link RootSelector} always emit the same set of shapes regardless of the input shape,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/IsSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/IsSelector.java
@@ -4,7 +4,11 @@
  */
 package software.amazon.smithy.model.selector;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
@@ -30,5 +34,23 @@ final class IsSelector implements InternalSelector {
         }
 
         return Response.CONTINUE;
+    }
+
+    @Override
+    public Collection<? extends Shape> getStartingShapes(Model model) {
+        // If all children provide narrower starting shapes, use their union instead of all model shapes.
+        Collection<? extends Shape> allShapes = model.toSet();
+        Set<Shape> union = null;
+        for (InternalSelector selector : selectors) {
+            Collection<? extends Shape> starting = selector.getStartingShapes(model);
+            if (starting == allShapes) {
+                return allShapes;
+            } else if (union == null) {
+                union = new HashSet<>(starting);
+            } else {
+                union.addAll(starting);
+            }
+        }
+        return union != null ? union : allShapes;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/NotSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/NotSelector.java
@@ -25,4 +25,17 @@ final class NotSelector implements InternalSelector {
             return Response.CONTINUE;
         }
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        switch (selector.emitsAnyOptimization(context, input)) {
+            case YES:
+                return ContainsShape.NO;
+            case NO:
+                return ContainsShape.YES;
+            case MAYBE:
+            default:
+                return ContainsShape.MAYBE;
+        }
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/RootSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/RootSelector.java
@@ -16,11 +16,9 @@ import software.amazon.smithy.model.shapes.Shape;
  */
 final class RootSelector implements InternalSelector {
 
-    private final InternalSelector selector;
     private final int id;
 
-    RootSelector(InternalSelector selector, int id) {
-        this.selector = selector;
+    RootSelector(int id) {
         this.id = id;
     }
 
@@ -38,6 +36,11 @@ final class RootSelector implements InternalSelector {
     @Override
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
         return context.getRootResult(id).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
+    }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return context.getRootResult(id).isEmpty() ? ContainsShape.NO : ContainsShape.YES;
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,6 +21,7 @@ import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SimpleParser;
+import software.amazon.smithy.utils.SliceMatcher;
 
 /**
  * Parses a selector expression.
@@ -28,19 +30,66 @@ final class SelectorParser extends SimpleParser {
 
     private static final Logger LOGGER = Logger.getLogger(SelectorParser.class.getName());
     private static final Set<Character> BREAK_TOKENS = SetUtils.of(',', ']', ')');
-    private static final Set<String> REL_TYPES = new HashSet<>();
+
+    // Hoisted varargs token arrays so each expect(...) call doesn't allocate a fresh char[] while parsing.
+    private static final char[] CLOSE_BRACKET_OR_COMMA = {']', ','};
+    private static final char[] CLOSE_PAREN_OR_COMMA = {')', ','};
+    private static final char[] ATTR_OPERATORS = {']', '=', '!', '^', '$', '*', '?', '>', '<'};
+    private static final char[] PROJECTION_COMPARATORS = {'<', '=', '!'};
+
+    private static final String[] RELATIONSHIP_LABELS = buildRelationshipLabels();
+    private static final Set<String> REL_TYPES = new HashSet<>(Arrays.asList(RELATIONSHIP_LABELS));
+    private static final SliceMatcher RELATIONSHIP_LABEL_MATCHER = new SliceMatcher(RELATIONSHIP_LABELS);
+
+    private static final SliceMatcher FUNCTION_NAMES = new SliceMatcher(
+            "not",
+            "test",
+            "is",
+            "in",
+            "root",
+            "topdown",
+            "recursive",
+            "each");
+
+    // The "dataType" keyword always expands to the same immutable pair of category selectors, which are stateless,
+    // so the list can be shared rather than rebuilt on each parse.
+    private static final List<InternalSelector> DATA_TYPE_SELECTORS = Arrays.asList(
+            new ShapeTypeCategoryEnumSelector(ShapeType.Category.SIMPLE),
+            new ShapeTypeCategoryEnumSelector(ShapeType.Category.AGGREGATE));
+
+    // The category keywords matched in createSelector, in index order. Indices < SHAPE_TYPE_OFFSET are handled by
+    // the switch below; indices >= SHAPE_TYPE_OFFSET are shape-type names resolved against SHAPE_TYPES.
+    private static final ShapeType[] SHAPE_TYPES = ShapeType.values();
+    private static final int SHAPE_TYPE_OFFSET = 6;
+    private static final SliceMatcher TYPE_KEYWORDS = buildTypeKeywordMatcher();
+
+    private static SliceMatcher buildTypeKeywordMatcher() {
+        String[] keywords = new String[SHAPE_TYPE_OFFSET + SHAPE_TYPES.length];
+        keywords[0] = "number";
+        keywords[1] = "simpleType";
+        keywords[2] = "collection";
+        keywords[3] = "aggregateType";
+        keywords[4] = "serviceType";
+        keywords[5] = "dataType";
+        for (int i = 0; i < SHAPE_TYPES.length; i++) {
+            keywords[SHAPE_TYPE_OFFSET + i] = SHAPE_TYPES[i].toString();
+        }
+        return new SliceMatcher(keywords);
+    }
+
+    private static String[] buildRelationshipLabels() {
+        Set<String> labels = new LinkedHashSet<>();
+        for (RelationshipType rel : RelationshipType.values()) {
+            rel.getSelectorLabel().ifPresent(labels::add);
+        }
+        return labels.toArray(new String[0]);
+    }
+
     private final List<InternalSelector> roots = new ArrayList<>();
 
     // Assigns a dense, stable integer slot to each distinct variable name encountered while parsing. Variables are
     // addressed by this slot at evaluation time so the hot path can use array indexing instead of hash lookups.
     private final Map<String, Integer> variableIndices = new LinkedHashMap<>();
-
-    static {
-        // Adds selector relationship labels for warnings when unknown relationship names are used.
-        for (RelationshipType rel : RelationshipType.values()) {
-            rel.getSelectorLabel().ifPresent(REL_TYPES::add);
-        }
-    }
 
     private SelectorParser(String selector) {
         super(selector);
@@ -62,7 +111,7 @@ final class SelectorParser extends SimpleParser {
     }
 
     private List<InternalSelector> recursiveParse() {
-        List<InternalSelector> selectors = new IgnoreIdentitySelectorArray();
+        List<InternalSelector> selectors = new IgnoreIdentitySelectorArray(4);
 
         // createSelector() will strip leading ws.
         selectors.add(createSelector());
@@ -84,6 +133,10 @@ final class SelectorParser extends SimpleParser {
      * Filter out unnecessary identity selectors when creating the finalized AST to evaluate selectors.
      */
     private static final class IgnoreIdentitySelectorArray extends ArrayList<InternalSelector> {
+        IgnoreIdentitySelectorArray(int initialCapacity) {
+            super(initialCapacity);
+        }
+
         @Override
         public boolean add(InternalSelector o) {
             return o != InternalSelector.IDENTITY && super.add(o);
@@ -134,26 +187,30 @@ final class SelectorParser extends SimpleParser {
                 return parseVariable();
             default:
                 if (ParserUtils.isIdentifierStart(peek())) {
-                    String identifier = ParserUtils.parseIdentifier(this);
-                    switch (identifier) {
-                        case "number":
+                    // Consume the identifier in place and match it against the fixed type keyword set directly on the
+                    // input buffer, with no String allocation. The matcher returns an index to switch on: the first
+                    // SHAPE_TYPE_OFFSET indices are category keywords, the rest are shape-type names.
+                    int start = position();
+                    ParserUtils.consumeIdentifier(this);
+                    int index = sliceMatches(start, TYPE_KEYWORDS);
+                    switch (index) {
+                        case 0: // number
                             return new ShapeTypeCategorySelector(NumberShape.class);
-                        case "simpleType":
+                        case 1: // simpleType
                             return new ShapeTypeCategoryEnumSelector(ShapeType.Category.SIMPLE);
-                        case "collection":
+                        case 2: // collection
                             return new ShapeTypeCategorySelector(CollectionShape.class);
-                        case "aggregateType":
+                        case 3: // aggregateType
                             return new ShapeTypeCategoryEnumSelector(ShapeType.Category.AGGREGATE);
-                        case "serviceType":
+                        case 4: // serviceType
                             return new ShapeTypeCategoryEnumSelector(ShapeType.Category.SERVICE);
-                        case "dataType":
-                            return IsSelector.of(Arrays.asList(
-                                    new ShapeTypeCategoryEnumSelector(ShapeType.Category.SIMPLE),
-                                    new ShapeTypeCategoryEnumSelector(ShapeType.Category.AGGREGATE)));
-                        default:
-                            ShapeType shape = ShapeType.fromString(identifier)
-                                    .orElseThrow(() -> syntax("Unknown shape type: " + identifier));
-                            return new ShapeTypeSelector(shape);
+                        case 5: // dataType
+                            return IsSelector.of(DATA_TYPE_SELECTORS);
+                        case -1:
+                            String identifier = sliceFrom(start);
+                            throw syntax("Unknown shape type: " + identifier);
+                        default: // a shape-type name
+                            return new ShapeTypeSelector(SHAPE_TYPES[index - SHAPE_TYPE_OFFSET]);
                     }
                 } else if (peek() == Character.MIN_VALUE) {
                     throw syntax("Unexpected selector EOF");
@@ -212,18 +269,21 @@ final class SelectorParser extends SimpleParser {
     }
 
     private List<String> parseSelectorDirectedRelationships() {
-        List<String> relationships = new ArrayList<>();
+        List<String> relationships = new ArrayList<>(2);
         String next;
         char peek;
 
         do {
             // Requires at least one relationship type.
             ws();
-            next = ParserUtils.parseIdentifier(this);
+            int start = position();
+            ParserUtils.consumeIdentifier(this);
+            int relationshipIndex = sliceMatches(start, RELATIONSHIP_LABEL_MATCHER);
+            next = relationshipIndex == -1 ? sliceFrom(start) : RELATIONSHIP_LABELS[relationshipIndex];
             relationships.add(next);
 
             // Tolerate unknown relationships, but log a warning.
-            if (!REL_TYPES.contains(next)) {
+            if (relationshipIndex == -1) {
                 LOGGER.warning(String.format(
                         "Unknown relationship type '%s' found near %s. Expected one of: %s",
                         next,
@@ -232,7 +292,7 @@ final class SelectorParser extends SimpleParser {
             }
 
             ws();
-            peek = expect(']', ',');
+            peek = expect(CLOSE_BRACKET_OR_COMMA);
         } while (peek != ']');
 
         return relationships;
@@ -240,10 +300,11 @@ final class SelectorParser extends SimpleParser {
 
     private InternalSelector parseSelectorFunction() {
         int functionPosition = position();
-        String name = ParserUtils.parseIdentifier(this);
+        ParserUtils.consumeIdentifier(this);
+        int functionIndex = sliceMatches(functionPosition, FUNCTION_NAMES);
         List<InternalSelector> selectors = parseSelectorFunctionArgs();
-        switch (name) {
-            case "not":
+        switch (functionIndex) {
+            case 0: // not
                 if (selectors.size() != 1) {
                     throw new SelectorSyntaxException(
                             "The :not function requires a single selector argument",
@@ -253,11 +314,11 @@ final class SelectorParser extends SimpleParser {
                             column());
                 }
                 return new NotSelector(selectors.get(0));
-            case "test":
+            case 1: // test
                 return new TestSelector(selectors);
-            case "is":
+            case 2: // is
                 return IsSelector.of(selectors);
-            case "in":
+            case 3: // in
                 if (selectors.size() != 1) {
                     throw new SelectorSyntaxException(
                             "The :in function requires a single selector argument",
@@ -267,7 +328,7 @@ final class SelectorParser extends SimpleParser {
                             column());
                 }
                 return new InSelector(selectors.get(0));
-            case "root":
+            case 4: // root
                 if (selectors.size() != 1) {
                     throw new SelectorSyntaxException(
                             "The :root function requires a single selector argument",
@@ -279,7 +340,7 @@ final class SelectorParser extends SimpleParser {
                 InternalSelector root = new RootSelector(roots.size());
                 roots.add(selectors.get(0));
                 return root;
-            case "topdown":
+            case 5: // topdown
                 if (selectors.size() > 2) {
                     throw new SelectorSyntaxException(
                             "The :topdown function accepts 1 or 2 selectors, but found " + selectors.size(),
@@ -289,7 +350,7 @@ final class SelectorParser extends SimpleParser {
                             column());
                 }
                 return new TopDownSelector(selectors);
-            case "recursive":
+            case 6: // recursive
                 if (selectors.size() != 1) {
                     throw new SelectorSyntaxException(
                             "The :recursive function requires a single selector argument",
@@ -299,10 +360,11 @@ final class SelectorParser extends SimpleParser {
                             column());
                 }
                 return new RecursiveSelector(selectors.get(0));
-            case "each":
+            case 7: // each
                 LOGGER.warning("The `:each` selector function has been renamed to `:is`: " + input());
                 return IsSelector.of(selectors);
             default:
+                String name = sliceFrom(functionPosition);
                 LOGGER.warning(String.format("Unknown function name `%s` found in selector: %s",
                         name,
                         input()));
@@ -312,14 +374,14 @@ final class SelectorParser extends SimpleParser {
 
     private List<InternalSelector> parseSelectorFunctionArgs() {
         ws();
-        List<InternalSelector> selectors = new ArrayList<>();
+        List<InternalSelector> selectors = new ArrayList<>(2);
         expect('(');
         char next;
 
         do {
             selectors.add(AndSelector.of(recursiveParse()));
             ws();
-            next = expect(')', ',');
+            next = expect(CLOSE_PAREN_OR_COMMA);
         } while (next != ')');
 
         return selectors;
@@ -329,7 +391,7 @@ final class SelectorParser extends SimpleParser {
         ws();
         List<String> path = parseAttributePath();
         ws();
-        char next = expect(']', '=', '!', '^', '$', '*', '?', '>', '<');
+        char next = expect(ATTR_OPERATORS);
 
         if (next == ']') {
             return AttributeSelector.create(path, null, null, false);
@@ -395,7 +457,7 @@ final class SelectorParser extends SimpleParser {
                 }
                 break;
             case '{': // projection comparators
-                char nextSet = expect('<', '=', '!');
+                char nextSet = expect(PROJECTION_COMPARATORS);
                 if (nextSet == '<') {
                     if (peek() == '<') {
                         expect('<'); // {<<}
@@ -432,7 +494,7 @@ final class SelectorParser extends SimpleParser {
 
     // selector_scoped_comparison *("&&" selector_scoped_comparison)
     private List<ScopedAttributeSelector.Assertion> parseScopedAssertions() {
-        List<ScopedAttributeSelector.Assertion> assertions = new ArrayList<>();
+        List<ScopedAttributeSelector.Assertion> assertions = new ArrayList<>(2);
         assertions.add(parseScopedAssertion());
         ws();
 
@@ -453,7 +515,7 @@ final class SelectorParser extends SimpleParser {
         skip();
         AttributeComparator comparator = parseComparator(next);
 
-        List<ScopedAttributeSelector.ScopedFactory> rhs = new ArrayList<>();
+        List<ScopedAttributeSelector.ScopedFactory> rhs = new ArrayList<>(2);
         rhs.add(parseScopedValue());
 
         while (peek() == ',') {
@@ -486,7 +548,7 @@ final class SelectorParser extends SimpleParser {
             return Collections.emptyList();
         }
 
-        List<String> path = new ArrayList<>();
+        List<String> path = new ArrayList<>(2);
         // Parse the top-level namespace key.
         path.add(ParserUtils.parseIdentifier(this));
 
@@ -497,7 +559,7 @@ final class SelectorParser extends SimpleParser {
     }
 
     private List<String> parseAttributeValues() {
-        List<String> result = new ArrayList<>();
+        List<String> result = new ArrayList<>(2);
         result.add(parseAttributeValue(this));
         ws();
 
@@ -525,7 +587,7 @@ final class SelectorParser extends SimpleParser {
         parser.expect('{');
         // parse at least one path segment, followed by any number of
         // comma separated segments.
-        List<String> path = new ArrayList<>();
+        List<String> path = new ArrayList<>(2);
         path.add(parseSelectorPathSegment(parser));
         path.addAll(parseSelectorPath(parser));
         parser.expect('}');
@@ -595,7 +657,7 @@ final class SelectorParser extends SimpleParser {
             return Collections.emptyList();
         }
 
-        List<String> result = new ArrayList<>();
+        List<String> result = new ArrayList<>(2);
         do {
             parser.skip(); // skip '|'
             result.add(parseSelectorPathSegment(parser));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -332,15 +332,14 @@ final class SelectorParser extends SimpleParser {
         char next = expect(']', '=', '!', '^', '$', '*', '?', '>', '<');
 
         if (next == ']') {
-            TraitExistenceSelector traitSelector = TraitExistenceSelector.tryCreate(path);
-            return traitSelector != null ? traitSelector : AttributeSelector.existence(path);
+            return AttributeSelector.create(path, null, null, false);
         }
 
         AttributeComparator comparator = parseComparator(next);
         List<String> values = parseAttributeValues();
         boolean insensitive = parseCaseInsensitiveToken();
         expect(']');
-        return new AttributeSelector(path, values, comparator, insensitive);
+        return AttributeSelector.create(path, values, comparator, insensitive);
     }
 
     private boolean parseCaseInsensitiveToken() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -332,7 +332,8 @@ final class SelectorParser extends SimpleParser {
         char next = expect(']', '=', '!', '^', '$', '*', '?', '>', '<');
 
         if (next == ']') {
-            return AttributeSelector.existence(path);
+            TraitExistenceSelector traitSelector = TraitExistenceSelector.tryCreate(path);
+            return traitSelector != null ? traitSelector : AttributeSelector.existence(path);
         }
 
         AttributeComparator comparator = parseComparator(next);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -8,7 +8,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 import software.amazon.smithy.model.loader.ParserUtils;
@@ -29,6 +31,10 @@ final class SelectorParser extends SimpleParser {
     private static final Set<String> REL_TYPES = new HashSet<>();
     private final List<InternalSelector> roots = new ArrayList<>();
 
+    // Assigns a dense, stable integer slot to each distinct variable name encountered while parsing. Variables are
+    // addressed by this slot at evaluation time so the hot path can use array indexing instead of hash lookups.
+    private final Map<String, Integer> variableIndices = new LinkedHashMap<>();
+
     static {
         // Adds selector relationship labels for warnings when unknown relationship names are used.
         for (RelationshipType rel : RelationshipType.values()) {
@@ -43,7 +49,7 @@ final class SelectorParser extends SimpleParser {
     static Selector parse(String selector) {
         SelectorParser parser = new SelectorParser(selector);
         List<InternalSelector> result = parser.parse();
-        return new WrappedSelector(selector, result, parser.roots);
+        return new WrappedSelector(selector, result, parser.roots, parser.variableIndices);
     }
 
     List<InternalSelector> parse() {
@@ -162,6 +168,11 @@ final class SelectorParser extends SimpleParser {
         return new SelectorSyntaxException(message, input().toString(), position(), line(), column());
     }
 
+    // Returns the dense slot assigned to a variable name, assigning a new one if this is the first occurrence.
+    private int variableSlot(String name) {
+        return variableIndices.computeIfAbsent(name, n -> variableIndices.size());
+    }
+
     private InternalSelector parseVariable() {
         ws();
 
@@ -171,7 +182,7 @@ final class SelectorParser extends SimpleParser {
             String variableName = ParserUtils.parseIdentifier(this);
             ws();
             expect('}');
-            return new VariableGetSelector(variableName);
+            return new VariableGetSelector(variableSlot(variableName));
         }
 
         String name = ParserUtils.parseIdentifier(this);
@@ -182,7 +193,7 @@ final class SelectorParser extends SimpleParser {
         ws();
         expect(')');
 
-        return new VariableStoreSelector(name, selector);
+        return new VariableStoreSelector(variableSlot(name), selector);
     }
 
     // Parses a multi edge neighbor selector: "-[" relationship-type *("," relationship-type) "]"

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/SelectorParser.java
@@ -276,7 +276,7 @@ final class SelectorParser extends SimpleParser {
                             line(),
                             column());
                 }
-                InternalSelector root = new RootSelector(selectors.get(0), roots.size());
+                InternalSelector root = new RootSelector(roots.size());
                 roots.add(selectors.get(0));
                 return root;
             case "topdown":

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelector.java
@@ -40,4 +40,9 @@ final class ShapeTypeCategoryEnumSelector implements InternalSelector {
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
         return shape.getType().getCategory() == category ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return input.getType().getCategory() == category ? ContainsShape.YES : ContainsShape.NO;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelector.java
@@ -33,4 +33,9 @@ final class ShapeTypeCategorySelector implements InternalSelector {
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
         return getStartingShapes(context.getModel()).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return shapeCategory.isInstance(input) ? ContainsShape.YES : ContainsShape.NO;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
@@ -37,4 +37,9 @@ final class ShapeTypeSelector implements InternalSelector {
                 ? ContainsShape.YES
                 : ContainsShape.NO;
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return input.getType().isShapeType(shapeType) ? ContainsShape.YES : ContainsShape.NO;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TestSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TestSelector.java
@@ -32,4 +32,27 @@ final class TestSelector implements InternalSelector {
         // Continue to receive shapes because other shapes could match.
         return Response.CONTINUE;
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        // `:test` emits the input iff any child emits. A definite YES or NO is side-effect-free by contract, so
+        // fall back to a full push only when a child cannot answer without running.
+        if (selectors.size() == 1) {
+            return selectors.get(0).emitsAnyOptimization(context, input);
+        }
+
+        for (InternalSelector predicate : selectors) {
+            switch (predicate.emitsAnyOptimization(context, input)) {
+                case YES:
+                    return ContainsShape.YES;
+                case MAYBE:
+                    return ContainsShape.MAYBE;
+                case NO:
+                default:
+                    break;
+            }
+        }
+
+        return ContainsShape.NO;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.selector;
+
+import java.util.Collection;
+import java.util.List;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
+
+/**
+ * Specialized selector for the extremely common {@code [trait|X]} existence check.
+ */
+final class TraitExistenceSelector implements InternalSelector {
+
+    private final ShapeId traitId;
+
+    TraitExistenceSelector(ShapeId traitId) {
+        this.traitId = traitId;
+    }
+
+    /**
+     * Creates a TraitExistenceSelector if the path represents a simple {@code [trait|X]} existence check,
+     * otherwise returns null.
+     *
+     * @param path The attribute path parsed from the selector.
+     * @return A TraitExistenceSelector if applicable, otherwise null.
+     */
+    static TraitExistenceSelector tryCreate(List<String> path) {
+        if (path.size() == 2
+                && path.get(0).equals("trait")
+                && !path.get(1).startsWith("(")) {
+            ShapeId traitId = ShapeId.from(Trait.makeAbsoluteName(path.get(1)));
+            return new TraitExistenceSelector(traitId);
+        }
+        return null;
+    }
+
+    @Override
+    public Response push(Context context, Shape shape, Receiver next) {
+        if (shape.hasTrait(traitId)) {
+            return next.apply(context, shape);
+        }
+        return Response.CONTINUE;
+    }
+
+    @Override
+    public Collection<? extends Shape> getStartingShapes(Model model) {
+        return model.getShapesWithTrait(traitId);
+    }
+
+    @Override
+    public ContainsShape containsShapeOptimization(Context context, Shape shape) {
+        return shape.hasTrait(traitId) ? ContainsShape.YES : ContainsShape.NO;
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
@@ -5,11 +5,9 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.Collection;
-import java.util.List;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.Trait;
 
 /**
  * Specialized selector for the extremely common {@code [trait|X]} existence check.
@@ -22,29 +20,11 @@ final class TraitExistenceSelector implements InternalSelector {
         this.traitId = traitId;
     }
 
-    /**
-     * Creates a TraitExistenceSelector if the path represents a simple {@code [trait|X]} existence check,
-     * otherwise returns null.
-     *
-     * @param path The attribute path parsed from the selector.
-     * @return A TraitExistenceSelector if applicable, otherwise null.
-     */
-    static TraitExistenceSelector tryCreate(List<String> path) {
-        if (path.size() == 2
-                && path.get(0).equals("trait")
-                && !path.get(1).startsWith("(")) {
-            ShapeId traitId = ShapeId.from(Trait.makeAbsoluteName(path.get(1)));
-            return new TraitExistenceSelector(traitId);
-        }
-        return null;
-    }
-
     @Override
     public Response push(Context context, Shape shape, Receiver next) {
-        if (shape.hasTrait(traitId)) {
-            return next.apply(context, shape);
-        }
-        return Response.CONTINUE;
+        return shape.hasTrait(traitId)
+                ? next.apply(context, shape)
+                : Response.CONTINUE;
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
@@ -36,4 +36,9 @@ final class TraitExistenceSelector implements InternalSelector {
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
         return shape.hasTrait(traitId) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return input.hasTrait(traitId) ? ContainsShape.YES : ContainsShape.NO;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableGetSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableGetSelector.java
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.model.selector;
 
-import java.util.Collections;
 import java.util.Set;
 import software.amazon.smithy.model.shapes.Shape;
 
@@ -12,10 +11,10 @@ import software.amazon.smithy.model.shapes.Shape;
  * Pushes the shapes stored in a specific variable to the next selector.
  */
 final class VariableGetSelector implements InternalSelector {
-    private final String variableName;
+    private final int slot;
 
-    VariableGetSelector(String variableName) {
-        this.variableName = variableName;
+    VariableGetSelector(int slot) {
+        this.slot = slot;
     }
 
     @Override
@@ -32,7 +31,7 @@ final class VariableGetSelector implements InternalSelector {
     }
 
     private Set<Shape> getShapes(Context context) {
-        return context.getVars().getOrDefault(variableName, Collections.emptySet());
+        return context.getVariable(slot);
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableGetSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableGetSelector.java
@@ -38,4 +38,9 @@ final class VariableGetSelector implements InternalSelector {
     public ContainsShape containsShapeOptimization(Context context, Shape shape) {
         return getShapes(context).contains(shape) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public ContainsShape emitsAnyOptimization(Context context, Shape input) {
+        return getShapes(context).isEmpty() ? ContainsShape.NO : ContainsShape.YES;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableStoreSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableStoreSelector.java
@@ -12,17 +12,17 @@ import software.amazon.smithy.model.shapes.Shape;
  * Stores a variable in the {@link Context} object using a selector.
  *
  * <p>The result of evaluating the selector is stored in the {@code Context}
- * using the given variable name. This selector is much like the ':test()'
+ * using the given variable slot. This selector is much like the ':test()'
  * function in that it does not change the current node. Selectors run after
  * a {@code VariableStoreSelector} start processing shapes from the same
  * point that the variable capture occurred.
  */
 final class VariableStoreSelector implements InternalSelector {
-    private final String variableName;
+    private final int slot;
     private final InternalSelector selector;
 
-    VariableStoreSelector(String variableName, InternalSelector selector) {
-        this.variableName = variableName;
+    VariableStoreSelector(int slot, InternalSelector selector) {
+        this.slot = slot;
         this.selector = selector;
     }
 
@@ -31,7 +31,7 @@ final class VariableStoreSelector implements InternalSelector {
         // Buffer the result of piping the shape through the selector
         // so that it can be retrieved through context vars.
         Set<Shape> captures = selector.pushResultsToCollection(context, shape, new HashSet<>());
-        context.getVars().put(variableName, captures);
+        context.setVariable(slot, captures);
 
         // Now send the received shape to the next receiver.
         return next.apply(context, shape);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
@@ -6,8 +6,10 @@ package software.amazon.smithy.model.selector;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -28,10 +30,17 @@ final class WrappedSelector implements Selector {
     private final String expression;
     private final InternalSelector delegate;
     private final List<InternalSelector> roots;
+    private final Map<String, Integer> variableIndices;
 
-    WrappedSelector(String expression, List<InternalSelector> selectors, List<InternalSelector> roots) {
+    WrappedSelector(
+            String expression,
+            List<InternalSelector> selectors,
+            List<InternalSelector> roots,
+            Map<String, Integer> variableIndices
+    ) {
         this.expression = expression;
         this.roots = roots;
+        this.variableIndices = Collections.unmodifiableMap(variableIndices);
         this.delegate = AndSelector.of(selectors);
     }
 
@@ -104,7 +113,7 @@ final class WrappedSelector implements Selector {
         NeighborProviderIndex index = NeighborProviderIndex.of(model);
         List<Set<Shape>> computedRoots = computeRoots(model);
         return streamStartingShapes(startingShapes).flatMap(shape -> {
-            Context context = new Context(model, index, computedRoots);
+            Context context = new Context(model, index, computedRoots, variableIndices);
             return delegate.pushResultsToCollection(context, shape, new ArrayList<>()).stream();
         });
     }
@@ -116,7 +125,7 @@ final class WrappedSelector implements Selector {
         List<Set<Shape>> computedRoots = computeRoots(model);
         return streamStartingShapes(startingShapes).flatMap(shape -> {
             List<ShapeMatch> result = new ArrayList<>();
-            delegate.push(new Context(model, index, computedRoots), shape, (ctx, s) -> {
+            delegate.push(new Context(model, index, computedRoots, variableIndices), shape, (ctx, s) -> {
                 result.add(new ShapeMatch(s, ctx.getVars()));
                 return InternalSelector.Response.CONTINUE;
             });
@@ -147,10 +156,10 @@ final class WrappedSelector implements Selector {
             List<Set<Shape>> results
     ) {
         Collection<? extends Shape> shapesToEmit = selector.getStartingShapes(model);
-        Context isolatedContext = new Context(model, index, results);
+        Context isolatedContext = new Context(model, index, results, variableIndices);
         Set<Shape> captures = new HashSet<>();
         for (Shape rootShape : shapesToEmit) {
-            isolatedContext.getVars().clear();
+            isolatedContext.clearVariables();
             selector.push(isolatedContext, rootShape, (c, s) -> {
                 captures.add(s);
                 return InternalSelector.Response.CONTINUE;
@@ -166,9 +175,19 @@ final class WrappedSelector implements Selector {
             InternalSelector.Receiver acceptor
     ) {
         Objects.requireNonNull(startingShapes);
-        Context context = new Context(model, NeighborProviderIndex.of(model), computeRoots(model));
+        Context context = new Context(model, NeighborProviderIndex.of(model), computeRoots(model), variableIndices);
+
+        // When the selector's output is independent of the input shape (e.g., it begins with a
+        // ":root(...)" rooted subexpression), every starting shape produces the identical result.
+        // Pushing a single shape avoids re-deriving the same result once per starting shape, which
+        // is O(n^2) work for selectors like ":root(*)".
+        if (delegate.isInputShapeIndependent() && !startingShapes.isEmpty()) {
+            delegate.push(context, startingShapes.iterator().next(), acceptor);
+            return;
+        }
+
         for (Shape shape : startingShapes) {
-            context.getVars().clear();
+            context.clearVariables();
             delegate.push(context, shape, acceptor);
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeType.java
@@ -5,6 +5,8 @@
 package software.amazon.smithy.model.shapes;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -141,13 +143,18 @@ public enum ShapeType {
      * @return Returns the Type in an Optional.
      */
     public static Optional<ShapeType> fromString(String text) {
-        for (ShapeType e : values()) {
-            if (e.stringValue.equals(text)) {
-                return Optional.of(e);
-            }
-        }
+        return Optional.ofNullable(BY_STRING_VALUE.get(text));
+    }
 
-        return Optional.empty();
+    // Precomputed mapping from each type's string value to the type.
+    private static final Map<String, ShapeType> BY_STRING_VALUE = buildStringValueIndex();
+
+    private static Map<String, ShapeType> buildStringValueIndex() {
+        Map<String, ShapeType> map = new HashMap<>();
+        for (ShapeType e : values()) {
+            map.put(e.stringValue, e);
+        }
+        return map;
     }
 
     /**

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/SimpleParser.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/SimpleParser.java
@@ -23,6 +23,11 @@ public class SimpleParser {
     public static final char EOF = Character.MIN_VALUE;
 
     private final CharSequence input;
+    // A char[] mirror of the input and its cached length. Hot parser loops can read directly from the array instead
+    // of repeatedly dispatching through CharSequence.charAt(). The CharSequence is retained for the public input()
+    // API.
+    private final char[] chars;
+    private final int length;
     private final int maxNestingLevel;
     private int position = 0;
     private int line = 1;
@@ -50,6 +55,17 @@ public class SimpleParser {
      */
     public SimpleParser(CharSequence input, int maxNestingLevel) {
         this.input = Objects.requireNonNull(input, "expression must not be null");
+        this.length = input.length();
+        // String can copy directly to a char array; fall back to a char-by-char copy for other CharSequence types
+        // (StringBuilder, CharBuffer, etc.).
+        if (input instanceof String) {
+            this.chars = ((String) input).toCharArray();
+        } else {
+            this.chars = new char[length];
+            for (int i = 0; i < length; i++) {
+                this.chars[i] = input.charAt(i);
+            }
+        }
         this.maxNestingLevel = maxNestingLevel;
 
         if (maxNestingLevel < 0) {
@@ -110,7 +126,7 @@ public class SimpleParser {
      * @return Returns true if the parser has reached the end.
      */
     public final boolean eof() {
-        return position >= input.length();
+        return position >= length;
     }
 
     /**
@@ -135,11 +151,11 @@ public class SimpleParser {
      */
     public final char peek(int offset) {
         int target = position + offset;
-        if (target >= input.length() || target < 0) {
+        if (target >= length || target < 0) {
             return EOF;
         }
 
-        return input.charAt(target);
+        return chars[target];
     }
 
     /**
@@ -259,7 +275,7 @@ public class SimpleParser {
             return;
         }
 
-        switch (input.charAt(position)) {
+        switch (chars[position]) {
             case '\r':
                 if (peek(1) == '\n') {
                     position++;
@@ -276,6 +292,21 @@ public class SimpleParser {
         }
 
         position++;
+    }
+
+    /**
+     * Skips a single non-newline character while tracking columns.
+     *
+     * <p>This method must only be called when the current character is known not to be {@code '\r'} or {@code '\n'}.
+     * Use {@link #skip()} when the current character might be a line break.
+     */
+    public final void skipNonNewline() {
+        if (eof()) {
+            return;
+        }
+
+        position++;
+        column++;
     }
 
     /**
@@ -307,7 +338,40 @@ public class SimpleParser {
      * @return Returns the copied slice of the expression from {@code start} to {@link #position}.
      */
     public final String sliceFrom(int start) {
-        return input.subSequence(start, position).toString();
+        return new String(chars, start, position - start);
+    }
+
+    /**
+     * Compares the slice of the expression from {@code start} to the current position against the given string,
+     * without allocating a substring.
+     *
+     * @param start Start position of the slice (inclusive), ending at the current position (exclusive).
+     * @param candidate String to compare the slice against.
+     * @return Returns true if the slice equals the candidate string character-for-character.
+     */
+    public final boolean sliceEquals(int start, String candidate) {
+        int len = position - start;
+        if (candidate.length() != len) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            if (chars[start + i] != candidate.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Matches the slice of the expression from {@code start} to the current position against a fixed set of
+     * candidate keywords, without allocating a substring.
+     *
+     * @param start Start position of the slice (inclusive), ending at the current position (exclusive).
+     * @param matcher Matcher holding the candidate keywords.
+     * @return The index of the matching candidate, or {@code -1} if none match.
+     */
+    public final int sliceMatches(int start, SliceMatcher matcher) {
+        return matcher.match(chars, start, position - start);
     }
 
     /**

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/SliceMatcher.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/SliceMatcher.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.utils;
+
+/**
+ * Matches a slice of a {@code char[]} against a fixed set of candidate keywords without allocating a string.
+ *
+ * <p>The candidates are supplied once at construction in a caller-defined order, and {@link #match} returns the index
+ * of the matching candidate (or {@code -1}). Callers typically {@code switch} on the returned index. This lets a
+ * parser dispatch on a keyword by comparing directly against its character buffer instead of allocating a substring
+ * and comparing strings.
+ *
+ * <p>Matching works like a shallow trie: candidates are first bucketed by length (the cheapest discriminator,
+ * precomputed once), and only candidates whose length equals the slice length are then compared character by
+ * character. Keyword sets are typically small and largely length-distinct, so this eliminates most candidates before
+ * any character comparison.
+ */
+public final class SliceMatcher {
+
+    // Keywords stored as char[] so matching is a plain array-vs-array comparison, avoiding String.charAt's
+    // Latin1/UTF16 coder dispatch on every character.
+    private final char[][] keywords;
+    private final int minLength;
+    // byLength[len - minLength] holds the indices of every keyword whose length is len.
+    private final int[][] byLength;
+
+    /**
+     * Creates a matcher over the given candidate keywords.
+     *
+     * <p>The index of each keyword in this array is what {@link #match} returns when that keyword matches. If a
+     * keyword appears more than once, the lowest index wins.
+     *
+     * @param keywords Candidate keywords in the order callers will switch on.
+     */
+    public SliceMatcher(String... keywords) {
+        this.keywords = new char[keywords.length][];
+        for (int i = 0; i < keywords.length; i++) {
+            this.keywords[i] = keywords[i].toCharArray();
+        }
+
+        if (keywords.length == 0) {
+            this.minLength = 0;
+            this.byLength = new int[0][];
+            return;
+        }
+
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (char[] keyword : this.keywords) {
+            min = Math.min(min, keyword.length);
+            max = Math.max(max, keyword.length);
+        }
+        this.minLength = min;
+
+        int[] counts = new int[max - min + 1];
+        for (char[] keyword : this.keywords) {
+            counts[keyword.length - min]++;
+        }
+
+        int[][] buckets = new int[counts.length][];
+        for (int i = 0; i < buckets.length; i++) {
+            buckets[i] = new int[counts[i]];
+        }
+
+        int[] fill = new int[counts.length];
+        for (int i = 0; i < this.keywords.length; i++) {
+            int bucket = this.keywords[i].length - min;
+            buckets[bucket][fill[bucket]++] = i;
+        }
+        this.byLength = buckets;
+    }
+
+    /**
+     * Matches the slice {@code chars[offset, offset + length)} against the candidates.
+     *
+     * @param chars Character buffer containing the slice.
+     * @param offset Start of the slice (inclusive).
+     * @param length Length of the slice.
+     * @return The index of the matching candidate, or {@code -1} if none match.
+     */
+    public int match(char[] chars, int offset, int length) {
+        int bucket = length - minLength;
+        if (bucket < 0 || bucket >= byLength.length) {
+            return -1;
+        }
+
+        outer:
+        for (int candidate : byLength[bucket]) {
+            char[] keyword = keywords[candidate];
+            for (int i = 0; i < length; i++) {
+                if (chars[offset + i] != keyword[i]) {
+                    continue outer;
+                }
+            }
+            return candidate;
+        }
+
+        return -1;
+    }
+}

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/SliceMatcher.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/SliceMatcher.java
@@ -86,8 +86,7 @@ public final class SliceMatcher {
             return -1;
         }
 
-        outer:
-        for (int candidate : byLength[bucket]) {
+        outer: for (int candidate : byLength[bucket]) {
             char[] keyword = keywords[candidate];
             for (int i = 0; i < length; i++) {
                 if (chars[offset + i] != keyword[i]) {

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/SimpleParserTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/SimpleParserTest.java
@@ -121,6 +121,16 @@ public class SimpleParserTest {
     }
 
     @Test
+    public void skipsKnownNonNewlineCharacters() {
+        SimpleParser p = new SimpleParser("foo");
+
+        p.skipNonNewline();
+        assertThat(p.position(), equalTo(1));
+        assertThat(p.line(), equalTo(1));
+        assertThat(p.column(), equalTo(2));
+    }
+
+    @Test
     public void assertsNestingNotTooDeep() {
         SimpleParser p = new SimpleParser("foo", 2);
         p.increaseNestingLevel();
@@ -218,5 +228,56 @@ public class SimpleParserTest {
         });
 
         assertThat(e.getMessage(), containsString("Expected a line break, but found 'H'"));
+    }
+
+    @Test
+    public void sliceEqualsComparesSliceWithoutAllocating() {
+        SimpleParser p = new SimpleParser("structure");
+        int start = p.position();
+        while (!p.eof()) {
+            p.skipNonNewline();
+        }
+
+        assertThat(p.sliceEquals(start, "structure"), is(true));
+        assertThat(p.sliceEquals(start, "service"), is(false));
+        assertThat(p.sliceEquals(start, "structures"), is(false)); // longer
+        assertThat(p.sliceEquals(start, "struct"), is(false)); // shorter
+    }
+
+    @Test
+    public void sliceMatchesReturnsCandidateIndex() {
+        SliceMatcher matcher = new SliceMatcher("service", "structure", "member");
+        SimpleParser p = new SimpleParser("structure");
+        int start = p.position();
+        while (!p.eof()) {
+            p.skipNonNewline();
+        }
+
+        assertThat(p.sliceMatches(start, matcher), is(1));
+    }
+
+    @Test
+    public void sliceMatchesReturnsNegativeOneWhenNoCandidateMatches() {
+        SliceMatcher matcher = new SliceMatcher("service", "structure");
+        SimpleParser p = new SimpleParser("operation");
+        int start = p.position();
+        while (!p.eof()) {
+            p.skipNonNewline();
+        }
+
+        assertThat(p.sliceMatches(start, matcher), is(-1));
+    }
+
+    @Test
+    public void supportsNonStringCharSequenceInput() {
+        // Exercises the char-by-char copy fallback for non-String CharSequence inputs.
+        SimpleParser p = new SimpleParser(new StringBuilder("foo bar"));
+        assertThat(p.peek(), equalTo('f'));
+        int start = p.position();
+        while (!p.eof() && p.peek() != ' ') {
+            p.skipNonNewline();
+        }
+        assertThat(p.sliceFrom(start), equalTo("foo"));
+        assertThat(p.sliceEquals(start, "foo"), is(true));
     }
 }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/SliceMatcherTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/SliceMatcherTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+public class SliceMatcherTest {
+
+    private int match(SliceMatcher matcher, String text) {
+        char[] chars = ("xx" + text + "xx").toCharArray();
+        return matcher.match(chars, 2, text.length());
+    }
+
+    @Test
+    public void matchesByIndex() {
+        SliceMatcher matcher = new SliceMatcher("number", "structure", "string");
+        assertThat(match(matcher, "number"), is(0));
+        assertThat(match(matcher, "structure"), is(1));
+        assertThat(match(matcher, "string"), is(2));
+    }
+
+    @Test
+    public void returnsNegativeOneWhenNoMatch() {
+        SliceMatcher matcher = new SliceMatcher("number", "structure");
+        assertThat(match(matcher, "service"), is(-1));
+        assertThat(match(matcher, "numbe"), is(-1));
+        assertThat(match(matcher, "numbers"), is(-1));
+        assertThat(match(matcher, ""), is(-1));
+    }
+
+    @Test
+    public void distinguishesSameLengthCandidates() {
+        // "blob" and "long" are both length 4 and land in the same length bucket.
+        SliceMatcher matcher = new SliceMatcher("blob", "long", "byte");
+        assertThat(match(matcher, "blob"), is(0));
+        assertThat(match(matcher, "long"), is(1));
+        assertThat(match(matcher, "byte"), is(2));
+        assertThat(match(matcher, "lonb"), is(-1));
+    }
+
+    @Test
+    public void handlesEmptyMatcher() {
+        SliceMatcher matcher = new SliceMatcher();
+        assertThat(match(matcher, "anything"), is(-1));
+    }
+
+    @Test
+    public void matchesAtNonZeroOffset() {
+        SliceMatcher matcher = new SliceMatcher("map", "list");
+        char[] chars = "prefix:list:suffix".toCharArray();
+        assertThat(matcher.match(chars, 7, 4), is(1));
+    }
+
+    @Test
+    public void lowestIndexWinsOnDuplicates() {
+        SliceMatcher matcher = new SliceMatcher("set", "set");
+        assertThat(match(matcher, "set"), is(0));
+    }
+}


### PR DESCRIPTION
Assign variables an index
Avoid recomputing trait shapeIDs over and over
Cache whether an expression is independent


#### Background
* What do these changes do? optimize selectors
* Why are they important? selectors are used a ton when loading models

#### Testing
* How did you test these changes?
Unit tests in the repo, benchmarks

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

```
  ┌─────────────────────────────────────────────────────┬──────────┬───────┬─────────┐
  │                      Benchmark                      │ Baseline │ Final │ Speedup │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ evaluateDoubleRootSelector (:root(*):root(*))       │ 533.5    │ 11.8  │ 45×     │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ isMultiType (:is(service, operation, resource))     │ 10.0     │ 0.94  │ 11×     │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ notTrait (:not([trait|input]) :not([trait|output])) │ 16.7     │ 3.10  │ 5.4×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ traitExistence ([trait|error])                      │ 7.67     │ 1.87  │ 4.1×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ evaluateSuboptimalHttpBindingSelector               │ 25.4     │ 7.42  │ 3.4×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ traitWithValue ([trait|error = "client"])           │ 8.21     │ 2.33  │ 3.5×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ evaluateHttpBindingSelector                         │ 0.60     │ 0.34  │ 1.8×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ preludeDataType (compound validator)                │ 25.4     │ 12.4  │ 2.1×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ structureMembers (structure > member)               │ 6.40     │ 5.30  │ 1.2×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ testNestedStructure                                 │ 6.17     │ 4.87  │ 1.3×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ recursiveToOperation (service ~> operation)         │ 7.57     │ 7.55  │ 1.0×    │
  ├─────────────────────────────────────────────────────┼──────────┼───────┼─────────┤
  │ evaluateHttpBindingManually (hand-written ref)      │ 0.158    │ 0.152 │ —       │
  └─────────────────────────────────────────────────────┴──────────┴───────┴─────────┘
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
