### PR TITLE
Remove NodeMapper from rules-engine traits and optimize Shape trait m…

### DIFF
--- a/.changes/next-release/feature-179a86d69880120bf404f168583e703df3d84b00.json
+++ b/.changes/next-release/feature-179a86d69880120bf404f168583e703df3d84b00.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Improved model loading performance by replacing NodeMapper with direct Node API calls in rules-engine traits and eliminating unnecessary trait map copies during shape construction.",
+  "pull_requests": []
+}

--- a/.changes/next-release/feature-179a86d69880120bf404f168583e703df3d84b00.json
+++ b/.changes/next-release/feature-179a86d69880120bf404f168583e703df3d84b00.json
@@ -1,5 +1,7 @@
 {
   "type": "feature",
   "description": "Improved model loading performance by replacing NodeMapper with direct Node API calls in rules-engine traits and eliminating unnecessary trait map copies during shape construction.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3185](https://github.com/smithy-lang/smithy/pull/3185)"
+  ]
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/AbstractShapeBuilder.java
@@ -326,6 +326,6 @@ public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<B, S>,
     }
 
     Map<ShapeId, Trait> getTraits() {
-        return traits.get();
+        return traits.copy();
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -61,7 +61,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
         id = SmithyBuilder.requiredState("id", builder.getId());
         validateShapeId(expectMemberSegments);
 
-        introducedTraits = MapUtils.copyOf(builder.getTraits());
+        introducedTraits = builder.getTraits();
         mixins = MapUtils.orderedCopyOf(builder.getMixins());
 
         if (mixins.isEmpty()) {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/Deprecated.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/Deprecated.java
@@ -7,7 +7,6 @@ package software.amazon.smithy.rulesengine.language.syntax.parameters;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.ToNode;
 
@@ -58,9 +57,14 @@ public final class Deprecated implements ToNode {
 
     @Override
     public Node toNode() {
-        NodeMapper mapper = new NodeMapper();
-        mapper.disableToNodeForClass(Deprecated.class);
-        return mapper.serialize(this);
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        if (message != null) {
+            builder.withMember(MESSAGE, message);
+        }
+        if (since != null) {
+            builder.withMember(SINCE, since);
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamDefinition.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamDefinition.java
@@ -6,6 +6,9 @@ package software.amazon.smithy.rulesengine.traits;
 
 import java.util.Objects;
 import java.util.Optional;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -15,7 +18,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * A service client context parameter definition.
  */
 @SmithyUnstableApi
-public final class ClientContextParamDefinition implements ToSmithyBuilder<ClientContextParamDefinition> {
+public final class ClientContextParamDefinition implements ToNode, ToSmithyBuilder<ClientContextParamDefinition> {
     private final ShapeType type;
     private final String documentation;
 
@@ -24,16 +27,22 @@ public final class ClientContextParamDefinition implements ToSmithyBuilder<Clien
         this.documentation = builder.documentation;
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     public ShapeType getType() {
         return type;
     }
 
     public Optional<String> getDocumentation() {
         return Optional.ofNullable(documentation);
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder()
+                .withMember("type", type.toString());
+        if (documentation != null) {
+            builder.withMember("documentation", documentation);
+        }
+        return builder.build();
     }
 
     public Builder toBuilder() {
@@ -57,6 +66,18 @@ public final class ClientContextParamDefinition implements ToSmithyBuilder<Clien
         }
         ClientContextParamDefinition that = (ClientContextParamDefinition) o;
         return getType() == that.getType() && Objects.equals(getDocumentation(), that.getDocumentation());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ClientContextParamDefinition fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder();
+        obj.expectStringMember("type", s -> builder.type(ShapeType.fromString(s).orElse(null)));
+        obj.getStringMember("documentation", builder::documentation);
+        return builder.build();
     }
 
     public static final class Builder implements SmithyBuilder<ClientContextParamDefinition> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamsTrait.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.rulesengine.traits;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -41,8 +41,11 @@ public final class ClientContextParamsTrait extends AbstractTrait implements ToS
 
     @Override
     protected Node createNode() {
-        NodeMapper mapper = new NodeMapper();
-        return mapper.serialize(this.getParameters()).expectObjectNode();
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        for (Map.Entry<String, ClientContextParamDefinition> entry : parameters.entrySet()) {
+            builder.withMember(entry.getKey(), entry.getValue().toNode());
+        }
+        return builder.build();
     }
 
     @Override
@@ -57,13 +60,10 @@ public final class ClientContextParamsTrait extends AbstractTrait implements ToS
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            NodeMapper mapper = new NodeMapper();
-
             Map<String, ClientContextParamDefinition> parameters = new LinkedHashMap<>();
             value.expectObjectNode().getMembers().forEach((stringNode, node) -> {
-                parameters.put(stringNode.getValue(), mapper.deserialize(node, ClientContextParamDefinition.class));
+                parameters.put(stringNode.getValue(), ClientContextParamDefinition.fromNode(node));
             });
-
             ClientContextParamsTrait trait = builder()
                     .parameters(parameters)
                     .sourceLocation(value)

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ContextParamTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ContextParamTrait.java
@@ -5,7 +5,7 @@
 package software.amazon.smithy.rulesengine.traits;
 
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -38,10 +38,9 @@ public final class ContextParamTrait extends AbstractTrait implements ToSmithyBu
 
     @Override
     protected Node createNode() {
-        NodeMapper mapper = new NodeMapper();
-        mapper.disableToNodeForClass(ContextParamTrait.class);
-        mapper.setOmitEmptyValues(true);
-        return mapper.serialize(this).expectObjectNode();
+        return Node.objectNodeBuilder()
+                .withMember("name", name)
+                .build();
     }
 
     @Override
@@ -58,10 +57,10 @@ public final class ContextParamTrait extends AbstractTrait implements ToSmithyBu
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            NodeMapper mapper = new NodeMapper();
-            mapper.disableFromNodeForClass(ContextParamTrait.class);
-            mapper.setOmitEmptyValues(true);
-            ContextParamTrait trait = mapper.deserialize(value, ContextParamTrait.class);
+            ObjectNode obj = value.expectObjectNode();
+            Builder builder = builder().sourceLocation(value);
+            obj.expectStringMember("name", builder::name);
+            ContextParamTrait trait = builder.build();
             trait.setNodeCache(value);
             return trait;
         }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestCase.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestCase.java
@@ -9,7 +9,10 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -19,7 +22,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * Describes an endpoint rule-set test case.
  */
 @SmithyUnstableApi
-public final class EndpointTestCase implements FromSourceLocation, ToSmithyBuilder<EndpointTestCase> {
+public final class EndpointTestCase implements ToNode, FromSourceLocation, ToSmithyBuilder<EndpointTestCase> {
     private final SourceLocation sourceLocation;
     private final String documentation;
     private final ObjectNode params;
@@ -32,10 +35,6 @@ public final class EndpointTestCase implements FromSourceLocation, ToSmithyBuild
         this.params = builder.params;
         this.operationInputs = builder.operationInputs.copy();
         this.expect = SmithyBuilder.requiredState("expect", builder.expect);
-    }
-
-    public static Builder builder() {
-        return new Builder();
     }
 
     public Optional<String> getDocumentation() {
@@ -52,6 +51,23 @@ public final class EndpointTestCase implements FromSourceLocation, ToSmithyBuild
 
     public EndpointTestExpectation getExpect() {
         return expect;
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        builder.withOptionalMember("documentation", getDocumentation().map(Node::from));
+        if (params != null && !params.isEmpty()) {
+            builder.withMember("params", params);
+        }
+        if (!operationInputs.isEmpty()) {
+            ArrayNode.Builder operationInputsBuilder = ArrayNode.builder();
+            for (EndpointTestOperationInput operationInput : operationInputs) {
+                operationInputsBuilder.withValue(operationInput.toNode());
+            }
+            builder.withMember("operationInputs", operationInputsBuilder.build());
+        }
+        return builder.withMember("expect", expect.toNode()).build();
     }
 
     @Override
@@ -82,6 +98,20 @@ public final class EndpointTestCase implements FromSourceLocation, ToSmithyBuild
                 && Objects.equals(getParams(), that.getParams())
                 && Objects.equals(getOperationInputs(), that.getOperationInputs())
                 && Objects.equals(getExpect(), that.getExpect());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static EndpointTestCase fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder().sourceLocation(node);
+        obj.getStringMember("documentation", builder::documentation);
+        obj.getObjectMember("params", builder::params);
+        obj.getArrayMember("operationInputs", EndpointTestOperationInput::fromNode, builder::operationInputs);
+        obj.expectMember("expect", EndpointTestExpectation::fromNode, builder::expect);
+        return builder.build();
     }
 
     public static final class Builder implements SmithyBuilder<EndpointTestCase> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestExpectation.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestExpectation.java
@@ -8,6 +8,9 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -16,7 +19,8 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * An endpoint test case expectation.
  */
 @SmithyUnstableApi
-public final class EndpointTestExpectation implements FromSourceLocation, ToSmithyBuilder<EndpointTestExpectation> {
+public final class EndpointTestExpectation
+        implements ToNode, FromSourceLocation, ToSmithyBuilder<EndpointTestExpectation> {
     private final SourceLocation sourceLocation;
     private final String error;
     private final ExpectedEndpoint endpoint;
@@ -27,16 +31,23 @@ public final class EndpointTestExpectation implements FromSourceLocation, ToSmit
         this.endpoint = builder.endpoint;
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     public Optional<String> getError() {
         return Optional.ofNullable(error);
     }
 
     public Optional<ExpectedEndpoint> getEndpoint() {
         return Optional.ofNullable(endpoint);
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        if (error != null) {
+            builder.withMember("error", Node.from(error));
+        } else if (endpoint != null) {
+            builder.withMember("endpoint", endpoint.toNode());
+        }
+        return builder.build();
     }
 
     @Override
@@ -67,6 +78,18 @@ public final class EndpointTestExpectation implements FromSourceLocation, ToSmit
         }
         EndpointTestExpectation that = (EndpointTestExpectation) o;
         return Objects.equals(getError(), that.getError()) && Objects.equals(getEndpoint(), that.getEndpoint());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static EndpointTestExpectation fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder().sourceLocation(node);
+        obj.getStringMember("error", builder::error);
+        obj.getMember("endpoint", ExpectedEndpoint::fromNode, builder::endpoint);
+        return builder.build();
     }
 
     public static final class Builder implements SmithyBuilder<EndpointTestExpectation> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
@@ -7,7 +7,9 @@ package software.amazon.smithy.rulesengine.traits;
 import java.util.Objects;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -16,7 +18,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * A description of a service operation and input used to verify an endpoint rule-set test case.
  */
 @SmithyUnstableApi
-public final class EndpointTestOperationInput implements FromSourceLocation,
+public final class EndpointTestOperationInput implements ToNode, FromSourceLocation,
         ToSmithyBuilder<EndpointTestOperationInput> {
     private final SourceLocation sourceLocation;
     private final String operationName;
@@ -30,10 +32,6 @@ public final class EndpointTestOperationInput implements FromSourceLocation,
         this.operationParams = builder.operationParams;
         this.builtInParams = builder.builtInParams;
         this.clientParams = builder.clientParams;
-    }
-
-    public static Builder builder() {
-        return new Builder();
     }
 
     public String getOperationName() {
@@ -50,6 +48,22 @@ public final class EndpointTestOperationInput implements FromSourceLocation,
 
     public ObjectNode getClientParams() {
         return clientParams;
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        builder.withMember("operationName", Node.from(operationName));
+        if (operationParams != null) {
+            builder.withMember("operationParams", operationParams);
+        }
+        if (builtInParams != null) {
+            builder.withMember("builtInParams", builtInParams);
+        }
+        if (clientParams != null) {
+            builder.withMember("clientParams", clientParams);
+        }
+        return builder.build();
     }
 
     @Override
@@ -85,6 +99,20 @@ public final class EndpointTestOperationInput implements FromSourceLocation,
                 .operationParams(operationParams)
                 .builtInParams(builtInParams)
                 .clientParams(clientParams);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static EndpointTestOperationInput fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder().sourceLocation(node);
+        obj.expectStringMember("operationName", builder::operationName);
+        obj.getObjectMember("operationParams", builder::operationParams);
+        obj.getObjectMember("builtInParams", builder::builtInParams);
+        obj.getObjectMember("clientParams", builder::clientParams);
+        return builder.build();
     }
 
     public static final class Builder implements SmithyBuilder<EndpointTestOperationInput> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTrait.java
@@ -5,8 +5,9 @@
 package software.amazon.smithy.rulesengine.traits;
 
 import java.util.List;
+import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -31,18 +32,6 @@ public final class EndpointTestsTrait extends AbstractTrait implements ToSmithyB
         this.testCases = builder.testCases.copy();
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static EndpointTestsTrait fromNode(Node node) {
-        NodeMapper mapper = new NodeMapper();
-        mapper.disableFromNodeForClass(EndpointTestsTrait.class);
-        EndpointTestsTrait trait = mapper.deserialize(node, EndpointTestsTrait.class);
-        trait.setNodeCache(node);
-        return trait;
-    }
-
     public String getVersion() {
         return version;
     }
@@ -53,10 +42,15 @@ public final class EndpointTestsTrait extends AbstractTrait implements ToSmithyB
 
     @Override
     protected Node createNode() {
-        NodeMapper mapper = new NodeMapper();
-        mapper.setOmitEmptyValues(true);
-        mapper.disableToNodeForClass(EndpointTestsTrait.class);
-        return mapper.serialize(this);
+        ArrayNode.Builder builder = ArrayNode.builder();
+        for (EndpointTestCase testCase : testCases) {
+            builder.withValue(testCase.toNode());
+        }
+        return Node.objectNodeBuilder()
+                .sourceLocation(getSourceLocation())
+                .withMember("version", Node.from(version))
+                .withMember("testCases", builder.build())
+                .build();
     }
 
     @Override
@@ -73,6 +67,20 @@ public final class EndpointTestsTrait extends AbstractTrait implements ToSmithyB
         public Trait createTrait(ShapeId target, Node value) {
             return EndpointTestsTrait.fromNode(value);
         }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static EndpointTestsTrait fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder().sourceLocation(node);
+        obj.expectStringMember("version", builder::version);
+        obj.expectArrayMember("testCases", EndpointTestCase::fromNode, builder::testCases);
+        EndpointTestsTrait trait = builder.build();
+        trait.setNodeCache(node);
+        return trait;
     }
 
     public static final class Builder extends AbstractTraitBuilder<EndpointTestsTrait, Builder> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
@@ -4,12 +4,17 @@
  */
 package software.amazon.smithy.rulesengine.traits;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -20,7 +25,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * An endpoint test-case expectation.
  */
 @SmithyUnstableApi
-public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuilder<ExpectedEndpoint> {
+public final class ExpectedEndpoint implements ToNode, FromSourceLocation, ToSmithyBuilder<ExpectedEndpoint> {
     private final SourceLocation sourceLocation;
     private final String url;
     private final Map<String, List<String>> headers;
@@ -33,10 +38,6 @@ public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuild
         this.properties = builder.properties.copy();
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     public String getUrl() {
         return url;
     }
@@ -47,6 +48,35 @@ public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuild
 
     public Map<String, Node> getProperties() {
         return properties;
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        if (url != null) {
+            builder.withMember("url", url);
+        }
+        if (!headers.isEmpty()) {
+            ObjectNode.Builder headersBuilder = ObjectNode.builder();
+            for (Map.Entry<String, List<String>> kvp : headers.entrySet()) {
+                StringNode headerName = Node.from(kvp.getKey());
+                ArrayNode.Builder valuesBuilder = ArrayNode.builder();
+                for (String value : kvp.getValue()) {
+                    valuesBuilder.withValue(Node.from(value));
+                }
+                headersBuilder.withMember(headerName, valuesBuilder.build());
+            }
+            builder.withMember("headers", headersBuilder.build());
+        }
+        if (!properties.isEmpty()) {
+            ObjectNode.Builder propertiesBuilder = ObjectNode.builder();
+            for (Map.Entry<String, Node> kvp : properties.entrySet()) {
+                propertiesBuilder.withMember(kvp.getKey(), kvp.getValue());
+            }
+            builder.withMember("properties", propertiesBuilder.build());
+        }
+
+        return builder.build();
     }
 
     @Override
@@ -96,6 +126,32 @@ public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuild
                                     2)));
         }
         return sb.toString();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ExpectedEndpoint fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder().sourceLocation(node);
+        obj.expectStringMember("url", builder::url);
+        obj.getObjectMember("headers", headersNode -> {
+            for (Map.Entry<String, Node> entry : headersNode.getStringMap().entrySet()) {
+                List<String> values = new ArrayList<>();
+                entry.getValue()
+                        .expectArrayNode()
+                        .getElements()
+                        .forEach(n -> values.add(n.expectStringNode().getValue()));
+                builder.putHeader(entry.getKey(), values);
+            }
+        });
+        obj.getObjectMember("properties", propsNode -> {
+            for (Map.Entry<String, Node> entry : propsNode.getStringMap().entrySet()) {
+                builder.putProperty(entry.getKey(), entry.getValue());
+            }
+        });
+        return builder.build();
     }
 
     public static final class Builder implements SmithyBuilder<ExpectedEndpoint> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamDefinition.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamDefinition.java
@@ -5,6 +5,9 @@
 package software.amazon.smithy.rulesengine.traits;
 
 import java.util.Objects;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -13,19 +16,22 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * An operation context parameter definition.
  */
 @SmithyUnstableApi
-public final class OperationContextParamDefinition implements ToSmithyBuilder<OperationContextParamDefinition> {
+public final class OperationContextParamDefinition implements ToNode, ToSmithyBuilder<OperationContextParamDefinition> {
     private final String path;
 
     private OperationContextParamDefinition(Builder builder) {
         this.path = SmithyBuilder.requiredState("path", builder.path);
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     public String getPath() {
         return path;
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.objectNodeBuilder()
+                .withMember("path", path)
+                .build();
     }
 
     @Override
@@ -48,6 +54,17 @@ public final class OperationContextParamDefinition implements ToSmithyBuilder<Op
         }
         OperationContextParamDefinition that = (OperationContextParamDefinition) o;
         return getPath().equals(that.getPath());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static OperationContextParamDefinition fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        Builder builder = builder();
+        obj.expectStringMember("path", builder::path);
+        return builder.build();
     }
 
     public static final class Builder implements SmithyBuilder<OperationContextParamDefinition> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamsTrait.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.rulesengine.traits;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -41,9 +41,11 @@ public final class OperationContextParamsTrait extends AbstractTrait
 
     @Override
     protected Node createNode() {
-        NodeMapper mapper = new NodeMapper();
-        mapper.setOmitEmptyValues(true);
-        return mapper.serialize(getParameters()).expectObjectNode();
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        for (Map.Entry<String, OperationContextParamDefinition> entry : parameters.entrySet()) {
+            builder.withMember(entry.getKey(), entry.getValue().toNode());
+        }
+        return builder.build();
     }
 
     @Override
@@ -58,10 +60,9 @@ public final class OperationContextParamsTrait extends AbstractTrait
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            NodeMapper mapper = new NodeMapper();
             Map<String, OperationContextParamDefinition> parameters = new LinkedHashMap<>();
             value.expectObjectNode().getMembers().forEach((stringNode, node) -> {
-                parameters.put(stringNode.getValue(), mapper.deserialize(node, OperationContextParamDefinition.class));
+                parameters.put(stringNode.getValue(), OperationContextParamDefinition.fromNode(node));
             });
             OperationContextParamsTrait trait = builder()
                     .sourceLocation(value)

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/StaticContextParamDefinition.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/StaticContextParamDefinition.java
@@ -6,6 +6,8 @@ package software.amazon.smithy.rulesengine.traits;
 
 import java.util.Objects;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -14,19 +16,22 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * An operation static context parameter definition.
  */
 @SmithyUnstableApi
-public final class StaticContextParamDefinition implements ToSmithyBuilder<StaticContextParamDefinition> {
+public final class StaticContextParamDefinition implements ToNode, ToSmithyBuilder<StaticContextParamDefinition> {
     private final Node value;
 
     private StaticContextParamDefinition(Builder builder) {
         this.value = SmithyBuilder.requiredState("value", builder.value);
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     public Node getValue() {
         return value;
+    }
+
+    @Override
+    public Node toNode() {
+        return Node.objectNodeBuilder()
+                .withMember("value", value)
+                .build();
     }
 
     @Override
@@ -49,6 +54,15 @@ public final class StaticContextParamDefinition implements ToSmithyBuilder<Stati
         }
         StaticContextParamDefinition that = (StaticContextParamDefinition) o;
         return getValue().equals(that.getValue());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static StaticContextParamDefinition fromNode(Node node) {
+        ObjectNode obj = node.expectObjectNode();
+        return builder().value(obj.expectMember("value")).build();
     }
 
     public static final class Builder implements SmithyBuilder<StaticContextParamDefinition> {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/StaticContextParamsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/StaticContextParamsTrait.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.rulesengine.traits;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
@@ -40,9 +40,11 @@ public final class StaticContextParamsTrait extends AbstractTrait implements ToS
 
     @Override
     protected Node createNode() {
-        NodeMapper mapper = new NodeMapper();
-        mapper.setOmitEmptyValues(true);
-        return mapper.serialize(getParameters()).expectObjectNode();
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        for (Map.Entry<String, StaticContextParamDefinition> entry : parameters.entrySet()) {
+            builder.withMember(entry.getKey(), entry.getValue().toNode());
+        }
+        return builder.build();
     }
 
     @Override
@@ -57,10 +59,9 @@ public final class StaticContextParamsTrait extends AbstractTrait implements ToS
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            NodeMapper mapper = new NodeMapper();
             Map<String, StaticContextParamDefinition> parameters = new LinkedHashMap<>();
             value.expectObjectNode().getMembers().forEach((stringNode, node) -> {
-                parameters.put(stringNode.getValue(), mapper.deserialize(node, StaticContextParamDefinition.class));
+                parameters.put(stringNode.getValue(), StaticContextParamDefinition.fromNode(node));
             });
             StaticContextParamsTrait trait = builder()
                     .sourceLocation(value)


### PR DESCRIPTION
#### Background
* Replace `NodeMapper` reflection-based serialization/deserialization with direct `Node` API calls in all `smithy-rules-engine` trait classes (`EndpointTestsTrait`, `ContextParamTrait`, `ClientContextParamsTrait`, `StaticContextParamsTrait`, `OperationContextParamsTrait`, and their associated definition classes).
* Optimize `Shape` construction by switching `AbstractShapeBuilder.getTraits()` from `traits.get()` to `traits.copy()` and removing the redundant `MapUtils.copyOf()` in the `Shape` constructor, leveraging `BuilderRef`'s copy-on-write semantics for zero-copy in the common case.
* These changes reduce CPU time on the model loading hot path, as identified via flamegraph profiling of the AWS model corpus benchmark.

#### Testing
* All existing tests pass (`smithy-rules-engine`, `smithy-aws-endpoints`, downstream modules).
* Verified via JMH benchmark (`SmfCombinedBenchmark.jsonViaAssembler`) and async-profiler flamegraphs that `NodeMapper`/`BeanMapper` frames are no longer present in the rules-engine trait loading path.

#### Links
* N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
