### PR TITLE
Add package attribution to trait docs

### DIFF
--- a/.changes/next-release/documentation-22edcbf15513075c224a37a6a24e93bcebdbacbb.json
+++ b/.changes/next-release/documentation-22edcbf15513075c224a37a6a24e93bcebdbacbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "documentation",
+  "description": "Updated trait docs to show what package the trait is defined in.",
+  "pull_requests": [
+    "[#3217](https://github.com/smithy-lang/smithy/pull/3217)"
+  ]
+}

--- a/docs/smithy/traitindex.py
+++ b/docs/smithy/traitindex.py
@@ -1,9 +1,29 @@
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
 
 from sphinx.locale import _
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
 
 SMITHY_TRAITS_ATTR = "smithy_traits"
+
+# Traits in this namespace are part of the prelude and are always available, so
+# there's no package for a user to depend on. They're grouped under this label
+# in the index instead of a package name, and note that they come from the
+# prelude rather than an artifact.
+PRELUDE_NAMESPACE = "smithy.api"
+PRELUDE_GROUP = "Prelude"
+
+# The reStructuredText label of the section that documents the prelude, linked
+# to from the "Provided by" note on prelude traits.
+PRELUDE_LABEL = "prelude"
+
+# The Maven group a bare :package: name belongs to (packages outside it are
+# authored as a full "group:artifact" coordinate), and the artifact page a
+# package's "Provided by" note links to.
+DEFAULT_PACKAGE_GROUP = "software.amazon.smithy"
+MAVEN_ARTIFACT_URL = "https://central.sonatype.com/artifact/{group}/{artifact}"
 
 
 # Placeholder node that will be replaced with the trait index.
@@ -15,19 +35,36 @@ class SmithyTraitIndexNode(nodes.General, nodes.Element):
 # Usage: .. smithy-trait-index::
 class SmithyTraitIndexDirective(Directive):
     def run(self):
+        # The index aggregates traits from every other page, so it has to be
+        # re-rendered whenever any of them changes, not just when its own source
+        # does. Marking it for a re-read on every build keeps it from going
+        # stale during incremental builds.
+        self.state.document.settings.env.note_reread()
         return [SmithyTraitIndexNode("")]
 
 
 # Directive that marks the location of a smithy trait in the docs.
-# Usage: .. smithy-trait: ns.example#shapeId
+# Usage:
+#     .. smithy-trait:: ns.example#shapeId
+#        :package: some-package
+#
+# The package is the artifact that provides the trait (a bare artifact name for
+# artifacts in the software.amazon.smithy group, or a group:artifact coordinate
+# otherwise). It's used to group the trait index by package and to note the
+# providing package on the trait itself. Prelude traits may omit it, but it's
+# otherwise required whenever any trait declares one. This is validated by
+# validate_trait_packages.
 class SmithyTraitDirective(Directive):
 
     # Makes the shape id argument required
     required_arguments = 1
 
+    option_spec = {"package": directives.unchanged}
+
     def run(self):
         env = self.state.document.settings.env
         shape_id = self.arguments[0]
+        package = self.options.get("package")
 
         # Make the shape id url-friendly
         stripped_shape_id = shape_id.strip().replace("#", "-").replace(".", "-").lower()
@@ -44,8 +81,11 @@ class SmithyTraitDirective(Directive):
         env.smithy_traits.append(
             {
                 "docname": env.docname,
+                "lineno": self.lineno,
                 "target": target_node,
+                "target_id": target_id,
                 "shape_id": shape_id,
+                "package": package,
             }
         )
 
@@ -69,48 +109,224 @@ def merge_smithy_traits(app, env, docnames, other):
         env.smithy_traits.extend(other.smithy_traits)
 
 
