### PR TITLE
Add OpenAPI option to use operation input and output schema names

### DIFF
--- a/.changes/next-release/feature-53b24a08a91d33c36656fcc88da53e6994761c41.json
+++ b/.changes/next-release/feature-53b24a08a91d33c36656fcc88da53e6994761c41.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Added an OpenAPI setting to name synthesized operation input and output content schemas after their Smithy structure names.",
+  "pull_requests": []
+}

--- a/.changes/next-release/feature-53b24a08a91d33c36656fcc88da53e6994761c41.json
+++ b/.changes/next-release/feature-53b24a08a91d33c36656fcc88da53e6994761c41.json
@@ -1,5 +1,7 @@
 {
   "type": "feature",
   "description": "Added an OpenAPI setting to name synthesized operation input and output content schemas after their Smithy structure names.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3182](https://github.com/smithy-lang/smithy/pull/3182)"
+  ]
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -99,6 +99,7 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private ErrorStatusConflictHandlingStrategy onErrorStatusConflict;
     private OpenApiVersion version = OpenApiVersion.VERSION_3_0_2;
     private boolean useStringsForArbitraryPrecision = false;
+    private boolean useOperationInputOutputShapeNames = false;
 
     public OpenApiConfig() {
         super();
@@ -388,6 +389,24 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setUseStringsForArbitraryPrecision(boolean useStringsForArbitraryPrecision) {
         this.useStringsForArbitraryPrecision = useStringsForArbitraryPrecision;
+    }
+
+    public boolean getUseOperationInputOutputShapeNames() {
+        return useOperationInputOutputShapeNames;
+    }
+
+    /**
+     * Set to true to name synthesized operation input and output content schemas
+     * after the Smithy input and output structures.
+     *
+     * <p>By default, synthesized operation content schemas are named after the
+     * operation with a {@code RequestContent} or {@code ResponseContent} suffix.
+     *
+     * @param useOperationInputOutputShapeNames True to use the Smithy input and
+     *                                          output shape names when possible.
+     */
+    public void setUseOperationInputOutputShapeNames(boolean useOperationInputOutputShapeNames) {
+        this.useOperationInputOutputShapeNames = useOperationInputOutputShapeNames;
     }
 
     /**

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -650,8 +650,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
 
         // Synthesize a schema for the body of the request.
         Schema schema = createDocumentSchema(context, operation, bindings, MessageType.REQUEST);
-        String contextName = context.getService().getContextualName(operation);
-        String synthesizedName = stripNonAlphaNumericCharsIfNecessary(context, contextName) + "RequestContent";
+        String synthesizedName = getRequestDocumentName(context, operation);
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
@@ -892,9 +891,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         //
         // **NOTE: this same blurb applies to why we do this on input.**
         Schema schema = createDocumentSchema(context, operationOrError, bindings, messageType);
-        String contextName = context.getService().getContextualName(operationOrError);
-        String synthesizedName = stripNonAlphaNumericCharsIfNecessary(context, contextName)
-                + "ResponseContent";
+        String synthesizedName = getResponseDocumentName(context, operationOrError, operation);
         String pointer = context.putSynthesizedSchema(synthesizedName, schema);
         MediaTypeObject mediaTypeObject = MediaTypeObject.builder()
                 .schema(Schema.builder().ref(pointer).build())
@@ -902,6 +899,29 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
                 .build();
 
         responseBuilder.putContent(mediaType, mediaTypeObject);
+    }
+
+    private String getRequestDocumentName(Context<T> context, OperationShape operation) {
+        if (context.getConfig().getUseOperationInputOutputShapeNames()
+                && !operation.getInputShape().equals(operation.getOutputShape())) {
+            String shapeName = context.getService().getContextualName(operation.getInputShape());
+            return stripNonAlphaNumericCharsIfNecessary(context, shapeName);
+        }
+
+        String contextName = context.getService().getContextualName(operation);
+        return stripNonAlphaNumericCharsIfNecessary(context, contextName) + "RequestContent";
+    }
+
+    private String getResponseDocumentName(Context<T> context, Shape operationOrError, OperationShape operation) {
+        if (operationOrError instanceof OperationShape
+                && context.getConfig().getUseOperationInputOutputShapeNames()
+                && !operation.getOutputShape().equals(operation.getInputShape())) {
+            String shapeName = context.getService().getContextualName(operation.getOutputShape());
+            return stripNonAlphaNumericCharsIfNecessary(context, shapeName);
+        }
+
+        String contextName = context.getService().getContextualName(operationOrError);
+        return stripNonAlphaNumericCharsIfNecessary(context, contextName) + "ResponseContent";
     }
 
     private String stripNonAlphaNumericCharsIfNecessary(Context<T> context, String name) {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/RpcV2JsonProtocolConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/RpcV2JsonProtocolConverter.java
@@ -127,12 +127,14 @@ public final class RpcV2JsonProtocolConverter implements OpenApiProtocol<Rpcv2Js
                     buildResponseObject(context,
                             operation.getOutputShape(),
                             operation,
+                            operation,
                             "ResponseContent"));
 
             OperationIndex operationIndex = OperationIndex.of(context.getModel());
             for (StructureShape error : operationIndex.getErrors(operation)) {
                 String errorCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, error);
-                result.put(errorCode, buildResponseObject(context, error.toShapeId(), error, "ErrorContent"));
+                result.put(errorCode,
+                        buildResponseObject(context, error.toShapeId(), error, operation, "ErrorContent"));
             }
         }
         return result;
@@ -142,10 +144,11 @@ public final class RpcV2JsonProtocolConverter implements OpenApiProtocol<Rpcv2Js
             Context<Rpcv2JsonTrait> context,
             ShapeId shape,
             Shape operationOrError,
+            OperationShape operation,
             String suffix
     ) {
         Schema schema = convertToSchema(context, shape);
-        MediaTypeObject mediaTypeObject = createMediaTypeObject(context, schema, operationOrError, suffix);
+        MediaTypeObject mediaTypeObject = createMediaTypeObject(context, schema, operationOrError, operation, suffix);
 
         return ResponseObject.builder()
                 .description("Response Object")
@@ -159,7 +162,8 @@ public final class RpcV2JsonProtocolConverter implements OpenApiProtocol<Rpcv2Js
     ) {
         if (operation.getInput().isPresent()) {
             Schema schema = convertToSchema(context, operation.getInputShape());
-            MediaTypeObject mediaTypeObject = createMediaTypeObject(context, schema, operation, "RequestContent");
+            MediaTypeObject mediaTypeObject =
+                    createMediaTypeObject(context, schema, operation, operation, "RequestContent");
 
             return Optional.of(RequestBodyObject.builder()
                     .description("Request Object")
@@ -173,12 +177,32 @@ public final class RpcV2JsonProtocolConverter implements OpenApiProtocol<Rpcv2Js
             Context<Rpcv2JsonTrait> context,
             Schema schema,
             Shape operationOrError,
+            OperationShape operation,
             String suffix
     ) {
-        return getMediaTypeObject(context, schema, operationOrError, shape -> {
-            String shapeName = context.getService().getContextualName(shape.getId());
-            return shapeName + suffix;
-        });
+        return getMediaTypeObject(context,
+                schema,
+                operationOrError,
+                shape -> getSynthesizedContentName(context, shape, operation, suffix));
+    }
+
+    private String getSynthesizedContentName(
+            Context<Rpcv2JsonTrait> context,
+            Shape operationOrError,
+            OperationShape operation,
+            String suffix
+    ) {
+        if (context.getConfig().getUseOperationInputOutputShapeNames()
+                && !operation.getInputShape().equals(operation.getOutputShape())) {
+            if ("RequestContent".equals(suffix)) {
+                return context.getService().getContextualName(operation.getInputShape());
+            } else if ("ResponseContent".equals(suffix)) {
+                return context.getService().getContextualName(operation.getOutputShape());
+            }
+        }
+
+        String shapeName = context.getService().getContextualName(operationOrError.getId());
+        return shapeName + suffix;
     }
 
     private MediaTypeObject getMediaTypeObject(

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConfigTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConfigTest.java
@@ -81,4 +81,13 @@ public class OpenApiConfigTest {
         assertThat(config.getJsonSchemaVersion(), equalTo(JsonSchemaVersion.DRAFT2020_12));
     }
 
+    @Test
+    public void correctlySetsUseOperationInputOutputShapeNames() {
+        Node mappedTest = Node.objectNode().withMember("useOperationInputOutputShapeNames", true);
+
+        OpenApiConfig config = OpenApiConfig.fromNode(mappedTest);
+
+        assertThat(config.getUseOperationInputOutputShapeNames(), equalTo(true));
+    }
+
 }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1ProtocolTest.java
@@ -70,6 +70,109 @@ public class AwsRestJson1ProtocolTest {
     }
 
     @Test
+    public void canUseOperationInputOutputShapeNamesForContentSchemas() {
+        Model model = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+
+                        namespace smithy.example
+
+                        use aws.protocols#restJson1
+
+                        @restJson1
+                        service Service {
+                            version: "2006-03-01"
+                            operations: [DoSomething]
+                        }
+
+                        /// Do something given its name
+                        @http(method: "POST", uri: "/do-something")
+                        operation DoSomething {
+                            input: DoSomethingInput
+                            output: DoSomethingOutput
+                        }
+
+                        structure DoSomethingInput {
+                            @required
+                            nameOfSomething: String
+                        }
+
+                        structure DoSomethingOutput {
+                            comment: String
+                        }
+                        """)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        ObjectNode result = convertWithOperationInputOutputShapeNames(model);
+
+        Assertions.assertEquals("#/components/schemas/DoSomethingInput",
+                getRequestSchemaRef(result, "/do-something"));
+        Assertions.assertEquals("#/components/schemas/DoSomethingOutput",
+                getResponseSchemaRef(result, "/do-something", "200"));
+        result.expectObjectMember("components")
+                .expectObjectMember("schemas")
+                .expectObjectMember("DoSomethingInput");
+        result.expectObjectMember("components")
+                .expectObjectMember("schemas")
+                .expectObjectMember("DoSomethingOutput");
+    }
+
+    @Test
+    public void canUseElidedOperationInputOutputShapeNamesForContentSchemas() {
+        Model model = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+
+                        namespace smithy.example
+
+                        use aws.protocols#restJson1
+
+                        @restJson1
+                        service Service {
+                            version: "2006-03-01"
+                            operations: [DoSomething]
+                        }
+
+                        /// Do something given its name
+                        @http(method: "POST", uri: "/do-something")
+                        operation DoSomething {
+                            input := {
+                                @required
+                                nameOfSomething: String
+                            }
+                            output := {
+                                comment: String
+                            }
+                        }
+                        """)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        ObjectNode result = convertWithOperationInputOutputShapeNames(model);
+
+        Assertions.assertEquals("#/components/schemas/DoSomethingInput",
+                getRequestSchemaRef(result, "/do-something"));
+        Assertions.assertEquals("#/components/schemas/DoSomethingOutput",
+                getResponseSchemaRef(result, "/do-something", "200"));
+    }
+
+    @Test
+    public void fallsBackToContentSuffixesWhenInputAndOutputShapesAreShared() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("synthesizes-contents.json"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        ObjectNode result = convertWithOperationInputOutputShapeNames(model);
+
+        Assertions.assertEquals("#/components/schemas/CreateDocumentRequestContent",
+                getRequestSchemaRef(result, "/document"));
+        Assertions.assertEquals("#/components/schemas/CreateDocumentResponseContent",
+                getResponseSchemaRef(result, "/document", "200"));
+    }
+
+    @Test
     public void canUseCustomMediaType() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("adds-json-document-bodies.json"))
@@ -333,6 +436,40 @@ public class AwsRestJson1ProtocolTest {
                 Arguments.of("/boolean", "GetBooleanDocument_example1", booleanValue),
                 Arguments.of("/number", "GetNumberDocument_example1", numberValue),
                 Arguments.of("/null", "GetNullDocument_example1", nullValue));
+    }
+
+    private ObjectNode convertWithOperationInputOutputShapeNames(Model model) {
+        OpenApiConfig config = new OpenApiConfig();
+        config.setService(ShapeId.from("smithy.example#Service"));
+        config.setUseOperationInputOutputShapeNames(true);
+        return OpenApiConverter.create()
+                .config(config)
+                .convertToNode(model);
+    }
+
+    private String getRequestSchemaRef(ObjectNode result, String path) {
+        return result.expectObjectMember("paths")
+                .expectObjectMember(path)
+                .expectObjectMember("post")
+                .expectObjectMember("requestBody")
+                .expectObjectMember("content")
+                .expectObjectMember("application/json")
+                .expectObjectMember("schema")
+                .expectStringMember("$ref")
+                .getValue();
+    }
+
+    private String getResponseSchemaRef(ObjectNode result, String path, String statusCode) {
+        return result.expectObjectMember("paths")
+                .expectObjectMember(path)
+                .expectObjectMember("post")
+                .expectObjectMember("responses")
+                .expectObjectMember(statusCode)
+                .expectObjectMember("content")
+                .expectObjectMember("application/json")
+                .expectObjectMember("schema")
+                .expectStringMember("$ref")
+                .getValue();
     }
 
     @Test


### PR DESCRIPTION
#### Background
* Adds an opt-in OpenAPI setting, `useOperationInputOutputShapeNames`, to name synthesized operation request and response content schemas after the Smithy input/output structures when possible.
* This lets generated OpenAPI use component names like `DoSomethingInput` and `DoSomethingOutput` instead of `DoSomethingRequestContent` and `DoSomethingResponseContent`.
* The existing naming behavior remains the default. If an operation reuses the same structure for both input and output, the converter falls back to the existing suffix-based names to avoid component collisions.
* This is important for OpenAPI consumers and code generators that depend on stable schema names matching the original Smithy operation structures.

#### Testing
* Ran `./gradlew :smithy-openapi:spotlessApply --no-daemon --max-workers=1`
* Ran `./gradlew :smithy-openapi:test --tests software.amazon.smithy.openapi.fromsmithy.protocols.AwsRestJson1ProtocolTest --tests software.amazon.smithy.openapi.fromsmithy.OpenApiConfigTest -PnoFormat --no-daemon --max-workers=1`

#### Links
* Closes #2469

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.