### PR TITLE
Recommend against `id` as a resource id name

### DIFF
--- a/.changes/next-release/documentation-b73dc1700d15c090b9d197ad559f675f5b19e045.json
+++ b/.changes/next-release/documentation-b73dc1700d15c090b9d197ad559f675f5b19e045.json
@@ -1,0 +1,5 @@
+{
+  "type": "documentation",
+  "description": "Updated resource docs to recommend against using the literal `id` as a resource name, since it can cause confusion in child resources.",
+  "pull_requests": []
+}

--- a/.changes/next-release/documentation-b73dc1700d15c090b9d197ad559f675f5b19e045.json
+++ b/.changes/next-release/documentation-b73dc1700d15c090b9d197ad559f675f5b19e045.json
@@ -1,5 +1,7 @@
 {
   "type": "documentation",
   "description": "Updated resource docs to recommend against using the literal `id` as a resource name, since it can cause confusion in child resources.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3198](https://github.com/smithy-lang/smithy/pull/3198)"
+  ]
 }

--- a/docs/source-2.0/aws/aws-auth.rst
+++ b/docs/source-2.0/aws/aws-auth.rst
@@ -262,12 +262,12 @@ details.
     }
 
     @cognitoUserPoolsScopes(["email", "profile"])
-    @http(method: "GET", uri: "/things/{id}")
+    @http(method: "GET", uri: "/things/{thingId}")
     operation GetThing {
         input := {
             @httpLabel
             @required
-            id: String
+            thingId: String
         }
     }
 

--- a/docs/source-2.0/guides/style-guide.rst
+++ b/docs/source-2.0/guides/style-guide.rst
@@ -191,6 +191,14 @@ Member names
 Member names use a strict form of lowerCamelCase (e.g., "xmlRequest", "fooId").
 
 
+Resource identifier names
+-------------------------
+
+Resource identifiers should not use the literal ``id`` or other ambiguous
+terms as a name. An identifier name in the form ``<resource>Id`` should be
+preferred. (For example, ``forecastId`` for a resource named ``Forecast``.)
+
+
 Trait names
 -----------
 

