### PR TITLE
add protocol test coverage for json nested union and cbor union

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/unions.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/unions.smithy
@@ -47,6 +47,13 @@ union MyUnion {
     // Note that this uses a conflicting structure name with
     // GreetingStruct, so it must be renamed in the service.
     renamedStructureValue: aws.protocoltests.restjson.nested#GreetingStruct
+
+    unionValue: NestedUnion
+}
+
+/// A union used to test unions nested inside unions.
+union NestedUnion {
+    stringValue: String
 }
 
 apply JsonUnions @httpRequestTests([
@@ -245,6 +252,28 @@ apply JsonUnions @httpRequestTests([
             }
         }
     }
+    {
+        id: "RestJsonSerializeNestedUnionValue"
+        documentation: "Serializes a nested union value"
+        protocol: restJson1
+        method: "PUT"
+        uri: "/JsonUnions"
+        body: """
+            {
+                "contents": {
+                    "unionValue": {
+                        "stringValue": "foo"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "Content-Type": "application/json" }
+        params: {
+            contents: {
+                unionValue: { stringValue: "foo" }
+            }
+        }
+    }
 ])
 
 apply JsonUnions @httpResponseTests([
@@ -409,6 +438,27 @@ apply JsonUnions @httpResponseTests([
         params: {
             contents: {
                 structureValue: { hi: "hello" }
+            }
+        }
+    }
+    {
+        id: "RestJsonDeserializeNestedUnionValue"
+        documentation: "Deserializes a nested union value"
+        protocol: restJson1
+        code: 200
+        body: """
+            {
+                "contents": {
+                    "unionValue": {
+                        "stringValue": "foo"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "Content-Type": "application/json" }
+        params: {
+            contents: {
+                unionValue: { stringValue: "foo" }
             }
         }
     }

--- a/smithy-protocol-tests/model/rpcv2Cbor/main.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/main.smithy
@@ -16,6 +16,7 @@ service RpcV2Protocol {
         RpcV2CborLists
         RpcV2CborDenseMaps
         RpcV2CborSparseMaps
+        RpcV2CborUnions
         RecursiveShapes
         GreetingWithErrors
         FractionalSeconds

--- a/smithy-protocol-tests/model/rpcv2Cbor/unions.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/unions.smithy
@@ -1,0 +1,94 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.rpcv2Cbor
+
+use smithy.protocols#rpcv2Cbor
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// This operation uses unions for inputs and outputs.
+@idempotent
+operation RpcV2CborUnions {
+    input: RpcV2CborUnionInputOutput
+    output: RpcV2CborUnionInputOutput
+}
+
+structure RpcV2CborUnionInputOutput {
+    contents: RpcV2CborUnion
+    otherValue: String
+}
+
+union RpcV2CborUnion {
+    stringValue: String
+    unionValue: RpcV2CborNestedUnion
+}
+
+union RpcV2CborNestedUnion {
+    stringValue: String
+}
+
+apply RpcV2CborUnions @httpRequestTests([
+    {
+        id: "RpcV2CborSerializesUnionValue"
+        documentation: "Serializes a union followed by another structure member"
+        protocol: rpcv2Cbor
+        method: "POST"
+        uri: "/service/RpcV2Protocol/operation/RpcV2CborUnions"
+        body: "omhjb250ZW50c6Frc3RyaW5nVmFsdWVjZm9vam90aGVyVmFsdWVjYmFy"
+        bodyMediaType: "application/cbor"
+        headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor", Accept: "application/cbor" }
+        requireHeaders: ["Content-Length"]
+        params: {
+            contents: { stringValue: "foo" }
+            otherValue: "bar"
+        }
+    }
+    {
+        id: "RpcV2CborSerializesNestedUnionValue"
+        documentation: "Serializes a nested union followed by another structure member"
+        protocol: rpcv2Cbor
+        method: "POST"
+        uri: "/service/RpcV2Protocol/operation/RpcV2CborUnions"
+        body: "omhjb250ZW50c6FqdW5pb25WYWx1ZaFrc3RyaW5nVmFsdWVjZm9vam90aGVyVmFsdWVjYmFy"
+        bodyMediaType: "application/cbor"
+        headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor", Accept: "application/cbor" }
+        requireHeaders: ["Content-Length"]
+        params: {
+            contents: {
+                unionValue: { stringValue: "foo" }
+            }
+            otherValue: "bar"
+        }
+    }
+])
+
+apply RpcV2CborUnions @httpResponseTests([
+    {
+        id: "RpcV2CborDeserializesUnionValue"
+        documentation: "Deserializes a tagged union followed by another structure member"
+        protocol: rpcv2Cbor
+        code: 200
+        body: "omhjb250ZW50c6Frc3RyaW5nVmFsdWVjZm9vam90aGVyVmFsdWVjYmFy"
+        bodyMediaType: "application/cbor"
+        headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor" }
+        params: {
+            contents: { stringValue: "foo" }
+            otherValue: "bar"
+        }
+    }
+    {
+        id: "RpcV2CborDeserializesNestedUnionValue"
+        documentation: "Deserializes a nested union followed by another structure member"
+        protocol: rpcv2Cbor
+        code: 200
+        body: "omhjb250ZW50c6FqdW5pb25WYWx1ZaFrc3RyaW5nVmFsdWVjZm9vam90aGVyVmFsdWVjYmFy"
+        bodyMediaType: "application/cbor"
+        headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor" }
+        params: {
+            contents: {
+                unionValue: { stringValue: "foo" }
+            }
+            otherValue: "bar"
+        }
+    }
+])


### PR DESCRIPTION
#### Background
* adds restJson1 coverage for nested union serde
* adds rpcv2Cbor coverage for union serde

#### Testing
* regenerated in the go v2 sdk and ran tests

#### Links
* nested union deserialization issue: [aws/smithy-go#671](https://github.com/aws/smithy-go/issues/671)
* CBOR union serialization issue: [aws/aws-sdk-go-v2#3441](https://github.com/aws/aws-sdk-go-v2/issues/3441)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
