### PR TITLE
Clean orphaned endpoint ruleset params after shape removal

### DIFF
--- a/.changes/next-release/bugfix-c35a024fd386cf988a719cd17f8766106591fc91.json
+++ b/.changes/next-release/bugfix-c35a024fd386cf988a719cd17f8766106591fc91.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Clean orphaned endpoint ruleset params after shape removal",
+  "pull_requests": [
+    "[#3219](https://github.com/smithy-lang/smithy/pull/3219)"
+  ]
+}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParameters.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParameters.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.rulesengine.traits;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.transform.ModelTransformerPlugin;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
+import software.amazon.smithy.rulesengine.language.syntax.rule.Condition;
+import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
+import software.amazon.smithy.rulesengine.language.syntax.rule.TreeRule;
+import software.amazon.smithy.rulesengine.transforms.CompileBdd;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Removes orphaned endpoint ruleset parameters and their associated rules from a service's
+ * {@code @endpointRuleSet} trait when operations are removed from the model.
+ *
+ * <p>When operations are removed via {@link ModelTransformer#filterShapes} or
+ * {@link ModelTransformer#removeShapes}, parameters that were only bound through
+ * the removed operations' {@code @staticContextParams}, {@code @operationContextParams},
+ * or {@code @contextParam} traits may become orphaned. To prevent validation failures, this plugin
+ * removes those orphaned parameters and prunes any rules that reference them, recompiles the
+ * {@code @endpointBdd} trait from the cleaned ruleset, and drops {@code @endpointTests} cases that
+ * reference them.
+ */
+@SmithyInternalApi
+public final class CleanEndpointRuleSetParameters implements ModelTransformerPlugin {
+    @Override
+    public Model onRemove(ModelTransformer transformer, Collection<Shape> removed, Model model) {
+        if (!hasRelevantRemovals(removed)) {
+            return model;
+        }
+
+        Set<Shape> servicesToUpdate = new HashSet<>();
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+
+        for (ServiceShape service : model.getServiceShapesWithTrait(EndpointRuleSetTrait.class)) {
+            ServiceShape updated = cleanRuleSetParameters(model, topDownIndex, service);
+            if (updated != null) {
+                servicesToUpdate.add(updated);
+            }
+        }
+
+        if (servicesToUpdate.isEmpty()) {
+            return model;
+        }
+        return transformer.replaceShapes(model, servicesToUpdate);
+    }
+
+    private boolean hasRelevantRemovals(Collection<Shape> removed) {
+        for (Shape shape : removed) {
+            if (shape.isOperationShape() || shape.isMemberShape()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private ServiceShape cleanRuleSetParameters(Model model, TopDownIndex topDownIndex, ServiceShape service) {
+        Set<String> boundParams = computeBoundParameters(model, topDownIndex, service);
+        EndpointRuleSetTrait endpointRuleSetTrait = service.expectTrait(EndpointRuleSetTrait.class);
+        EndpointRuleSet ruleSet = endpointRuleSetTrait.getEndpointRuleSet();
+
+        Set<String> orphanedParams = new HashSet<>();
+        for (Parameter parameter : ruleSet.getParameters()) {
+            String name = parameter.getName().toString();
+            if (!parameter.isBuiltIn() && !boundParams.contains(name)) {
+                orphanedParams.add(name);
+            }
+        }
+
+        if (orphanedParams.isEmpty()) {
+            return null;
+        }
+
+        // Prune rules that reference orphaned parameters.
+        List<Rule> prunedRules = pruneRules(ruleSet.getRules(), orphanedParams);
+
+        // Remove orphaned parameter declarations.
+        Parameters.Builder paramsBuilder = Parameters.builder();
+        for (Parameter parameter : ruleSet.getParameters()) {
+            if (!orphanedParams.contains(parameter.getName().toString())) {
+                paramsBuilder.addParameter(parameter);
+            }
+        }
+
+        EndpointRuleSet updatedRuleSet = ruleSet.toBuilder()
+                .parameters(paramsBuilder.build())
+                .rules(prunedRules)
+                .build();
+
+        EndpointRuleSetTrait updatedTrait = endpointRuleSetTrait.toBuilder()
+                .ruleSet(updatedRuleSet.toNode())
+                .build();
+
+        ServiceShape.Builder serviceBuilder = service.toBuilder().addTrait(updatedTrait);
+
+        // Compile BDD based on updated endpoint ruleset
+        if (service.hasTrait(EndpointBddTrait.ID)) {
+            serviceBuilder.addTrait(CompileBdd.compileBdd(updatedRuleSet));
+        }
+
+        // Clean endpoint tests that reference orphaned parameters.
+        if (service.hasTrait(EndpointTestsTrait.ID)) {
+            EndpointTestsTrait testsTrait = service.expectTrait(EndpointTestsTrait.class);
+            serviceBuilder.addTrait(cleanEndpointTests(testsTrait, orphanedParams));
+        }
+
+        return serviceBuilder.build();
+    }
+
+    private List<Rule> pruneRules(List<Rule> rules, Set<String> orphanedParams) {
+        List<Rule> result = new ArrayList<>(rules.size());
+        for (Rule rule : rules) {
+            Rule pruned = pruneRule(rule, orphanedParams);
+            if (pruned != null) {
+                result.add(pruned);
+            }
+        }
+        return result;
+    }
+
+    private Rule pruneRule(Rule rule, Set<String> orphanedParams) {
+        // Drop the rule if any of its conditions reference an orphaned parameter.
+        if (conditionsReferenceOrphanedParam(rule.getConditions(), orphanedParams)) {
+            return null;
+        }
+
+        if (rule instanceof TreeRule) {
+            List<Rule> prunedChildren = pruneRules(((TreeRule) rule).getRules(), orphanedParams);
+            // Drop the tree rule if all of its children were pruned.
+            if (prunedChildren.isEmpty()) {
+                return null;
+            }
+            // Always rebuild with the surviving children rather than trying to detect "unchanged"
+            // and reuse the original.
+            return Rule.builder(rule)
+                    .conditions(rule.getConditions())
+                    .description(rule.getDocumentation().orElse(null))
+                    .treeRule(prunedChildren);
+        }
+
+        // Leaf rules do not need to be pruned.
+        return rule;
+    }
+
+    private boolean conditionsReferenceOrphanedParam(List<Condition> conditions, Set<String> orphanedParams) {
+        for (Condition condition : conditions) {
+            for (String reference : condition.getFunction().getReferences()) {
+                if (orphanedParams.contains(reference)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private EndpointTestsTrait cleanEndpointTests(EndpointTestsTrait testsTrait, Set<String> orphanedParams) {
+        List<EndpointTestCase> cleanedCases = new ArrayList<>();
+        for (EndpointTestCase testCase : testsTrait.getTestCases()) {
+            if (!testCaseReferencesOrphanedParam(testCase, orphanedParams)) {
+                cleanedCases.add(testCase);
+            }
+        }
+        return testsTrait.toBuilder().testCases(cleanedCases).build();
+    }
+
+    private boolean testCaseReferencesOrphanedParam(EndpointTestCase testCase, Set<String> orphanedParams) {
+        ObjectNode params = testCase.getParams();
+        for (Map.Entry<StringNode, Node> entry : params.getMembers().entrySet()) {
+            if (orphanedParams.contains(entry.getKey().getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Set<String> computeBoundParameters(Model model, TopDownIndex topDownIndex, ServiceShape service) {
+        Set<String> boundParams = new HashSet<>();
+        if (service.hasTrait(ClientContextParamsTrait.ID)) {
+            boundParams.addAll(service.expectTrait(ClientContextParamsTrait.class).getParameters().keySet());
+        }
+        for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+            if (operation.hasTrait(StaticContextParamsTrait.ID)) {
+                boundParams.addAll(operation.expectTrait(StaticContextParamsTrait.class).getParameters().keySet());
+            }
+            if (operation.hasTrait(OperationContextParamsTrait.ID)) {
+                boundParams.addAll(
+                        operation.expectTrait(OperationContextParamsTrait.class).getParameters().keySet());
+            }
+
+            StructureShape input = model.expectShape(operation.getInputShape(), StructureShape.class);
+            for (MemberShape member : input.members()) {
+                if (member.hasTrait(ContextParamTrait.ID)) {
+                    boundParams.add(member.expectTrait(ContextParamTrait.class).getName());
+                }
+            }
+        }
+        return boundParams;
+    }
+}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParameters.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParameters.java
@@ -22,10 +22,16 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.model.transform.ModelTransformerPlugin;
+import software.amazon.smithy.rulesengine.language.Endpoint;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.language.evaluation.TestEvaluator;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
 import software.amazon.smithy.rulesengine.language.syntax.rule.Condition;
+import software.amazon.smithy.rulesengine.language.syntax.rule.EndpointRule;
+import software.amazon.smithy.rulesengine.language.syntax.rule.ErrorRule;
 import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
 import software.amazon.smithy.rulesengine.language.syntax.rule.TreeRule;
 import software.amazon.smithy.rulesengine.transforms.CompileBdd;
@@ -94,7 +100,7 @@ public final class CleanEndpointRuleSetParameters implements ModelTransformerPlu
         }
 
         // Prune rules that reference orphaned parameters.
-        List<Rule> prunedRules = pruneRules(ruleSet.getRules(), orphanedParams);
+        List<Rule> retainedRules = pruneRules(ruleSet.getRules(), orphanedParams);
 
         // Remove orphaned parameter declarations.
         Parameters.Builder paramsBuilder = Parameters.builder();
@@ -106,7 +112,7 @@ public final class CleanEndpointRuleSetParameters implements ModelTransformerPlu
 
         EndpointRuleSet updatedRuleSet = ruleSet.toBuilder()
                 .parameters(paramsBuilder.build())
-                .rules(prunedRules)
+                .rules(retainedRules)
                 .build();
 
         EndpointRuleSetTrait updatedTrait = endpointRuleSetTrait.toBuilder()
@@ -123,7 +129,8 @@ public final class CleanEndpointRuleSetParameters implements ModelTransformerPlu
         // Clean endpoint tests that reference orphaned parameters.
         if (service.hasTrait(EndpointTestsTrait.ID)) {
             EndpointTestsTrait testsTrait = service.expectTrait(EndpointTestsTrait.class);
-            serviceBuilder.addTrait(cleanEndpointTests(testsTrait, orphanedParams));
+            EndpointTestsTrait cleanedTests = cleanEndpointTests(testsTrait, orphanedParams, updatedRuleSet);
+            serviceBuilder.addTrait(cleanedTests);
         }
 
         return serviceBuilder.build();
@@ -132,24 +139,25 @@ public final class CleanEndpointRuleSetParameters implements ModelTransformerPlu
     private List<Rule> pruneRules(List<Rule> rules, Set<String> orphanedParams) {
         List<Rule> result = new ArrayList<>(rules.size());
         for (Rule rule : rules) {
-            Rule pruned = pruneRule(rule, orphanedParams);
-            if (pruned != null) {
-                result.add(pruned);
+            Rule retainedRule = pruneRule(rule, orphanedParams);
+            if (retainedRule != null) {
+                result.add(retainedRule);
             }
         }
         return result;
     }
 
     private Rule pruneRule(Rule rule, Set<String> orphanedParams) {
-        // Drop the rule if any of its conditions reference an orphaned parameter.
+        // Conditions gate every rule type, a condition referencing an orphaned parameter drops the
+        // rule (and, for a tree rule, its whole subtree).
         if (conditionsReferenceOrphanedParam(rule.getConditions(), orphanedParams)) {
             return null;
         }
 
         if (rule instanceof TreeRule) {
-            List<Rule> prunedChildren = pruneRules(((TreeRule) rule).getRules(), orphanedParams);
+            List<Rule> retainedChildren = pruneRules(((TreeRule) rule).getRules(), orphanedParams);
             // Drop the tree rule if all of its children were pruned.
-            if (prunedChildren.isEmpty()) {
+            if (retainedChildren.isEmpty()) {
                 return null;
             }
             // Always rebuild with the surviving children rather than trying to detect "unchanged"
@@ -157,32 +165,86 @@ public final class CleanEndpointRuleSetParameters implements ModelTransformerPlu
             return Rule.builder(rule)
                     .conditions(rule.getConditions())
                     .description(rule.getDocumentation().orElse(null))
-                    .treeRule(prunedChildren);
+                    .treeRule(retainedChildren);
         }
 
-        // Leaf rules do not need to be pruned.
+        // A leaf rule can also reference a parameter in its value: an endpoint rule's URL, headers,
+        // or properties, or an error rule's error expression.
+        if (leafValueReferencesOrphanedParam(rule, orphanedParams)) {
+            return null;
+        }
+
         return rule;
+    }
+
+    private boolean leafValueReferencesOrphanedParam(Rule rule, Set<String> orphanedParams) {
+        if (rule instanceof EndpointRule) {
+            Endpoint endpoint = ((EndpointRule) rule).getEndpoint();
+            if (referencesOrphanedParam(endpoint.getUrl().getReferences(), orphanedParams)) {
+                return true;
+            }
+            for (List<Expression> headerValues : endpoint.getHeaders().values()) {
+                for (Expression headerValue : headerValues) {
+                    if (referencesOrphanedParam(headerValue.getReferences(), orphanedParams)) {
+                        return true;
+                    }
+                }
+            }
+            for (Literal property : endpoint.getProperties().values()) {
+                if (referencesOrphanedParam(property.getReferences(), orphanedParams)) {
+                    return true;
+                }
+            }
+        } else if (rule instanceof ErrorRule) {
+            return referencesOrphanedParam(((ErrorRule) rule).getError().getReferences(), orphanedParams);
+        }
+        return false;
     }
 
     private boolean conditionsReferenceOrphanedParam(List<Condition> conditions, Set<String> orphanedParams) {
         for (Condition condition : conditions) {
-            for (String reference : condition.getFunction().getReferences()) {
-                if (orphanedParams.contains(reference)) {
-                    return true;
-                }
+            if (referencesOrphanedParam(condition.getFunction().getReferences(), orphanedParams)) {
+                return true;
             }
         }
         return false;
     }
 
-    private EndpointTestsTrait cleanEndpointTests(EndpointTestsTrait testsTrait, Set<String> orphanedParams) {
+    private boolean referencesOrphanedParam(Set<String> references, Set<String> orphanedParams) {
+        for (String reference : references) {
+            if (orphanedParams.contains(reference)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private EndpointTestsTrait cleanEndpointTests(
+            EndpointTestsTrait testsTrait,
+            Set<String> orphanedParams,
+            EndpointRuleSet updatedRuleSet
+    ) {
         List<EndpointTestCase> cleanedCases = new ArrayList<>();
         for (EndpointTestCase testCase : testsTrait.getTestCases()) {
-            if (!testCaseReferencesOrphanedParam(testCase, orphanedParams)) {
+            // Static check: drop test cases that explicitly set an orphaned parameter.
+            if (testCaseReferencesOrphanedParam(testCase, orphanedParams)) {
+                continue;
+            }
+            // Dynamic check: a test case can also rely on an orphaned parameter implicitly.
+            if (testCasePasses(updatedRuleSet, testCase)) {
                 cleanedCases.add(testCase);
             }
         }
         return testsTrait.toBuilder().testCases(cleanedCases).build();
+    }
+
+    private boolean testCasePasses(EndpointRuleSet ruleSet, EndpointTestCase testCase) {
+        try {
+            TestEvaluator.evaluate(ruleSet, testCase);
+            return true;
+        } catch (RuntimeException e) {
+            return false;
+        }
     }
 
     private boolean testCaseReferencesOrphanedParam(EndpointTestCase testCase, Set<String> orphanedParams) {

--- a/smithy-rules-engine/src/main/resources/META-INF/services/software.amazon.smithy.model.transform.ModelTransformerPlugin
+++ b/smithy-rules-engine/src/main/resources/META-INF/services/software.amazon.smithy.model.transform.ModelTransformerPlugin
@@ -1,1 +1,2 @@
 software.amazon.smithy.rulesengine.traits.CleanEndpointTestOperationInput
+software.amazon.smithy.rulesengine.traits.CleanEndpointRuleSetParameters

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParametersTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParametersTest.java
@@ -175,6 +175,9 @@ public class CleanEndpointRuleSetParametersTest {
 
         assertFalse(paramNames.contains("StreamARN"));
         assertFalse(paramNames.contains("OperationType"));
+
+        // DefaultArn is bound only by OperationA; despite having a default it must be removed.
+        assertFalse(paramNames.contains("DefaultArn"));
         assertTrue(paramNames.contains("Region"));
         assertTrue(paramNames.contains("Bucket"));
         assertTrue(paramNames.contains("endpoint"));
@@ -184,9 +187,51 @@ public class CleanEndpointRuleSetParametersTest {
         assertTrue(endpointUrlExists(ruleSet.getRules(), "https://special.{Region}.example.com"));
         assertTrue(endpointUrlExists(ruleSet.getRules(), "https://bucket.{Region}.example.com"));
 
+        // The DefaultArn leaf is not gated by any condition referencing DefaultArn, so it can only
+        // be pruned by scanning the rule's endpoint value. It must be gone.
+        assertFalse(endpointUrlExists(ruleSet.getRules(), "https://{DefaultArn}.arn.example.com"));
+
+        // Leaves whose header or property references DefaultArn must also be pruned.
+        assertFalse(endpointUrlExists(ruleSet.getRules(), "https://header.{Region}.example.com"));
+        assertFalse(endpointUrlExists(ruleSet.getRules(), "https://property.{Region}.example.com"));
+
+        // A leaf whose header and property reference only the in-scope Region must survive.
+        assertTrue(endpointUrlExists(ruleSet.getRules(), "https://safe.{Region}.example.com"));
+
         // Empty-tree collapse
         assertFalse(endpointUrlExists(ruleSet.getRules(), "https://control.example.com"));
         assertFalse(endpointUrlExists(ruleSet.getRules(), "https://data.example.com"));
+
+        // The cleaned model must validate.
+        Model pruned = transformer.removeUnreferencedShapes(transformed);
+        ValidatedResult<Model> result = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addModel(pruned)
+                .assemble();
+        result.getValidationEvents(Severity.ERROR)
+                .forEach(event -> assertFalse(event.getId().startsWith("RuleSetParameter")));
+        assertFalse(result.isBroken());
+    }
+
+    @Test
+    public void dynamicallyPrunesTestCaseImplicitlyDependingOnOrphanedDefault() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-implicit-default-model.smithy"))
+                .assemble()
+                .unwrap();
+        ShapeId serviceId = ShapeId.from("smithy.example#ImplicitDefaultService");
+
+        ModelTransformer transformer = ModelTransformer.create();
+        Model transformed = transformer.filterShapes(model, shape -> !shape.getId().equals(OPERATION_A));
+
+        ServiceShape service = transformed.expectShape(serviceId, ServiceShape.class);
+        EndpointTestsTrait testsTrait = service.expectTrait(EndpointTestsTrait.class);
+
+        // Only the regional test case (which does not depend on DefaultArn) survives.
+        assertEquals(1, testsTrait.getTestCases().size());
+        assertTrue(testsTrait.getTestCases().get(0).getDocumentation().orElse("").contains("Regional endpoint"));
 
         // The cleaned model must validate.
         Model pruned = transformer.removeUnreferencedShapes(transformed);

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParametersTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/CleanEndpointRuleSetParametersTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.rulesengine.traits;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
+import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
+import software.amazon.smithy.rulesengine.language.syntax.rule.TreeRule;
+import software.amazon.smithy.rulesengine.transforms.CompileBdd;
+import software.amazon.smithy.utils.ListUtils;
+
+public class CleanEndpointRuleSetParametersTest {
+    private static final ShapeId SERVICE_ID = ShapeId.from("smithy.example#EndpointService");
+    private static final ShapeId OPERATION_A = ShapeId.from("smithy.example#OperationA");
+    private static final ShapeId OPERATION_B = ShapeId.from("smithy.example#OperationB");
+
+    @Test
+    public void removesOrphanedParametersAndRulesWhenOperationRemoved() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-test-model.smithy"))
+                .assemble()
+                .unwrap();
+        Model transformed = ModelTransformer.create()
+                .filterShapes(model, shape -> !shape.getId().equals(OPERATION_A));
+
+        assertFalse(transformed.getShape(OPERATION_A).isPresent());
+
+        Set<String> paramNames = getRuleSetParameterNames(transformed);
+
+        // OperationType and StreamARN were only bound by OperationA — they must be removed.
+        assertFalse(paramNames.contains("OperationType"));
+        assertFalse(paramNames.contains("StreamARN"));
+
+        // Region (clientContextParams) and endpoint (builtIn) must be retained.
+        assertTrue(paramNames.contains("Region"));
+        assertTrue(paramNames.contains("endpoint"));
+
+        // Rules referencing orphaned params must be pruned.
+        List<Rule> rules = getRules(transformed);
+        // Original had 5 rules, the OperationType rule and StreamARN rule should be removed.
+        assertEquals(3, rules.size());
+    }
+
+    @Test
+    public void retainsAllParametersWhenUnrelatedOperationRemoved() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-test-model.smithy"))
+                .assemble()
+                .unwrap();
+        Model transformed = ModelTransformer.create()
+                .filterShapes(model, shape -> !shape.getId().equals(OPERATION_B));
+
+        assertFalse(transformed.getShape(OPERATION_B).isPresent());
+
+        // OperationB binds no endpoint parameters, so nothing should change.
+        Set<String> paramNames = getRuleSetParameterNames(transformed);
+        assertTrue(paramNames.contains("Region"));
+        assertTrue(paramNames.contains("OperationType"));
+        assertTrue(paramNames.contains("StreamARN"));
+        assertTrue(paramNames.contains("endpoint"));
+
+        List<Rule> rules = getRules(transformed);
+        assertEquals(5, rules.size());
+    }
+
+    @Test
+    public void retainsParameterWhileStillBoundByAnotherOperation() {
+        Model sharedModel = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-shared-model.smithy"))
+                .assemble()
+                .unwrap();
+        ShapeId serviceId = ShapeId.from("smithy.example#SharedEndpointService");
+        ModelTransformer transformer = ModelTransformer.create();
+
+        // Remove only OperationA: OperationB still binds SharedParam, so it must be retained.
+        Model afterARemoved = transformer.filterShapes(sharedModel, shape -> !shape.getId().equals(OPERATION_A));
+        EndpointRuleSet ruleSetAfterARemoved = afterARemoved.expectShape(serviceId, ServiceShape.class)
+                .expectTrait(EndpointRuleSetTrait.class)
+                .getEndpointRuleSet();
+        assertTrue(getRuleSetParameterNames(ruleSetAfterARemoved).contains("SharedParam"));
+        assertTrue(endpointUrlExists(ruleSetAfterARemoved.getRules(), "https://{SharedParam}.example.com"));
+
+        // Remove both operations: SharedParam is now orphaned and must be removed.
+        Model afterBothRemoved = transformer.filterShapes(sharedModel,
+                shape -> !shape.getId().equals(OPERATION_A) && !shape.getId().equals(OPERATION_B));
+        EndpointRuleSet ruleSetAfterBothRemoved = afterBothRemoved.expectShape(serviceId, ServiceShape.class)
+                .expectTrait(EndpointRuleSetTrait.class)
+                .getEndpointRuleSet();
+        assertFalse(getRuleSetParameterNames(ruleSetAfterBothRemoved).contains("SharedParam"));
+        assertFalse(endpointUrlExists(ruleSetAfterBothRemoved.getRules(), "https://{SharedParam}.example.com"));
+    }
+
+    @Test
+    public void removesTestCasesReferencingOrphanedParams() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-test-model.smithy"))
+                .assemble()
+                .unwrap();
+        Model transformed = ModelTransformer.create()
+                .filterShapes(model, shape -> !shape.getId().equals(OPERATION_A));
+
+        ServiceShape service = transformed.expectShape(SERVICE_ID, ServiceShape.class);
+        assertTrue(service.hasTrait(EndpointTestsTrait.class));
+
+        EndpointTestsTrait testsTrait = service.expectTrait(EndpointTestsTrait.class);
+        // Original had 4 test cases, the OperationType and StreamARN ones should be removed.
+        // The endpoint override and default regional cases reference no orphaned params and survive.
+        assertEquals(2, testsTrait.getTestCases().size());
+    }
+
+    @Test
+    public void transformedModelPassesValidation() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-test-model.smithy"))
+                .assemble()
+                .unwrap();
+        ModelTransformer transformer = ModelTransformer.create();
+        Model transformed = transformer.filterShapes(model, shape -> !shape.getId().equals(OPERATION_A));
+        transformed = transformer.removeUnreferencedShapes(transformed);
+
+        ValidatedResult<Model> result = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addModel(transformed)
+                .assemble();
+
+        result.getValidationEvents(Severity.ERROR)
+                .forEach(event -> assertFalse(event.getId().startsWith("RuleSetParameter")));
+        assertFalse(result.isBroken());
+    }
+
+    @Test
+    public void prunesDeeplyNestedLeafReferencingOrphanedParam() {
+        Model nestedModel = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-nested-model.smithy"))
+                .assemble()
+                .unwrap();
+
+        ModelTransformer transformer = ModelTransformer.create();
+        Model transformed = transformer.filterShapes(nestedModel, shape -> !shape.getId().equals(OPERATION_A));
+
+        ServiceShape service = transformed.expectShape(
+                ShapeId.from("smithy.example#NestedEndpointService"),
+                ServiceShape.class);
+        EndpointRuleSet ruleSet = service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
+
+        Set<String> paramNames = getParameterNames(ruleSet.getParameters());
+
+        assertFalse(paramNames.contains("StreamARN"));
+        assertFalse(paramNames.contains("OperationType"));
+        assertTrue(paramNames.contains("Region"));
+        assertTrue(paramNames.contains("Bucket"));
+        assertTrue(paramNames.contains("endpoint"));
+
+        // The deep StreamARN leaf must be pruned, its non-referencing siblings must survive.
+        assertFalse(endpointUrlExists(ruleSet.getRules(), "https://stream.example.com"));
+        assertTrue(endpointUrlExists(ruleSet.getRules(), "https://special.{Region}.example.com"));
+        assertTrue(endpointUrlExists(ruleSet.getRules(), "https://bucket.{Region}.example.com"));
+
+        // Empty-tree collapse
+        assertFalse(endpointUrlExists(ruleSet.getRules(), "https://control.example.com"));
+        assertFalse(endpointUrlExists(ruleSet.getRules(), "https://data.example.com"));
+
+        // The cleaned model must validate.
+        Model pruned = transformer.removeUnreferencedShapes(transformed);
+        ValidatedResult<Model> result = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addModel(pruned)
+                .assemble();
+        result.getValidationEvents(Severity.ERROR)
+                .forEach(event -> assertFalse(event.getId().startsWith("RuleSetParameter")));
+        assertFalse(result.isBroken());
+    }
+
+    @Test
+    public void recompilesBddParametersWhenOperationRemoved() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-test-model.smithy"))
+                .assemble()
+                .unwrap();
+
+        Model withBdd = addCompiledBdd(model);
+
+        Model transformed = ModelTransformer.create()
+                .filterShapes(withBdd, shape -> !shape.getId().equals(OPERATION_A));
+
+        ServiceShape service = transformed.expectShape(SERVICE_ID, ServiceShape.class);
+        assertTrue(service.hasTrait(EndpointBddTrait.class));
+
+        Set<String> bddParams = getParameterNames(service.expectTrait(EndpointBddTrait.class).getParameters());
+        // The same orphans removed from the ruleset must be gone from the BDD too.
+        assertFalse(bddParams.contains("OperationType"));
+        assertFalse(bddParams.contains("StreamARN"));
+        assertTrue(bddParams.contains("Region"));
+        assertTrue(bddParams.contains("endpoint"));
+
+        // BDD and ruleset parameter sets must be identical after cleaning.
+        assertEquals(getRuleSetParameterNames(transformed), bddParams);
+    }
+
+    @Test
+    public void bddBearingModelPassesValidationAfterRemoval() {
+        Model model = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addImport(CleanEndpointRuleSetParametersTest.class.getResource(
+                        "clean-ruleset-params-test-model.smithy"))
+                .assemble()
+                .unwrap();
+
+        ModelTransformer transformer = ModelTransformer.create();
+        Model withBdd = addCompiledBdd(model);
+        Model transformed = transformer.filterShapes(withBdd, shape -> !shape.getId().equals(OPERATION_A));
+        transformed = transformer.removeUnreferencedShapes(transformed);
+
+        ValidatedResult<Model> result = Model.assembler()
+                .discoverModels(CleanEndpointRuleSetParametersTest.class.getClassLoader())
+                .addModel(transformed)
+                .assemble();
+
+        result.getValidationEvents(Severity.ERROR)
+                .forEach(event -> assertFalse(event.getId().startsWith("RuleSetParameter")));
+        assertFalse(result.isBroken());
+    }
+
+    private static Model addCompiledBdd(Model source) {
+        ServiceShape service = source.expectShape(SERVICE_ID, ServiceShape.class);
+        EndpointRuleSet ruleSet = service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
+        ServiceShape withBdd = service.toBuilder()
+                .addTrait(CompileBdd.compileBdd(ruleSet))
+                .build();
+        return ModelTransformer.create().replaceShapes(source, ListUtils.of(withBdd));
+    }
+
+    private static Set<String> getRuleSetParameterNames(Model transformed) {
+        ServiceShape service = transformed.expectShape(SERVICE_ID, ServiceShape.class);
+        return getParameterNames(service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet().getParameters());
+    }
+
+    private static Set<String> getRuleSetParameterNames(EndpointRuleSet ruleSet) {
+        return getParameterNames(ruleSet.getParameters());
+    }
+
+    private static List<Rule> getRules(Model transformed) {
+        ServiceShape service = transformed.expectShape(SERVICE_ID, ServiceShape.class);
+        EndpointRuleSet ruleSet = service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
+        return ruleSet.getRules();
+    }
+
+    private static Set<String> getParameterNames(Iterable<Parameter> parameters) {
+        Set<String> names = new HashSet<>();
+        for (Parameter parameter : parameters) {
+            names.add(parameter.getName().toString());
+        }
+        return names;
+    }
+
+    private static boolean endpointUrlExists(List<Rule> rules, String url) {
+        for (Rule rule : rules) {
+            if (rule instanceof TreeRule) {
+                if (endpointUrlExists(((TreeRule) rule).getRules(), url)) {
+                    return true;
+                }
+            } else if (rule.toString().contains(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-implicit-default-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-implicit-default-model.smithy
@@ -1,0 +1,91 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use smithy.rules#clientContextParams
+use smithy.rules#contextParam
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@clientContextParams(
+    Region: {type: "string", documentation: "The AWS region"}
+)
+service ImplicitDefaultService {
+    version: "2022-01-01",
+    operations: [OperationA, OperationB]
+}
+
+apply ImplicitDefaultService @endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        Region: {type: "string", documentation: "The AWS region"},
+        // Bound only by OperationA and has a default, so it is required and in scope without a
+        // gating condition. Removing OperationA orphans it.
+        DefaultArn: {type: "string", required: true, default: "default-arn", documentation: "A defaulted ARN"}
+    },
+    rules: [
+        {
+            "documentation": "Uses DefaultArn's default directly in the URL with no gating condition",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "Region"}]},
+                {"fn": "stringEquals", "argv": [{"ref": "Region"}, "arn-region"]}
+            ],
+            "endpoint": {"url": "https://{DefaultArn}.arn.example.com", "properties": {}, "headers": {}},
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Default regional endpoint",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "Region"}]}
+            ],
+            "endpoint": {"url": "https://service.{Region}.example.com", "properties": {}, "headers": {}},
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Fallback error",
+            "conditions": [],
+            "error": "No endpoint could be resolved",
+            "type": "error"
+        }
+    ]
+})
+
+apply ImplicitDefaultService @endpointTests({
+    "version": "1.0",
+    "testCases": [
+        {
+            "documentation": "Explicitly sets DefaultArn - pruned by the static param-name scan",
+            "params": {"Region": "arn-region", "DefaultArn": "explicit-arn"},
+            "expect": {"endpoint": {"url": "https://explicit-arn.arn.example.com"}}
+        },
+        {
+            "documentation": "Implicitly depends on DefaultArn default - pruned only by dynamic evaluation",
+            "params": {"Region": "arn-region"},
+            "expect": {"endpoint": {"url": "https://default-arn.arn.example.com"}}
+        },
+        {
+            "documentation": "Regional endpoint - survives, does not depend on DefaultArn",
+            "params": {"Region": "us-east-1"},
+            "expect": {"endpoint": {"url": "https://service.us-east-1.example.com"}}
+        }
+    ]
+})
+
+operation OperationA {
+    input: OperationAInput
+}
+
+@input
+structure OperationAInput {
+    @contextParam(name: "DefaultArn")
+    defaultArn: String
+}
+
+operation OperationB {
+    input: OperationBInput
+}
+
+@input
+structure OperationBInput {
+    name: String
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-nested-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-nested-model.smithy
@@ -22,6 +22,7 @@ apply NestedEndpointService @endpointRuleSet({
         Bucket: {type: "string", documentation: "The bucket name"},
         StreamARN: {type: "string", documentation: "The stream ARN"},
         OperationType: {type: "string", documentation: "Type of operation"},
+        DefaultArn: {type: "string", required: true, default: "default-arn", documentation: "A defaulted ARN"},
         endpoint: {type: "string", builtIn: "SDK::Endpoint", documentation: "Override endpoint"}
     },
     rules: [
@@ -106,6 +107,48 @@ apply NestedEndpointService @endpointRuleSet({
                             "type": "endpoint"
                         }
                     ]
+                },
+                {
+                    "documentation": "Header ref leaf (level 2) - a header references DefaultArn",
+                    "conditions": [
+                        {"fn": "stringEquals", "argv": [{"ref": "Region"}, "header-region"]}
+                    ],
+                    "endpoint": {
+                        "url": "https://header.{Region}.example.com",
+                        "properties": {},
+                        "headers": {"x-arn": ["{DefaultArn}"]}
+                    },
+                    "type": "endpoint"
+                },
+                {
+                    "documentation": "Property ref leaf (level 2) - a property references DefaultArn",
+                    "conditions": [
+                        {"fn": "stringEquals", "argv": [{"ref": "Region"}, "property-region"]}
+                    ],
+                    "endpoint": {
+                        "url": "https://property.{Region}.example.com",
+                        "properties": {"arnProp": "{DefaultArn}"},
+                        "headers": {}
+                    },
+                    "type": "endpoint"
+                },
+                {
+                    "documentation": "Safe leaf (level 2) - header and property reference only in-scope Region, must survive",
+                    "conditions": [
+                        {"fn": "stringEquals", "argv": [{"ref": "Region"}, "safe-region"]}
+                    ],
+                    "endpoint": {
+                        "url": "https://safe.{Region}.example.com",
+                        "properties": {"regionProp": "{Region}"},
+                        "headers": {"x-region": ["{Region}"]}
+                    },
+                    "type": "endpoint"
+                },
+                {
+                    "documentation": "Defaulted ARN leaf (level 2) - no condition references DefaultArn, but the URL does",
+                    "conditions": [],
+                    "endpoint": {"url": "https://{DefaultArn}.arn.example.com", "properties": {}, "headers": {}},
+                    "type": "endpoint"
                 }
             ]
         },
@@ -120,7 +163,8 @@ apply NestedEndpointService @endpointRuleSet({
 
 @staticContextParams(
     Region: {value: "us-east-1"},
-    OperationType: {value: "control"}
+    OperationType: {value: "control"},
+    DefaultArn: {value: "operation-a-arn"}
 )
 operation OperationA {
     input: OperationAInput

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-nested-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-nested-model.smithy
@@ -1,0 +1,143 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use smithy.rules#clientContextParams
+use smithy.rules#contextParam
+use smithy.rules#endpointRuleSet
+use smithy.rules#staticContextParams
+
+@clientContextParams(
+    Region: {type: "string", documentation: "The AWS region"}
+)
+service NestedEndpointService {
+    version: "2022-01-01",
+    operations: [OperationA, OperationB]
+}
+
+apply NestedEndpointService @endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        Region: {type: "string", documentation: "The AWS region"},
+        Bucket: {type: "string", documentation: "The bucket name"},
+        StreamARN: {type: "string", documentation: "The stream ARN"},
+        OperationType: {type: "string", documentation: "Type of operation"},
+        endpoint: {type: "string", builtIn: "SDK::Endpoint", documentation: "Override endpoint"}
+    },
+    rules: [
+        {
+            "documentation": "Custom endpoint override",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "endpoint"}]}
+            ],
+            "endpoint": {"url": "{endpoint}", "properties": {}, "headers": {}},
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Region gate (level 1)",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "Region"}]}
+            ],
+            "type": "tree",
+            "rules": [
+                {
+                    "documentation": "Bucket gate (level 2)",
+                    "conditions": [
+                        {"fn": "isSet", "argv": [{"ref": "Bucket"}]}
+                    ],
+                    "type": "tree",
+                    "rules": [
+                        {
+                            "documentation": "Bucket value gate (level 3)",
+                            "conditions": [
+                                {"fn": "stringEquals", "argv": [{"ref": "Bucket"}, "special"]}
+                            ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "documentation": "Deep StreamARN leaf (level 4) - orphaned after OperationA removal",
+                                    "conditions": [
+                                        {"fn": "isSet", "argv": [{"ref": "StreamARN"}]},
+                                        {"fn": "stringEquals", "argv": [{"ref": "StreamARN"}, "arn:special"]}
+                                    ],
+                                    "endpoint": {"url": "https://stream.example.com", "properties": {}, "headers": {}},
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "documentation": "Deep fallback leaf (level 4)",
+                                    "conditions": [],
+                                    "endpoint": {"url": "https://special.{Region}.example.com", "properties": {}, "headers": {}},
+                                    "type": "endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "documentation": "Bucket default (level 3)",
+                            "conditions": [],
+                            "endpoint": {"url": "https://bucket.{Region}.example.com", "properties": {}, "headers": {}},
+                            "type": "endpoint"
+                        }
+                    ]
+                },
+                {
+                    "documentation": "Collapsible subtree (level 2) - gated by Bucket, but ALL children reference OperationType",
+                    "conditions": [
+                        {"fn": "isSet", "argv": [{"ref": "Bucket"}]},
+                        {"fn": "stringEquals", "argv": [{"ref": "Bucket"}, "routed"]}
+                    ],
+                    "type": "tree",
+                    "rules": [
+                        {
+                            "documentation": "Control routing (level 3)",
+                            "conditions": [
+                                {"fn": "isSet", "argv": [{"ref": "OperationType"}]},
+                                {"fn": "stringEquals", "argv": [{"ref": "OperationType"}, "control"]}
+                            ],
+                            "endpoint": {"url": "https://control.example.com", "properties": {}, "headers": {}},
+                            "type": "endpoint"
+                        },
+                        {
+                            "documentation": "Data routing (level 3)",
+                            "conditions": [
+                                {"fn": "isSet", "argv": [{"ref": "OperationType"}]},
+                                {"fn": "stringEquals", "argv": [{"ref": "OperationType"}, "data"]}
+                            ],
+                            "endpoint": {"url": "https://data.example.com", "properties": {}, "headers": {}},
+                            "type": "endpoint"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "documentation": "Fallback error",
+            "conditions": [],
+            "error": "No endpoint could be resolved",
+            "type": "error"
+        }
+    ]
+})
+
+@staticContextParams(
+    Region: {value: "us-east-1"},
+    OperationType: {value: "control"}
+)
+operation OperationA {
+    input: OperationAInput
+}
+
+@input
+structure OperationAInput {
+    @contextParam(name: "StreamARN")
+    streamArn: String
+}
+
+operation OperationB {
+    input: OperationBInput
+}
+
+@input
+structure OperationBInput {
+    @contextParam(name: "Bucket")
+    bucket: String
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-shared-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-shared-model.smithy
@@ -1,0 +1,66 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use smithy.rules#contextParam
+use smithy.rules#endpointRuleSet
+use smithy.rules#staticContextParams
+
+service SharedEndpointService {
+    version: "2022-01-01",
+    operations: [OperationA, OperationB]
+}
+
+apply SharedEndpointService @endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        SharedParam: {type: "string", documentation: "Bound by both operations"},
+        endpoint: {type: "string", builtIn: "SDK::Endpoint", documentation: "Override endpoint"}
+    },
+    rules: [
+        {
+            "documentation": "Custom endpoint override",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "endpoint"}]}
+            ],
+            "endpoint": {"url": "{endpoint}", "properties": {}, "headers": {}},
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Route based on SharedParam",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "SharedParam"}]}
+            ],
+            "endpoint": {"url": "https://{SharedParam}.example.com", "properties": {}, "headers": {}},
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Fallback error",
+            "conditions": [],
+            "error": "No endpoint could be resolved",
+            "type": "error"
+        }
+    ]
+})
+
+@staticContextParams(
+    SharedParam: {value: "operation-a"}
+)
+operation OperationA {
+    input: OperationAInput
+}
+
+@input
+structure OperationAInput {
+    name: String
+}
+
+operation OperationB {
+    input: OperationBInput
+}
+
+@input
+structure OperationBInput {
+    @contextParam(name: "SharedParam")
+    sharedB: String
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-test-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/clean-ruleset-params-test-model.smithy
@@ -1,0 +1,173 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use smithy.rules#clientContextParams
+use smithy.rules#contextParam
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+use smithy.rules#staticContextParams
+
+@clientContextParams(
+    Region: {type: "string", documentation: "The AWS region"}
+)
+service EndpointService {
+    version: "2022-01-01",
+    operations: [OperationA, OperationB]
+}
+
+apply EndpointService @endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        Region: {type: "string", documentation: "The AWS region"},
+        OperationType: {type: "string", documentation: "Type of operation"},
+        StreamARN: {type: "string", documentation: "The stream ARN"},
+        endpoint: {type: "string", builtIn: "SDK::Endpoint", documentation: "Override endpoint"}
+    },
+    rules: [
+        {
+            "documentation": "Custom endpoint override",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [{"ref": "endpoint"}]
+                }
+            ],
+            "endpoint": {
+                "url": "{endpoint}",
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Route based on OperationType",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [{"ref": "OperationType"}]
+                },
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "OperationType"}, "control"]
+                }
+            ],
+            "endpoint": {
+                "url": "https://control.example.com",
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Route based on StreamARN",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [{"ref": "StreamARN"}]
+                }
+            ],
+            "endpoint": {
+                "url": "https://stream.example.com",
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Default regional endpoint",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [{"ref": "Region"}]
+                }
+            ],
+            "endpoint": {
+                "url": "https://service.{Region}.example.com",
+                "properties": {},
+                "headers": {}
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Fallback error",
+            "conditions": [],
+            "error": "No endpoint could be resolved",
+            "type": "error"
+        }
+    ]
+})
+
+apply EndpointService @endpointTests({
+    "version": "1.0",
+    "testCases": [
+        {
+            "documentation": "Custom endpoint override",
+            "params": {
+                "endpoint": "https://override.example.com"
+            },
+            "expect": {
+                "endpoint": {
+                    "url": "https://override.example.com"
+                }
+            }
+        },
+        {
+            "documentation": "Default regional",
+            "params": {
+                "Region": "us-east-1"
+            },
+            "expect": {
+                "endpoint": {
+                    "url": "https://service.us-east-1.example.com"
+                }
+            }
+        },
+        {
+            "documentation": "Control operation type routing",
+            "params": {
+                "Region": "us-east-1",
+                "OperationType": "control"
+            },
+            "expect": {
+                "endpoint": {
+                    "url": "https://control.example.com"
+                }
+            }
+        },
+        {
+            "documentation": "Stream ARN routing",
+            "params": {
+                "Region": "us-east-1",
+                "StreamARN": "arn:aws:kinesis:us-east-1:123456789:stream/my-stream"
+            },
+            "expect": {
+                "endpoint": {
+                    "url": "https://stream.example.com"
+                }
+            }
+        }
+    ]
+})
+
+@staticContextParams(
+    OperationType: {value: "control"}
+)
+operation OperationA {
+    input: OperationAInput
+}
+
+@input
+structure OperationAInput {
+    @contextParam(name: "StreamARN")
+    streamArn: String
+}
+
+operation OperationB {
+    input: OperationBInput
+}
+
+@input
+structure OperationBInput {
+    name: String
+}


### PR DESCRIPTION
#### Background
#3190  reported validation failure caused by the orphaned paramters in `@endpointRuleSet` after the `removeShape` transform. This PR introduces a new model transform plugin `CleanEndpointRuleSetParameters` to clean up the orphaned paramters in `@endpointRuleSet`, `@endpointTests` and `@endpointBdd`.

After merge, this PR will fix #3190 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
