### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
     labels:
      - "dependencies"
      - "no-changelog-needed"
+
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "software.amazon.smithy.gradle.smithy-jar"
     labels:
      - "dependencies"
      - "no-changelog-needed"
@@ -23,6 +33,7 @@ updates:
     ignore:
       - dependency-name: "com.opencastsoftware:prettier4j"
         versions: [ "0.3.1", "0.3.2" ]
+
   - package-ecosystem: "pip"
     directories:
       - "/docs"
@@ -30,6 +41,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
     labels:
      - "dependencies"
      - "no-changelog-needed"


### PR DESCRIPTION
This updates the dependabot config to add a one-week cooldown period on all dependencies. We could further configure that, but I don't think it's necessary at the moment. I also updated the schedule to consistently trigger at 10 utc on Wednesday. Most were already on Wednesday, and the time was picked because it guarantees that it gets in early for the EU crowd.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
