### PR TITLE
Add a union trait getter with covariant return

### DIFF
--- a/.changes/next-release/bugfix-922e5164c811cb68317d8291ed84e40981b144ff.json
+++ b/.changes/next-release/bugfix-922e5164c811cb68317d8291ed84e40981b144ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Added a new getter for generated union trait values with a covariant return type to address the issue of the old getters erasing value types. The old getters are still around by default, but are deprecated. They may be omitted entirely via a plugin setting.",
+  "pull_requests": [
+      "[#3196](https://github.com/smithy-lang/smithy/pull/3196)"
+  ]
+}

--- a/smithy-trait-codegen/README.md
+++ b/smithy-trait-codegen/README.md
@@ -47,6 +47,7 @@ The generator supports the following configuration options:
 | `namespace` | Smithy namespace to search for traits | Yes |
 | `header` | Header lines to include in generated files | Yes |
 | `excludeTags` | Smithy tags to exclude from generation | No |
+| `excludeDeprecatedUnionGetters` | Omit the deprecated, type-erased `getValue()` accessor from generated union traits, leaving only the type-safe `getContents()` getter. Defaults to `false`. | No |
 
 An example for `smithy-build.json`:
 

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -466,7 +466,7 @@ public class LoadsFromModelTest {
                 // Unions
                 Arguments.of("unions/union-trait.smithy",
                         UnionTrait.class,
-                        MapUtils.of("getValue", ListUtils.of("1"))),
+                        MapUtils.of("getContents", ListUtils.of("1"))),
                 // Strings
                 Arguments.of("string-trait.smithy",
                         StringTrait.class,

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/UnionValueGetterTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/UnionValueGetterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.traitcodegen.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.example.traits.unions.UnionTrait;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Verifies the value getters generated for union traits.
+ *
+ * <p>The type-safe {@code getContents()} getter narrows to the variant's value type via a
+ * covariant return, so callers keep the concrete type after an {@code instanceof}
+ * check. The legacy {@code getValue()} getter is retained, but deprecated, for
+ * backwards compatibility and is exercised separately as a regression test.
+ */
+public class UnionValueGetterTest {
+
+    @Test
+    void valueGetterReturnsConcreteTypeForStringVariant() {
+        UnionTrait trait = UnionTrait.builder()
+                .stringVariantMember(ShapeId.from("test.abc#myShape"))
+                .build();
+
+        // The covariant return lets the value be used at its concrete type after
+        // narrowing, with no cast.
+        if (trait instanceof UnionTrait.StringVariantMember member) {
+            ShapeId value = member.getContents();
+            assertEquals(ShapeId.from("test.abc#myShape"), value);
+        } else {
+            throw new AssertionError("Expected a StringVariantMember but got " + trait.getClass());
+        }
+    }
+
+    @Test
+    void valueGetterReturnsConcreteTypeForListVariant() {
+        UnionTrait trait = UnionTrait.builder()
+                .listVariantMember(ListUtils.of("1", "2", "3"))
+                .build();
+
+        UnionTrait.ListVariantMember member = (UnionTrait.ListVariantMember) trait;
+        List<String> value = member.getContents();
+        assertEquals(ListUtils.of("1", "2", "3"), value);
+    }
+
+    @Test
+    void valueGetterReturnsNullForUnitVariant() {
+        UnionTrait trait = UnionTrait.builder().unitVariantMember().build();
+
+        assertNull(trait.getContents());
+    }
+
+    @Test
+    void baseValueGetterReturnsObject() {
+        UnionTrait trait = UnionTrait.builder()
+                .integerVariantMember(123)
+                .build();
+
+        // On the base type the value is exposed as Object, so no false type promise is
+        // made to the caller.
+        Object value = trait.getContents();
+        assertEquals(123, value);
+    }
+
+    /**
+     * The deprecated, type-erased {@code getValue()} getter still returns the value,
+     * but the synthetic cast inserted at the call site throws when the caller assumes
+     * the wrong type. This is the unsafe behavior that
+     * {@link UnionTrait#getContents()} replaces.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedGetValueStillWorksButErasesType() {
+        UnionTrait trait = UnionTrait.builder()
+                .integerVariantMember(123)
+                .build();
+
+        Integer correct = trait.getValue();
+        assertEquals(123, correct);
+
+        // The unchecked cast inside getValue() is a no-op. The real cast happens at the
+        // call site and fails there.
+        assertThrows(ClassCastException.class, () -> {
+            String wrong = trait.getValue();
+        });
+    }
+}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
@@ -28,6 +28,10 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  *     <dt>"excludeTags" ({@code List<String>})</dt>
  *     <dd>List of Smithy tags to use for filtering out trait shapes
  *     from the trait code generation process.</dd>
+ *     <dt>"excludeDeprecatedUnionGetters" ({@code boolean})</dt>
+ *     <dd>Omit the deprecated, type-erased {@code getValue()} accessor from generated union traits, leaving only
+ *     the type-safe {@code getContents()} getter. Defaults to {@code false} so that existing code continues to
+ *     compile.</dd>
  * </dl>
  */
 @SmithyUnstableApi
@@ -46,6 +50,7 @@ public final class TraitCodegenSettings {
     private final String smithyNamespace;
     private final List<String> headerLines;
     private final List<String> excludeTags;
+    private final boolean excludeDeprecatedUnionGetters;
 
     /**
      * Settings for trait code generation. These can be set in the
@@ -57,12 +62,15 @@ public final class TraitCodegenSettings {
      *                    license header or copyright header that should be included in all generated files.
      * @param excludeTags smithy tags to exclude from trait code generation. Traits with these tags will be
      *                    ignored when generating java classes.
+     * @param excludeDeprecatedUnionGetters if true, the deprecated type-erased union {@code getValue()} accessor
+     *                                      is omitted from generated code.
      */
     TraitCodegenSettings(
             String packageName,
             String smithyNamespace,
             List<String> headerLines,
-            List<String> excludeTags
+            List<String> excludeTags,
+            boolean excludeDeprecatedUnionGetters
     ) {
         this.packageName = Objects.requireNonNull(packageName);
         if (isReservedNamespace(smithyNamespace)) {
@@ -71,6 +79,7 @@ public final class TraitCodegenSettings {
         this.smithyNamespace = Objects.requireNonNull(smithyNamespace);
         this.headerLines = Objects.requireNonNull(headerLines);
         this.excludeTags = Objects.requireNonNull(excludeTags);
+        this.excludeDeprecatedUnionGetters = excludeDeprecatedUnionGetters;
     }
 
     /**
@@ -87,7 +96,8 @@ public final class TraitCodegenSettings {
                         .getElementsAs(el -> el.expectStringNode().getValue()),
                 node.getArrayMember("excludeTags")
                         .map(n -> n.getElementsAs(el -> el.expectStringNode().getValue()))
-                        .orElse(Collections.emptyList()));
+                        .orElse(Collections.emptyList()),
+                node.getBooleanMemberOrDefault("excludeDeprecatedUnionGetters", false));
     }
 
     /**
@@ -124,6 +134,15 @@ public final class TraitCodegenSettings {
      */
     public List<String> excludeTags() {
         return excludeTags;
+    }
+
+    /**
+     * Whether the deprecated, type-erased union {@code getValue()} accessor is omitted from generated code.
+     *
+     * @return true if the deprecated union getter should be excluded
+     */
+    public boolean excludeDeprecatedUnionGetters() {
+        return excludeDeprecatedUnionGetters;
     }
 
     /**

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/TraitGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/TraitGenerator.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.model.traits.StringListTrait;
 import software.amazon.smithy.model.traits.StringTrait;
 import software.amazon.smithy.traitcodegen.GenerateTraitDirective;
 import software.amazon.smithy.traitcodegen.TraitCodegenContext;
+import software.amazon.smithy.traitcodegen.TraitCodegenSettings;
 import software.amazon.smithy.traitcodegen.TraitCodegenUtils;
 import software.amazon.smithy.traitcodegen.sections.ClassSection;
 import software.amazon.smithy.traitcodegen.writer.TraitCodegenWriter;
@@ -87,7 +88,10 @@ class TraitGenerator implements Consumer<GenerateTraitDirective> {
                         new GetterGenerator(writer, directive.symbolProvider(), directive.model(), directive.shape())
                                 .run();
                         directive.shape()
-                                .accept(new NestedClassVisitor(writer, directive.symbolProvider(), directive.model()));
+                                .accept(new NestedClassVisitor(writer,
+                                        directive.symbolProvider(),
+                                        directive.model(),
+                                        directive.context().settings()));
                         new BuilderGenerator(writer,
                                 directive.symbol(),
                                 directive.symbolProvider(),
@@ -184,11 +188,18 @@ class TraitGenerator implements Consumer<GenerateTraitDirective> {
         private final TraitCodegenWriter writer;
         private final SymbolProvider symbolProvider;
         private final Model model;
+        private final TraitCodegenSettings settings;
 
-        private NestedClassVisitor(TraitCodegenWriter writer, SymbolProvider symbolProvider, Model model) {
+        private NestedClassVisitor(
+                TraitCodegenWriter writer,
+                SymbolProvider symbolProvider,
+                Model model,
+                TraitCodegenSettings settings
+        ) {
             this.writer = writer;
             this.symbolProvider = symbolProvider;
             this.model = model;
+            this.settings = settings;
         }
 
         @Override
@@ -213,7 +224,7 @@ class TraitGenerator implements Consumer<GenerateTraitDirective> {
 
         @Override
         public Void unionShape(UnionShape shape) {
-            new UnionShapeGenerator().writeNestedClasses(shape, writer, symbolProvider, model);
+            new UnionShapeGenerator().writeNestedClasses(shape, writer, symbolProvider, model, settings);
             writer.newLine();
             return null;
         }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/UnionShapeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/UnionShapeGenerator.java
@@ -26,8 +26,10 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.traitcodegen.GenerateTraitDirective;
+import software.amazon.smithy.traitcodegen.TraitCodegenSettings;
 import software.amazon.smithy.traitcodegen.sections.ClassSection;
 import software.amazon.smithy.traitcodegen.writer.TraitCodegenWriter;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 public final class UnionShapeGenerator implements Consumer<GenerateTraitDirective> {
     @Override
@@ -62,7 +64,8 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
                                 writeNestedClasses(directive.shape(),
                                         writer,
                                         directive.symbolProvider(),
-                                        directive.model());
+                                        directive.model(),
+                                        directive.context().settings());
                                 new BuilderGenerator(writer,
                                         directive.symbol(),
                                         directive.symbolProvider(),
@@ -82,27 +85,41 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
      * @param writer writer to write generated code to.
      * @param symbolProvider symbol provider.
      * @param model smithy model used for code generation.
+     * @param settings trait codegen settings.
      */
+    @SmithyInternalApi
     public void writeNestedClasses(
             Shape shape,
             TraitCodegenWriter writer,
             SymbolProvider symbolProvider,
-            Model model
+            Model model,
+            TraitCodegenSettings settings
     ) {
         writeEnumClass(writer, shape, symbolProvider);
-        writeVariantClasses(writer, shape, symbolProvider, model);
+        writeVariantClasses(writer, shape, symbolProvider, model, settings);
     }
 
     private void writeVariantClasses(
             TraitCodegenWriter writer,
             Shape unionShape,
             SymbolProvider symbolProvider,
-            Model model
+            Model model,
+            TraitCodegenSettings settings
     ) {
         writer.writeWithNoFormatting("abstract Node asNode();");
         writer.newLine();
-        writer.writeWithNoFormatting("public abstract <T> T getValue();");
+
+        // The type-safe accessor, narrowed to the variant's value type by a covariant
+        // return on each member.
+        writer.writeWithNoFormatting("public abstract Object getContents();");
         writer.newLine();
+
+        // The original accessor erases its type and is only retained for backwards
+        // compatibility.
+        if (!settings.excludeDeprecatedUnionGetters()) {
+            writeDeprecatedGetValue(writer);
+        }
+
         Symbol unionSymbol = symbolProvider.toSymbol(unionShape);
         boolean isTrait = unionShape.hasTrait(TraitDefinition.ID);
         for (MemberShape memberShape : unionShape.members()) {
@@ -129,7 +146,7 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
                         writeAsNodeMethod(writer, memberShape, symbolProvider, model);
                         writer.newLine();
 
-                        writeGetValue(writer, isTargetUnitType);
+                        writeGetContents(writer, memberSymbol, isTargetUnitType);
                     });
             writer.newLine();
             writer.popState();
@@ -233,21 +250,39 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
                 () -> memberShape.accept(new VariantAsNodeGenerator(writer, model, provider)));
     }
 
-    private void writeGetValue(
+    private void writeGetContents(
             TraitCodegenWriter writer,
+            Symbol memberSymbol,
             boolean isTargetUnitType
     ) {
         writer.override();
+
+        // A covariant return narrows the value to its concrete type so callers retain
+        // it after an instanceof check. The unit variant has no value, so it falls
+        // back to the base Object return type.
+        if (isTargetUnitType) {
+            writer.openBlock("public Object getContents() {",
+                    "}",
+                    () -> writer.writeWithNoFormatting("return null;"));
+        } else {
+            writer.openBlock("public $T getContents() {",
+                    "}",
+                    memberSymbol,
+                    () -> writer.writeWithNoFormatting("return value;"));
+        }
+    }
+
+    private void writeDeprecatedGetValue(TraitCodegenWriter writer) {
+        writer.writeWithNoFormatting("/**");
+        writer.writeWithNoFormatting(
+                " * @deprecated this getter erases the value type, use {@link #getContents()} instead.");
+        writer.writeWithNoFormatting(" */");
+        writer.writeWithNoFormatting("@Deprecated");
         writer.writeWithNoFormatting("@SuppressWarnings(\"unchecked\")");
         writer.openBlock("public <T> T getValue() {",
                 "}",
-                () -> {
-                    if (isTargetUnitType) {
-                        writer.writeWithNoFormatting("return null;");
-                    } else {
-                        writer.writeWithNoFormatting("return (T) value;");
-                    }
-                });
+                () -> writer.writeWithNoFormatting("return (T) getContents();"));
+        writer.newLine();
     }
 
     private void writeEquals(TraitCodegenWriter writer, Symbol symbol) {
@@ -268,7 +303,7 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
                             () -> {
                                 writer.write("$1T b = ($1T) other;", symbol).newLine();
                                 writer.writeWithNoFormatting(
-                                        "return type == b.getType() && Objects.equals(getValue(), b.getValue());\n");
+                                        "return type == b.getType() && Objects.equals(getContents(), b.getContents());\n");
                             }).newLine();
                     writer.enableNewlines();
                 });
