### PR TITLE
Fix EnumShape synthetic handling

### DIFF
--- a/.changes/next-release/feature-d48cee4ea9c14ede4ba553a3657bcefee59bb283.json
+++ b/.changes/next-release/feature-d48cee4ea9c14ede4ba553a3657bcefee59bb283.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Added missing EnumShape hasTrait override.",
+  "pull_requests": [
+    "[#3183](https://github.com/smithy-lang/smithy/pull/3183)"
+  ]
+}

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/generators/StructuredShapeGenerator.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/generators/StructuredShapeGenerator.java
@@ -18,6 +18,7 @@ import software.amazon.smithy.docgen.sections.ShapeMembersSection;
 import software.amazon.smithy.docgen.sections.ShapeSection;
 import software.amazon.smithy.docgen.sections.ShapeSubheadingSection;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -82,8 +83,11 @@ public final class StructuredShapeGenerator implements BiConsumer<Shape, MemberL
     @Override
     public void accept(Shape shape, MemberListingType listingType) {
         // Legacy enums using the trait on a string shape should be upgraded
-        // to `enum` shapes. If not, skip them here.
-        if (shape.isStringShape() && shape.hasTrait(EnumTrait.ID)) {
+        // to `enum` shapes. If not, skip them here. This checks the STRING type
+        // explicitly because enum shapes also report isStringShape() == true and
+        // now respond to hasTrait(EnumTrait.ID) via their synthetic enum trait;
+        // without the type check this would skip every enum shape too.
+        if (shape.getType() == ShapeType.STRING && shape.hasTrait(EnumTrait.ID)) {
             return;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/selector/TraitExistenceSelector.java
@@ -5,9 +5,13 @@
 package software.amazon.smithy.model.selector;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.synthetic.SyntheticEnumTrait;
 
 /**
  * Specialized selector for the extremely common {@code [trait|X]} existence check.
@@ -29,7 +33,19 @@ final class TraitExistenceSelector implements InternalSelector {
 
     @Override
     public Collection<? extends Shape> getStartingShapes(Model model) {
-        return model.getShapesWithTrait(traitId);
+        Set<Shape> shapes = model.getShapesWithTrait(traitId);
+        // Enum shapes carry the synthetic enum trait rather than smithy.api#enum, so the trait index does not list
+        // them under smithy.api#enum. Include them when matching on the enum trait so this starting-shape
+        // optimization doesn't skip every enum shape (which their hasTrait check would otherwise match).
+        if (traitId.equals(EnumTrait.ID)) {
+            Set<Shape> enumShapes = model.getShapesWithTrait(SyntheticEnumTrait.ID);
+            if (!enumShapes.isEmpty()) {
+                Set<Shape> combined = new LinkedHashSet<>(shapes);
+                combined.addAll(enumShapes);
+                return combined;
+            }
+        }
+        return shapes;
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -93,6 +93,16 @@ public final class EnumShape extends StringShape {
         return super.findTrait(id);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean hasTrait(ShapeId id) {
+        // Mirror findTrait, so an enum shape responds to the smithy.api#enum trait via its synthetic enum trait.
+        if (id.equals(EnumTrait.ID)) {
+            return super.hasTrait(SyntheticEnumTrait.ID);
+        }
+        return super.hasTrait(id);
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/selector/SelectorTest.java
@@ -1219,4 +1219,47 @@ public class SelectorTest {
                 () -> Selector.parse("string ) extra"));
         assertThat(e.getMessage(), containsString(")"));
     }
+
+    // Enum shapes store their enum trait as the synthetic enum trait rather than smithy.api#enum, so selectors that
+    // match on the enum trait have to account for the redirect. These guard against a regression where [trait|enum]
+    // stopped matching enum shapes.
+    @Test
+    public void matchesEnumShapesWithTraitEnumSelector() {
+        Model model = Model.assembler()
+                .addImport(SelectorTest.class.getResource("enum-shapes.smithy"))
+                .assemble()
+                .unwrap();
+
+        // Top-level [trait|enum] exercises the getStartingShapes optimization.
+        Set<String> matches = ids(model, "[trait|enum]");
+
+        assertThat(matches, hasItem("smithy.example#Suit"));
+        assertThat(matches, not(hasItem("smithy.example#PlainString")));
+    }
+
+    @Test
+    public void matchesEnumShapesWithNestedTraitEnumSelector() {
+        Model model = Model.assembler()
+                .addImport(SelectorTest.class.getResource("enum-shapes.smithy"))
+                .assemble()
+                .unwrap();
+
+        // A wrapped [trait|enum] exercises the per-shape hasTrait path instead of the starting-shape optimization.
+        Set<String> matches = ids(model, "[id|namespace=smithy.example]:test(string, enum):test([trait|enum])");
+
+        assertThat(matches, contains("smithy.example#Suit"));
+    }
+
+    @Test
+    public void excludesEnumShapesWithNegatedTraitEnumSelector() {
+        Model model = Model.assembler()
+                .addImport(SelectorTest.class.getResource("enum-shapes.smithy"))
+                .assemble()
+                .unwrap();
+
+        // :not([trait|enum]) on enum shapes also relies on the per-shape hasTrait redirect.
+        Set<String> matches = ids(model, "[id|namespace=smithy.example]:test(string, enum):not([trait|enum])");
+
+        assertThat(matches, contains("smithy.example#PlainString"));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EnumShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/EnumShapeTest.java
@@ -67,6 +67,21 @@ public class EnumShapeTest {
     }
 
     @Test
+    public void redirectsEnumTraitLookupsToTheSyntheticTrait() {
+        EnumShape.Builder builder = (EnumShape.Builder) EnumShape.builder().id("ns.foo#bar");
+        EnumShape shape = builder.addMember("foo", "bar").build();
+
+        // The enum trait is stored as the synthetic enum trait, but every accessor for smithy.api#enum must redirect
+        // to it consistently. hasTrait(ShapeId) in particular looks IDs up directly in the trait map, so it has to
+        // honor the redirect like findTrait, getTrait, and the other hasTrait overloads (regression check).
+        assertTrue(shape.hasTrait(EnumTrait.ID));
+        assertTrue(shape.hasTrait(EnumTrait.class));
+        assertTrue(shape.hasTrait("smithy.api#enum"));
+        assertTrue(shape.findTrait(EnumTrait.ID).isPresent());
+        assertTrue(shape.getTrait(EnumTrait.class).isPresent());
+    }
+
+    @Test
     public void addMemberShape() {
         EnumShape.Builder builder = (EnumShape.Builder) EnumShape.builder().id("ns.foo#bar");
         MemberShape member = MemberShape.builder()

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/attribute-existence.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/cases/attribute-existence.smithy
@@ -3,6 +3,9 @@ $version: "2.0"
 metadata selectorTests = [
     {
         selector: "[trait|enum]"
+        // The prelude defines enum shapes (e.g. smithy.api#Severity) that carry the synthetic enum trait, so
+        // [trait|enum] legitimately matches them. This case only cares about the user-defined enums.
+        skipPreludeShapes: true
         matches: [
             smithy.example#SimpleEnum
             smithy.example#EnumWithTags

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/selector/enum-shapes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/selector/enum-shapes.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace smithy.example
+
+/// Enum shapes carry the synthetic enum trait internally rather than smithy.api#enum, so they exercise the
+/// trait redirect that [trait|enum] relies on.
+enum Suit {
+    DIAMOND
+    CLUB
+    HEART
+    SPADE
+}
+
+string PlainString


### PR DESCRIPTION
#### Background
* What do these changes do? 
EnumShape does not override hasTrait, so it returned false when asked if it's an enum using the `[trait|enum]` selector. This was an unintentional regression introduced in 6ae0045e342a9f287661de47c2da0c2e97e179b8 and exposed when we started using hasTrait as a Selector optimization.

* Why are they important?
cmon man

#### Testing
* How did you test these changes?
Unit tests added to reproduce issues we found trying to deploy the recent selector changes.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