-# Generates a list of links to known smithy traits, replacing any
-# SmithyTraitIndexNodes
+def is_prelude(smithy_trait_info):
+    return smithy_trait_info["shape_id"].split("#", 1)[0] == PRELUDE_NAMESPACE
+
+
+def is_aws(smithy_trait_info):
+    return smithy_trait_info["shape_id"].startswith("aws.")
+
+
+# The label that a trait is grouped under in the index. This is the prelude
+# group for prelude traits, otherwise its providing package. If there's no
+# package, it's reported as "unknown". validate_trait_packages will ensure
+# that this results in a build time error.
+def trait_group(smithy_trait_info):
+    if is_prelude(smithy_trait_info):
+        return PRELUDE_GROUP
+    return smithy_trait_info.get("package", "unknown")
+
+
+# Orders the index groups: the prelude first (it holds the core traits), then
+# non-AWS packages alphabetically, then AWS packages last (they only matter to
+# models that integrate with AWS). A group counts as AWS when its traits are in
+# an aws.* namespace.
+def sorted_groups(groups):
+    def key(name):
+        is_prelude_group = name == PRELUDE_GROUP
+        is_aws_group = any(is_aws(t) for t in groups[name])
+        return (not is_prelude_group, is_aws_group, name.lower())
+
+    return sorted(groups, key=key)
+
+
+# Builds a link to the section labeled by a std-domain reference label, or None
+# if the label can't be resolved. Resolves the label directly since this runs
+# after cross-references have already been processed.
+def label_reference(app, fromdocname, label, text):
+    std = app.builder.env.get_domain("std")
+    if label not in std.labels:
+        return None
+    docname, target_id, _title = std.labels[label]
+
+    ref_node = nodes.reference("", "")
+    ref_node["refuri"] = app.builder.get_relative_uri(fromdocname, docname)
+    if target_id:
+        ref_node["refuri"] += "#" + target_id
+    ref_node += nodes.Text(text)
+    return ref_node
+
+
+# The Maven Central page for a :package:, whose value is either a bare artifact
+# name in the default group or a full "group:artifact" coordinate.
+def maven_artifact_url(package):
+    group, _, artifact = package.rpartition(":")
+    return MAVEN_ARTIFACT_URL.format(
+        group=group or DEFAULT_PACKAGE_GROUP, artifact=artifact
+    )
+
+
+# Notes where a trait comes from by appending a "Provided by" entry to the
+# definition list that describes it (the same list that holds its Summary,
+# selector, and value type). Only runs once package attribution is in use (the
+# 2.0 docs). The 1.0 docs declare no packages, so they remain unchanged.
+def annotate_trait_packages(app, doctree, fromdocname):
+    env = app.builder.env
+    smithy_traits = getattr(env, SMITHY_TRAITS_ATTR, [])
+
+    # Bail early if there are no package attributions.
+    if not any(t.get("package") for t in smithy_traits):
+        return
+
+    trait_by_target_id = {t["target_id"]: t for t in smithy_traits}
+
+    for section in doctree.traverse(nodes.section):
+        # The trait's target sits just before its heading, so docutils folds the
+        # target id onto the section that the heading opens.
+        smithy_trait_info = next(
+            (trait_by_target_id[i] for i in section["ids"] if i in trait_by_target_id),
+            None,
+        )
+        if smithy_trait_info is None:
+            continue
+
+        # The Summary/selector/value-type block is authored as a definition list.
+        definition_list = next(
+            (c for c in section.children if isinstance(c, nodes.definition_list)),
+            None,
+        )
+
+        if definition_list is None:
+            logger.warning(
+                "smithy-trait %s is followed by a trait definition that omits "
+                "a definition list, so it may be malformed. The :package: "
+                "attribution could therefore not be added.",
+                smithy_trait_info["shape_id"],
+                location=(smithy_trait_info["docname"], smithy_trait_info["lineno"]),
+            )
+            continue
+
+        paragraph = provided_by_paragraph(app, fromdocname, smithy_trait_info)
+        if paragraph is None:
+            continue
+
+        definition = nodes.definition()
+        definition += paragraph
+        item = nodes.definition_list_item()
+        item += nodes.term("", "Provided by")
+        item += definition
+        definition_list += item
+
+
+# The "Provided by" note shown on a trait, as a paragraph, or None if there's
+# no known pacakge. Prelude traits get a fixed note that links to the prelude
+# while every other trait names its providing artifact.
+def provided_by_paragraph(app, fromdocname, smithy_trait_info):
+    paragraph = nodes.paragraph()
+    if is_prelude(smithy_trait_info):
+        prelude = label_reference(app, fromdocname, PRELUDE_LABEL, "prelude")
+        paragraph += nodes.Text("Provided by the ")
+        paragraph += prelude if prelude is not None else nodes.Text("prelude")
+        paragraph += nodes.Text(", available to all models.")
+    elif smithy_trait_info.get("package"):
+        package = smithy_trait_info["package"]
+        link = nodes.reference("", "", refuri=maven_artifact_url(package))
+        link += nodes.literal("", package)
+        paragraph += nodes.Text("Provided by the ")
+        paragraph += link
+        paragraph += nodes.Text(" package.")
+    else:
+        return None
+    return paragraph
+
+
+# Builds a link to a documented trait, shown as its emphasized shape id.
+def trait_reference(app, fromdocname, smithy_trait_info):
+    shape_id = smithy_trait_info["shape_id"]
+
+    ref_node = nodes.reference("", "")
+    ref_node["refdocname"] = smithy_trait_info["docname"]
+    ref_node["refuri"] = app.builder.get_relative_uri(
+        fromdocname, smithy_trait_info["docname"]
+    )
+    ref_node["refuri"] += "#" + smithy_trait_info["target"]["refid"]
+    ref_node += nodes.emphasis(_(shape_id), _(shape_id))
+
+    para = nodes.paragraph()
+    para += ref_node
+    list_item = nodes.list_item()
+    list_item += para
+    return list_item
+
+
+# A flat, alphabetical list of links to every trait.
+def flat_index(app, fromdocname, smithy_traits):
+    bullet_list = nodes.bullet_list()
+    for smithy_trait_info in smithy_traits:
+        bullet_list += trait_reference(app, fromdocname, smithy_trait_info)
+    return [bullet_list]
+
+
+# Links to every trait, split into a section per providing package (plus the
+# prelude), each holding an alphabetical list of the traits it provides.
+def grouped_index(app, fromdocname, smithy_traits):
+    groups = {}
+    for smithy_trait_info in smithy_traits:
+        groups.setdefault(trait_group(smithy_trait_info), []).append(smithy_trait_info)
+
+    index_nodes = []
+    for group in sorted_groups(groups):
+        rubric = nodes.rubric()
+        rubric += nodes.Text(group)
+        index_nodes.append(rubric)
+        index_nodes += flat_index(app, fromdocname, groups[group])
+    return index_nodes
+
+
+# Generates the trait index, replacing any SmithyTraitIndexNodes. The index is
+# grouped by providing package when any trait declares one, and is otherwise a
+# single flat list (e.g. the 1.0 docs, which predate package attribution).
 def process_smithy_nodes(app, doctree, fromdocname):
     env = app.builder.env
 
     if not hasattr(env, SMITHY_TRAITS_ATTR):
         env.smithy_traits = []
 
