### PR TITLE
Fix ABNF rendering

### DIFF
--- a/docs/smithy/__init__.py
+++ b/docs/smithy/__init__.py
@@ -1,36 +1,49 @@
-from sphinx.locale import _
-from sphinx.writers.html import HTMLTranslator as SphinxHTMLTranslator
-
 from docutils import nodes
+from sphinx import addnodes
 
 from .traitindex import setup_smithy_trait_index
 from .redirects import setup as setup_redirects
 
 
 def setup(app):
-    app.set_translator('html', HTMLTranslator)
+    app.add_node(
+        addnodes.productionlist,
+        override=True,
+        html=(visit_productionlist, None),
+    )
     setup_smithy_trait_index(app)
     setup_redirects(app)
 
-class HTMLTranslator(SphinxHTMLTranslator):
 
-    # Make production lists use ABNF and not BNF notation.
-    def visit_productionlist(self, node):
-        # type: (nodes.Node) -> None
-        node.get('classes', []).append("productionlist")
-        node.get('classes', []).append("highlight")
-        self.body.append(self.starttag(node, 'pre'))
-        lastname = None
-        for production in node:
-            if production['tokenname']:
-                if lastname is not None:
-                    self.body.append('\n')
-                lastname = production['tokenname']
-                self.body.append(self.starttag(production, 'strong', ''))
-                self.body.append(lastname + "</strong> =\n    ")
-            elif lastname is not None:
-                self.body.append('  ')
-            production.walkabout(self)
-            self.body.append('\n')
-        self.body.append('</pre>\n')
-        raise nodes.SkipNode
+def visit_productionlist(translator, node):
+    """Render production lists using ABNF rather than BNF notation."""
+    node.get('classes', []).extend(("productionlist", "highlight"))
+    translator.body.append(translator.starttag(node, 'pre'))
+    has_token = False
+
+    for production in node:
+        children = iter(production.children)
+        first_child = next(children)
+
+        if production['tokenname']:
+            if has_token:
+                translator.body.append('\n')
+            has_token = True
+
+            # Sphinx includes the token name and " ::= " separator as the
+            # first two children. Keep the name so its cross-reference target
+            # is preserved, but replace the BNF separator with ABNF.
+            first_child.walkabout(translator)
+            separator = next(children)
+            translator.body.append(separator.astext().replace("::=", "="))
+        else:
+            # Sphinx aligns continuation lines with the BNF right-hand side.
+            # Remove the two columns dropped when "::=" becomes "=".
+            translator.body.append(first_child.astext()[:-2])
+
+        for child in children:
+            child.walkabout(translator)
+        translator.body.append('\n')
+
+    translator.body.append('</pre>\n')
+    raise nodes.SkipNode


### PR DESCRIPTION
Sphinx renders the `productionlist` directive in BNF format, but Smithy is defined in ABNF, which is typically formatted slightly differently. We have a customization to patch over the difference, but it seems at some point it stopped working.

This updates that customization so that it works in current versions of sphinx. Essentially all it does is replace the separator while preserving formatting.

This is what it currently looks like:

<img width="781" height="201" alt="Screenshot 2026-07-29 at 11 23 36" src="https://github.com/user-attachments/assets/fa4519bd-d47c-455e-8bb4-079b8006d300" />

This is what it looks like with these changes:

<img width="781" height="165" alt="Screenshot 2026-07-29 at 11 24 35" src="https://github.com/user-attachments/assets/535fefb8-96a4-45e5-93d2-31bcfeab02de" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

