### PR TITLE
Fix trait codegen for maps with an idRef key

### DIFF
--- a/.changes/next-release/bugfix-d6a2f585b8496827c7aa7a74c3ff937c4fccdb95.json
+++ b/.changes/next-release/bugfix-d6a2f585b8496827c7aa7a74c3ff937c4fccdb95.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fixed trait code generation for maps with an `@idRef` key, which produced uncompilable code. The generated `createNode()` and `fromNode()` methods hard-coded the map entry key type as `String` instead of deriving it from the key shape, which is a `ShapeId` for an `@idRef` key.",
+  "pull_requests": []
+}

--- a/.changes/next-release/bugfix-d6a2f585b8496827c7aa7a74c3ff937c4fccdb95.json
+++ b/.changes/next-release/bugfix-d6a2f585b8496827c7aa7a74c3ff937c4fccdb95.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fixed trait code generation for maps with an `@idRef` key, which produced uncompilable code. The generated `createNode()` and `fromNode()` methods hard-coded the map entry key type as `String` instead of deriving it from the key shape, which is a `ShapeId` for an `@idRef` key.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3207](https://github.com/smithy-lang/smithy/pull/3207)"
+  ]
 }

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -18,12 +18,14 @@ import com.example.traits.enums.MyIntEnumTrait;
 import com.example.traits.enums.SomeEnum;
 import com.example.traits.enums.StringEnumTrait;
 import com.example.traits.enums.SuitTrait;
+import com.example.traits.idref.IdRefKeyMapTrait;
 import com.example.traits.idref.IdRefListTrait;
 import com.example.traits.idref.IdRefMapTrait;
 import com.example.traits.idref.IdRefMemberListTrait;
 import com.example.traits.idref.IdRefMemberMapTrait;
 import com.example.traits.idref.IdRefMemberStructTrait;
 import com.example.traits.idref.IdRefMemberStructWithNestedIdsTrait;
+import com.example.traits.idref.IdRefNestedKeyMapTrait;
 import com.example.traits.idref.IdRefStringTrait;
 import com.example.traits.idref.IdRefStructTrait;
 import com.example.traits.idref.IdRefStructWithNestedIdsTrait;
@@ -164,6 +166,13 @@ public class LoadsFromModelTest {
                 Arguments.of("idref/idref-map-member.smithy",
                         IdRefMemberMapTrait.class,
                         MapUtils.of("getValues", MapUtils.of("a", TARGET_ONE, "b", TARGET_TWO))),
+                Arguments.of("idref/idref-key-map.smithy",
+                        IdRefKeyMapTrait.class,
+                        MapUtils.of("getValues", MapUtils.of(TARGET_ONE, "a", TARGET_TWO, "b"))),
+                Arguments.of("idref/idref-nested-key-map.smithy",
+                        IdRefNestedKeyMapTrait.class,
+                        MapUtils.of("getValues",
+                                MapUtils.of("outer", MapUtils.of(TARGET_ONE, "a", TARGET_TWO, "b")))),
                 Arguments.of("idref/idref-struct.smithy",
                         IdRefStructTrait.class,
                         MapUtils.of("getFieldA", Optional.of(TARGET_ONE))),

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-key-map.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-key-map.smithy
@@ -1,0 +1,15 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.idref#IdRefKeyMap
+
+@IdRefKeyMap(
+    "test.smithy.traitcodegen#IdRefTarget1": "a"
+    "test.smithy.traitcodegen#IdRefTarget2": "b"
+)
+structure myStruct {}
+
+string IdRefTarget1
+
+string IdRefTarget2

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-nested-key-map.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-nested-key-map.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.idref#IdRefNestedKeyMap
+
+@IdRefNestedKeyMap(
+    outer: {
+        "test.smithy.traitcodegen#IdRefTarget1": "a"
+        "test.smithy.traitcodegen#IdRefTarget2": "b"
+    }
+)
+structure myStruct {}
+
+string IdRefTarget1
+
+string IdRefTarget2

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
@@ -129,7 +129,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
         if (nestedLevel > 0) {
             writer.write("$T<$T, $T> $L = new $T<>();",
                     Map.class,
-                    String.class,
+                    symbolProvider.toSymbol(shape.getKey()),
                     symbolProvider.toSymbol(shape.getValue()),
                     "value" + nestedLevel,
                     LinkedHashMap.class);

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ToNodeMapperVisitor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ToNodeMapperVisitor.java
@@ -117,7 +117,7 @@ final class ToNodeMapperVisitor extends TraitVisitor<Void> {
         int nextLevel = nestedLevel + 1;
         writer.write("for ($T<$T, $T> $L : $L.entrySet()) {",
                 Map.Entry.class,
-                String.class,
+                symbolProvider.toSymbol(shape.getKey()),
                 symbolProvider.toSymbol(shape.getValue()),
                 "entry" + nextLevel,
                 varName);

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ObjectNode;
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 104;
+    private static final int EXPECTED_NUMBER_OF_FILES = 106;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-key-map.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-key-map.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.idref
+
+@trait
+map IdRefKeyMap {
+    @idRef
+    key: String
+
+    value: String
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-nested-key-map.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-nested-key-map.smithy
@@ -1,0 +1,15 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.idref
+
+@trait
+map IdRefNestedKeyMap {
+    key: String
+    value: IdRefKeyInnerMap
+}
+
+map IdRefKeyInnerMap {
+    @idRef
+    key: String
+    value: String
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -14,6 +14,8 @@ idref/idref-list.smithy
 idref/idref-list-member.smithy
 idref/idref-map.smithy
 idref/idref-map-member.smithy
+idref/idref-key-map.smithy
+idref/idref-nested-key-map.smithy
 idref/idref-string.smithy
 idref/idref-struct-with-nested-refs.smithy
 idref/idref-struct-with-nested-member-refs.smithy


### PR DESCRIPTION
The map serializers hard-coded the entry key type as `String`, so a trait whose map key member carries `@idRef` generated uncompilable `createNode()` and `fromNode()` code once the key resolved to a `ShapeId`. Both `ToNodeMapperVisitor` and `FromNodeMapperVisitor` now derive the key type from the key shape's symbol, with integration tests covering top-level and nested `@idRef`-keyed maps.

Fixes #3204 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