+    smithy_traits = sorted(env.smithy_traits, key=lambda x: x["shape_id"])
+    has_packages = any(t.get("package") for t in smithy_traits)
+
     for node in doctree.traverse(SmithyTraitIndexNode):
-        new_index_node = nodes.bullet_list()
+        if has_packages:
+            index_nodes = grouped_index(app, fromdocname, smithy_traits)
+        else:
+            index_nodes = flat_index(app, fromdocname, smithy_traits)
+        node.replace_self(index_nodes)
 
-        smithy_traits = sorted(env.smithy_traits, key=lambda x: x["shape_id"])
 
-        for smithy_trait_info in smithy_traits:
-            shape_id = smithy_trait_info["shape_id"]
+# Once any trait declares a :package:, every non-prelude trait must, so no
+# providing package is silently dropped.
+def validate_trait_packages(app, env):
+    smithy_traits = getattr(env, SMITHY_TRAITS_ATTR, [])
+    if not any(t.get("package") for t in smithy_traits):
+        return
 
-            # Create a reference node, which becomes a link with the text being
-            # the shape id.
-            ref_node = nodes.reference("", "")
-            inner_node = nodes.emphasis(_(shape_id), _(shape_id))
-            ref_node["refdocname"] = smithy_trait_info["docname"]
-            ref_node["refuri"] = app.builder.get_relative_uri(
-                fromdocname, smithy_trait_info["docname"]
-            )
-            ref_node["refuri"] += "#" + smithy_trait_info["target"]["refid"]
-            ref_node.append(inner_node)
-
-            # Wrap the reference in a paragraph and construct a list item from it.
-            para = nodes.paragraph()
-            para += ref_node
-            list_item = nodes.list_item()
-            list_item += para
-
-            new_index_node.append(list_item)
-
-        node.replace_self(new_index_node)
+    for smithy_trait_info in smithy_traits:
+        if smithy_trait_info.get("package") or is_prelude(smithy_trait_info):
+            continue
+        logger.warning(
+            "smithy-trait %s is missing a :package: option, which is required for "
+            "all non-prelude traits once any trait declares one.",
+            smithy_trait_info["shape_id"],
+            location=(smithy_trait_info["docname"], smithy_trait_info["lineno"]),
+        )
 
 
 def setup_smithy_trait_index(app):
     app.add_node(SmithyTraitIndexNode)
     app.add_directive("smithy-trait", SmithyTraitDirective)
     app.add_directive("smithy-trait-index", SmithyTraitIndexDirective)
+    app.connect("doctree-resolved", annotate_trait_packages)
     app.connect("doctree-resolved", process_smithy_nodes)
     app.connect("env-purge-doc", purge_smithy_traits)
     app.connect("env-merge-info", merge_smithy_traits)
+    app.connect("env-check-consistency", validate_trait_packages)

--- a/docs/source-2.0/additional-specs/ai-traits.rst
+++ b/docs/source-2.0/additional-specs/ai-traits.rst
@@ -8,6 +8,7 @@ Smithy AI traits provide metadata for service authors to embed contextual inform
 
 
 .. smithy-trait:: smithy.ai#prompts
+   :package: software.amazon.smithy.java:smithy-ai-traits
 .. _smithy.ai#prompts-trait:
 
 ---------------------------

--- a/docs/source-2.0/additional-specs/contract-traits.rst
+++ b/docs/source-2.0/additional-specs/contract-traits.rst
@@ -20,6 +20,7 @@ These traits often express contracts using higher-level constructs and simpler b
 Services will usually check these contracts outside of service frameworks in more efficient ways.
 
 .. smithy-trait:: smithy.contracts#conditions
+    :package: smithy-contract-traits
 .. _conditions-trait:
 
 --------------------

--- a/docs/source-2.0/additional-specs/event-stream-protocol-compliance-tests.rst
+++ b/docs/source-2.0/additional-specs/event-stream-protocol-compliance-tests.rst
@@ -26,6 +26,7 @@ for a specific protocol.
 
 
 .. smithy-trait:: smithy.test#eventStreamTests
