### PR TITLE
Update awsQueryCompatible for rpcv2Json

### DIFF
--- a/docs/source-2.0/aws/protocols/aws-query-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-query-protocol.rst
@@ -572,15 +572,23 @@ Summary
     trait.
 
     The ``awsQueryCompatible`` trait allows services to backward compatibly
-    migrate from ``awsQuery`` to :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trait>`
-    without removing values defined in the ``awsQueryError`` trait.
+    migrate from ``awsQuery`` to other wire protocols without removing values
+    defined in the ``awsQueryError`` trait.
 
     This trait adds the ``x-amzn-query-error`` header in the form of
     ``Code;Fault`` to error responses. ``Code`` is the value defined in the
     :ref:`awsQueryError <aws.protocols#awsQueryError-trait>`, and ``Fault`` is
     one of ``Sender`` or ``Receiver``.
 Trait selector
-    ``service :test([trait|aws.protocols#awsJson1_0], [trait|smithy.protocols#rpcv2Cbor])``
+    .. code-block:: none
+
+        service :test([trait|aws.protocols#awsJson1_0],
+                      [trait|smithy.protocols#rpcv2Cbor],
+                      [trait|smithy.protocols#rpcv2Json])
+
+    A service with the :ref:`awsJson1_0 <aws.protocols#awsJson1_0-trait>`,
+    :ref:`rpcv2Cbor <smithy.protocols#rpcv2Cbor-trait>`, or
+    :ref:`rpcv2Json <smithy.protocols#rpcv2Json-trait>` protocol.
 Value type
     Annotation trait
 

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.smithy
@@ -82,7 +82,12 @@ structure awsQueryError {
 
 /// Enable backward compatibility when migrating from awsQuery to the awsJson
 /// protocol or Smithy RPC v2 CBOR.
-@trait(selector: "service :test([trait|aws.protocols#awsJson1_0], [trait|smithy.protocols#rpcv2Cbor])")
+@trait(
+    selector: """
+        service :test([trait|aws.protocols#awsJson1_0],
+                      [trait|smithy.protocols#rpcv2Cbor],
+                      [trait|smithy.protocols#rpcv2Json])"""
+)
 structure awsQueryCompatible {}
 
 /// An RPC-based protocol that sends 'POST' requests in the body as Amazon EC2

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/aws-query-compatible.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/aws-query-compatible.smithy
@@ -6,6 +6,7 @@ use aws.protocols#awsQueryCompatible
 use aws.protocols#awsQueryError
 use aws.protocols#awsJson1_0
 use smithy.protocols#rpcv2Cbor
+use smithy.protocols#rpcv2Json
 
 @awsQueryCompatible
 @awsJson1_0
@@ -26,6 +27,13 @@ structure InvalidThingException {
 @awsQueryCompatible
 @rpcv2Cbor
 service MyService2 {
+    version: "2020-02-05",
+    errors: [InvalidThingException]
+}
+
+@awsQueryCompatible
+@rpcv2Json
+service MyService3 {
     version: "2020-02-05",
     errors: [InvalidThingException]
 }

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/aws-query-compatible-does-not-support-non-aws-json.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/aws-query-compatible-does-not-support-non-aws-json.errors
@@ -1,2 +1,2 @@
 [WARNING] smithy.example#MyService: This shape applies a trait that is deprecated: aws.protocols#awsQuery | DeprecatedTrait
-[ERROR] smithy.example#MyService: Trait `aws.protocols#awsQueryCompatible` cannot be applied to `smithy.example#MyService`. This trait may only be applied to shapes that match the following selector: service :test([trait|aws.protocols#awsJson1_0], [trait|smithy.protocols#rpcv2Cbor]) | TraitTarget
+[ERROR] smithy.example#MyService: Trait `aws.protocols#awsQueryCompatible` cannot be applied to `smithy.example#MyService`. This trait may only be applied to shapes that match the following selector: service :test( | TraitTarget


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