@@ -279,7 +314,7 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
         writer.override();
         writer.openBlock("public int hashCode() {",
                 "}",
-                () -> writer.write("return $T.hash(type, getValue());", Objects.class));
+                () -> writer.write("return $T.hash(type, getContents());", Objects.class));
     }
 
     private static final class VariantFromNodeGenerator extends ShapeVisitor.Default<Void> {

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.traitcodegen;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -100,6 +101,61 @@ public class TraitCodegenPluginTest {
 
         assertFalse(manifest.getFiles().isEmpty());
         assertEquals(EXPECTED_NUMBER_OF_FILES - 1, manifest.getFiles().size());
+    }
+
+    @Test
+    public void generatesBothUnionGettersByDefault() {
+        PluginContext context = PluginContext.builder()
+                .fileManifest(manifest)
+                .settings(ObjectNode.builder()
+                        .withMember("package", "com.example.traits")
+                        .withMember("namespace", "test.smithy.traitcodegen")
+                        .withMember("header", ArrayNode.fromStrings("Header line One"))
+                        .build())
+                .model(model)
+                .build();
+
+        new TraitCodegenPlugin().execute(context);
+
+        String unionTrait = manifest.getFileString("/com/example/traits/unions/UnionTrait.java").get();
+        assertThat(unionTrait, containsString("public abstract Object getContents();"));
+        assertThat(unionTrait, containsString("public <T> T getValue() {"));
+        assertThat(unionTrait, containsString("@Deprecated"));
+
+        // A union nested in another trait is generated through a separate path and
+        // must behave the same.
+        String nestedUnion = manifest.getFileString("/com/example/traits/structures/MyUnion.java").get();
+        assertThat(nestedUnion, containsString("public abstract Object getContents();"));
+        assertThat(nestedUnion, containsString("public <T> T getValue() {"));
+    }
+
+    @Test
+    public void excludesDeprecatedUnionGetterWhenConfigured() {
+        PluginContext context = PluginContext.builder()
+                .fileManifest(manifest)
+                .settings(ObjectNode.builder()
+                        .withMember("package", "com.example.traits")
+                        .withMember("namespace", "test.smithy.traitcodegen")
+                        .withMember("header", ArrayNode.fromStrings("Header line One"))
+                        .withMember("excludeDeprecatedUnionGetters", true)
+                        .build())
+                .model(model)
+                .build();
+
+        new TraitCodegenPlugin().execute(context);
+
+        String unionTrait = manifest.getFileString("/com/example/traits/unions/UnionTrait.java").get();
+
+        // The type-safe getter remains, but the deprecated type-erased getter is
+        // dropped entirely.
+        assertThat(unionTrait, containsString("public abstract Object getContents();"));
+        assertThat(unionTrait, not(containsString("public <T> T getValue() {")));
+
+        // The setting also applies to unions nested in another trait, which take a
+        // separate generation path.
+        String nestedUnion = manifest.getFileString("/com/example/traits/structures/MyUnion.java").get();
+        assertThat(nestedUnion, containsString("public abstract Object getContents();"));
+        assertThat(nestedUnion, not(containsString("public <T> T getValue() {")));
     }
 
     @Test

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenSettingsTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenSettingsTest.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.traitcodegen;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
@@ -37,7 +38,8 @@ class TraitCodegenSettingsTest {
                 () -> new TraitCodegenSettings("com.example",
                         namespace,
                         Collections.emptyList(),
-                        Collections.emptyList()));
+                        Collections.emptyList(),
+                        false));
         assertEquals("The `smithy` namespace and its sub-namespaces are reserved.", exception.getMessage());
     }
 