+    :package: smithy-protocol-test-traits
 .. _eventStreamTests-trait:
 
 -----------------

--- a/docs/source-2.0/additional-specs/http-protocol-compliance-tests.rst
+++ b/docs/source-2.0/additional-specs/http-protocol-compliance-tests.rst
@@ -59,6 +59,7 @@ constraints:
 
 
 .. smithy-trait:: smithy.test#httpRequestTests
+    :package: smithy-protocol-test-traits
 .. _httpRequestTests-trait:
 
 ----------------
@@ -316,6 +317,7 @@ that uses :ref:`HTTP binding traits <http-traits>`.
 
 
 .. smithy-trait:: smithy.test#httpResponseTests
+    :package: smithy-protocol-test-traits
 .. _httpResponseTests-trait:
 
 -----------------
@@ -523,6 +525,7 @@ that uses :ref:`HTTP binding traits <http-traits>`.
 
 
 .. smithy-trait:: smithy.test#httpMalformedRequestTests
+    :package: smithy-protocol-test-traits
 .. _httpMalformedRequestTests-trait:
 
 -------------------------

--- a/docs/source-2.0/additional-specs/mqtt.rst
+++ b/docs/source-2.0/additional-specs/mqtt.rst
@@ -129,6 +129,7 @@ MQTT topic templates MUST adhere to the following constraints:
 
 
 .. smithy-trait:: smithy.mqtt#publish
+    :package: smithy-mqtt-traits
 .. _smithy.mqtt#publish-trait:
 
 -----------------------------
@@ -201,6 +202,7 @@ Publish validation
 
 
 .. smithy-trait:: smithy.mqtt#subscribe
+    :package: smithy-mqtt-traits
 .. _smithy.mqtt#subscribe-trait:
 
 -------------------------------
@@ -295,6 +297,7 @@ Subscribe validation
 
 
 .. smithy-trait:: smithy.mqtt#topicLabel
+    :package: smithy-mqtt-traits
 .. _smithy.mqtt#topicLabel-trait:
 
 --------------------------------

--- a/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2-cbor.rst
+++ b/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2-cbor.rst
@@ -8,6 +8,7 @@ This specification defines the ``smithy.protocols#rpcv2Cbor`` protocol. This
 protocol is used to expose services that serialize RPC payloads as CBOR.
 
 .. smithy-trait:: smithy.protocols#rpcv2Cbor
+    :package: smithy-protocol-traits
 .. _smithy.protocols#rpcv2Cbor-trait:
 
 

--- a/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2-json.rst
+++ b/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2-json.rst
@@ -8,6 +8,7 @@ This specification defines the ``smithy.protocols#rpcv2Json`` protocol. This
 protocol is used to expose services that serialize RPC payloads as JSON.
 
 .. smithy-trait:: smithy.protocols#rpcv2Json
+    :package: smithy-protocol-traits
 .. _smithy.protocols#rpcv2Json-trait:
 
 

--- a/docs/source-2.0/additional-specs/rules-engine/parameters.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/parameters.rst
@@ -137,6 +137,7 @@ following rule set:
 
 
 .. smithy-trait:: smithy.rules#clientContextParams
+    :package: smithy-rules-engine
 .. _smithy.rules#clientContextParams-trait:
 
 ``smithy.rules#clientContextParams`` trait
@@ -196,6 +197,7 @@ configurable values:
     }
 
 .. smithy-trait:: smithy.rules#staticContextParams
+    :package: smithy-rules-engine
 .. _smithy.rules#staticContextParams-trait:
 
 ``smithy.rules#staticContextParams`` trait
@@ -249,6 +251,7 @@ operation:
 
 
 .. smithy-trait:: smithy.rules#operationContextParams
+    :package: smithy-rules-engine
 .. _smithy.rules#operationContextParams-trait:
 
 ``smithy.rules#operationContextParams`` trait
@@ -330,6 +333,7 @@ to a subset of JMESPath:
 
 
 .. smithy-trait:: smithy.rules#contextParam
+    :package: smithy-rules-engine
 .. _smithy.rules#contextParam-trait:
 
 ``smithy.rules#contextParam`` trait

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -30,6 +30,7 @@ features, and built-ins have been available since version 1.0. Any feature, func
 the feature's introduction version must be less than or equal to the trait version.
 
 .. smithy-trait:: smithy.rules#endpointRuleSet
+    :package: smithy-rules-engine
 .. _smithy.rules#endpointRuleSet-trait:
 
 --------------------------------------
@@ -83,6 +84,7 @@ empty set of conditions to provide a more meaningful default or error depending
 on the scenario.
 
 .. smithy-trait:: smithy.rules#endpointBdd
+    :package: smithy-rules-engine
 .. _smithy.rules#endpointBdd-trait:
 
 ----------------------------------
@@ -923,6 +925,7 @@ The following two expressions are equivalent:
 
 
 .. smithy-trait:: smithy.rules#endpointTests
+    :package: smithy-rules-engine
 .. _smithy.rules#endpointTests-trait:
 
 ------------------------------------

