### PR TITLE
Reorder the members to match what NodeMapper outputs

### DIFF
--- a/.changes/next-release/bugfix-bec96dcbcdfb3a3690a9eeeb9e1f8aae56fec410.json
+++ b/.changes/next-release/bugfix-bec96dcbcdfb3a3690a9eeeb9e1f8aae56fec410.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Reordered the in the rules-engine traits members to match what NodeMapper outputs to avoid spurious diff changes",
+  "pull_requests": [
+    "https://github.com/smithy-lang/smithy/pull/3210"
+  ]
+}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamDefinition.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ClientContextParamDefinition.java
@@ -37,11 +37,11 @@ public final class ClientContextParamDefinition implements ToNode, ToSmithyBuild
 
     @Override
     public Node toNode() {
-        ObjectNode.Builder builder = Node.objectNodeBuilder()
-                .withMember("type", type.toString());
+        ObjectNode.Builder builder = Node.objectNodeBuilder();
         if (documentation != null) {
             builder.withMember("documentation", documentation);
         }
+        builder.withMember("type", type.toString());
         return builder.build();
     }
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestCase.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestCase.java
@@ -55,11 +55,9 @@ public final class EndpointTestCase implements ToNode, FromSourceLocation, ToSmi
 
     @Override
     public Node toNode() {
-        ObjectNode.Builder builder = Node.objectNodeBuilder();
+        ObjectNode.Builder builder = ObjectNode.builder();
         builder.withOptionalMember("documentation", getDocumentation().map(Node::from));
-        if (params != null && !params.isEmpty()) {
-            builder.withMember("params", params);
-        }
+        builder.withMember("expect", expect.toNode());
         if (!operationInputs.isEmpty()) {
             ArrayNode.Builder operationInputsBuilder = ArrayNode.builder();
             for (EndpointTestOperationInput operationInput : operationInputs) {
@@ -67,7 +65,10 @@ public final class EndpointTestCase implements ToNode, FromSourceLocation, ToSmi
             }
             builder.withMember("operationInputs", operationInputsBuilder.build());
         }
-        return builder.withMember("expect", expect.toNode()).build();
+        if (params != null && !params.isEmpty()) {
+            builder.withMember("params", params);
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
@@ -53,14 +53,14 @@ public final class EndpointTestOperationInput implements ToNode, FromSourceLocat
     @Override
     public Node toNode() {
         ObjectNode.Builder builder = Node.objectNodeBuilder();
-        if (builtInParams != null) {
+        if (builtInParams != null && !builtInParams.isEmpty()) {
             builder.withMember("builtInParams", builtInParams);
         }
-        if (clientParams != null) {
+        if (clientParams != null && !clientParams.isEmpty()) {
             builder.withMember("clientParams", clientParams);
         }
         builder.withMember("operationName", Node.from(operationName));
-        if (operationParams != null) {
+        if (operationParams != null && !operationParams.isEmpty()) {
             builder.withMember("operationParams", operationParams);
         }
         return builder.build();

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
@@ -53,15 +53,15 @@ public final class EndpointTestOperationInput implements ToNode, FromSourceLocat
     @Override
     public Node toNode() {
         ObjectNode.Builder builder = Node.objectNodeBuilder();
-        builder.withMember("operationName", Node.from(operationName));
-        if (operationParams != null) {
-            builder.withMember("operationParams", operationParams);
-        }
         if (builtInParams != null) {
             builder.withMember("builtInParams", builtInParams);
         }
         if (clientParams != null) {
             builder.withMember("clientParams", clientParams);
+        }
+        builder.withMember("operationName", Node.from(operationName));
+        if (operationParams != null) {
+            builder.withMember("operationParams", operationParams);
         }
         return builder.build();
     }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTrait.java
@@ -48,8 +48,8 @@ public final class EndpointTestsTrait extends AbstractTrait implements ToSmithyB
         }
         return Node.objectNodeBuilder()
                 .sourceLocation(getSourceLocation())
-                .withMember("version", Node.from(version))
                 .withMember("testCases", builder.build())
+                .withMember("version", Node.from(version))
                 .build();
     }
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
@@ -53,9 +53,6 @@ public final class ExpectedEndpoint implements ToNode, FromSourceLocation, ToSmi
     @Override
     public Node toNode() {
         ObjectNode.Builder builder = Node.objectNodeBuilder();
-        if (url != null) {
-            builder.withMember("url", url);
-        }
         if (!headers.isEmpty()) {
             ObjectNode.Builder headersBuilder = ObjectNode.builder();
             for (Map.Entry<String, List<String>> kvp : headers.entrySet()) {
@@ -75,7 +72,9 @@ public final class ExpectedEndpoint implements ToNode, FromSourceLocation, ToSmi
             }
             builder.withMember("properties", propertiesBuilder.build());
         }
-
+        if (url != null) {
+            builder.withMember("url", url);
+        }
         return builder.build();
     }
 


### PR DESCRIPTION
#### Background

In a previous change (#3185) the use of `NodeMapper` was removed in favor of the use of direct implementation of `toNode` and `fromNode`. This change caused drift in the serialization of the model by changing the order of the keys in `ObjectNode`. `NodeMapper` serializes by key order. This change replicates this behavior to avoid spurious diff changes.

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
