### PR TITLE
Fix trait codegen for default values of members with `@idRef` trait applied

### DIFF
--- a/.changes/next-release/bugfix-d9dc99ad0777c243ee320e9b714b7240d33127ef.json
+++ b/.changes/next-release/bugfix-d9dc99ad0777c243ee320e9b714b7240d33127ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fixed trait code generation for shapes with an `@idRef`-annotated member or member's target, which produced uncompilable code. The generated default value for a member didn't respect `@idRef` trait on member or member's target and generated vanilla string literal, while generated member type is `ShapeId`.",
+  "pull_requests": [
+    "https://github.com/smithy-lang/smithy/pull/3214"
+  ]
+}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/BuilderGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/BuilderGenerator.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.ShortShape;
@@ -571,6 +572,10 @@ final class BuilderGenerator implements Runnable {
 
         @Override
         public Void memberShape(MemberShape memberShape) {
+            if (memberShape.getMemberTrait(model, IdRefTrait.class).isPresent()) {
+                writer.write("$T.from($S)", ShapeId.class, defaultValue.expectStringNode().getValue());
+                return null;
+            }
             return model.expectShape(memberShape.getTarget()).accept(this);
         }
 

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ObjectNode;
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 106;
+    private static final int EXPECTED_NUMBER_OF_FILES = 107;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -57,6 +57,7 @@ structures/structure-trait.smithy
 structures/struct-with-listofmap-trait.smithy
 structures/struct-with-uniqueitems-list-trait.smithy
 structures/struct-with-idref-member-trait.smithy
+structures/struct-with-idref-member-trait-with-defaults.smithy
 structures/struct-member-with-timestamp-format-trait.smithy
 structures/struct-with-enum-default-trait.smithy
 structures/struct-with-union-trait.smithy

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/struct-with-idref-member-trait-with-defaults.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/struct-with-idref-member-trait-with-defaults.smithy
@@ -1,0 +1,18 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.structures
+
+enum Foo {
+    BAR
+}
+
+@idRef
+string IdRefPointer
+
+@trait
+structure StructWithIdrefMemberWithDefault {
+    @idRef
+    idRefDefault: String = Foo$BAR
+
+    idRefTargetDefault: IdRefPointer = Foo$BAR
+}


### PR DESCRIPTION
Closes #3212 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
