### PR TITLE
Add a documentation member to shape closures

### DIFF
--- a/docs/source-2.0/spec/shape-closures.rst
+++ b/docs/source-2.0/spec/shape-closures.rst
@@ -86,6 +86,9 @@ value is a list of ``ShapeClosure`` structures with the following members:
           MAY be renamed.
         * A rename MUST use a name that is case-sensitively different
           from the original shape ID name.
+    * - documentation
+      - ``string``
+      - Documentation for the closure in the CommonMark_ format.
 
 A closure MUST define at least one of ``includeNamespaces`` or
 ``includeBySelector``.
@@ -120,3 +123,5 @@ operate on. For example, a code generator might generate types for every
 shape in the named closure, or the
 :ref:`includeClosures <includeClosures-transform>` build transform might
 filter the model down to those shapes.
+
+.. _CommonMark: https://spec.commonmark.org/

--- a/smithy-model/src/main/java/software/amazon/smithy/model/metadata/ShapeClosure.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/metadata/ShapeClosure.java
@@ -39,6 +39,7 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
     private final Set<String> includeNamespaces;
     private final String includeBySelector;
     private final Map<ShapeId, String> rename;
+    private final String documentation;
     private final SourceLocation sourceLocation;
 
     private ShapeClosure(Builder builder) {
@@ -46,6 +47,7 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
         includeNamespaces = builder.includeNamespaces.copy();
         includeBySelector = builder.includeBySelector;
         rename = builder.rename.copy();
+        documentation = builder.documentation;
         sourceLocation = builder.sourceLocation;
     }
 
@@ -157,6 +159,15 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
         return rename;
     }
 
+    /**
+     * Gets the documentation for the closure.
+     *
+     * @return the documentation for the closure.
+     */
+    public Optional<String> getDocumentation() {
+        return Optional.ofNullable(documentation);
+    }
+
     @Override
     public SourceLocation getSourceLocation() {
         return sourceLocation;
@@ -214,6 +225,7 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
         private final BuilderRef<Set<String>> includeNamespaces = BuilderRef.forOrderedSet();
         private String includeBySelector;
         private final BuilderRef<Map<ShapeId, String>> rename = BuilderRef.forOrderedMap();
+        private String documentation;
         private SourceLocation sourceLocation = SourceLocation.NONE;
 
         private Builder() {}
@@ -242,6 +254,11 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
         public Builder rename(Map<ShapeId, String> rename) {
             this.rename.clear();
             this.rename.get().putAll(rename);
+            return this;
+        }
+
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
             return this;
         }
 

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -428,6 +428,9 @@ structure ShapeClosure {
     /// - A rename MUST use a name that is case-sensitively different
     ///   from the original shape id name.
     rename: Renames = {}
+
+    /// Documentation for the shape closure in CommonMark format.
+    documentation: CommonMark
 }
 
 /// An identifier for a closure. This matches the shape id format.
@@ -475,6 +478,11 @@ map Renames {
     /// The new name for the shape.
     value: Identifier
 }
+
+/// A string containing CommonMark-formatted text.
+@externalDocumentation("CommonMark Specification": "https://commonmark.org/")
+@mediaType("text/markdown; charset=UTF-8; variant=CommonMark")
+string CommonMark
 
 /// A string matching the `Identifier` ABNF production used for shape names.
 @private

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/shapeClosures/documentation.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/shapeClosures/documentation.smithy
@@ -1,0 +1,18 @@
+$version: "2.0"
+
+metadata shapeClosures = [
+    {
+        id: "com.example#hasDocs"
+        includeNamespaces: [
+            "com.example"
+        ]
+        documentation: """
+            This is documentation for a shape closure. It isn't necessarily
+            expected to show up anywhere, but it's useful to have in the model
+            anyway."""
+    }
+]
+
+namespace com.example
+
+string Foo


### PR DESCRIPTION
This adds a docs member to shape closures. It's not necessarily expected to be rendered anywhere, but it's useful to describe what the closure is there for.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
