### PR TITLE
Upgrade maven-resolver to 2.0.18

### DIFF
--- a/.changes/next-release/other-a26e81c9c20b373ad1d842de458440a554e90603.json
+++ b/.changes/next-release/other-a26e81c9c20b373ad1d842de458440a554e90603.json
@@ -1,0 +1,7 @@
+{
+  "type": "other",
+  "description": "Upgraded maven-resolver to 2.x. This is a transparent change to smithy-cli users, including those who supply their own dependency resolver implementation.",
+  "pull_requests": [
+    "[#3194](https://github.com/smithy-lang/smithy/pull/3194)"
+  ]
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,10 @@ smithy-gradle = "1.4.0"
 assertj = "3.27.7"
 prettier4j = "0.3.0"
 maven-resolver-provider = "3.9.16"
-# TODO: upgrade major version
-maven-resolver = "1.9.27"
+# Resolver 2.x core, paired with the Maven 3.9.x provider via maven-resolver-supplier-mvn3.
+# Staying on the Maven 3 provider keeps the Java 8 baseline, upgrading to Maven 4 will
+# require bumping the runtime Java version to 17.
+maven-resolver = "2.0.18"
 slf4j = "2.0.18"
 mockserver = "7.2.0"
 compile-testing = "0.23.0"
@@ -32,7 +34,16 @@ maven-resolver-util = { module = "org.apache.maven.resolver:maven-resolver-util"
 maven-resolver-impl = { module = "org.apache.maven.resolver:maven-resolver-impl", version.ref =  "maven-resolver" }
 maven-resolver-connector-basic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref =  "maven-resolver" }
 maven-resolver-transport-file = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref =  "maven-resolver" }
-maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref =  "maven-resolver" }
+
+# Resolver 2.x replaced transport-http with transport-apache (same Apache HttpClient 4.5 engine).
+# There's now alternate http transport implementations, but for now we're keeping the same
+# behavior.
+maven-resolver-transport-apache = { module = "org.apache.maven.resolver:maven-resolver-transport-apache", version.ref =  "maven-resolver" }
+
+# Supplier replaces the removed DefaultServiceLocator bootstrap. The mvn3 variant keeps Maven 3
+# semantics. We may eventually want to upgrade to Maven 4, but that'll require a runtime Java
+# version bump to 17+.
+maven-resolver-supplier = { module = "org.apache.maven.resolver:maven-resolver-supplier-mvn3", version.ref =  "maven-resolver" }
 
 slf4j-jul = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
 

--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -73,7 +73,8 @@ dependencies {
     implementation(libs.maven.resolver.impl)
     implementation(libs.maven.resolver.connector.basic)
     implementation(libs.maven.resolver.transport.file)
-    implementation(libs.maven.resolver.transport.http)
+    implementation(libs.maven.resolver.transport.apache)
+    implementation(libs.maven.resolver.supplier)
     implementation(libs.slf4j.jul) // Route slf4j used by Maven through JUL like the rest of Smithy.
 
     testImplementation(libs.mockserver)
@@ -217,6 +218,16 @@ tasks {
         archiveClassifier.set("")
 
         mergeServiceFiles()
+
+        // Maven Resolver ships Sisu component indexes under META-INF/sisu. Merge them like service files so
+        // the class names they list are relocated alongside the relocated bytecode. Otherwise the index points
+        // at the original org.apache.maven.* names that no longer exist in the shaded jar.
+        //
+        // Strictly speaking, we don't *need* to do this. The CLI will probably work just fine without doing
+        // this. But it's a build time thing that doesn't take long and makes the output more technically correct.
+        mergeServiceFiles {
+            path = "META-INF/sisu"
+        }
 
         // Shade dependencies to prevent conflicts with other dependencies.
         relocate("org.slf4j", "software.amazon.smithy.cli.shaded.slf4j")

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/MavenDependencyResolver.java
@@ -15,26 +15,21 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.Proxy;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
-import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
+import org.eclipse.aether.supplier.SessionBuilderSupplier;
 import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import software.amazon.smithy.build.model.MavenRepository;
@@ -49,9 +44,9 @@ public final class MavenDependencyResolver implements DependencyResolver {
 
     private final List<RemoteRepository> remoteRepositories = new ArrayList<>();
     private final List<Dependency> dependencies = new ArrayList<>();
-    private final DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
     private final DependencyFilter filter = DependencyFilterUtils.classpathFilter(RUNTIME, COMPILE);
     private final RepositorySystem repositorySystem;
+    private final CloseableSession session;
     private final Proxy commonProxy;
 
     public MavenDependencyResolver() {
@@ -62,19 +57,8 @@ public final class MavenDependencyResolver implements DependencyResolver {
      * @param cacheLocation Maven local cache location.
      */
     public MavenDependencyResolver(String cacheLocation) {
-        final DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
-        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
-        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-        locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
-            @Override
-            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
-                throw new DependencyResolverException(exception);
-            }
-        });
         commonProxy = getProxy(EnvironmentVariable.SMITHY_PROXY_HOST.get(),
                 EnvironmentVariable.SMITHY_PROXY_CREDENTIALS.get());
-        repositorySystem = locator.getService(RepositorySystem.class);
 
         // Sets a default maven local to the default local repo of the user.
         if (cacheLocation == null) {
@@ -83,8 +67,26 @@ public final class MavenDependencyResolver implements DependencyResolver {
             LOGGER.fine("Set default Maven local cache location to ~/.m2/repository");
         }
 
-        LocalRepository local = new LocalRepository(cacheLocation);
-        session.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(session, local));
+        // RepositorySystemSupplier replaces the DefaultServiceLocator removed in resolver 2.x. Its default
+        // factories already register the file + Apache HTTP transports and the basic connector, matching the
+        // services this class wired by hand under 1.x. SessionBuilderSupplier likewise reproduces the
+        // dependency traverser/manager/selector, conflict resolver, and artifact type registry that
+        // MavenRepositorySystemUtils.newSession() set up under 1.x, so resolution behavior is preserved.
+        // Both replace the 1.x ServiceLocator error handler by throwing unchecked, so wrap them together.
+        //
+        // The session and repository system are both closeable/shutdownable resources in 2.x, but this resolver
+        // is short-lived (built, used for a single resolve(), then discarded per CLI invocation), so we let
+        // process exit reclaim them rather than thread Closeable through the customer-facing DependencyResolver
+        // SPI. Revisit if this is ever reused in a long-lived or embedded context.
+        try {
+            repositorySystem = new RepositorySystemSupplier().get();
+            session = new SessionBuilderSupplier(repositorySystem)
+                    .get()
+                    .withLocalRepositories(new LocalRepository(cacheLocation))
+                    .build();
+        } catch (RuntimeException e) {
+            throw new DependencyResolverException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
This upgrades the maven-resolver to 2.x.

Bootstrapping is now handled via RepositorySystemSupplier + SessionBuilderSupplier instead of DefaultServiceLocator, which was removed in 2.x. The supplier defaults register the same file + Apache HTTP transports and basic connector, and reproduce the newSession() resolution defaults, so behavior is preserved.

The transport-http package was removed, as 2.x supplies multiple http backends. This replaces it with the transport-apache package, which keeps the same behavior as the old transport-http package. (That is, an http client based on Apache 4.5).

Notably this does not change any version requirements. While this will make it easy for us to upgrade to maven 4, which requires Java 17, it does not require us to. We're staying on Maven 3 until we decide to do that bump.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
