### PR TITLE
Model loading optimizations

### DIFF
--- a/.changes/next-release/feature-432853f2aca1168fd38f46d6ba08bf413e057ad9.json
+++ b/.changes/next-release/feature-432853f2aca1168fd38f46d6ba08bf413e057ad9.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Optimized model loading by ~50% by fixing a path traversal bug, reducing JSON allocations, reducing ShapeID string allocations, improving ShapeId and Model blackboard caches, optimizing selectors based on relevance, and skipping construction of suppressed unresolved-trait validation events.",
+  "pull_requests": [
+    "[#3176](https://github.com/smithy-lang/smithy/pull/3176)"
+  ]
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ModelBuilder.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ModelBuilder.java
@@ -157,6 +157,9 @@ final class ModelBuilder {
 
             if (validationMode == Validator.Mode.QUIET_CORE_ONLY) {
                 assembler.disableValidation();
+                // This mode discards non-core/sub-threshold events anyway, so don't pay to construct the loader's
+                // "unable to resolve trait" warnings when unknown traits are already being allowed.
+                assembler.putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS_QUIET, true);
             }
 
             // Emit status updates.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import software.amazon.smithy.model.knowledge.KnowledgeIndex;
@@ -82,7 +81,7 @@ public final class Model implements ToSmithyBuilder<Model> {
     private final Map<ShapeType.Category, Set<? extends Shape>> cachedCategories = new ConcurrentHashMap<>();
 
     /** Cache of computed {@link KnowledgeIndex} instances. */
-    private final Map<String, KnowledgeIndex> blackboard = new ConcurrentSkipListMap<>();
+    private final Map<String, KnowledgeIndex> blackboard = new ConcurrentHashMap<>();
 
     /** Lazily computed trait mappings. */
     private volatile TraitCache traitCache;
@@ -913,7 +912,20 @@ public final class Model implements ToSmithyBuilder<Model> {
      */
     @SuppressWarnings("unchecked")
     public <T extends KnowledgeIndex> T getKnowledge(Class<T> type, Function<Model, T> constructor) {
-        return (T) blackboard.computeIfAbsent(type.getName(), t -> constructor.apply(this));
+        // Don't use computeIfAbsent: a KnowledgeIndex constructor commonly requests other knowledge indexes, which
+        // re-enters this method and modifies the same map. ConcurrentHashMap forbids recursive updates inside a
+        // computeIfAbsent mapping function and throws. Construct outside the map, then putIfAbsent so concurrent
+        // callers converge on a single instance.
+        String key = type.getName();
+        KnowledgeIndex index = blackboard.get(key);
+        if (index == null) {
+            index = constructor.apply(this);
+            KnowledgeIndex existing = blackboard.putIfAbsent(key, index);
+            if (existing != null) {
+                index = existing;
+            }
+        }
+        return (T) index;
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/SourceLocation.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/SourceLocation.java
@@ -16,7 +16,6 @@ public final class SourceLocation implements FromSourceLocation, Comparable<Sour
     private final String filename;
     private final int line;
     private final int column;
-    private int hash;
 
     public SourceLocation(String filename, int line, int column) {
         this.filename = Objects.requireNonNull(filename);
@@ -72,19 +71,18 @@ public final class SourceLocation implements FromSourceLocation, Comparable<Sour
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof SourceLocation && toString().equals(other.toString());
+        if (other == this) {
+            return true;
+        } else if (!(other instanceof SourceLocation)) {
+            return false;
+        }
+        SourceLocation o = (SourceLocation) other;
+        return line == o.line && column == o.column && filename.equals(o.filename);
     }
 
     @Override
     public int hashCode() {
-        int h = hash;
-
-        if (h == 0) {
-            h = 1 + filename.hashCode() + line * 17 + column;
-            hash = h;
-        }
-
-        return h;
+        return 1 + filename.hashCode() + line * 17 + column;
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/JsonAstLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/JsonAstLoader.java
@@ -6,7 +6,6 @@ package software.amazon.smithy.model.loader;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import software.amazon.smithy.model.SourceException;
@@ -116,7 +115,7 @@ final class JsonAstLoader {
         SourceLocation modelLocation = reader.currentLocation();
         reader.startObject();
 
-        Keys topLevelKeys = new Keys();
+        List<String> additionalProperties = null;
         boolean isModel = false;
 
         // The version drives version-specific shape/trait validation, so it must be applied before any
@@ -125,7 +124,7 @@ final class JsonAstLoader {
         Node deferredShapes = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            topLevelKeys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, TOP_LEVEL_PROPERTIES);
             switch (key) {
                 case SMITHY: {
                     String versionString = reader.expectStringValue("`smithy` member");
@@ -164,7 +163,7 @@ final class JsonAstLoader {
             loadDeferredShapes(deferredShapes);
         }
 
-        checkAdditionalProperties(topLevelKeys.list, null, TOP_LEVEL_PROPERTIES, modelLocation);
+        checkAdditionalProperties(additionalProperties, null, TOP_LEVEL_PROPERTIES, modelLocation);
         return true;
     }
 
@@ -355,26 +354,26 @@ final class JsonAstLoader {
     // ===== Shape kinds. Each consumes the remaining members of the (already type-read) shape object. =====
 
     private void loadApply(ShapeId id, SourceLocation location) {
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, APPLY_PROPERTIES);
             if (TRAITS.equals(key)) {
                 applyTraitsFromCursor(id);
             } else {
                 reader.skipValue();
             }
         }
-        checkAdditionalProperties(keys.list, id, APPLY_PROPERTIES, location);
+        checkAdditionalProperties(additionalProperties, id, APPLY_PROPERTIES, location);
     }
 
     private void loadSimpleShape(ShapeId id, SourceLocation location, AbstractShapeBuilder<?, ?> builder) {
         builder.id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, SIMPLE_PROPERTY_NAMES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -387,17 +386,17 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, SIMPLE_PROPERTY_NAMES, location);
+        checkAdditionalProperties(additionalProperties, id, SIMPLE_PROPERTY_NAMES, location);
         operations.accept(operation);
     }
 
     private void loadNamedMemberShape(ShapeId id, SourceLocation location, AbstractShapeBuilder<?, ?> builder) {
         builder.id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, NAMED_MEMBER_SHAPE_PROPERTY_NAMES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -413,17 +412,17 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, NAMED_MEMBER_SHAPE_PROPERTY_NAMES, location);
+        checkAdditionalProperties(additionalProperties, id, NAMED_MEMBER_SHAPE_PROPERTY_NAMES, location);
         operations.accept(operation);
     }
 
     private void loadCollection(ShapeId id, SourceLocation location, CollectionShape.Builder<?, ?> builder) {
         builder.id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, COLLECTION_PROPERTY_NAMES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -439,17 +438,17 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, COLLECTION_PROPERTY_NAMES, location);
+        checkAdditionalProperties(additionalProperties, id, COLLECTION_PROPERTY_NAMES, location);
         operations.accept(operation);
     }
 
     private void loadMap(ShapeId id, SourceLocation location) {
         MapShape.Builder builder = MapShape.builder().id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, MAP_PROPERTY_NAMES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -468,17 +467,17 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, MAP_PROPERTY_NAMES, location);
+        checkAdditionalProperties(additionalProperties, id, MAP_PROPERTY_NAMES, location);
         operations.accept(operation);
     }
 
     private void loadOperation(ShapeId id, SourceLocation location) {
         OperationShape.Builder builder = OperationShape.builder().id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, OPERATION_PROPERTY_NAMES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -500,17 +499,17 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, OPERATION_PROPERTY_NAMES, location);
+        checkAdditionalProperties(additionalProperties, id, OPERATION_PROPERTY_NAMES, location);
         operations.accept(operation);
     }
 
     private void loadResource(ShapeId id, SourceLocation location) {
         ResourceShape.Builder builder = ResourceShape.builder().id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, RESOURCE_PROPERTIES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -556,17 +555,17 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, RESOURCE_PROPERTIES, location);