--- a/docs/source-2.0/additional-specs/smoke-tests.rst
+++ b/docs/source-2.0/additional-specs/smoke-tests.rst
@@ -28,6 +28,7 @@ generated clients against live services to ensure core functionality is working,
 and continues to work as the client and service evolve.
 
 .. smithy-trait:: smithy.test#smokeTests
+    :package: smithy-smoke-test-traits
 .. _smokeTests-trait:
 
 ----------

--- a/docs/source-2.0/additional-specs/waiters.rst
+++ b/docs/source-2.0/additional-specs/waiters.rst
@@ -27,6 +27,7 @@ following client pseudocode:
 
 
 .. smithy-trait:: smithy.waiters#waitable
+    :package: smithy-waiters
 .. _smithy.waiters#waitable-trait:
 
 ``smithy.waiters#waitable`` trait

--- a/docs/source-2.0/aws/amazon-apigateway.rst
+++ b/docs/source-2.0/aws/amazon-apigateway.rst
@@ -11,6 +11,7 @@ Authentication and authorization
 --------------------------------
 
 .. smithy-trait:: aws.apigateway#apiKeyRequired
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#apiKeyRequired-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -52,6 +53,7 @@ but not on ``HealthCheck``:
     customers.
 
 .. smithy-trait:: aws.apigateway#apiKeySource
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#apiKeySource-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -104,6 +106,7 @@ The following example sets the ``X-API-Key`` header as the API key source.
     customers.
 
 .. smithy-trait:: aws.apigateway#authorizer
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#authorizer-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,6 +138,7 @@ See also
     customers.
 
 .. smithy-trait:: aws.apigateway#authorizers
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#authorizers-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -316,6 +320,7 @@ Method and response handling
 ----------------------------
 
 .. smithy-trait:: aws.apigateway#gatewayResponses
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#gatewayResponses-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -408,6 +413,7 @@ CORS-generated headers. Review the merged output to confirm the
 effective headers match your intent.
 
 .. smithy-trait:: aws.apigateway#minimumCompressionSize
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#minimumCompressionSize-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -442,6 +448,7 @@ The following example sets the minimum compression size to 10240 bytes:
     }
 
 .. smithy-trait:: aws.apigateway#requestValidator
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#requestValidator-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -510,6 +517,7 @@ Integrations
 ------------
 
 .. smithy-trait:: aws.apigateway#integration
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#integration-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -706,6 +714,7 @@ operation within the service.
     customers.
 
 .. smithy-trait:: aws.apigateway#mockIntegration
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#mockIntegration-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -817,6 +826,7 @@ API endpoint and access control
 -------------------------------
 
 .. smithy-trait:: aws.apigateway#apiTlsPolicy
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#apiTlsPolicy-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -884,6 +894,7 @@ endpoint access mode:
     customers.
 
 .. smithy-trait:: aws.apigateway#endpointConfiguration
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#endpointConfiguration-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -967,6 +978,7 @@ requires ``dualstack`` for private endpoints.
     customers.
 
 .. smithy-trait:: aws.apigateway#resourcePolicy
+    :package: smithy-aws-apigateway-traits
 .. _aws.apigateway#resourcePolicy-trait:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source-2.0/aws/aws-auth.rst
+++ b/docs/source-2.0/aws/aws-auth.rst
@@ -7,6 +7,7 @@ AWS Authentication Traits
 This document defines AWS authentication schemes.
 
 .. smithy-trait:: aws.auth#sigv4
+    :package: smithy-aws-traits
 .. _aws.auth#sigv4-trait:
 
 ------------------------
@@ -61,6 +62,7 @@ unauthenticated request.
 
 
 .. smithy-trait:: aws.auth#sigv4a
+    :package: smithy-aws-traits
 .. _aws.auth#sigv4a-trait:
 
 -------------------------
@@ -120,6 +122,7 @@ supports signatures for multi-region API requests.
 
 
 .. smithy-trait:: aws.auth#unsignedPayload
+    :package: smithy-aws-traits
 .. _aws.auth#unsignedPayload-trait:
 
 ----------------------------------
@@ -165,6 +168,7 @@ literal string ``UNSIGNED-PAYLOAD`` is used when constructing a
 
 
 .. smithy-trait:: aws.auth#cognitoUserPools
+    :package: smithy-aws-traits
 .. _aws.auth#cognitoUserPools-trait:
 
 -----------------------------------
@@ -214,6 +218,7 @@ See also
 
 
 .. smithy-trait:: aws.auth#cognitoUserPoolsScopes
+    :package: smithy-aws-traits
 .. _aws.auth#cognitoUserPoolsScopes-trait:
 
 -----------------------------------------

--- a/docs/source-2.0/aws/aws-cloudformation.rst
+++ b/docs/source-2.0/aws/aws-cloudformation.rst
@@ -20,6 +20,7 @@ Interface`_ to build, register, and deploy `resource providers`_.
 
 
 .. smithy-trait:: aws.cloudformation#cfnResource
+    :package: smithy-aws-cloudformation-traits
 .. _aws.cloudformation#cfnResource-trait:
 
 ----------------------------------------
@@ -141,6 +142,7 @@ of these structures can be excluded by applying the :ref:`aws.cloudformation#cfn
 
 
 .. smithy-trait:: aws.cloudformation#cfnExcludeProperty