--- a/docs/source-2.0/spec/mixins.rst
+++ b/docs/source-2.0/spec/mixins.rst
@@ -15,7 +15,7 @@ shape.
 
     @mixin
     structure UserIdentifiersMixin {
-        id: String
+        userId: String
     }
 
     structure UserDetails with [UserIdentifiersMixin] {
@@ -28,7 +28,7 @@ Multiple mixins can be applied:
 
     @mixin
     structure UserIdentifiersMixin {
-        id: String
+        userId: String
     }
 
     @mixin
@@ -606,7 +606,7 @@ Operation shapes with the :ref:`mixin-trait` MAY define errors.
 
     operation GetUsername with [ValidatedOperation] {
         input := {
-            id: String
+            userId: String
         }
         output := {
             name: String

--- a/docs/source-2.0/spec/service-types.rst
+++ b/docs/source-2.0/spec/service-types.rst
@@ -449,6 +449,21 @@ property, all of the identifiers of the parent resource MUST be repeated
 verbatim in the child resource, and the child resource MAY introduce any
 number of additional identifiers.
 
+.. important::
+
+    Because child resources must inherit all identifiers of their parent
+    resources, it is recommended to avoid using the literal ``id`` or other
+    ambiguous terms as an identifier name. Child resources will inherit that
+    identifier, which may cause confusion since it refers to the parent
+    resource.
+
+    Instead, ``id`` SHOULD be prefixed with the resource name. For example,
+    ``forecastId`` is preferable to ``id`` for a resource named ``Forecast``.
+
+    If necessary, the :ref:`resourceIdentifier trait <resourceIdentifier-trait>`
+    may be used to bind operation input or output members to an identifier even
+    if the member name does not match.
+
 :dfn:`Parent identifiers` are the identifiers of the parent of a resource.
 All parent identifiers MUST be bound as identifiers in the input of every
 operation bound as a child to a resource. :dfn:`Child identifiers` are the
@@ -637,7 +652,7 @@ Explicit identifier bindings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *Explicit identifier bindings* are defined by applying the
-:ref:`resourceIdentifier-trait` to a member of the input of for an
+:ref:`resourceIdentifier-trait` to a member of the input of an
 operation bound to a resource. Explicit bindings are necessary when the name of
 the input structure member differs from the name of the resource identifier to
 which the input member corresponds.

--- a/docs/source-2.0/spec/type-refinement-traits.rst
+++ b/docs/source-2.0/spec/type-refinement-traits.rst
@@ -556,7 +556,7 @@ The mixin trait is a structure that contains the following members:
 
     @mixin
     structure BaseUser {
-        id: String
+        userId: String
     }
 
     structure UserDetails with [BaseUser] {

--- a/docs/source-2.0/tutorials/full-stack-tutorial.rst
+++ b/docs/source-2.0/tutorials/full-stack-tutorial.rst
@@ -243,7 +243,7 @@ Let's compose these shapes together to create our representation of an order:
 
     /// An Order, which has an id, a status, and the type of coffee ordered
     structure Order {
-        id: Uuid
+        orderId: Uuid
         coffeeType: CoffeeType
         status: OrderStatus
     }
@@ -260,7 +260,7 @@ and its operations with :ref:`resources <resource>`. Instead of the above struct
     /// An Order resource, which has a unique id and describes an order by the type of coffee
     /// and the order's status
     resource Order {
-        identifiers: { id: Uuid }
+        identifiers: { orderId: Uuid }
         properties: { coffeeType: CoffeeType, status: OrderStatus }
         read: GetOrder // <--- we will create this next!
         create: CreateOrder  // <--- we will create this next!
@@ -284,7 +284,7 @@ represent the state of an instance. In this case, we will only define a subset o
 
         output := for Order {
             @required
-            $id
+            $orderId
 
             @required
             $coffeeType
@@ -296,17 +296,17 @@ represent the state of an instance. In this case, we will only define a subset o
 
     /// Retrieve an order
     @readonly
-    @http(method: "GET", uri: "/order/{id}")
+    @http(method: "GET", uri: "/order/{orderId}")
     operation GetOrder {
         input := for Order {
             @httpLabel
             @required
-            $id
+            $orderId
         }
 
         output := for Order {
             @required
-            $id
+            $orderId
 
             @required
             $coffeeType
@@ -493,7 +493,7 @@ the server imports the generated code from. Let's take a look at the core of the
         }
 
         async GetOrder(input: GetOrderServerInput, context: CoffeeShopContext): Promise<GetOrderServerOutput> {
-            console.log(`getting an order (${input.id})...`)
+            console.log(`getting an order (${input.orderId})...`)
             // TODO: Implement me!
             return;
         }
@@ -563,7 +563,7 @@ and updates this queue. Let's implement order submission, or ``CreateOrder``:
 
             console.log(`created order: ${JSON.stringify(order)}`)
             return {
-                id: order.orderId,
+                orderId: order.orderId,
                 coffeeType: order.coffeeType,
                 status: order.status
             }
@@ -576,19 +576,19 @@ through the ``GetOrder`` operation. Let's implement it now:
     :caption: ``server/src/CoffeeShop.ts``
 
         async GetOrder(input: GetOrderServerInput, context: CoffeeShopContext): Promise<GetOrderServerOutput> {
-            console.log(`getting an order (${input.id})...`)
-            if (context.orders.has(input.id)) {
-                const order = context.orders.get(input.id)
+            console.log(`getting an order (${input.orderId})...`)
+            if (context.orders.has(input.orderId)) {
+                const order = context.orders.get(input.orderId)
                 return {
-                    id: order.orderId,
+                    orderId: order.orderId,
                     coffeeType: order.coffeeType,
                     status: order.status
                 }
             } else {
-                console.log(`order (${input.id}) does not exist.`)
+                console.log(`order (${input.orderId}) does not exist.`)
                 throw new OrderNotFound({
-                    message: `order ${input.id} not found.`,
-                    orderId: input.id
+                    message: `order ${input.orderId} not found.`,
+                    orderId: input.orderId
                 })
             }
         }
@@ -712,7 +712,7 @@ After creating the order, you should get response like:
         // metadata, such as response code, added by the client
       },
       coffeeType: 'DRIP', // <--- the type of coffee we ordered
-      id: 'ee97e900-d8dd-4770-904c-3d175cda90c3',  // <--- the order id
+      orderId: 'ee97e900-d8dd-4770-904c-3d175cda90c3',  // <--- the order id
       status: 'IN_PROGRESS' // <--- the order status
     }
 
@@ -721,7 +721,7 @@ The order should be ready by the time you submit this next command. Let's retrie
 .. code-block:: TypeScript
     :caption: ``repl``
 
-    await client.getOrder({ id: '<PUT YOUR ORDER-ID HERE!>' }) // <--- make sure to replace with your id
+    await client.getOrder({ orderId: '<PUT YOUR ORDER-ID HERE!>' }) // <--- make sure to replace with your id
 
 Once you execute the command, you should see your order information:
 
@@ -733,7 +733,7 @@ Once you execute the command, you should see your order information:
         // ...
       },
       coffeeType: 'DRIP', // <--- the type of coffee we ordered
-      id: 'ee97e900-d8dd-4770-904c-3d175cda90c3',  // <--- the order id
+      orderId: 'ee97e900-d8dd-4770-904c-3d175cda90c3',  // <--- the order id
       status: 'COMPLETED' // <--- the order status, which should be 'COMPLETED'
     }
 


### PR DESCRIPTION
This updates the docs to recommend against using the literal `id` as a resource shape identifier name, since it can be confusing when child resources are brought into the mix. This also updates examples across the board.

Fixes #3159

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