+        checkAdditionalProperties(additionalProperties, id, RESOURCE_PROPERTIES, location);
         operations.accept(operation);
     }
 
     private void loadService(ShapeId id, SourceLocation location) {
         ServiceShape.Builder builder = new ServiceShape.Builder().id(id).source(location);
         LoadOperation.DefineShape operation = createShape(builder);
-        Keys keys = new Keys(TYPE);
+        List<String> additionalProperties = null;
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, SERVICE_PROPERTIES);
             switch (key) {
                 case TRAITS:
                     applyTraitsFromCursor(id);
@@ -594,7 +593,7 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, id, SERVICE_PROPERTIES, location);
+        checkAdditionalProperties(additionalProperties, id, SERVICE_PROPERTIES, location);
         operations.accept(operation);
     }
 
@@ -649,13 +648,13 @@ final class JsonAstLoader {
         }
         SourceLocation memberLocation = reader.currentLocation();
         MemberShape.Builder builder = MemberShape.builder().source(memberLocation).id(memberId);
-        Keys keys = new Keys();
+        List<String> additionalProperties = null;
         ShapeId target = null;
         boolean sawTarget = false;
         reader.startObject();
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, MEMBER_PROPERTIES);
             switch (key) {
                 case TARGET:
                     target = expectShapeId(reader.expectStringValue("`target` member"), reader.currentLocation());
@@ -669,7 +668,7 @@ final class JsonAstLoader {
                     break;
             }
         }
-        checkAdditionalProperties(keys.list, memberId, MEMBER_PROPERTIES, memberLocation);
+        checkAdditionalProperties(additionalProperties, memberId, MEMBER_PROPERTIES, memberLocation);
         if (!sawTarget) {
             throw new SourceException("Missing expected member `target`.", memberLocation);
         }
@@ -705,13 +704,13 @@ final class JsonAstLoader {
                     reader.currentLocation());
         }
         SourceLocation location = reader.currentLocation();