+    :package: smithy-aws-cloudformation-traits
 .. _aws.cloudformation#cfnExcludeProperty-trait:
 
 -----------------------------------------------
@@ -340,6 +342,7 @@ The computed resource property mutabilities are:
 
 
 .. smithy-trait:: aws.cloudformation#cfnMutability
+    :package: smithy-aws-cloudformation-traits
 .. _aws.cloudformation#cfnMutability-trait:
 
 ------------------------------------------
@@ -548,6 +551,7 @@ derivable ``secret`` and ``password`` properties as write only:
 
 
 .. smithy-trait:: aws.cloudformation#cfnName
+    :package: smithy-aws-cloudformation-traits
 .. _aws.cloudformation#cfnName-trait:
 
 ------------------------------------
@@ -592,6 +596,7 @@ the following property names are derived from it:
 
 
 .. smithy-trait:: aws.cloudformation#cfnAdditionalIdentifier
+    :package: smithy-aws-cloudformation-traits
 .. _aws.cloudformation#cfnAdditionalIdentifier-trait:
 
 ----------------------------------------------------
@@ -657,6 +662,7 @@ The following example defines a CloudFormation resource that has the
     }
 
 .. smithy-trait:: aws.cloudformation#cfnDefaultValue
+    :package: smithy-aws-cloudformation-traits
 .. _aws.cloudformation#cfnDefaultValue-trait:
 
 --------------------------------------------

--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -6,6 +6,7 @@ Various AWS-specific traits are used to integrate Smithy models with other
 AWS products like AWS CloudFormation and tools like the AWS SDKs.
 
 .. smithy-trait:: aws.api#service
+    :package: smithy-aws-traits
 .. _aws.api#service-trait:
 
 -------------------------
@@ -258,6 +259,7 @@ value SHOULD begin with ``AWS/`` and the value after SHOULD be PascalCased.
 
 
 .. smithy-trait:: aws.api#arn
+    :package: smithy-aws-traits
 .. _aws.api#arn-trait:
 
 ---------------------
@@ -445,6 +447,7 @@ resource.
 
 
 .. smithy-trait:: aws.api#arnReference
+    :package: smithy-aws-traits
 .. _aws.api#arnReference-trait:
 
 ------------------------------
@@ -529,6 +532,7 @@ previous example:
 
 
 .. smithy-trait:: aws.api#data
+    :package: smithy-aws-traits
 .. _aws.api#data-trait:
 
 ----------------------
@@ -630,6 +634,7 @@ applied through the ``aws.api#data`` trait.
 
 
 .. smithy-trait:: aws.api#controlPlane
+    :package: smithy-aws-traits
 .. _aws.api#controlPlane-trait:
 
 ------------------------------
@@ -664,6 +669,7 @@ plane unless an operation or resource is marked with the
 
 
 .. smithy-trait:: aws.api#dataPlane
+    :package: smithy-aws-traits
 .. _aws.api#dataPlane-trait:
 
 ---------------------------
@@ -710,6 +716,7 @@ following traits provide the information needed to perform this.
 
 
 .. smithy-trait:: aws.api#clientEndpointDiscovery
+    :package: smithy-aws-traits
 .. _client-endpoint-discovery-trait:
 
 ``aws.api#clientEndpointDiscovery`` trait
@@ -759,6 +766,7 @@ The operation output MUST contain a member ``Endpoints`` that is a list of
 
 
 .. smithy-trait:: aws.api#clientDiscoveredEndpoint
+    :package: smithy-aws-traits
 .. _client-discovered-endpoint-trait:
 
 ``aws.api#clientDiscoveredEndpoint`` trait
@@ -792,6 +800,7 @@ following members:
 
 
 .. smithy-trait:: aws.api#clientEndpointDiscoveryId
+    :package: smithy-aws-traits
 .. _client-endpoint-discovery-id-trait:
 
 ``aws.api#clientEndpointDiscoveryId`` trait
@@ -936,6 +945,7 @@ Clients SHOULD scope the cache globally or to a specific client instance.
 
 
 .. smithy-trait:: aws.protocols#httpChecksum
+    :package: smithy-aws-traits
 .. _aws.protocols#httpChecksum-trait:
 
 ------------------------------------
@@ -1292,6 +1302,7 @@ trait.
 
 
 .. smithy-trait:: aws.api#tagEnabled
+    :package: smithy-aws-traits
 .. _tagEnabled-trait:
 
 ----------------------------
