### PR TITLE
Fix changelog action for external contributor PRs

### DIFF
--- a/.changes/next-release/bugfix-8c9d4efe80f2482aa95f63fb71304782d2ac6d7f.json
+++ b/.changes/next-release/bugfix-8c9d4efe80f2482aa95f63fb71304782d2ac6d7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fix changelog action for external contributor PRs",
+  "pull_requests": [
+    "[#3220](https://github.com/smithy-lang/smithy/pull/3220)"
+  ]
+}

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -51,6 +51,9 @@ jobs:
                 # the checkout faster, but also makes it harder to accidentally
                 # run code from the PR branch.
                 sparse-checkout: .changes/next-release
+                # New setting introduced in checkout v7. Set to `true` to avoid
+                # workflow failure in external contributors' PRs.
+                allow-unsafe-pr-checkout: true
 
             # This is needed so that the changelog tool can check the diff for
             # newly-introduced changes by comparing its head against that of


### PR DESCRIPTION
#### Background
Several changelog validation failures in external contributors' PRs were spotted today and they are related to the recent [upgrade of GH action/checkout](https://github.com/smithy-lang/smithy/pull/3180). `checkout v7` addressed security risks of the `pull_request_target` by refusing to check out fork code by default and the new `allow-unsafe-pr-checkout` setting re-enables it. It should be safe to set `allow-unsafe-pr-checkout` to `true` given this changelog validation action only read the forked code and validate the changelog.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