-        Keys keys = new Keys();
+        List<String> additionalProperties = null;
         ShapeId target = null;
         boolean sawTarget = false;
         reader.startObject();
         String key;
         while ((key = reader.nextKey()) != null) {
-            keys.add(key);
+            additionalProperties = addAdditionalProperty(additionalProperties, key, REFERENCE_PROPERTIES);
             if (TARGET.equals(key)) {
                 target = expectShapeId(reader.expectStringValue("`target` member"), reader.currentLocation());
                 sawTarget = true;
@@ -719,7 +718,7 @@ final class JsonAstLoader {
                 reader.skipValue();
             }
         }
-        checkAdditionalProperties(keys.list, id, REFERENCE_PROPERTIES, location);
+        checkAdditionalProperties(additionalProperties, id, REFERENCE_PROPERTIES, location);
         if (!sawTarget) {
             throw new SourceException("Missing expected member `target`.", location);
         }
@@ -795,21 +794,22 @@ final class JsonAstLoader {
         operations.accept(new LoadOperation.Event(event));
     }
 
+    private List<String> addAdditionalProperty(List<String> additional, String key, Collection<String> allowed) {
+        if (!allowed.contains(key)) {
+            if (additional == null) {
+                additional = new ArrayList<>();
+            }
+            additional.add(key);
+        }
+        return additional;
+    }
+
     private void checkAdditionalProperties(
-            List<String> keys,
+            List<String> additional,
             ShapeId shape,
             Collection<String> allowed,
             SourceLocation location
     ) {
-        List<String> additional = null;
-        for (String key : keys) {
-            if (!allowed.contains(key)) {
-                if (additional == null) {
-                    additional = new ArrayList<>();
-                }
-                additional.add(key);
-            }
-        }
         if (additional != null) {
             String message = String.format(
                     "Expected an object with possible properties of %s, but found additional properties: %s",
@@ -822,19 +822,6 @@ final class JsonAstLoader {
                     .sourceLocation(location)
                     .shapeId(shape)
                     .build());
-        }
-    }
-
-    // Accumulates the member keys seen in an object for the additional-properties check.
-    private static final class Keys {
-        final List<String> list = new ArrayList<>();
-
-        Keys(String... initial) {
-            Collections.addAll(list, initial);
-        }
-
-        void add(String key) {
-            list.add(key);
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/JsonAstReader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/JsonAstReader.java
@@ -55,9 +55,19 @@ final class JsonAstReader implements AstReader {
     private static final int DEDUP_SIZE = 512; // power of two
     private static final int DEDUP_MASK = DEDUP_SIZE - 1;
 
+    // Longer-string dedup cache (see endCaptureLongDeduped). Strings up to this length are deduplicated by hashing
+    // the captured buffer slice and comparing against the cached string's characters, so a cache hit allocates
+    // nothing. This catches the many repeated long strings in models (shape-ID targets like "smithy.api#String",
+    // recurring trait values) that exceed the 8-char packed-key fast path. The cap bounds the per-miss comparison
+    // cost and avoids retaining very long one-off strings (e.g. documentation) in the cache.
+    private static final int MAX_LONG_DEDUP_CHARS = 64;
+    private static final int LONG_DEDUP_SIZE = 1024; // power of two
+    private static final int LONG_DEDUP_MASK = LONG_DEDUP_SIZE - 1;
+
     private static final class StringDedupCache {
         final long[] keys = new long[DEDUP_SIZE];
         final String[] vals = new String[DEDUP_SIZE];
+        final String[] longVals = new String[LONG_DEDUP_SIZE];
     }
 
     // One cache per thread, reused across parses without clearing (the packed key is exact, so a
@@ -97,6 +107,7 @@ final class JsonAstReader implements AstReader {
     // Dedup cache arrays, fetched from the per-thread pool on the first short string.
     private long[] dedupKeys;
     private String[] dedupVals;
+    private String[] longDedupVals;
 
     private JsonAstReader(String filename, Reader reader, boolean allowComments, int bufferSize) {
         if (reader == null) {
@@ -719,7 +730,7 @@ final class JsonAstReader implements AstReader {
             return "";
         }
         if (len > MAX_DEDUP_CHARS) {
-            return endCapture();
+            return len <= MAX_LONG_DEDUP_CHARS ? endCaptureLongDeduped(start, len) : endCapture();
         }
 
         long key = 0;
@@ -750,6 +761,47 @@ final class JsonAstReader implements AstReader {
         keys[slot] = key;
         vals[slot] = s;
         return s;
+    }
+
+    // Deduplicates captured strings longer than the packed-key fast path by hashing the buffer slice and comparing
+    // it against the single cached string in its slot. A hit returns the cached String without allocating; a miss
+    // allocates once and overwrites the slot. captureStart has not yet been reset when this is called.
+    private String endCaptureLongDeduped(int start, int len) {
+        captureStart = -1;
+
+        // FNV-1a hash over the captured slice.
+        int h = 0x811c9dc5;
+        for (int i = 0; i < len; i++) {
+            h = (h ^ buffer[start + i]) * 0x01000193;
+        }
+        int slot = (h ^ (h >>> 16)) & LONG_DEDUP_MASK;
+
+        String[] longVals = this.longDedupVals;
+        if (longVals == null) {
+            longVals = this.longDedupVals = DEDUP_CACHE.get().longVals;
+        }
+
+        String cached = longVals[slot];
+        if (cached != null && matchesSlice(cached, start, len)) {
+            return cached;
+        }
+
+        String s = new String(buffer, start, len);
+        longVals[slot] = s;
+        return s;
+    }
+
+    // True if the cached string equals buffer[start, start+len) character-for-character, without allocating.
+    private boolean matchesSlice(String cached, int start, int len) {
+        if (cached.length() != len) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            if (cached.charAt(i) != buffer[start + i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void captureTokenLocation() {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoadOperationProcessor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoadOperationProcessor.java
@@ -41,6 +41,7 @@ final class LoadOperationProcessor implements Consumer<LoadOperation> {
             TraitFactory traitFactory,
             Model prelude,
             boolean allowUnknownTraits,
+            boolean quietUnknownTraits,
             Consumer<ValidationEvent> validationEventListener,
             ValidationEventDecorator decorator
     ) {
@@ -65,7 +66,7 @@ final class LoadOperationProcessor implements Consumer<LoadOperation> {
 
         this.prelude = prelude;
         shapeMap = new LoaderShapeMap(prelude, events);
-        traitMap = new LoaderTraitMap(traitFactory, events, allowUnknownTraits);
+        traitMap = new LoaderTraitMap(traitFactory, events, allowUnknownTraits, quietUnknownTraits);
 
         this.visitor = new LoadOperation.Visitor() {
             @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderTraitMap.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/LoaderTraitMap.java
@@ -38,13 +38,20 @@ final class LoaderTraitMap {
     private final Map<ShapeId, Map<ShapeId, Node>> traits = new HashMap<>();
     private final List<ValidationEvent> events;
     private final boolean allowUnknownTraits;
+    private final boolean quietUnknownTraits;
     private final Map<ShapeId, Map<ShapeId, Trait>> unclaimed = new HashMap<>();
     private final Set<ShapeId> claimed = new HashSet<>();
 
-    LoaderTraitMap(TraitFactory traitFactory, List<ValidationEvent> events, boolean allowUnknownTraits) {
+    LoaderTraitMap(
+            TraitFactory traitFactory,
+            List<ValidationEvent> events,
+            boolean allowUnknownTraits,
+            boolean quietUnknownTraits
+    ) {
         this.traitFactory = traitFactory;
         this.events = events;
         this.allowUnknownTraits = allowUnknownTraits;
+        this.quietUnknownTraits = quietUnknownTraits;
     }
 
     void applyTraitsToNonMixinsInShapeMap(LoaderShapeMap shapeMap, List<ShapeId> undefinedTraits) {
@@ -134,6 +141,12 @@ final class LoaderTraitMap {
             LoaderShapeMap shapeMap
     ) {
         if (!shapeMap.isRootShapeDefined(traitId) && (trait == null || !trait.isSynthetic())) {
+            // When unknown traits are allowed, these are only WARNINGs. If the caller has also asked to silence them
+            // (ALLOW_UNKNOWN_TRAITS_QUIET), skip building the event entirely rather than constructing a ValidationEvent
+            // and its formatted message per unresolved trait.
+            if (allowUnknownTraits && quietUnknownTraits) {
+                return;
+            }
             Severity severity = allowUnknownTraits ? Severity.WARNING : Severity.ERROR;
             events.add(ValidationEvent.builder()
                     .id(Validator.MODEL_ERROR + UNRESOLVED_TRAIT_SUFFIX)

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -62,6 +62,18 @@ public final class ModelAssembler {
     public static final String ALLOW_UNKNOWN_TRAITS = "assembler.allowUnknownTraits";
 
     /**
+     * Suppresses the "unable to resolve trait" validation events that are emitted when a trait is applied but its
+     * definition is not present in the model.
+     *
+     * <p>This is only honored together with {@link #ALLOW_UNKNOWN_TRAITS} (otherwise unknown traits are errors that
+     * must be reported). When set to {@code true}, the loader skips constructing these {@code WARNING} events
+     * entirely, which avoids materializing a {@link ValidationEvent} (and its formatted message) per unresolved
+     * trait. This is useful for tools that load large models with intentionally absent trait definitions and do not
+     * care about these warnings (for example, querying a model with a selector).
+     */
+    public static final String ALLOW_UNKNOWN_TRAITS_QUIET = "assembler.allowUnknownTraitsQuiet";
+
+    /**
      * Sets {@link URLConnection#setUseCaches} to false.
      *
      * <p>When running in a build environment, using caches can cause exceptions
@@ -521,6 +533,7 @@ public final class ModelAssembler {
                 traitFactory,
                 prelude,
                 areUnknownTraitsAllowed(),
+                areUnknownTraitsQuiet(),
                 validationEventListener,
                 decorator);
         List<ValidationEvent> events = processor.events();
@@ -601,5 +614,10 @@ public final class ModelAssembler {
     private boolean areUnknownTraitsAllowed() {
         Object allowUnknown = properties.get(ModelAssembler.ALLOW_UNKNOWN_TRAITS);
         return allowUnknown != null && (boolean) allowUnknown;
+    }
+
+    private boolean areUnknownTraitsQuiet() {
+        Object quiet = properties.get(ModelAssembler.ALLOW_UNKNOWN_TRAITS_QUIET);
+        return quiet != null && (boolean) quiet;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelAssembler.java
@@ -260,10 +260,11 @@ public final class ModelAssembler {
         Objects.requireNonNull(importPath, "The importPath provided to ModelAssembler#addImport was null");
 
         if (Files.isDirectory(importPath)) {
-            try (Stream<Path> files = Files.walk(importPath, FileVisitOption.FOLLOW_LINKS)
-                    .filter(p -> !p.equals(importPath))
-                    .filter(p -> Files.isDirectory(p) || Files.isRegularFile(p))) {
-                files.forEach(this::addImport);
+            // Files.walk already recurses the entire subtree, so only regular files need to be forwarded to
+            // addImport. Recursing into each emitted subdirectory (the previous behavior) re-walked every directory
+            // once per level of nesting and performed redundant isDirectory/isRegularFile stat calls on each entry.
+            try (Stream<Path> files = Files.walk(importPath, FileVisitOption.FOLLOW_LINKS)) {
+                files.filter(Files::isRegularFile).forEach(this::addImport);
             } catch (IOException e) {
                 throw new ModelImportException("Error loading the contents of " + importPath, e);
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborProvider.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/NeighborProvider.java
@@ -140,24 +140,31 @@ public interface NeighborProvider {
      * @return Returns the reverse neighbor provider.
      */
     static NeighborProvider reverse(Model model, NeighborProvider forwardProvider) {
-        // Note: this method previously needed lots of intermediate representations
-        // stored in memory to create a Map<ShapeId, List<RelationShip>> that contains
-        // only unique relationships. It was done using Stream, distinct, and groupingBy.
-        // However, when trying to load ridiculously large models, that approach consumes
-        // tons of heap. This approach allocates as little as possible (I think), but
-        // does require creating an ArrayList copy of a Set each time neighbors are returned.
-        Map<ShapeId, Set<Relationship>> targetedFrom = new HashMap<>();
-
-        for (Shape shape : model.toSet()) {
+        // Build the reverse adjacency using Sets to dedup relationships without holding the large intermediate
+        // representations that a Stream/distinct/groupingBy approach would require on very large models. Each Set is
+        // then frozen into an unmodifiable List once, so per-lookup reads return the prebuilt list directly instead
+        // of allocating an ArrayList copy of the Set on every getNeighbors call (this provider is queried per shape
+        // across many validators, so that per-call copy was a significant source of transient garbage).
+        Set<Shape> shapes = model.toSet();
+        Map<ShapeId, Set<Relationship>> building = new HashMap<>(shapes.size());
+        for (Shape shape : shapes) {
             for (Relationship rel : forwardProvider.getNeighbors(shape)) {
-                targetedFrom.computeIfAbsent(rel.getNeighborShapeId(), id -> new HashSet<>()).add(rel);
+                ShapeId target = rel.getNeighborShapeId();
+                Set<Relationship> set = building.get(target);
+                if (set == null) {
+                    set = new HashSet<>();
+                    building.put(target, set);
+                }
+                set.add(rel);
             }
         }
 
-        return shape -> {
-            Set<Relationship> shapes = targetedFrom.get(shape.getId());
-            return shapes == null ? Collections.emptyList() : ListUtils.copyOf(shapes);
-        };
+        Map<ShapeId, List<Relationship>> targetedFrom = new HashMap<>(building.size());
+        for (Map.Entry<ShapeId, Set<Relationship>> entry : building.entrySet()) {
+            targetedFrom.put(entry.getKey(), ListUtils.copyOf(entry.getValue()));
+        }
+
+        return shape -> targetedFrom.getOrDefault(shape.getId(), Collections.emptyList());
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AndSelector.java
@@ -70,6 +70,11 @@ final class AndSelector {
         }
 
         @Override
+        public boolean isOutputSubsetOfInput() {
+            return leftSelector.isOutputSubsetOfInput() && rightSelector.isOutputSubsetOfInput();
+        }
+
+        @Override
         public Collection<? extends Shape> getStartingShapes(Model model) {
             return leftSelector.getStartingShapes(model);
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/AttributeSelector.java
@@ -106,6 +106,11 @@ final class AttributeSelector implements InternalSelector {
         }
     }
 
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
+
     private boolean matchesAttribute(Shape shape, Context stack) {
         AttributeValue lhs = extractor.extract(shape, stack.getVars());
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Context.java
@@ -22,9 +22,9 @@ import software.amazon.smithy.model.shapes.Shape;
  */
 final class Context {
 
-    NeighborProviderIndex neighborIndex;
     private final Model model;
     private final List<Set<Shape>> roots;
+    private NeighborProviderIndex neighborIndex;
 
     // Selector variables are addressed by a dense integer slot assigned at parse time rather than by name. This lets
     // the hot path (storing and getting variables) use plain array indexing instead of hash map lookups, and lets the
@@ -50,6 +50,15 @@ final class Context {
         this.roots = roots;
         this.variableIndices = variableIndices;
         this.variableSlots = (Set<Shape>[]) new Set<?>[variableIndices.size()];
+    }
+
+    NeighborProviderIndex getNeighborIndex() {
+        NeighborProviderIndex result = neighborIndex;
+        if (result == null) {
+            result = NeighborProviderIndex.of(model);
+            neighborIndex = result;
+        }
+        return result;
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/IdentitySelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/IdentitySelector.java
@@ -56,6 +56,11 @@ final class IdentitySelector implements Selector {
     }
 
     @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "*";
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InSelector.java
@@ -39,6 +39,11 @@ final class InSelector implements InternalSelector {
         }
     }
 
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
+
     private static final class FilteredHolder implements InternalSelector.Receiver {
         private final Shape shapeToMatch;
         private boolean matched;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/InternalSelector.java
@@ -145,6 +145,19 @@ interface InternalSelector {
     }
 
     /**
+     * Returns true if this selector can only emit shapes that were provided as input.
+     *
+     * <p>This is useful for callers that only need to test a known set of candidate shapes. Pure filter selectors
+     * can be evaluated with just the candidates, while selectors that traverse to other shapes must still start from
+     * the whole model to discover whether a candidate appears in their output.
+     *
+     * @return Returns true if this selector's output is always a subset of its input.
+     */
+    default boolean isOutputSubsetOfInput() {
+        return false;
+    }
+
+    /**
      * Receives shapes from an InternalSelector.
      */
     interface Receiver {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/IsSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/IsSelector.java
@@ -53,4 +53,14 @@ final class IsSelector implements InternalSelector {
         }
         return union != null ? union : allShapes;
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        for (InternalSelector selector : selectors) {
+            if (!selector.isOutputSubsetOfInput()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/NeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/NeighborSelector.java
@@ -42,8 +42,8 @@ final class NeighborSelector implements InternalSelector {
             @Override
             protected Function<Context, NeighborProvider> neighborFactory(boolean includeTraits) {
                 return includeTraits
-                        ? context -> context.neighborIndex.getProviderWithTraitRelationships()
-                        : context -> context.neighborIndex.getProvider();
+                        ? context -> context.getNeighborIndex().getProviderWithTraitRelationships()
+                        : context -> context.getNeighborIndex().getProvider();
             }
         },
         REVERSE {
@@ -55,8 +55,8 @@ final class NeighborSelector implements InternalSelector {
             @Override
             protected Function<Context, NeighborProvider> neighborFactory(boolean includeTraits) {
                 return includeTraits
-                        ? context -> context.neighborIndex.getReverseProviderWithTraitRelationships()
-                        : context -> context.neighborIndex.getReverseProvider();
+                        ? context -> context.getNeighborIndex().getReverseProviderWithTraitRelationships()
+                        : context -> context.getNeighborIndex().getReverseProvider();
             }
         };
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/NotSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/NotSelector.java
@@ -38,4 +38,9 @@ final class NotSelector implements InternalSelector {
                 return ContainsShape.MAYBE;
         }
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/RecursiveNeighborSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/RecursiveNeighborSelector.java
@@ -23,7 +23,7 @@ final class RecursiveNeighborSelector implements InternalSelector {
 
     @Override
     public Response push(Context context, Shape shape, Receiver next) {
-        Walker walker = new Walker(context.neighborIndex.getProvider());
+        Walker walker = new Walker(context.getNeighborIndex().getProvider());
         Iterator<Shape> shapeIterator = walker.iterateShapes(shape, ONLY_DIRECTED);
 
         while (shapeIterator.hasNext()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ScopedAttributeSelector.java
@@ -61,6 +61,11 @@ final class ScopedAttributeSelector implements InternalSelector {
         }
     }
 
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
+
     private boolean matchesAssertions(Shape shape, Map<String, Set<Shape>> vars) {
         // First resolve the scope of the assertions.
         AttributeValue scope = AttributeValue.shape(shape, vars).getPath(path);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/Selector.java
@@ -115,6 +115,15 @@ public interface Selector {
     }
 
     /**
+     * Returns true if this selector can only emit shapes that were provided as input.
+     *
+     * @return Returns true if this selector's output is always a subset of its input.
+     */
+    default boolean isOutputSubsetOfInput() {
+        return false;
+    }
+
+    /**
      * Matches a selector to a set of shapes and receives each matched shape
      * with the variables that were set when the shape was matched.
      *

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategoryEnumSelector.java
@@ -45,4 +45,9 @@ final class ShapeTypeCategoryEnumSelector implements InternalSelector {
     public ContainsShape emitsAnyOptimization(Context context, Shape input) {
         return input.getType().getCategory() == category ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeCategorySelector.java
@@ -38,4 +38,9 @@ final class ShapeTypeCategorySelector implements InternalSelector {
     public ContainsShape emitsAnyOptimization(Context context, Shape input) {
         return shapeCategory.isInstance(input) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/ShapeTypeSelector.java
@@ -42,4 +42,9 @@ final class ShapeTypeSelector implements InternalSelector {
     public ContainsShape emitsAnyOptimization(Context context, Shape input) {
         return input.getType().isShapeType(shapeType) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TestSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TestSelector.java
@@ -55,4 +55,9 @@ final class TestSelector implements InternalSelector {
 
         return ContainsShape.NO;
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TopDownSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TopDownSelector.java
@@ -58,7 +58,7 @@ final class TopDownSelector implements InternalSelector {
         }
 
         // Recursively check each nested resource/operation.
-        for (Relationship rel : context.neighborIndex.getProvider().getNeighbors(shape)) {
+        for (Relationship rel : context.getNeighborIndex().getProvider().getNeighbors(shape)) {
             if (rel.getNeighborShape().isPresent() && !rel.getNeighborShapeId().equals(shape.getId())) {
                 if (rel.getRelationshipType() == RelationshipType.RESOURCE
                         || rel.getRelationshipType() == RelationshipType.OPERATION) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
@@ -57,4 +57,9 @@ final class TraitExistenceSelector implements InternalSelector {
     public ContainsShape emitsAnyOptimization(Context context, Shape input) {
         return input.hasTrait(traitId) ? ContainsShape.YES : ContainsShape.NO;
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableStoreSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/VariableStoreSelector.java
@@ -36,4 +36,9 @@ final class VariableStoreSelector implements InternalSelector {
         // Now send the received shape to the next receiver.
         return next.apply(context, shape);
     }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return true;
+    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
@@ -16,7 +16,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
@@ -110,10 +109,9 @@ final class WrappedSelector implements Selector {
     @Override
     public Stream<Shape> shapes(Model model, StartingContext startingContext) {
         Collection<? extends Shape> startingShapes = getStartingShapes(model, startingContext);
-        NeighborProviderIndex index = NeighborProviderIndex.of(model);
         List<Set<Shape>> computedRoots = computeRoots(model);
         return streamStartingShapes(startingShapes).flatMap(shape -> {
-            Context context = new Context(model, index, computedRoots, variableIndices);
+            Context context = new Context(model, null, computedRoots, variableIndices);
             return delegate.pushResultsToCollection(context, shape, new ArrayList<>()).stream();
         });
     }
@@ -121,11 +119,10 @@ final class WrappedSelector implements Selector {
     @Override
     public Stream<ShapeMatch> matches(Model model, StartingContext startingContext) {
         Collection<? extends Shape> startingShapes = getStartingShapes(model, startingContext);
-        NeighborProviderIndex index = NeighborProviderIndex.of(model);
         List<Set<Shape>> computedRoots = computeRoots(model);
         return streamStartingShapes(startingShapes).flatMap(shape -> {
             List<ShapeMatch> result = new ArrayList<>();
-            delegate.push(new Context(model, index, computedRoots, variableIndices), shape, (ctx, s) -> {
+            delegate.push(new Context(model, null, computedRoots, variableIndices), shape, (ctx, s) -> {
                 result.add(new ShapeMatch(s, ctx.getVars()));
                 return InternalSelector.Response.CONTINUE;
             });
@@ -139,10 +136,9 @@ final class WrappedSelector implements Selector {
 
     // Eagerly compute roots over all model shapes before evaluating shapes one at a time.
     private List<Set<Shape>> computeRoots(Model model) {
-        NeighborProviderIndex index = NeighborProviderIndex.of(model);
         List<Set<Shape>> rootResults = new ArrayList<>(roots.size());
         for (InternalSelector selector : roots) {
-            Set<Shape> result = evalRoot(model, index, selector, rootResults);
+            Set<Shape> result = evalRoot(model, selector, rootResults);
             rootResults.add(result);
         }
         return rootResults;
@@ -151,12 +147,11 @@ final class WrappedSelector implements Selector {
     // Eagerly compute a root subexpression.
     private Set<Shape> evalRoot(
             Model model,
-            NeighborProviderIndex index,
             InternalSelector selector,
             List<Set<Shape>> results
     ) {
         Collection<? extends Shape> shapesToEmit = selector.getStartingShapes(model);
-        Context isolatedContext = new Context(model, index, results, variableIndices);
+        Context isolatedContext = new Context(model, null, results, variableIndices);
         Set<Shape> captures = new HashSet<>();
         for (Shape rootShape : shapesToEmit) {
             isolatedContext.clearVariables();
@@ -175,7 +170,7 @@ final class WrappedSelector implements Selector {
             InternalSelector.Receiver acceptor
     ) {
         Objects.requireNonNull(startingShapes);
-        Context context = new Context(model, NeighborProviderIndex.of(model), computeRoots(model), variableIndices);
+        Context context = new Context(model, null, computeRoots(model), variableIndices);
 
         // When the selector's output is independent of the input shape (e.g., it begins with a
         // ":root(...)" rooted subexpression), every starting shape produces the identical result.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/WrappedSelector.java
@@ -68,7 +68,7 @@ final class WrappedSelector implements Selector {
         Collection<? extends Shape> startingShapes = getStartingShapes(model, startingContext);
 
         if (isParallel(startingShapes)) {
-            return shapes(model).collect(Collectors.toSet());
+            return shapes(model, startingContext).collect(Collectors.toSet());
         } else {
             // This is more optimized than using shapes() for smaller models that aren't parallelized.
             Set<Shape> result = new HashSet<>();
@@ -87,6 +87,11 @@ final class WrappedSelector implements Selector {
 
     private boolean isParallel(Collection<? extends Shape> startingShapes) {
         return startingShapes.size() >= PARALLEL_THRESHOLD;
+    }
+
+    @Override
+    public boolean isOutputSubsetOfInput() {
+        return delegate.isOutputSubsetOfInput();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -191,7 +191,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
 
     protected final void validateMemberShapeIds() {
         for (MemberShape member : members()) {
-            if (!member.getId().toString().startsWith(getId().toString())) {
+            if (!member.getId().isMemberOf(getId())) {
                 ShapeId expected = getId().withMember(member.getMemberName());
                 throw new SourceException(String.format(
                         "Expected the `%s` member of `%s` to have an ID of `%s` but found `%s`",

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeId.java
@@ -4,13 +4,10 @@
  */
 package software.amazon.smithy.model.shapes;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import software.amazon.smithy.model.loader.ParserUtils;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.node.Node;
@@ -21,7 +18,7 @@ import software.amazon.smithy.model.node.Node;
  * <p>A shape ID is constructed from an absolute or relative shape
  * reference. A shape reference has the following structure:
  *
- * {@code NAMESPACE#NAME$MEMBER}
+ * <p>{@code NAMESPACE#NAME$MEMBER}
  *
  * <p>An absolute reference contains a namespace and a pound sign.
  * A relative reference omits the namespace and pound sign prefix. In
@@ -42,7 +39,7 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
     private final String namespace;
     private final String name;
     private final String member;
-    private final String absoluteName;
+    private String absoluteName;
     private int hash;
 
     private ShapeId(String absoluteName, String namespace, String name, String member) {
@@ -50,10 +47,6 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
         this.name = name;
         this.member = member;
         this.absoluteName = absoluteName;
-    }
-
-    private ShapeId(String namespace, String name, String member) {
-        this(buildAbsoluteIdFromParts(namespace, name, member), namespace, name, member);
     }
 
     /**
@@ -162,16 +155,17 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
      * @throws ShapeIdSyntaxException when the ID is malformed.
      */
     public static ShapeId fromParts(String namespace, String name, String member) {
-        String idFromParts = buildAbsoluteIdFromParts(namespace, name, member);
-        validateParts(idFromParts, namespace, name, member);
-        return new ShapeId(idFromParts, namespace, name, member);
+        validateParts(namespace, name, member);
+        // Pass a null absolute name so it is built lazily only if the ID is ever stringified.
+        return new ShapeId(null, namespace, name, member);
     }
 
-    private static void validateParts(String absoluteId, String namespace, String name, String member) {
+    private static void validateParts(String namespace, String name, String member) {
         if (!isValidNamespace(namespace)
                 || !isValidIdentifier(name)
                 || (member != null && !isValidIdentifier(member))) {
-            throw new ShapeIdSyntaxException("Invalid shape ID: " + absoluteId);
+            throw new ShapeIdSyntaxException(
+                    "Invalid shape ID: " + buildAbsoluteIdFromParts(namespace, name, member));
         }
     }
 
@@ -252,7 +246,7 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
             throw new ShapeIdSyntaxException("Invalid shape ID member: " + member);
         }
 
-        return new ShapeId(namespace, name, member);
+        return new ShapeId(null, namespace, name, member);
     }
 
     @Override
@@ -279,7 +273,7 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
         if (member == null) {
             return this;
         } else {
-            return new ShapeId(namespace, name, null);
+            return new ShapeId(null, namespace, name, null);
         }
     }
 
@@ -342,6 +336,18 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
     }
 
     /**
+     * Checks whether this ID is a member of the given container ID, i.e. it shares the container's namespace and
+     * name and has a member component. Equivalent to {@code toString().startsWith(container.toString())} for member
+     * IDs, but compares the parts directly so neither absolute name is materialized.
+     *
+     * @param container Candidate container shape ID.
+     * @return True if this ID is a member of {@code container}.
+     */
+    boolean isMemberOf(ShapeId container) {
+        return member != null && name.equals(container.name) && namespace.equals(container.namespace);
+    }
+
+    /**
      * Creates a string that contains a relative reference to the ID.
      *
      * @return Returns a relative shape ID string with no namespace.
@@ -363,25 +369,37 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
         } else if (!isValidNamespace(namespace)) {
             throw new ShapeIdSyntaxException("Invalid shape ID: " + namespace);
         } else {
-            return new ShapeId(namespace, name, member);
+            return new ShapeId(null, namespace, name, member);
         }
     }
 
     /**
      * Converts the {@code Id} into a shape ID string.
      *
-     * For example: "com.foo.bar#Baz$member".
+     * <p>For example: "com.foo.bar#Baz$member".
      *
      * @return Returns a shape ID as a string.
      */
     @Override
     public String toString() {
-        return absoluteName;
+        String result = absoluteName;
+        if (result == null) {
+            result = buildAbsoluteIdFromParts(namespace, name, member);
+            absoluteName = result;
+        }
+        return result;
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ShapeId && other.toString().equals(this.toString());
+        if (this == other) {
+            return true;
+        } else if (!(other instanceof ShapeId)) {
+            return false;
+        } else {
+            ShapeId o = (ShapeId) other;
+            return name.equals(o.name) && Objects.equals(member, o.member) && namespace.equals(o.namespace);
+        }
     }
 
     @Override
@@ -397,64 +415,36 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
     }
 
     /**
-     * A least-recently used flyweight factory that creates shape IDs.
-     *
-     * <p>Prelude IDs are stored separately from non-prelude IDs because we can make a reasonable estimate about the
-     * size of the prelude and stop caching IDs when that size is exceeded. Prelude shapes are stored in a
-     * ConcurrentHashMap with a bounded size. Once the size exceeds 500, then items are no longer stored in the cache.
-     * Non-prelude shapes are stored in a bounded, synchronized LRU cache based on {@link LinkedHashMap}.
+     * A bounded flyweight factory that creates shape IDs, striped to reduce lock contention.
      */
     private static final class ShapeIdFactory {
-        private static final int NON_PRELUDE_MAX_SIZE = 8192;
-        private static final int PRELUDE_MAX_SIZE = 500;
-        private static final String PRELUDE_PREFIX = Prelude.NAMESPACE + '#';
-
-        private final Map<String, ShapeId> nonPreludeCache;
-        private final ConcurrentMap<String, ShapeId> preludeCache;
+        private static final int MAX_SIZE = 65536;
+        private static final int STRIPE_COUNT = 32;
+        private static final int STRIPE_MAX_SIZE = MAX_SIZE / STRIPE_COUNT;
+        private final CacheStripe[] stripes;
 
         ShapeIdFactory() {
-            preludeCache = new ConcurrentHashMap<>(PRELUDE_MAX_SIZE);
-
-            // A simple LRU cache based on LinkedHashMap, wrapped in a synchronized map.
-            nonPreludeCache = Collections.synchronizedMap(new LinkedHashMap<String, ShapeId>(
-                    NON_PRELUDE_MAX_SIZE + 1,
-                    1.0f,
-                    true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, ShapeId> eldest) {
-                    return this.size() > NON_PRELUDE_MAX_SIZE;
-                }
-            });
+            stripes = new CacheStripe[STRIPE_COUNT];
+            for (int i = 0; i < STRIPE_COUNT; i++) {
+                stripes[i] = new CacheStripe(STRIPE_MAX_SIZE);
+            }
         }
 
         ShapeId create(final String key) {
-            if (key.startsWith(PRELUDE_PREFIX)) {
-                return getPreludeId(key);
-            } else {
-                return getNonPreludeId(key);
-            }
-        }
-
-        private ShapeId getPreludeId(String key) {
-            // computeIfAbsent isn't used here since we need to limit the cache size and creating multiple IDs
-            // simultaneously isn't an issue.
-            ShapeId result = preludeCache.get(key);
+            CacheStripe stripe = stripes[getStripeIndex(key)];
+            ShapeId result = stripe.getCached(key);
             if (result != null) {
                 return result;
+            } else {
+                result = buildShapeId(key);
+                return stripe.putIfAbsentOrGet(key, result);
             }
-
-            // The ID wasn't found so build it, and add it to the cache if the cache isn't too big already.
-            result = buildShapeId(key);
-
-            if (preludeCache.size() <= PRELUDE_MAX_SIZE) {
-                preludeCache.putIfAbsent(key, result);
-            }
-
-            return result;
         }
 
-        private ShapeId getNonPreludeId(String key) {
-            return nonPreludeCache.computeIfAbsent(key, ShapeIdFactory::buildShapeId);
+        private static int getStripeIndex(String key) {
+            int hash = key.hashCode();
+            hash ^= hash >>> 16;
+            return hash & (STRIPE_COUNT - 1);
         }
 
         private static ShapeId buildShapeId(String absoluteShapeId) {
@@ -477,8 +467,35 @@ public final class ShapeId implements ToShapeId, Comparable<ShapeId> {
                 memberName = absoluteShapeId.substring(memberPosition + 1);
             }
 
-            validateParts(absoluteShapeId, namespace, name, memberName);
+            validateParts(namespace, name, memberName);
             return new ShapeId(absoluteShapeId, namespace, name, memberName);
+        }
+
+        private static final class CacheStripe extends LinkedHashMap<String, ShapeId> {
+            private final int maxSize;
+
+            CacheStripe(int maxSize) {
+                super((int) (maxSize / 0.75f) + 1, 0.75f, true);
+                this.maxSize = maxSize;
+            }
+
+            synchronized ShapeId getCached(String key) {
+                return get(key);
+            }
+
+            synchronized ShapeId putIfAbsentOrGet(String key, ShapeId value) {
+                ShapeId previous = get(key);
+                if (previous != null) {
+                    return previous;
+                }
+                put(key, value);
+                return value;
+            }
+
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, ShapeId> eldest) {
+                return size() > maxSize;
+            }
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
@@ -9,6 +9,7 @@ import static java.lang.String.format;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,9 +38,9 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
     public List<ValidationEvent> validate(Model model) {
         // There are usually far fewer resources than members, precompute the identifiers
         // so various short circuits can be added.
-        Set<String> identifierNames = getAllIdentifierNames(model);
+        Map<String, Map<ShapeId, Set<ShapeId>>> resourceIdsByIdentifier = getResourceIdsByIdentifier(model);
         // Short circuit validating all the members if we don't have any resources to test.
-        if (identifierNames.isEmpty()) {
+        if (resourceIdsByIdentifier.isEmpty()) {
             return ListUtils.of();
         }
 
@@ -51,7 +52,8 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
         List<ValidationEvent> events = new ArrayList<>();
         for (MemberShape member : model.getMemberShapes()) {
             // Only the known identifier names can match for this, skip names that we don't know.
-            if (!identifierNames.contains(member.getMemberName())) {
+            Map<ShapeId, Set<ShapeId>> candidateTargets = resourceIdsByIdentifier.get(member.getMemberName());
+            if (candidateTargets == null) {
                 continue;
             }
             // Only strings can be identifiers, so skip non-String targets.
@@ -59,7 +61,16 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
                 continue;
             }
 
-            Set<ShapeId> potentialReferences = computePotentialReferences(model, reverseProvider, member);
+            Set<ShapeId> candidateResources = candidateTargets.get(member.getTarget());
+            if (candidateResources == null) {
+                continue;
+            }
+
+            Set<ShapeId> potentialReferences = computePotentialReferences(
+                    model,
+                    reverseProvider,
+                    member,
+                    candidateResources);
             if (!potentialReferences.isEmpty()) {
                 events.add(warning(member,
                         format("This member appears to reference the following resources without "
@@ -71,15 +82,24 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
         return events;
     }
 
-    private Set<String> getAllIdentifierNames(Model model) {
-        Set<String> identifierNames = new HashSet<>();
+    private Map<String, Map<ShapeId, Set<ShapeId>>> getResourceIdsByIdentifier(Model model) {
+        Map<String, Map<ShapeId, Set<ShapeId>>> result = new HashMap<>();
         for (ResourceShape resource : model.getResourceShapes()) {
-            identifierNames.addAll(resource.getIdentifiers().keySet());
+            for (Map.Entry<String, ShapeId> identifier : resource.getIdentifiers().entrySet()) {
+                result.computeIfAbsent(identifier.getKey(), key -> new HashMap<>())
+                        .computeIfAbsent(identifier.getValue(), key -> new HashSet<>())
+                        .add(resource.getId());
+            }
         }
-        return identifierNames;
+        return result;
     }
 
-    private Set<ShapeId> computePotentialReferences(Model model, NeighborProvider reverseProvider, MemberShape member) {
+    private Set<ShapeId> computePotentialReferences(
+            Model model,
+            NeighborProvider reverseProvider,
+            MemberShape member,
+            Set<ShapeId> candidateResources
+    ) {
         // Exclude any resources already in `@references` on the member or container structure.
         Set<ShapeId> resourcesToIgnore = new HashSet<>();
         ignoreReferencedResources(member, resourcesToIgnore);
@@ -97,17 +117,14 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
 
         // Check each resource in the model for something missed.
         Set<ShapeId> potentialResources = new HashSet<>();
-        for (ResourceShape resource : model.getResourceShapes()) {
+        for (ShapeId resourceId : candidateResources) {
             // Exclude members bound to resource hierarchies from generating events,
             // including for resources that are within the same hierarchy.
-            if (resourcesToIgnore.contains(resource.getId())) {
+            if (resourcesToIgnore.contains(resourceId)) {
                 continue;
             }
 
-            // This member matches the identifier for the resource we're checking, add it to a list.
-            if (isIdentifierMatch(resource, member)) {
-                potentialResources.add(resource.getId());
-            }
+            potentialResources.add(resourceId);
         }
 
         // Clean up any resources added through other paths that should be ignored.
@@ -162,9 +179,4 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
         }
     }
 
-    private boolean isIdentifierMatch(ResourceShape resource, MemberShape member) {
-        Map<String, ShapeId> identifiers = resource.getIdentifiers();
-        return identifiers.containsKey(member.getMemberName())
-                && identifiers.get(member.getMemberName()).equals(member.getTarget());
-    }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/OperationValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/OperationValidator.java
@@ -150,9 +150,10 @@ public final class OperationValidator extends AbstractValidator {
     }
 
     private void validateOperationNameAmbiguity(Model model, OperationShape operation, List<ValidationEvent> events) {
+        ShapeId operationId = operation.getId();
         ShapeId input = operation.getInputShape();
         for (String suffix : INPUT_SUFFIXES) {
-            ShapeId test = ShapeId.from(operation.getId().toShapeId() + suffix);
+            ShapeId test = ShapeId.fromParts(operationId.getNamespace(), operationId.getName() + suffix);
             if (!test.equals(input)) {
                 model.getShape(test).ifPresent(ambiguousShape -> {
                     events.add(createAmbiguousEvent(ambiguousShape, operation, input, "input"));
@@ -162,7 +163,7 @@ public final class OperationValidator extends AbstractValidator {
 
         ShapeId output = operation.getOutputShape();
         for (String suffix : OUTPUT_SUFFIXES) {
-            ShapeId test = ShapeId.from(operation.getId().toShapeId() + suffix);
+            ShapeId test = ShapeId.fromParts(operationId.getNamespace(), operationId.getName() + suffix);
             if (!test.equals(output)) {
                 model.getShape(test).ifPresent(ambiguousShape -> {
                     events.add(createAmbiguousEvent(ambiguousShape, operation, output, "output"));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PaginatedTraitValidator.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -55,10 +54,13 @@ public final class PaginatedTraitValidator extends AbstractValidator {
             ShapeType.SHORT);
     private static final Set<ShapeType> TOKEN_SHAPES = SetUtils.of(ShapeType.STRING, ShapeType.MAP);
     private static final Set<ShapeType> DANGER_TOKEN_SHAPES = SetUtils.of(ShapeType.MAP);
-    private static final Pattern PATH_PATTERN = Pattern.compile("\\.");
     private static final String DEEPLY_NESTED = "DeeplyNested";
     private static final String SHOULD_NOT_BE_REQUIRED = "ShouldNotBeRequired";
     private static final String WRONG_SHAPE_TYPE = "WrongShapeType";
+    private static final InputTokenValidator INPUT_TOKEN_VALIDATOR = new InputTokenValidator();
+    private static final PageSizeValidator PAGE_SIZE_VALIDATOR = new PageSizeValidator();
+    private static final OutputTokenValidator OUTPUT_TOKEN_VALIDATOR = new OutputTokenValidator();
+    private static final ItemValidator ITEM_VALIDATOR = new ItemValidator();
 
     @Override
     public List<ValidationEvent> validate(Model model) {
@@ -84,22 +86,22 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         // Validate input.
-        events.addAll(validateMember(opIndex, model, null, operation, trait, new InputTokenValidator()));
-        events.addAll(validateMember(opIndex, model, null, operation, trait, new PageSizeValidator()));
+        events.addAll(validateMember(opIndex, model, null, operation, trait, INPUT_TOKEN_VALIDATOR));
+        events.addAll(validateMember(opIndex, model, null, operation, trait, PAGE_SIZE_VALIDATOR));
 
         // Validate output.
-        events.addAll(validateMember(opIndex, model, null, operation, trait, new OutputTokenValidator()));
-        events.addAll(validateMember(opIndex, model, null, operation, trait, new ItemValidator()));
+        events.addAll(validateMember(opIndex, model, null, operation, trait, OUTPUT_TOKEN_VALIDATOR));
+        events.addAll(validateMember(opIndex, model, null, operation, trait, ITEM_VALIDATOR));
 
         if (events.isEmpty()) {
             model.shapes(ServiceShape.class).forEach(svc -> {
-                if (topDownIndex.getContainedOperations(svc).contains(operation)) {
+                if (topDownIndex.getContainedOperations(svc, false).contains(operation)) {
                     // Create a merged trait if one is present on the service.
                     PaginatedTrait merged = svc.getTrait(PaginatedTrait.class).map(trait::merge).orElse(trait);
-                    events.addAll(validateMember(opIndex, model, svc, operation, merged, new InputTokenValidator()));
-                    events.addAll(validateMember(opIndex, model, svc, operation, merged, new PageSizeValidator()));
-                    events.addAll(validateMember(opIndex, model, svc, operation, merged, new OutputTokenValidator()));
-                    events.addAll(validateMember(opIndex, model, svc, operation, merged, new ItemValidator()));
+                    events.addAll(validateMember(opIndex, model, svc, operation, merged, INPUT_TOKEN_VALIDATOR));
+                    events.addAll(validateMember(opIndex, model, svc, operation, merged, PAGE_SIZE_VALIDATOR));
+                    events.addAll(validateMember(opIndex, model, svc, operation, merged, OUTPUT_TOKEN_VALIDATOR));
+                    events.addAll(validateMember(opIndex, model, svc, operation, merged, ITEM_VALIDATOR));
                 }
             });
         }
@@ -219,7 +221,7 @@ public final class PaginatedTraitValidator extends AbstractValidator {
             }
         }
 
-        if (validator.pathsAllowed() && PATH_PATTERN.split(memberPath).length > 2) {
+        if (validator.pathsAllowed() && hasMoreThanTwoParts(memberPath)) {
             events.add(warning(operation,
                     trait,
                     String.format(
@@ -232,6 +234,10 @@ public final class PaginatedTraitValidator extends AbstractValidator {
         }
 
         return events;
+    }
+
+    private boolean hasMoreThanTwoParts(String memberPath) {
+        return memberPath.indexOf('.') != memberPath.lastIndexOf('.');
     }
 
     private enum Optionality {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -5,8 +5,10 @@
 package software.amazon.smithy.model.validation.validators;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
@@ -17,6 +19,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Ensures that shapes in separate namespaces don't refer to shapes in other
@@ -26,21 +29,56 @@ public final class PrivateAccessValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {
-        NeighborProvider provider = NeighborProviderIndex.of(model).getReverseProviderWithTraitRelationships();
+        Set<Shape> privateShapes = model.getShapesWithTrait(PrivateTrait.class);
+        if (privateShapes.isEmpty()) {
+            return ListUtils.of();
+        }
+
+        Set<ShapeId> privateShapeIds = new HashSet<>(privateShapes.size());
+        for (Shape privateShape : privateShapes) {
+            privateShapeIds.add(privateShape.getId());
+        }
+
+        NeighborProvider provider = NeighborProviderIndex.of(model).getProvider();
 
         List<ValidationEvent> events = new ArrayList<>();
-        for (Shape privateShape : model.getShapesWithTrait(PrivateTrait.class)) {
-            validateNeighbors(privateShape, provider.getNeighbors(privateShape), events);
+        for (Shape shape : model.toSet()) {
+            validateNeighbors(shape, provider.getNeighbors(shape), privateShapeIds, events);
+            validateTraitRelationships(model, shape, privateShapeIds, events);
         }
 
         return events;
     }
 
-    private void validateNeighbors(Shape shape, List<Relationship> relationships, List<ValidationEvent> events) {
-        String namespace = shape.getId().getNamespace();
+    private void validateNeighbors(
+            Shape shape,
+            List<Relationship> relationships,
+            Set<ShapeId> privateShapeIds,
+            List<ValidationEvent> events
+    ) {
+        String sourceNamespace = shape.getId().getNamespace();
         for (Relationship rel : relationships) {
-            if (!rel.getShape().getId().getNamespace().equals(namespace)) {
+            ShapeId neighborId = rel.getNeighborShapeId();
+            if (!sourceNamespace.equals(neighborId.getNamespace()) && privateShapeIds.contains(neighborId)) {
                 events.add(getPrivateAccessValidationEvent(rel));
+            }
+        }
+    }
+
+    private void validateTraitRelationships(
+            Model model,
+            Shape shape,
+            Set<ShapeId> privateShapeIds,
+            List<ValidationEvent> events
+    ) {
+        String sourceNamespace = shape.getId().getNamespace();
+        for (ShapeId traitId : shape.getAllTraits().keySet()) {
+            if (!sourceNamespace.equals(traitId.getNamespace()) && privateShapeIds.contains(traitId)) {
+                Shape privateTrait = model.expectShape(traitId);
+                events.add(getPrivateAccessValidationEvent(Relationship.create(
+                        shape,
+                        RelationshipType.TRAIT,
+                        privateTrait)));
             }
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.model.validation.validators;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,11 +84,21 @@ public final class TraitTargetValidator extends AbstractValidator {
             Selector selector,
             List<ShapeId> traits
     ) {
-        Set<Shape> matches = selector.select(model);
+        Set<Shape> matches;
+        if (selector.isOutputSubsetOfInput()) {
+            Set<Shape> candidates = new HashSet<>();
+            for (ShapeId traitId : traits) {
+                candidates.addAll(model.getShapesWithTrait(traitId));
+            }
+            matches = selector.select(model, new Selector.StartingContext(candidates));
+        } else {
+            matches = selector.select(model);
+        }
 
         for (ShapeId traitId : traits) {
             // Find all shapes that have the used trait applied to it.
-            for (Shape shape : model.getShapesWithTrait(traitId)) {
+            Set<Shape> shapes = model.getShapesWithTrait(traitId);
+            for (Shape shape : shapes) {
                 // Emit events when a shape is applied to something that didn't match the selector.
                 if (!matches.contains(shape)) {
                     // Strip out newlines with successive spaces.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -1262,4 +1262,76 @@ public class SelectorTest {
 
         assertThat(matches, contains("smithy.example#PlainString"));
     }
+
+    @Test
+    public void detectsWhenOutputIsSubsetOfInput() {
+        // Pure filters only ever emit shapes that were pushed into them.
+        assertThat(Selector.parse("string").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse("[trait|trait]").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse("[id=smithy.api#String]").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse(":not([trait|trait])").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse(":test([trait|trait])").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse(":is(string, integer)").isOutputSubsetOfInput(), equalTo(true));
+        // A :test/:not that reaches out to neighbors or variables internally is still a filter: it only emits the
+        // shape that was pushed in, so it remains a subset of the input.
+        assertThat(Selector.parse(":test(~> operation)").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse("structure :not(> member)").isOutputSubsetOfInput(), equalTo(true));
+        // Reverse neighbors inside :test/:not only drive the boolean decision; the emitted shape is still the input.
+        assertThat(Selector.parse(":test(<)").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse("string :test(< member)").isOutputSubsetOfInput(), equalTo(true));
+        assertThat(Selector.parse(":not(<-[mixin]-)").isOutputSubsetOfInput(), equalTo(true));
+        // A trailing filter after a mapping selector keeps the chain non-subset because the mapping selector in the
+        // middle emits shapes other than the input.
+        assertThat(Selector.parse("$a(string) :test(${a})").isOutputSubsetOfInput(), equalTo(true));
+    }
+
+    @Test
+    public void detectsWhenOutputIsNotSubsetOfInput() {
+        // Selectors that emit shapes other than the input (neighbors, variable contents, roots) are not subsets.
+        assertThat(Selector.parse("> member").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse("<").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse("< member").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse("<-[mixin]-").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse("~> operation").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse("service ~> operation").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse("${a}").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse(":root(string)").isOutputSubsetOfInput(), equalTo(false));
+        // Any mapping selector anywhere in the chain makes the whole chain non-subset.
+        assertThat(Selector.parse("structure > member").isOutputSubsetOfInput(), equalTo(false));
+        assertThat(Selector.parse(":is(string, > member)").isOutputSubsetOfInput(), equalTo(false));
+    }
+
+    @Test
+    public void restrictingStartingShapesDoesNotChangeSubsetSelectorResults() {
+        // The TraitTargetValidator optimization relies on this: for a subset-of-input selector, evaluating against a
+        // restricted set of starting shapes yields the same membership for those shapes as evaluating the whole
+        // model. Verify across filters, negation, neighbor-reaching tests, and unions.
+        List<String> subsetSelectors = ListUtils.of(
+                "operation",
+                "structure",
+                "[trait|http]",
+                ":not([trait|http])",
+                ":test(~> member)",
+                ":test(<)",
+                "member :test(<)",
+                ":is(operation, structure, member)",
+                "operation :not([trait|http])");
+
+        for (String expression : subsetSelectors) {
+            Selector selector = Selector.parse(expression);
+            assertThat(expression + " should be subset-of-input", selector.isOutputSubsetOfInput(), equalTo(true));
+
+            Set<Shape> all = selector.select(httpModel);
+            // Restricting the starting shapes to the full model must not change the result...
+            Set<Shape> viaFullStartingContext = selector.select(httpModel,
+                    new Selector.StartingContext(httpModel.toSet()));
+            assertThat(expression, viaFullStartingContext, equalTo(all));
+
+            // ...and restricting to just the shapes that already matched must return exactly those shapes, since a
+            // subset selector never emits anything outside its input.
+            Set<Shape> viaMatchedStartingContext = selector.select(httpModel,
+                    new Selector.StartingContext(all));
+            assertThat(expression, viaMatchedStartingContext, equalTo(all));
+        }
+    }
 }


### PR DESCRIPTION
#### Background
* What do these changes do? Make lots of optimizations for loading many models.
* Why are they important? We often load all AWS models in a single command.

#### Testing
* How did you test these changes?
* Manually, added tests, ran tests

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

Before:

```
❯ time /opt/homebrew/bin/smithy select --aut --selector 'service [id=com.amazonaws.xray#AWSXRay]' ~/projects/api-models-aws/models
com.amazonaws.xray#AWSXRay

________________________________________________________
Executed in    9.84 secs    fish           external
   usr time   11.57 secs    0.17 millis   11.57 secs
   sys time    4.21 secs    1.61 millis    4.21 secs
```

After:

```
❯ time ./smithy-cli/build/image/smithy-cli-darwin-aarch64/bin/smithy select --aut --selector 'service [id=com.amazonaws.xray#AWSXRay]' ~/projects/api-models-aws/models
com.amazonaws.xray#AWSXRay

________________________________________________________
Executed in    4.32 secs    fish           external
   usr time   10.34 secs  118.00 micros   10.34 secs
   sys time    0.90 secs  842.00 micros    0.90 secs
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