@@ -1523,6 +1534,7 @@ default-named operation (``TagResource``, ``UntagResource``,
 
 
 .. smithy-trait:: aws.api#taggable
+    :package: smithy-aws-traits
 .. _taggable-trait:
 
 --------------------------
@@ -1658,6 +1670,7 @@ if applicable.
 
 
 .. smithy-trait:: aws.api#awsChunked
+    :package: smithy-aws-traits
 .. _aws.api#awsChunked-trait:
 
 -------------------------------

--- a/docs/source-2.0/aws/aws-endpoints-region.rst
+++ b/docs/source-2.0/aws/aws-endpoints-region.rst
@@ -50,6 +50,7 @@ Dual stack Endpoints
     <https://docs.aws.amazon.com/vpc/latest/userguide/aws-ipv6-support.html>`_.
 
 .. smithy-trait:: aws.endpoints#endpointsModifier
+    :package: smithy-aws-endpoints
 .. _aws.endpoints#endpointsModifier-trait:
 
 -----------------------------------------
@@ -113,6 +114,7 @@ can also support configuration settings.
 
 
 .. smithy-trait:: aws.endpoints#standardRegionalEndpoints
+    :package: smithy-aws-endpoints
 .. _aws.endpoints#standardRegionalEndpoints-trait:
 
 -------------------------------------------------
@@ -244,6 +246,7 @@ A ``RegionSpecialCase`` object contains the following properties:
       - Overrides the signingRegion used for this region.
 
 .. smithy-trait:: aws.endpoints#standardPartitionalEndpoints
+    :package: smithy-aws-endpoints
 .. _aws.endpoints#standardPartitionalEndpoints-trait:
 
 ----------------------------------------------------
@@ -340,6 +343,7 @@ A ``PartitionEndpointSpecialCase`` object contains the following properties:
       - When ``true``, the special case will apply to fips endpoint variants.
 
 .. smithy-trait:: aws.endpoints#dualStackOnlyEndpoints
+    :package: smithy-aws-endpoints
 .. _aws.endpoints#dualStackOnlyEndpoints-trait:
 
 ----------------------------------------------
@@ -374,6 +378,7 @@ is dual stack only:
      }
 
 .. smithy-trait:: aws.endpoints#rulesBasedEndpoints
+    :package: smithy-aws-endpoints
 .. _aws.endpoints#rulesBasedEndpoints-trait:
 
 -------------------------------------------

--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -25,6 +25,7 @@ Principal traits
 ----------------
 
 .. smithy-trait:: aws.iam#supportedPrincipalTypes
+    :package: smithy-aws-iam-traits
 .. _aws.iam#supportedPrincipalTypes-trait:
 
 ``aws.iam#supportedPrincipalTypes`` trait
@@ -76,6 +77,7 @@ Action traits
 -------------
 
 .. smithy-trait:: aws.iam#iamAction
+    :package: smithy-aws-iam-traits
 .. _aws.iam#iamAction-trait:
 
 ``aws.iam#iamAction`` trait
@@ -195,6 +197,7 @@ Deprecated action traits
 ========================
 
 .. smithy-trait:: aws.iam#actionName
+    :package: smithy-aws-iam-traits
 .. _aws.iam#actionName-trait:
 
 ``aws.iam#actionName`` trait
@@ -240,6 +243,7 @@ The following example defines two operations:
     operation OperationB {}
 
 .. smithy-trait:: aws.iam#actionPermissionDescription
+    :package: smithy-aws-iam-traits
 .. _aws.iam#actionPermissionDescription-trait:
 
 ``aws.iam#actionPermissionDescription`` trait
@@ -270,6 +274,7 @@ Value type
 
 
 .. smithy-trait:: aws.iam#requiredActions
+    :package: smithy-aws-iam-traits
 .. _aws.iam#requiredActions-trait:
 
 ``aws.iam#requiredActions`` trait
@@ -324,6 +329,7 @@ Resource Traits
 ---------------
 
 .. smithy-trait:: aws.iam#iamResource
+    :package: smithy-aws-iam-traits
 .. _aws.iam#iamResource-trait:
 
 ``aws.iam#iamResource`` trait
@@ -387,6 +393,7 @@ Condition key traits
 --------------------
 
 .. smithy-trait:: aws.iam#defineConditionKeys
+    :package: smithy-aws-iam-traits
 .. _aws.iam#defineConditionKeys-trait:
 
 ``aws.iam#defineConditionKeys`` trait
@@ -475,6 +482,7 @@ condition key name is specified, the service is inferred to be the
 
 
 .. smithy-trait:: aws.iam#conditionKeys
+    :package: smithy-aws-iam-traits
 .. _aws.iam#conditionKeys-trait:
 
 ``aws.iam#conditionKeys`` trait
@@ -537,6 +545,7 @@ keys. The ``MyOperation`` operation has the ``aws:region`` condition key.
 
 
 .. smithy-trait:: aws.iam#serviceResolvedConditionKeys
+    :package: smithy-aws-iam-traits
 .. _aws.iam#serviceResolvedConditionKeys-trait:
 
 ``aws.iam#serviceResolvedConditionKeys`` trait
@@ -588,6 +597,7 @@ The following example defines two service-specific condition keys:
 
 
 .. smithy-trait:: aws.iam#conditionKeyValue
+    :package: smithy-aws-iam-traits
 .. _aws.iam#conditionKeyValue-trait:
 
 ``aws.iam#conditionKeyValue`` trait