@@ -56,7 +58,8 @@ class TraitCodegenSettingsTest {
                 "com.example",
                 namespace,
                 Collections.emptyList(),
-                Collections.emptyList()));
+                Collections.emptyList(),
+                false));
     }
 
     @ParameterizedTest
@@ -66,7 +69,8 @@ class TraitCodegenSettingsTest {
                 () -> new TraitCodegenSettings(packageName,
                         namespace,
                         Collections.emptyList(),
-                        Collections.emptyList()));
+                        Collections.emptyList(),
+                        false));
     }
 
     static Stream<Arguments> nullParameterCombinations() {
@@ -81,11 +85,13 @@ class TraitCodegenSettingsTest {
                 "com.example",
                 "smithy.foo",
                 Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                false);
 
         assertEquals("com.example", settings.packageName());
         assertEquals("smithy.foo", settings.smithyNamespace());
         assertEquals(Collections.emptyList(), settings.headerLines());
         assertEquals(Collections.emptyList(), settings.excludeTags());
+        assertFalse(settings.excludeDeprecatedUnionGetters());
     }
 }


### PR DESCRIPTION
This adds a new getter for union values in trait codegen that has a covariant return type. The old getter had the unforutnate effect of type erasure. The old getter will still be generated, but it's deprecated and can be omitted via a plugin setting.

Fixes #3189

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
