### PR TITLE
Add Java to the server SDK list

### DIFF
--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1169,9 +1169,10 @@ html[data-mode="light"] { --logo-tint: brightness(0) opacity(.78); }
       </div>
 
       <div class="langs-group servers reveal d2">
-        <div class="glabel">Servers <span class="count">· 4</span></div>
+        <div class="glabel">Servers <span class="count">· 5</span></div>
         <ul class="lang-row">
           <li><a class="lang-pill" href="https://github.com/smithy-lang/smithy-typescript" target="_blank" rel="noopener" aria-label="TypeScript on GitHub"><span class="logo"><img src="assets/icons/ts.svg" alt=""/></span>TypeScript</a></li>
+          <li><a class="lang-pill" href="https://github.com/smithy-lang/smithy-java" target="_blank" rel="noopener" aria-label="Java on GitHub"><span class="logo"><img src="assets/icons/duke.svg" alt=""/></span>Java</a></li>
           <li><a class="lang-pill" href="https://github.com/smithy-lang/smithy-python" target="_blank" rel="noopener" aria-label="Python on GitHub"><span class="logo"><img src="assets/icons/python.svg" alt=""/></span>Python</a></li>
           <li><a class="lang-pill" href="https://github.com/aws/smithy-go" target="_blank" rel="noopener" aria-label="Go on GitHub"><span class="logo mono"><img src="assets/icons/go.svg" alt=""/></span>Go</a></li>
           <li><a class="lang-pill" href="https://github.com/smithy-lang/smithy-rs" target="_blank" rel="noopener" aria-label="Rust on GitHub"><span class="logo mono"><img src="assets/icons/rust.svg" alt=""/></span>Rust</a></li>


### PR DESCRIPTION
Java has a Smithy server generator (smithy-java), so include it in the Servers showcase alongside TypeScript; bump the count to 5.



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