@@ -654,6 +664,7 @@ explicitly binds ``ActionContextKey1`` to the field ``key``.
 
 
 .. smithy-trait:: aws.iam#disableConditionKeyInference
+    :package: smithy-aws-iam-traits
 .. _aws.iam#disableConditionKeyInference-trait:
 
 ``aws.iam#disableConditionKeyInference`` trait

--- a/docs/source-2.0/aws/protocols/aws-ec2-query-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-ec2-query-protocol.rst
@@ -8,6 +8,7 @@ This specification defines the ``aws.protocols#ec2`` protocol.
 
 
 .. smithy-trait:: aws.protocols#ec2Query
+    :package: smithy-aws-traits
 .. _aws.protocols#ec2Query-trait:
 
 --------------------------------
@@ -47,6 +48,7 @@ Value type
 
 
 .. smithy-trait:: aws.protocols#ec2QueryName
+    :package: smithy-aws-traits
 .. _aws.protocols#ec2QueryName-trait:
 
 ------------------------------------

--- a/docs/source-2.0/aws/protocols/aws-json-1_0-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-json-1_0-protocol.rst
@@ -8,6 +8,7 @@ This specification defines the ``aws.protocols#awsJson1_0`` protocol.
 
 
 .. smithy-trait:: aws.protocols#awsJson1_0
+    :package: smithy-aws-traits
 .. _aws.protocols#awsJson1_0-trait:
 
 ----------------------------------

--- a/docs/source-2.0/aws/protocols/aws-json-1_1-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-json-1_1-protocol.rst
@@ -8,6 +8,7 @@ This specification defines the ``aws.protocols#awsJson1_1`` protocol.
 
 
 .. smithy-trait:: aws.protocols#awsJson1_1
+    :package: smithy-aws-traits
 .. _aws.protocols#awsJson1_1-trait:
 
 ----------------------------------

--- a/docs/source-2.0/aws/protocols/aws-query-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-query-protocol.rst
@@ -461,6 +461,7 @@ following process:
 
 
 .. smithy-trait:: aws.protocols#awsQuery
+    :package: smithy-aws-traits
 .. _aws.protocols#awsQuery-trait:
 
 --------------------------------
@@ -495,6 +496,7 @@ See
 
 
 .. smithy-trait:: aws.protocols#awsQueryError
+    :package: smithy-aws-traits
 .. _aws.protocols#awsQueryError-trait:
 
 -------------------------------------
@@ -559,6 +561,7 @@ The following example defines an error that uses a custom "Code" of
 
 
 .. smithy-trait:: aws.protocols#awsQueryCompatible
+    :package: smithy-aws-traits
 .. _aws.protocols#awsQueryCompatible-trait:
 
 ------------------------------------------

--- a/docs/source-2.0/aws/protocols/aws-restjson1-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-restjson1-protocol.rst
@@ -11,6 +11,7 @@ status codes.
 
 
 .. smithy-trait:: aws.protocols#restJson1
+    :package: smithy-aws-traits
 .. _aws.protocols#restJson1-trait:
 
 ---------------------------------

--- a/docs/source-2.0/aws/protocols/aws-restxml-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-restxml-protocol.rst
@@ -8,6 +8,7 @@ This specification defines the ``aws.protocols#restXml`` protocol.
 
 
 .. smithy-trait:: aws.protocols#restXml
+    :package: smithy-aws-traits
 .. _aws.protocols#restXml-trait:
 
 -------------------------------

--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -1454,6 +1454,7 @@ of a Smithy model into an OpenAPI specification.
 Refer to `Converting to OpenAPI with smithy-build`_ for more detailed information about using the plugin and Gradle.
 
 .. smithy-trait:: smithy.openapi#specificationExtension
+    :package: smithy-openapi-traits
 .. _specification-extension-trait:
 
 ``specificationExtension`` trait


### PR DESCRIPTION
This updates the `smithy-trait` directive to take an optional package argument that indicates what package the trait is defined in. This is then used to append a "provided by" section to the trait's docs and is used to group traits in the trait index.

The argument becomes required if any trait uses it, essentially meaning that it's functionally required for non-prelude traits in the 2.0 docs since thats the only place I've updated them. The 1.0 docs are effectively unchanged by this.

Here's what a prelude trait def now looks like:

<img width="796" height="579" alt="Screenshot 2026-07-16 at 17 49 49" src="https://github.com/user-attachments/assets/a61f4b92-1ada-4778-a4d5-58f0f458ecb6" />

Here's what a non-prelude trait def now looks like:

<img width="795" height="515" alt="Screenshot 2026-07-16 at 17 48 09" src="https://github.com/user-attachments/assets/47a6198b-1218-4d9d-9fe6-e32e6533b5d5" />

And here's a portion of what the new index now looks like:

<img width="392" height="734" alt="Screenshot 2026-07-16 at 17 50 20" src="https://github.com/user-attachments/assets/942b25b5-da2d-4df5-9be6-9697c974f159" />

As always you can see the generated docs as an output in the CI run.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
